### PR TITLE
fix(cart): adding  missing closing quotes to img src and alt attributes

### DIFF
--- a/frontend/scripts/cart.js
+++ b/frontend/scripts/cart.js
@@ -294,10 +294,12 @@ function renderCart() {
                             AppUtils.defaultImage(
                                 item.img || item.image
                             )
-                        )}
+                        )}"
+
                         alt="${escapeHTML(
                             item.name || "Product"
-                        )}
+                        )}"
+                        
                         loading="lazy"
                     >
 


### PR DESCRIPTION
## Description

Fixed missing closing quotes in the `src` and `alt` attributes of the cart item image tag in `renderCart()`.

### Changes Made

* Added the missing closing quote for the `src` attribute.
* Added the missing closing quote for the `alt` attribute.
* Ensured the browser correctly parses the `<img>` element and its attributes.

### Issue Fixed

Closes #114
