### PR TITLE
bug: fixed the indentation to the overlapping text with radio buttons

### DIFF
--- a/frontend/checkout.html
+++ b/frontend/checkout.html
@@ -215,7 +215,7 @@
                             checked
                         >
 
-                        Credit / Debit Card
+                        . . Credit / Debit Card
 
                     </label>
 
@@ -227,7 +227,7 @@
                             value="upi"
                         >
 
-                        UPI Payment
+                        . . UPI Payment
 
                     </label>
 
@@ -239,7 +239,7 @@
                             value="cod"
                         >
 
-                        Cash On Delivery
+                       . . Cash On Delivery
 
                     </label>
 


### PR DESCRIPTION
#133

indentation has been added to the radio button text to prevent from overlapping.