### PR TITLE
Fix profile dropdown visibility for unauthenticated users

### DIFF
--- a/frontend/components/navbar.html
+++ b/frontend/components/navbar.html
@@ -73,14 +73,4 @@
             </ul>
         </nav>
     </div>
-
-    <script>
-        const user = JSON.parse(localStorage.getItem("user"));
-
-        if(user){
-        document
-            .getElementById("profile-dropdown")
-            .setAttribute("data-loggedin","true");
-        }
-    </script>
 </section>

--- a/frontend/components/navbar.html
+++ b/frontend/components/navbar.html
@@ -73,4 +73,14 @@
             </ul>
         </nav>
     </div>
+
+    <script>
+        const user = JSON.parse(localStorage.getItem("user"));
+
+        if(user){
+        document
+            .getElementById("profile-dropdown")
+            .setAttribute("data-loggedin","true");
+        }
+    </script>
 </section>

--- a/frontend/scripts/components.js
+++ b/frontend/scripts/components.js
@@ -103,6 +103,15 @@ async function initializeComponents() {
     );
 }
 
+const user = JSON.parse(localStorage.getItem("user"));
+
+const profileDropdown = document.getElementById("profile-dropdown");
+
+if (user && profileDropdown) {
+    profileDropdown.setAttribute("data-loggedin", "true");
+}
+
+
 // init
 document.addEventListener(
     "DOMContentLoaded",

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -289,7 +289,7 @@
 }
 
 /* desktop hover */
-.profile-wrapper:hover #profile-dropdown {
+.profile-wrapper:hover #profile-dropdown[data-loggedin="true"] {
     display: flex;
 }
 


### PR DESCRIPTION
Related Issue - #58

# Description - 

This PR fixes the issue where the profile dropdown menu appeared when interacting with the "Sign In" button for unauthenticated users.

# Changes Made - 

* Added authentication-based visibility handling for the profile dropdown
* Restricted dropdown display for guest users
* Updated navbar hover behavior to show dropdown only for logged-in users
* Improved overall authentication navigation flow and user experience

# Result  -

## Before - 

* Hovering/clicking on the "Sign In" button displayed profile-related options even when the user was not logged in

<img width="1918" height="923" alt="image" src="https://github.com/user-attachments/assets/70efe71b-8698-49b7-92fa-95b2c8423d33" />


## After - 

* Guest users now only see the "Sign In" button
* Profile dropdown appears only after successful authentication

https://github.com/user-attachments/assets/3d6885f7-4ed8-4096-9545-9d4137751c93

