### PR TITLE
Fix Stored XSS in quick view modal by using AppUtils.escapeHTML

### DIFF
--- a/frontend/scripts/script.js
+++ b/frontend/scripts/script.js
@@ -184,10 +184,10 @@ function createQuickViewModal(imageSrc, imageAlt) {
 
   const image = document.createElement("img");
   image.src =
-    typeof escapeHTML === "function" ? escapeHTML(imageSrc) : imageSrc;
+    typeof AppUtils !== "undefined" && typeof AppUtils.escapeHTML === "function" ? AppUtils.escapeHTML(imageSrc) : imageSrc;
   image.alt =
-    typeof escapeHTML === "function"
-      ? escapeHTML(imageAlt || "Product Image")
+    typeof AppUtils !== "undefined" && typeof AppUtils.escapeHTML === "function"
+      ? AppUtils.escapeHTML(imageAlt || "Product Image")
       : imageAlt || "Product Image";
   image.style.cssText = `
         width: 100%;


### PR DESCRIPTION
## Fix Broken Security Check in Quick View Modal

### 📌 Description
This Pull Request resolves a security vulnerability (Issue #184) in the Quick View Modal (`frontend/scripts/script.js`). 

Previously, the `createQuickViewModal` function attempted to sanitize image sources and alt text by checking `typeof escapeHTML === "function"`. However, because `escapeHTML` was refactored to be scoped under `window.AppUtils`, this check silently failed and bypassed sanitization entirely, leaving the modal vulnerable to DOM-based XSS.

The checks have been updated to correctly verify and call `AppUtils.escapeHTML()`.

Closes #184

### 🔄 Changes Made
*   **Updated `script.js`**: Modified lines 186-191 to check for `typeof AppUtils !== "undefined" && typeof AppUtils.escapeHTML === "function"` and call `AppUtils.escapeHTML(imageSrc)` respectively.

### 🧪 How to Test
1. Check out the `fix/modal-xss` branch locally.
2. In your local database or mock data, inject a basic payload like `"><script>alert(1)</script>` into a product's image URL or name.
3. Open the homepage and click on that product's image to open the Quick View Modal.
4. Verify that the script does not execute and the HTML entities are safely escaped in the DOM.

### ✅ Checklist
- [x] Fixed broken sanitization check.
- [x] Verified `AppUtils.escapeHTML` is correctly invoked.
- [x] Code has been tested locally.
