### PR TITLE
fix(order): explicitly begin database transaction on order creation

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -114,6 +114,9 @@ const createOrder =
                     });
             }
 
+            // begin transaction
+            await connection.beginTransaction();
+
             // create order via service
             const result =
                 await createOrderService(


### PR DESCRIPTION
## 📌 Description

This PR resolves a critical data integrity bug introduced in the order creation flow. While `backend/services/order.service.js` attempts to safely roll back on failure using `connection.rollback()`, the database transaction was actually **never officially started** by the controller. 

Because MySQL defaults to `autocommit` mode, this meant that `orders` were being permanently inserted immediately, and subsequent errors in item insertion or stock reduction could not be rolled back. 

### 🔄 Changes Made
* **Modified `backend/controllers/orderController.js`:** 
  * Added the missing `await connection.beginTransaction()` immediately after validating the request and acquiring the database connection. This ensures that the subsequent queries dispatched by `createOrderService` all run within an isolated, atomic transaction that can be successfully aborted if any step fails.

### 🔗 Related Issue
Fixes #45 

### ✅ Testing Steps (Manual)
*(Note: Bypassing automated test coverage per `CONTRIBUTING.md` guidelines)*
1. Trigger the order creation flow via Postman with a valid payload, but deliberately supply a payload that will cause a crash *after* the order is inserted (e.g. invalid item quantity).
2. Observe that the API returns an error response.
3. Check the `orders` table in the database and verify that the `INSERT` was successfully aborted, and no partial order row exists.
