### PR TITLE
Fix hardcoded database credentials in docker-compose (#185)

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: ecom-mysql
     restart: unless-stopped
     environment:
-      MYSQL_ROOT_PASSWORD: yourpassword
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       MYSQL_DATABASE: ecommerce
     ports:
       - "3306:3306"


### PR DESCRIPTION
## Fix Hardcoded Database Credentials in Docker Compose

### 📌 Description
This Pull Request resolves a security issue where the MySQL root password was hardcoded in plain text inside the `backend/docker-compose.yml` file. 

The static `yourpassword` string has been replaced with the `${DB_PASSWORD}` environment variable. This ensures that sensitive credentials are not accidentally checked into version control and aligns the Docker configuration with security best practices.

Closes #185

### 🔄 Changes Made
*   **Modified `backend/docker-compose.yml`**: Updated the `MYSQL_ROOT_PASSWORD` value under the `db` service to map dynamically to the `DB_PASSWORD` environment variable.

### 🧪 How to Test
1. Create or update your `.env` file to include `DB_PASSWORD=your_secure_password`.
2. Run `docker-compose up -d` in the `backend` directory.
3. Verify that the MySQL container initializes successfully and accepts the password you defined in your local `.env` file.

### ✅ Checklist
- [x] Removed hardcoded secrets.
- [x] Referenced environment variable correctly.
- [x] Code has been tested locally.
