### PR TITLE
Fix CORS misconfiguration

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -136,8 +136,7 @@ app.use(
         return callback(null, true);
       }
 
-      const isAllowed =
-        allowedOrigins.includes(origin) || origin.endsWith(".vercel.app");
+      const isAllowed = allowedOrigins.includes(origin);
 
       if (isAllowed) {
         return callback(null, true);


### PR DESCRIPTION
Fixes #156 
## 📌 Description
This PR patches a critical security misconfiguration in the Express backend's Cross-Origin Resource Sharing (CORS) policy. 

Previously, the CORS configuration included a dynamic fallback that allowed any origin ending with `.vercel.app` (`origin.endsWith(".vercel.app")`). Because anyone can create a `.vercel.app` subdomain, this allowed malicious third-party websites to successfully bypass CORS and make authenticated Cross-Origin API requests.

## 🛠️ Changes Made
- Removed the `origin.endsWith(".vercel.app")` wildcard fallback logic in `backend/server.js`.
- Restricted the `isAllowed` check to only validate against the explicitly defined `allowedOrigins` array.

## 🛡️ Impact
The API will now strictly deny Cross-Origin requests from untrusted and unauthorized Vercel domains, heavily improving the security posture of the backend.
