### PR TITLE
Fix unhandled promise rejections by exiting process

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -285,6 +285,7 @@ app.use((err, req, res, next) => {
 // unhandled promise rejection
 process.on("unhandledRejection", (reason) => {
   console.error("UNHANDLED REJECTION:", reason);
+  process.exit(1);
 });
 
 // uncaught exception


### PR DESCRIPTION
Fixes #158 

## 📌 Description
This PR fixes a stability and reliability issue in the Node.js backend regarding how it handles unresolved asynchronous operations.

Previously, the global `unhandledRejection` event listener caught rejected promises but only logged the error to the console, allowing the Node.js process to continue running.

## 🛠️ Changes Made
- Modified the `unhandledRejection` event listener in `backend/server.js` to gracefully shut down the application by calling `process.exit(1)` after logging the critical error.

## 🛡️ Impact
In modern Node.js environments, unhandled promise rejections are considered fatal errors. Exiting the process ensures the server doesn't linger in a corrupted, unpredictable state (which can cause memory leaks, dangling connections, or erratic behavior). Process managers (like PM2 or Docker) will now automatically and safely restart the clean server instance.
