### PR TITLE
fix: use index instead of id for cart drawer item removal

### DIFF
--- a/frontend/scripts/cart-drawer.js
+++ b/frontend/scripts/cart-drawer.js
@@ -119,7 +119,7 @@ function renderCartDrawer() {
 
     cartDrawerItems.innerHTML =
         drawerCart.map(
-            (item) => {
+            (item, index) => {
                 const qty =
                     safeQty(
                         item.qty
@@ -168,8 +168,8 @@ function renderCartDrawer() {
                         <button
                             type="button"
                             class="remove-drawer-item"
-                            data-id="${
-                                item.id
+                            data-index="${
+                                index
                             }"
                             aria-label="Remove item"
                         >
@@ -209,20 +209,26 @@ function renderCartDrawer() {
 
 // remove item
 function removeDrawerItem(
-    id
+    index
 ) {
     if (
-        !id
+        index === undefined || index === null
     ) {
         return;
     }
 
-    drawerCart =
-        drawerCart.filter(
-            (item) =>
-                String(item.id)
-                !== String(id)
-        );
+    const parsedIndex = parseInt(index, 10);
+
+    if (
+        isNaN(parsedIndex) || !drawerCart[parsedIndex]
+    ) {
+        return;
+    }
+
+    drawerCart.splice(
+        parsedIndex,
+        1
+    );
 
     AppUtils.saveCart(
         drawerCart
@@ -325,7 +331,7 @@ document.addEventListener(
         ) {
             event.preventDefault();
             removeDrawerItem(
-                removeBtn.dataset.id
+                removeBtn.dataset.index
             );
         }
     }


### PR DESCRIPTION
## Fix Cart Drawer Mass-Deleting Product Variants

### Description
This PR resolves Issue #84 where the Cart Drawer unexpectedly removed all variants of a single product when the user only intended to remove one specific variant.

Previously, `removeDrawerItem` filtered the cart based solely on the product `id`:
```javascript
drawerCart = drawerCart.filter((item) => String(item.id) !== String(id));
```
Because multiple variants of the same product (e.g., Red "M" and Blue "L") share the same product `id`, the filter operation would wipe out the entire cluster of variants instead of just the one the user clicked on.

### Changes Made
- Changed the drawer items generator in `frontend/scripts/cart-drawer.js` to map and embed the array `index` as `data-index` on the remove button, rather than using `data-id`.
- Updated the click event delegation listener to extract the `dataset.index`.
- Updated `removeDrawerItem(index)` to safely parse the index and use `drawerCart.splice(index, 1)` to remove only the specific clicked item, perfectly mirroring the robust logic already used in the main `cart.js`.

### Steps to Test
1. Pull this branch locally: `git pull origin fix/cart-drawer-variant-deletion` (or checkout from the fork).
2. Go to a product page that has color and size variants.
3. Select "Red" and click "Add to Cart".
4. Select "Blue" and click "Add to Cart".
5. Open the Cart Drawer.
6. Click the "✕" (remove) button next to the "Red" item.
7. Observe that ONLY the "Red" item is removed, and the "Blue" item safely remains in the cart.

### Related Issue
Closes #84
