### PR TITLE
fix(ui): use correct profileElements reference in profile.js

### DIFF
--- a/frontend/scripts/profile.js
+++ b/frontend/scripts/profile.js
@@ -274,7 +274,7 @@ function loadProfile() {
 edit profile
 ============================= */
 
-elements.editBtn?.addEventListener(
+profileElements.editBtn?.addEventListener(
     "click",
     () => {
 
@@ -286,7 +286,7 @@ elements.editBtn?.addEventListener(
 save profile
 ============================= */
 
-elements.profileForm?.addEventListener(
+profileElements.profileForm?.addEventListener(
     "submit",
     (event) => {
 
@@ -295,22 +295,22 @@ elements.profileForm?.addEventListener(
         const profile = {
 
             name:
-                elements.profileName.value.trim(),
+                profileElements.profileName.value.trim(),
 
             email:
-                elements.profileEmail.value.trim(),
+                profileElements.profileEmail.value.trim(),
 
             phone:
-                elements.profilePhone.value.trim(),
+                profileElements.profilePhone.value.trim(),
 
             address:
-                elements.profileAddress.value.trim(),
+                profileElements.profileAddress.value.trim(),
 
             bio:
-                elements.profileBio.value.trim(),
+                profileElements.profileBio.value.trim(),
 
             avatar:
-                elements.profilePreview.src
+                profileElements.profilePreview.src
         };
 
         AppUtils.setJSON(
@@ -341,7 +341,7 @@ elements.profileForm?.addEventListener(
 avatar upload
 ============================= */
 
-elements.avatarInput?.addEventListener(
+profileElements.avatarInput?.addEventListener(
     "change",
     (event) => {
 
@@ -358,7 +358,7 @@ elements.avatarInput?.addEventListener(
         reader.onload =
             (loadEvent) => {
 
-                elements.profilePreview.src =
+                profileElements.profilePreview.src =
                     loadEvent.target.result;
             };
 


### PR DESCRIPTION
## 🚀 Description
Fixes #67 
This Pull Request fixes a critical JavaScript crash on the Profile page that prevented users from editing or saving their profiles.

### 🐞 What was the issue?
In `frontend/scripts/profile.js`, the global object holding all the DOM element references was correctly instantiated as `profileElements`. However, all subsequent event listeners (e.g., clicking the edit button, submitting the profile form, or changing the avatar) mistakenly referred to an undefined `elements` variable. 

This resulted in an uncaught `ReferenceError: elements is not defined` as soon as the user tried to interact with the profile page, completely breaking the UI and execution.

### 🛠️ What did this PR do?
- Performed a global fix in `frontend/scripts/profile.js` replacing all instances of `elements.<property>` with the correct `profileElements.<property>`.
- Restored full functionality to the user profile page, including:
  - Switching between View and Edit modes.
  - Submitting updated profile details (Name, Email, Phone, Address, Bio) to `localStorage`.
  - Handling the avatar image upload preview correctly.

## 🔄 How to Test
1. Check out this branch.
2. Log into the application and navigate to `profile.html`.
3. Open the browser Developer Console to ensure no errors are thrown on load.
4. Click the "Edit Profile" button (The form should successfully switch to edit mode).
5. Modify some fields and update the avatar, then hit Save.
6. Verify that the profile data saves correctly and you see the success notification.

## ✅ Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tested the changes locally
- [x] Code follows the project's styling and structure
