### PR TITLE
fix(auth): prevent deactivated users from refreshing tokens

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -495,7 +495,8 @@ const refreshAccessToken =
                         id,
                         name,
                         email,
-                        role
+                        role,
+                        is_active
                     FROM users
                     WHERE refresh_token = ?
                     LIMIT 1
@@ -523,6 +524,21 @@ const refreshAccessToken =
 
             const user =
                 users[0];
+
+            // inactive account
+            if (
+                user.is_active === 0
+            ) {
+
+                return res.status(403)
+                    .json({
+
+                        success: false,
+
+                        message:
+                            "Account has been deactivated"
+                    });
+            }
 
             // rotate tokens
             const newAccessToken =


### PR DESCRIPTION
## 📌 Description

This PR resolves a critical security vulnerability where deactivated users could bypass their account restrictions by repeatedly hitting the `/refresh` token endpoint. 

While the `/login` route correctly blocks deactivated accounts, the `refreshAccessToken` logic in `backend/controllers/authController.js` was completely omitting the `is_active` check. This allowed a malicious user who was logged in *before* being banned to maintain indefinite access to the system.

### 🔄 Changes Made
* **Modified `backend/controllers/authController.js`:** 
  * Updated the `SELECT` query inside `refreshAccessToken` to fetch the `is_active` column.
  * Added a validation block to check `if (user.is_active === 0)` and reject the refresh attempt with a `403 Forbidden` response.

### 🔗 Related Issue
*Fixes #32 *

### ✅ Testing Steps (Manual)
*(Note: Bypassing automated test coverage per `CONTRIBUTING.md` guidelines)*
1. Log in as a valid user to obtain an `accessToken` and a `refreshToken`.
2. Manually deactivate the user in the database (`is_active = 0`).
3. Send a request to the `/refresh` endpoint using the `refreshToken`.
4. Verify that the server responds with `403 Forbidden` and the message `"Account has been deactivated"`, effectively revoking their access.
