### PR TITLE
fix: improve homepage banner responsiveness across breakpoints

### DIFF
--- a/frontend/styles/hero.css
+++ b/frontend/styles/hero.css
@@ -175,6 +175,8 @@ banner
     height: 40vh;
     background-size: cover;
     background-position: center;
+    padding-bottom: 30px;
+    box-sizing: border-box;
 }
 
 #banner h4{
@@ -204,6 +206,9 @@ small banners
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
+    gap: 16px;
+    padding: 0 80px;
+    box-sizing: border-box;
 }
 
 #sm-banner .banner-box{
@@ -212,11 +217,13 @@ small banners
     justify-content: flex-end;
     align-items: flex-start;
     background-image: url("../assets/images/b17.jpg");
-    min-width: 48%;
+    flex: 1 1 calc(50% - 8px);
+    min-width: 280px;
     height: 50vh;
     background-size: cover;
     background-position: center;
     padding: 30px;
+    box-sizing: border-box;
 }
 
 #sm-banner .banner-box2{
@@ -410,17 +417,24 @@ responsive layout
         margin: 15px;
     }
 
+    #sm-banner{
+        padding: 0 40px;
+        gap: 12px;
+    }
     #sm-banner .banner-box{
-        min-width: 100%;
+        flex: 1 1 100%;
         height: 30vh;
     }
-
     #banner3{
         padding: 0 40px;
     }
-
+    #banner3 .banner-link{
+        width: 48%;
+        margin-bottom: 16px;
+    }
     #banner3 .banner-box{
-        width: 28%;
+        width: 100%;
+        min-width: unset;
     }
 
     #newsletter .form{
@@ -493,12 +507,38 @@ responsive layout
         margin-top: 20px;
     }
 
+    #sm-banner{
+        padding: 0 16px;
+        gap: 12px;
+    }
     #banner3{
         padding: 0 20px;
     }
-
+    #banner3 .banner-link{
+        width: 100%;
+    }
     #banner3 .banner-box{
         width: 100%;
+        min-width: unset;
+        height: 160px;
+    }
+    #sm-banner h2{
+        font-size: 20px;
+    }
+    #sm-banner h4{
+        font-size: 16px;
+    }
+    #sm-banner span{
+        font-size: 12px;
+    }
+    #banner h2{
+        font-size: 22px;
+    }
+    #banner3 .banner-box h2{
+        font-size: 1.2rem;
+    }
+    #banner3 .banner-box h4{
+        font-size: 1rem;
     }
 
     #newsletter{

--- a/frontend/styles/hero.css
+++ b/frontend/styles/hero.css
@@ -452,11 +452,6 @@ responsive layout
         margin-top: 70px;
         padding: 0 20px;
     }
-
-
-    #hero h1{
-        font-size: 38px;
-    }
     #hero h1{  
         font-size: 1.2rem;
         line-height: 1.2rem;


### PR DESCRIPTION
## What does this PR do?
Fixes homepage banner layout and responsiveness issues. Adds missing `padding-bottom` to `#banner` so content is not clipped. Fixes `#sm-banner` spacing with `gap` and proper `padding` at all breakpoints. Makes `#banner3` links responsive — 3 columns on desktop, 2 on tablet, 1 on mobile. Adds `box-sizing: border-box` where missing to prevent overflow.

## Related issue
Fixes #150

## Type
- [ ] bug fix
- [x] feature
- [ ] enhancement
- [x] UI/UX

## Checklist
- [x] Code tested
- [x] No console errors

<img width="1164" height="804" alt="Screenshot 2026-06-16 at 1 14 16 PM" src="https://github.com/user-attachments/assets/bc89856c-9654-4781-a771-62a974829d27" />
<img width="1160" height="724" alt="Screenshot 2026-06-16 at 1 14 21 PM" src="https://github.com/user-attachments/assets/797141d1-21ad-49e8-a50f-81e3127110ac" />
