### PR TITLE
fix: Product Categories Showing "No Products Found" - Issue #35

### DIFF
--- a/frontend/scripts/shop.js
+++ b/frontend/scripts/shop.js
@@ -130,7 +130,18 @@ async function fetchProducts(
             );
 
         if (!data.success) {
-            renderEmptyState(data.message || "Failed to load products.");
+            const normCat = normalizeCategoryString(currentCategory);
+            const fallback = normCat === 'all'
+                ? fallbackProducts
+                : fallbackProducts.filter(p => categoriesMatch(p.category, currentCategory));
+            if (fallback.length > 0) {
+                currentProducts = fallback;
+                totalPages = 1;
+                applySorting();
+                renderPagination();
+            } else {
+                renderEmptyState("No products found.");
+            }
             return;
         }
 
@@ -146,16 +157,15 @@ async function fetchProducts(
                 ? fallbackProducts
                 : fallbackProducts.filter(p => categoriesMatch(p.category, currentCategory));
 
+            totalPages =
+                Number(
+                    data.totalPages || 1
+                );
             if (fallback.length > 0) {
-                currentProducts = fallback;
-                totalPages = 1;
+                    currentProducts = fallback;
+                    totalPages = 1;
+                }
             }
-        }
-
-        totalPages =
-            Number(
-                data.totalPages || 1
-            );
 
         // sorting
         applySorting();
@@ -164,15 +174,22 @@ async function fetchProducts(
         renderPagination();
 
     } catch (error) {
-
         console.error(
             "SHOP FETCH ERROR:",
             error
         );
-
-        renderEmptyState(
-            "Failed to load products."
-        );
+        const normCat = normalizeCategoryString(currentCategory);
+        const fallback = normCat === 'all'
+            ? fallbackProducts
+            : fallbackProducts.filter(p => categoriesMatch(p.category, currentCategory));
+        if (fallback.length > 0) {
+            currentProducts = fallback;
+            totalPages = 1;
+            applySorting();
+            renderPagination();
+        } else {
+            renderEmptyState("No products found.");
+        }
     }
 }
 

--- a/frontend/shop.html
+++ b/frontend/shop.html
@@ -151,7 +151,7 @@
 
             <button
                 class="filter-btn"
-                data-category="tshirt"
+                data-category="T-Shirts"
             >
 
                 T-Shirts
@@ -160,7 +160,7 @@
 
             <button
                 class="filter-btn"
-                data-category="hoodie"
+                data-category="Hoodies"
             >
 
                 Hoodies
@@ -169,7 +169,7 @@
 
             <button
                 class="filter-btn"
-                data-category="jacket"
+                data-category="Jackets"
             >
 
                 Jackets


### PR DESCRIPTION
Hey @BHUVANSH855
Finally Done with this...
---

###  What I Found

**The obvious one — category name mismatch**
The filter buttons in `shop.html` were sending `tshirt`, `hoodie`, 
`jacket` to the filtering logic, but the fallback products in `shop.js` 
are stored as `T-Shirts`, `Hoodies`, `Jackets`. Even after normalization, 
`tshirt` and `tshirts` are still different strings — so nothing ever matched 
and the shop just showed empty.

**The sneaky one — fallback never triggered on API failure**
When the backend is down or unreachable, `apiRequest()` quietly returns 
`{ success: false }` instead of throwing an error. The old code just showed 
"Failed to load products." and bailed out early — the fallback products 
sitting right there in the file never got loaded. Fixed this so fallback 
kicks in properly when the API is unavailable.

**The subtle one — pagination race condition**
Inside the fallback block, `totalPages` was set to `1` correctly, but then 
the very next line overwrote it with `data.totalPages` from the backend 
response. Small thing but it would've broken pagination on fallback products.

---

###  What I Fixed
- Aligned `data-category` values in `shop.html` → `T-Shirts`, `Hoodies`, `Jackets`
- Fallback products now load when backend returns `success: false`
- Fixed `totalPages` being overwritten after fallback assignment

---

###  Screenshots
<img width="1535" height="826" alt="image" src="https://github.com/user-attachments/assets/0d1a5c9f-11d5-40b9-a852-e8ee8d3330d5" />
<img width="1536" height="821" alt="image" src="https://github.com/user-attachments/assets/b34af87f-f60e-4ab2-a621-045391b9227a" />

---

###  Files Changed
- `frontend/shop.html`
- `frontend/scripts/shop.js`

---

Closes #35