### PR TITLE
Fixed the bug behind hero section image not visible in dark mode

### DIFF
--- a/frontend/styles/hero.css
+++ b/frontend/styles/hero.css
@@ -469,11 +469,11 @@ body.dark-theme #banner3 h2 {
   color: #ffffff;
 }
 /* Hero background overlay for dark mode */
+/* Hero background overlay for dark mode */
 body.dark-theme #hero {
-    background-color: #121212;
-    background-blend-mode: multiply;
+    background-color: rgba(0, 0, 0, 0.45); /* halka overlay */
+    background-blend-mode: darken; /* multiply ki jagah darken */
 }
-
 /* Product cards white background fix */
 body.dark-theme .products-grid .pro,
 body.dark-theme .products-grid > div,


### PR DESCRIPTION
Closes #94 
## Problem
In dark mode, the hero section image was becoming nearly invisible — it was blending into the dark background and losing all visual clarity.
## Root Cause
The background-blend-mode was set to multiply combined with a near-black background color. This mode mathematically multiplies the background color with image pixels, causing the hero image to render almost completely black in dark theme.
Fix
Replaced the multiply blend mode with darken and changed the background color to a semi-transparent overlay. This preserves the image visibility while still maintaining the dark theme aesthetic.
Visual Result

## before

<img width="1888" height="933" alt="image" src="https://github.com/user-attachments/assets/eddf9a39-501c-4fae-ae11-229d15d44c2e" />

## after 

<img width="1919" height="973" alt="image" src="https://github.com/user-attachments/assets/bfd18b7e-7e22-49dc-a1bb-eac949bb437f" />

✅ Hero image clearly visible in both light and dark modes
✅ Dark theme feel preserved
✅ Text readability maintained
✅ No other sections affected