### PR TITLE
fix: simplify product card actions and prioritize primary buttons

### DIFF
--- a/frontend/scripts/product-cards-home.js
+++ b/frontend/scripts/product-cards-home.js
@@ -125,44 +125,40 @@ function createProductCard(
                 <div class="product-actions">
                     <button
                         type="button"
-                        class="view-product-btn"
+                        class="view-product-btn primary-action"
                         data-id="${
                             product.id
                         }"
                     >
                         View
                     </button>
-
                     <button
                         type="button"
-                        class="add-cart-btn"
+                        class="add-cart-btn primary-action"
                         data-id="${
                             product.id
                         }"
                     >
                         Add Cart
                     </button>
-
-                    <button
-    type="button"
-    class="compare-btn"
-    data-id="${
-        product.id
-    }"
->
-    Compare
-</button>
-
-                    
                     <button
                         type="button"
-                        class="wishlist-btn"
+                        class="compare-btn icon-action"
+                        data-id="${product.id}"
+                        aria-label="Compare"
+                        title="Compare"
+                    >
+                        <i class="fas fa-balance-scale"></i>
+                    </button>
+                    <button
+                        type="button"
+                        class="wishlist-btn icon-action"
                         data-id="${product.id}"
                         aria-label="Add to Wishlist"
+                        title="Add to Wishlist"
                     >
                         <i class="${ AppUtils.getWishlist().some(item => String(item.id) === String(product.id)) ? 'fas' : 'far' } fa-heart"></i>
                     </button>
-
                 </div>
             </div>
         </div>

--- a/frontend/styles/product-card.css
+++ b/frontend/styles/product-card.css
@@ -116,14 +116,12 @@ product section
 /* product action buttons */
 .product-actions{
     display: flex;
-    gap: 10px;
+    gap: 8px;
     margin-top: 15px;
     width: 100%;
     align-items: center;
 }
-
-.product-actions button,
-.product-actions a{
+.product-actions .primary-action{
     flex: 1;
     border: none;
     padding: 12px;
@@ -134,6 +132,27 @@ product section
     background: var(--primary-color);
     color: white;
     transition: 0.3s ease;
+    font-size: 0.85rem;
+}
+.product-actions .icon-action{
+    flex: 0 0 auto;
+    width: 40px;
+    height: 40px;
+    border: 1px solid rgba(8,129,120,0.25);
+    border-radius: 8px;
+    cursor: pointer;
+    background: var(--white);
+    color: var(--primary-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: 0.3s ease;
+    padding: 0;
+}
+.product-actions .icon-action:hover{
+    background: var(--primary-color);
+    color: var(--white);
+    transform: translateY(-2px);
 }
 
 /* product badge */
@@ -185,13 +204,14 @@ product section
         max-width: 320px;
     }
 
-    .product-actions{
-        flex-direction: column;
+.product-actions{
+        flex-wrap: wrap;
+    }
+    .product-actions .primary-action{
+        flex: 1 1 calc(50% - 4px);
     }
 }
-
-.product-actions button:hover,
-.product-actions a:hover{
+.product-actions .primary-action:hover{
     opacity: 0.9;
     transform: translateY(-2px);
 }


### PR DESCRIPTION
## What does this PR do?
Redesigns the product card action buttons on the homepage to reduce visual clutter. View and Add Cart remain as primary text buttons, while Compare and Wishlist are converted to compact icon-only buttons. Updated responsive styles so the primary buttons wrap to two-per-row on smaller screens instead of stacking awkwardly.

## Note on product data accuracy
The reported product name/category mismatches (e.g. an image labeled "white sneakers" under category "footwear" not matching the actual product shown) could not be reproduced from the codebase. No such data exists in `seedProducts.js` or any product data file in this repo. Maybe this part of the issue was already fixed by a previously merged PR. 

## Changes
- `frontend/scripts/product-cards-home.js`: restructured `.product-actions` markup, added `primary-action` and `icon-action` classes to buttons
- `frontend/styles/product-card.css`: added distinct styling for primary vs icon action buttons, updated responsive breakpoint behavior

## Related issue
Fixes #153 (UI portion)

## Type
- [x] bug fix
- [ ] feature
- [ ] enhancement
- [x] UI/UX

## Checklist
- [x] Code tested locally
- [x] No console errors introduced
- [x] Verified rendered HTML output matches expected structure
- [ ] Documentation updated