### PR TITLE
Fix Chat History 403 Forbidden Error for Customers (#253)

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -23,6 +23,12 @@ const getConversationDetails = async (req, res) => {
         const id = safeNumber(req.params.id);
         if (!id) return res.status(400).json({ success: false, message: "Invalid ID" });
 
+        // Verify access to conversation
+        const hasAccess = await chatService.verifyConversationAccess(id, req.user.id, req.user.role);
+        if (!hasAccess) {
+            return res.status(403).json({ success: false, message: "Access forbidden" });
+        }
+
         const messages = await chatService.getConversationMessages(id);
         res.status(200).json({ success: true, messages });
     } catch (error) {

--- a/backend/routes/chatRoutes.js
+++ b/backend/routes/chatRoutes.js
@@ -3,13 +3,15 @@ const router = express.Router();
 const { authMiddleware, authorizeRoles } = require("../middleware/authMiddleware");
 const { getConversations, getConversationDetails, updateStatus, assignAdmin } = require("../controllers/chat.controller");
 
-// Admin only routes
+// Require auth for all chat routes
 router.use(authMiddleware);
-router.use(authorizeRoles("admin"));
 
-router.get("/conversations", getConversations);
+// Admin-only routes
+router.get("/conversations", authorizeRoles("admin"), getConversations);
+router.patch("/conversations/:id/status", authorizeRoles("admin"), updateStatus);
+router.patch("/conversations/:id/assign", authorizeRoles("admin"), assignAdmin);
+
+// Accessible by admin or the owner customer
 router.get("/conversations/:id", getConversationDetails);
-router.patch("/conversations/:id/status", updateStatus);
-router.patch("/conversations/:id/assign", assignAdmin);
 
 module.exports = router;


### PR DESCRIPTION

### Description
This pull request resolves the issue where regular customer users receive a `403 Forbidden` error when trying to load their chat history through the support chat widget.
Fixes #253 
Previously, `backend/routes/chatRoutes.js` globally applied `router.use(authorizeRoles("admin"))` to all downstream routes in the router. This blocked customers from calling GET `/api/chat/conversations/:id` to retrieve their previous message history.
### Proposed Changes
* **Granular Middleware Application:**
  - Removed `router.use(authorizeRoles("admin"))` from the global level of `chatRoutes.js`.
  - Explicitly applied the `authorizeRoles("admin")` middleware ONLY to admin-specific endpoints:
    - `GET /conversations` (List all chat conversations)
    - `PATCH /conversations/:id/status` (Update conversation status)
    - `PATCH /conversations/:id/assign` (Assign conversation to an admin)
  - Left the `GET /conversations/:id` endpoint accessible to any authenticated user (subject to controller-level checks).
* **Access Control Check in Controller:**
  - Modified `getConversationDetails` in `backend/controllers/chat.controller.js` to invoke `chatService.verifyConversationAccess(id, req.user.id, req.user.role)`.
  - This ensures that while customers can access `GET /conversations/:id` for their own conversations, they are securely forbidden (`403 Forbidden`) from fetching chat logs belonging to other users. Admins can view all conversation details.
### Verification & Testing
- **Security Check:** Verified that a customer fetching their own conversation ID successfully receives their messages, while requesting another customer's conversation ID yields a `403 Access forbidden` response.
- **Admin Verification:** Confirmed that admin accounts retain full access to all conversation list queries, status modifications, assignments, and conversation details.