### PR TITLE
fix: update global variant state on selection change

### DIFF
--- a/frontend/scripts/product-variants.js
+++ b/frontend/scripts/product-variants.js
@@ -120,6 +120,12 @@ function updateVariant() {
                 currentVariant.image
             );
     }
+
+    window.selectedColor =
+        selectedColor;
+
+    window.selectedSize =
+        selectedSize;
 }
 
 // color events


### PR DESCRIPTION
Fixes #83 
### Description
This PR fixes a critical bug where adding a product to the cart would always add the default variant (e.g., "Black", "M"), regardless of which color or size the user had actually selected on the product page. 

The issue was caused by a state synchronization flaw in `frontend/scripts/product-variants.js`. While the local variables `selectedColor` and `selectedSize` were updating correctly upon button clicks, the global window exports (`window.selectedColor` and `window.selectedSize`) were only assigned once during initialization. Because strings are primitive values, the global properties never reflected the new selections, causing the cart logic (`product-actions.js`) to perpetually read stale initial values.

### Changes Made
- Updated `updateVariant()` in `frontend/scripts/product-variants.js` to explicitly re-assign the updated `selectedColor` and `selectedSize` values to `window.selectedColor` and `window.selectedSize`.

### Steps to Test
1. Check out this branch locally: `git checkout fix/cart-ignores-product-variants`.
2. Navigate to a product page that has color and size variants.
3. Select a non-default color (e.g., "Blue") and a non-default size (e.g., "XL").
4. Click **"Add to Cart"**.
5. Verify in the Cart Drawer or Cart Page that the item added reflects your exact selections ("Blue" and "XL") instead of the default variants.
