### PR TITLE
Fixed the incorrect product unavailable notification

### DIFF
--- a/frontend/scripts/product.js
+++ b/frontend/scripts/product.js
@@ -364,6 +364,9 @@ function initializeProductPage() {
             product
         );
     }
+    setCurrentProduct(
+        product
+    );
 
     setupCartActions(
         product


### PR DESCRIPTION
Fixes #77

## Summary

This PR fixes an issue where an incorrect "Product unavailable" error notification was displayed when a product was successfully added to the cart.

## Changes Made

* Initialized the current product before setting up cart actions.
* Prevented the "Product unavailable" notification from appearing during successful add-to-cart operations.

## Testing

* Opened a product page.
* Clicked "Add to Cart".
* Verified the product was added successfully.
* Verified the incorrect error notification no longer appears.
