### PR TITLE
fix(navbar): add missing space in li tag for theme toggle

### DIFF
--- a/frontend/components/navbar.html
+++ b/frontend/components/navbar.html
@@ -38,7 +38,7 @@
             </li>
             
 
- <liclass="theme-toggle-item">
+ <li class="theme-toggle-item">
     <button id="theme-toggle" aria-label="Toggle theme">
         <span id="theme-icon">🌙</span>
     </button>


### PR DESCRIPTION
## Description

Fixed a malformed `<li>` tag in `navbar.html` by adding the missing space before the `class` attribute.

### Changes Made

* Corrected `<liclass="theme-toggle-item">` to `<li class="theme-toggle-item">`
* Restored proper rendering of the theme toggle button in the navigation bar

### Issue Fixed

Closes #107
