### PR TITLE
fix(auth): query full user profile in /me endpoint

### DIFF
--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -259,25 +259,48 @@ router.post(
 router.get(
     "/me",
     authMiddleware,
-    (
+    async (
         req,
         res
     ) => {
+        try {
+            const [users] = await db.query(
+                "SELECT id, name, email, role, is_active FROM users WHERE id = ? LIMIT 1",
+                [req.user.id]
+            );
 
-        return res.status(200)
-            .json({
+            if (!users || !users.length) {
+                return res.status(404).json({
+                    success: false,
+                    message: "User not found"
+                });
+            }
 
+            const user = users[0];
+
+            if (user.is_active === 0) {
+                return res.status(403).json({
+                    success: false,
+                    message: "Account has been deactivated"
+                });
+            }
+
+            return res.status(200).json({
                 success: true,
-
                 user: {
-
-                    id:
-                        req.user.id,
-
-                    role:
-                        req.user.role
+                    id: user.id,
+                    name: user.name,
+                    email: user.email,
+                    role: user.role
                 }
             });
+        } catch (error) {
+            console.error("GET ME ERROR:", error);
+            return res.status(500).json({
+                success: false,
+                message: "Server error"
+            });
+        }
     }
 );
 


### PR DESCRIPTION
## 📌 Description

This PR fixes a bug where the `/api/auth/me` endpoint failed to return the user's full profile information. 

Previously, the endpoint simply echoed back the decoded JWT payload (`id` and `role`). As a result, the frontend permanently lost access to the user's `name` and `email` upon any page reload. This fix updates the handler to query the database and fetch the full user profile.

### 🔄 Changes Made
* **Modified `backend/routes/authRoutes.js`:** 
  * Refactored the `/me` route to be `async`.
  * Added a `db.query` to `SELECT id, name, email, role, is_active FROM users WHERE id = ?`.
  * Added error handling to return a `404 Not Found` if the user no longer exists, and a `403 Forbidden` if their account was deactivated.
  * Successfully returns the populated `user` object in the API response.

### 🔗 Related Issue
*Fixes #55 *

### ✅ Testing Steps (Manual)
1. Successfully log into the frontend application.
2. Refresh the browser.
3. Observe that the frontend still correctly displays the user's name (and other profile data) because the `/me` endpoint now restores the full session!
