### PR TITLE
fix: correct HTML typo in navbar - liclass to li class

### DIFF
--- a/frontend/about.html
+++ b/frontend/about.html
@@ -340,20 +340,20 @@
 
         </div>
 
-        <div class="form">
+        <form class="form">
 
             <input
                 type="email"
                 placeholder="Your email address"
             >
 
-            <button class="normal">
+            <button class="normal" type="submit">
 
                 Sign Up
 
             </button>
 
-        </div>
+        </form>
 
     </section>
 

--- a/frontend/blog.html
+++ b/frontend/blog.html
@@ -199,10 +199,10 @@
             <h4>Sign Up For Newsletters</h4>
             <p>Get E-mail updates about our latest shop and <span>special offers.</span></p>
         </div>
-        <div class="form">
+        <form class="form">
             <input type="email" id="newsletter-email" placeholder="Your email address">
-            <button class="normal" id="newsletter-btn">Sign Up</button>
-        </div>
+            <button class="normal" id="newsletter-btn" type="submit">Sign Up</button>
+        </form>
     </section>
 
     <!-- Blog Modal Overlay -->

--- a/frontend/components/navbar.html
+++ b/frontend/components/navbar.html
@@ -38,7 +38,7 @@
             </li>
             
 
- <liclass="theme-toggle-item">
+ <li class="theme-toggle-item">
     <button id="theme-toggle" aria-label="Toggle theme">
         <span id="theme-icon">🌙</span>
     </button>

--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -285,15 +285,15 @@
             </p>
         </div>
 
-        <div class="form">
+        <form class="form">
             <input
                 type="email"
                 placeholder="Your email address"
             >
-            <button class="normal">
+            <button class="normal" type="submit">
                 Sign Up
             </button>
-        </div>
+        </form >
     </section>
 
     <!-- Footer -->

--- a/frontend/delivery.html
+++ b/frontend/delivery.html
@@ -234,15 +234,15 @@
             </p>
         </div>
 
-        <div class="form">
+        <form class="form">
             <input
                 type="email"
                 placeholder="Your email address"
             >
-            <button class="normal">
+            <button class="normal" type="submit">
                 Sign Up
             </button>
-        </div>
+        </form>
     </section>
 
     <!-- Footer -->

--- a/frontend/help.html
+++ b/frontend/help.html
@@ -297,20 +297,20 @@
 
         </div>
 
-        <div class="form">
+        <form class="form">
 
             <input
                 type="email"
                 placeholder="Your email address"
             >
 
-            <button class="normal">
+            <button class="normal" type="submit">
 
                 Sign Up
 
             </button>
 
-        </div>
+        </form>
 
     </section>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -347,15 +347,15 @@
                 </span>
             </p>
         </div>
-        <div class="form">
+        <form class="form">
             <input
                 type="email"
                 placeholder="Your email address"
             >
-            <button class="normal">
+            <button class="normal" type="submit">
                 Sign Up
             </button>
-        </div>
+        </form>
     </section>
 
     <!-- Footer -->

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -191,15 +191,15 @@
             </p>
         </div>
 
-        <div class="form">
+        <form class="form">
             <input
                 type="email"
                 placeholder="Your email address"
             >
-            <button class="normal">
+            <button class="normal" type="submit">
                 Sign Up
             </button>
-        </div>
+        </form>
     </section>
 
     <!-- Footer -->

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -290,20 +290,20 @@
 
         </div>
 
-        <div class="form">
+        <form class="form">
 
             <input
                 type="email"
                 placeholder="Your email address"
             >
 
-            <button class="normal">
+            <button class="normal" type="submit">
 
                 Sign Up
 
             </button>
 
-        </div>
+        </form>
 
     </section>
 


### PR DESCRIPTION
Fixes #109 

Fixed a typo in frontend/components/navbar.html at line 41.
<liclass="theme-toggle-item"> was missing a space, making it 
an invalid HTML tag. The theme toggle button was not being 
wrapped in a proper <li> element.

Changed:
<liclass="theme-toggle-item">  To
<li class="theme-toggle-item"> 