### PR TITLE
fix: add navigation to Learn More and Collection buttons on homepage …

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -281,7 +281,9 @@
                 The best classic dress is on sale at cara
             </span>
             <button class="white">
+                <a href="about.html">
                 Learn More
+                </a>
             </button>
         </div>
 
@@ -296,7 +298,9 @@
                 The best classic dress is on sale at cara
             </span>
             <button class="white">
+                <a href="shop.html">
                 Collection
+                </a>
             </button>
         </div>
     </section>
@@ -424,5 +428,5 @@
         src="scripts/script.js"
     ></script>
 
-  </body>
+</body>
 </html>


### PR DESCRIPTION
Fixes #80 

The "Learn More" and "Collection" buttons on the homepage promotional 
banners had no href or onclick - wrapped them with anchor tags linking 
to about.html and shop.html.

Contributing via SSOC 2026.