### PR TITLE
Fix layout thrashing bottleneck by caching wishlist Set in product render loops (#248)

### DIFF
--- a/frontend/scripts/product-cards-home.js
+++ b/frontend/scripts/product-cards-home.js
@@ -16,7 +16,7 @@ function safePrice(value) {
 }
 
 // render product card
-function createProductCard(product) {
+function createProductCard(product, wishlistIds = null) {
   const rating = Math.min(5, Math.max(0, Number(product.rating || 4)));
 
   const stars = Array.from(
@@ -29,6 +29,10 @@ function createProductCard(product) {
                 `;
     },
   ).join("");
+
+  const isWishlisted = (wishlistIds instanceof Set)
+    ? wishlistIds.has(String(product.id))
+    : AppUtils.getWishlist().some((item) => String(item.id) === String(product.id));
 
   return `
         <div class="pro fade-in">
@@ -93,7 +97,7 @@ function createProductCard(product) {
                         class="wishlist-btn secondary-action"
                         data-id="${product.id}"
                     >
-                        <i class="${AppUtils.getWishlist().some((item) => String(item.id) === String(product.id)) ? "fas" : "far"} fa-heart"></i>
+                        <i class="${isWishlisted ? "fas" : "far"} fa-heart"></i>
                         Wishlist
                     </button>
                 </div>
@@ -108,9 +112,10 @@ function renderFeaturedProducts(products = []) {
   }
 
   const featured = products.filter((product) => product.featured);
+  const wishlistIds = new Set(AppUtils.getWishlist().map((item) => String(item.id)));
 
   homeFeaturedContainer.innerHTML = featured.length
-    ? featured.slice(0, 8).map(createProductCard).join("")
+    ? featured.slice(0, 8).map((product) => createProductCard(product, wishlistIds)).join("")
     : `
                 <p class="empty-products">
                     No featured products found
@@ -142,8 +147,10 @@ function renderNewArrivals(products = []) {
     .filter((product) => Number(product.featured) !== 1)
     .slice(0, 8);
 
+  const wishlistIds = new Set(AppUtils.getWishlist().map((item) => String(item.id)));
+
   homeArrivalsContainer.innerHTML = arrivals.length
-    ? arrivals.map(createProductCard).join("")
+    ? arrivals.map((product) => createProductCard(product, wishlistIds)).join("")
     : `
                 <p class="empty-products">
                     No new arrivals found

--- a/frontend/scripts/recommendations.js
+++ b/frontend/scripts/recommendations.js
@@ -40,8 +40,9 @@ const Recommendations = (() => {
       ) {
         // Ensure UI functions are available and use the correct arguments
         if (typeof window.createProductCard === "function") {
+          const wishlistIds = new Set(AppUtils.getWishlist().map((item) => String(item.id)));
           container.innerHTML = response.data
-            .map(window.createProductCard)
+            .map((product) => window.createProductCard(product, wishlistIds))
             .join("");
 
           if (typeof window.addProductCardAnimations === "function") {

--- a/frontend/scripts/script.js
+++ b/frontend/scripts/script.js
@@ -137,13 +137,14 @@ function renderProducts(container, products = []) {
   }
 
   const fragment = document.createDocumentFragment();
+  const wishlistIds = new Set(AppUtils.getWishlist().map((item) => String(item.id)));
 
   AppUtils.safeArray(products).forEach((product) => {
     if (!product || !product.id) return;
 
     const card = document.createElement("div");
     card.innerHTML =
-      typeof createProductCard === "function" ? createProductCard(product) : "";
+      typeof createProductCard === "function" ? createProductCard(product, wishlistIds) : "";
 
     const productElement = card.firstElementChild;
     if (productElement) {

--- a/frontend/scripts/shop.js
+++ b/frontend/scripts/shop.js
@@ -233,7 +233,8 @@ function renderStars(
 
 // PRODUCT CARD
 function createProductCard(
-    product
+    product,
+    wishlistIds = null
 ) {
     const displayName =
         product.name ||
@@ -241,6 +242,10 @@ function createProductCard(
 
     const stock =
         Number(product.stock) || 0;
+
+    const isWishlisted = (wishlistIds instanceof Set)
+        ? wishlistIds.has(String(product.id))
+        : AppUtils.getWishlist().some(item => String(item.id) === String(product.id));
 
     return `
         <div
@@ -292,7 +297,7 @@ function createProductCard(
                     : `
                         <div style="position: absolute; bottom: 20px; right: 12px; display: flex; gap: 8px; z-index: 2;">
                             <button class="wishlist-btn-shop cart" data-id="${product.id}" aria-label="Add to Wishlist" style="position: relative; bottom: 0; right: 0;">
-                                <i class="${ AppUtils.getWishlist().some(item => String(item.id) === String(product.id)) ? 'fas' : 'far' } fa-heart"></i>
+                                <i class="${ isWishlisted ? 'fas' : 'far' } fa-heart"></i>
                             </button>
                             <button class="add-to-cart-icon cart" aria-label="Add to cart" style="position: relative; bottom: 0; right: 0;">
                                 <i class="fal fa-shopping-cart"></i>
@@ -326,10 +331,11 @@ function renderProducts(products = []) {
     }
 
     const fragment = document.createDocumentFragment();
+    const wishlistIds = new Set(AppUtils.getWishlist().map((item) => String(item.id)));
 
     displayList.forEach((product) => {
         const wrapper = document.createElement('div');
-        wrapper.innerHTML = createProductCard(product);
+        wrapper.innerHTML = createProductCard(product, wishlistIds);
         const card = wrapper.firstElementChild;
         if (card) {
             setupProductCard(card, product);


### PR DESCRIPTION


### Description
This pull request addresses the layout thrashing and performance degradation on mobile/low-end devices caused by synchronous `localStorage` reads during product list rendering loops. Fixes #248 
Previously, the `createProductCard` function would query `AppUtils.getWishlist()` within its template literal for each product card rendered. Under the hood, this performed sequential, synchronous `localStorage.getItem()` calls and `JSON.parse` operations inside `.map()` loops.

### Proposed Changes
1. **Wishlist Caching Strategy:**
   - Pre-calculate a `Set` of wishlist item IDs (as strings) before entering any product render/mapping loops.
   - Updated `createProductCard` signature to accept a second parameter: `wishlistIds = null`.
   - Perform an $O(1)$ lookup via `wishlistIds.has(String(product.id))` instead of invoking `AppUtils.getWishlist().some(...)` inside each card render block.

2. **Backwards Compatibility:**
   - Retained fallback checking to standard `AppUtils.getWishlist()` if the parameter is omitted or is not an instance of `Set` (e.g. standard array map signatures where the second argument is the map index).

3. **Optimized Files:**
   - **`frontend/scripts/product-cards-home.js`**: Caches wishlist state before rendering featured products and new arrivals.
   - **`frontend/scripts/shop.js`**: Caches wishlist state before rendering shop catalog items.
   - **`frontend/scripts/script.js`**: Caches wishlist state inside the generic product list rendering helper.
   - **`frontend/scripts/recommendations.js`**: Caches wishlist state before displaying recommended products.

### Verification & Testing
- **Visual Validation:** Verified that wishlist heart icons continue to correctly render their active/inactive status depending on whether they are in the user's wishlist.
- **Performance Verification:** CPU profile shows that layout/render blocking time is significantly reduced, and localStorage operations are capped at one read per rendering cycle instead of $N$ reads (where $N$ is the number of product cards rendered).
