### PR TITLE
Fix editProduct blocking native prompt dialogs

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -547,6 +547,44 @@
 
     </section>
 
+    <!-- Edit Product Modal -->
+    <div id="edit-product-modal" class="modal-overlay" style="display: none;">
+        <div class="modal-content">
+            <h2>Edit Product</h2>
+            <form id="edit-product-form">
+                <input type="hidden" id="edit-product-id">
+                <div class="form-grid">
+                    <input type="text" id="edit-product-name" placeholder="Product Name" required>
+                    <input type="number" id="edit-product-price" placeholder="Price" required>
+                    <select id="edit-product-category">
+                        <option value="fashion">Fashion</option>
+                        <option value="hoodie">Hoodie</option>
+                        <option value="shoes">Shoes</option>
+                        <option value="accessories">Accessories</option>
+                    </select>
+                    <input type="number" id="edit-product-stock" placeholder="Stock" required>
+                    <select id="edit-product-status">
+                        <option value="In Stock">In Stock</option>
+                        <option value="Out Of Stock">Out Of Stock</option>
+                        <option value="Hidden">Hidden</option>
+                    </select>
+                </div>
+                <textarea id="edit-product-description" placeholder="Product Description" required></textarea>
+                <input type="url" id="edit-product-image" placeholder="Image URL" required>
+                <div class="featured-toggle">
+                    <label>
+                        <input type="checkbox" id="edit-featured-product">
+                        Featured Product
+                    </label>
+                </div>
+                <div class="modal-actions" style="display: flex; gap: 10px; margin-top: 20px;">
+                    <button type="button" id="edit-cancel-btn" class="normal" style="background: #6c757d;">Cancel</button>
+                    <button type="submit" class="normal">Save Changes</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
     <!-- Footer -->
 
     <div id="footer"></div>

--- a/frontend/scripts/admin.js
+++ b/frontend/scripts/admin.js
@@ -703,151 +703,34 @@ async function DeleteeProduct(
 }
 
 // edit product
-async function editProduct(
-    id
-) {
+function editProduct(id) {
+    const product = products.find(p => p.id === id);
+    if (!product) return;
 
-    const product =
-        products.find(
-            (
-                p
-            ) => {
-
-                return p.id === id;
+    // Populate modal
+    document.getElementById("edit-product-id").value = product.id;
+    document.getElementById("edit-product-name").value = product.name || "";
+    document.getElementById("edit-product-price").value = product.price || 0;
+    
+    // Set Category
+    const categorySelect = document.getElementById("edit-product-category");
+    if (product.category) {
+        for(let i=0; i<categorySelect.options.length; i++) {
+            if (categorySelect.options[i].value.toLowerCase() === product.category.toLowerCase()) {
+                categorySelect.selectedIndex = i;
+                break;
             }
-        );
-
-    if (
-        !product
-    ) {
-
-        return;
-    }
-
-    const newName =
-        prompt(
-            "Edit Product Name",
-            product.name
-        );
-
-    const newPrice =
-        prompt(
-            "Edit Product Price",
-            product.price
-        );
-
-    const newStock =
-        prompt(
-            "Edit Product Stock",
-            product.stock
-        );
-
-    if (
-        !newName?.trim()
-        ||
-        isNaN(
-            newPrice
-        )
-        ||
-        isNaN(
-            newStock
-        )
-    ) {
-
-        AppUtils.notify(
-            "Invalid product details.",
-            "error"
-        );
-
-        return;
-    }
-
-    const updatedData = {
-
-        name:
-            newName.trim(),
-
-        description:
-            product.description || "",
-
-        price:
-            parseFloat(
-                newPrice
-            ) || 0,
-
-        image:
-            product.image || "",
-
-        category:
-            product.category || "",
-
-        stock:
-            parseInt(
-                newStock,
-                10
-            ) || 0,
-
-        featured:
-            product.featured || false
-    };
-
-    try {
-
-        const response =
-            await AppUtils.apiRequest(
-                `/products/${id}`,
-                {
-
-                    method:
-                        "PUT",
-
-                    body:
-                        JSON.stringify(
-                            updatedData
-                        )
-                }
-            );
-
-        if (
-            response.success
-        ) {
-
-            Object.assign(
-                product,
-                updatedData
-            );
-
-            renderProducts();
-
-            renderStats();
-
-            AppUtils.notify(
-                "Product updated successfully!",
-                "success"
-            );
-
-        } else {
-
-            AppUtils.notify(
-                response.message
-                ||
-                "Failed to update product.",
-                "error"
-            );
         }
-
-    } catch (error) {
-
-        console.error(
-            "EDIT PRODUCT ERROR:",
-            error
-        );
-
-        AppUtils.notify(
-            "Failed to update product.",
-            "error"
-        );
     }
+    
+    document.getElementById("edit-product-stock").value = product.stock || 0;
+    document.getElementById("edit-product-status").value = (product.stock > 0) ? "In Stock" : "Out Of Stock";
+    document.getElementById("edit-product-description").value = product.description || "";
+    document.getElementById("edit-product-image").value = product.image || "";
+    document.getElementById("edit-featured-product").checked = !!product.featured;
+
+    // Show modal
+    document.getElementById("edit-product-modal").style.display = "flex";
 }
 
 // render orders
@@ -1287,3 +1170,55 @@ if (selectAllCb) {
 setTimeout(() => {
     loadAdminDashboard();
 }, 500);
+
+// Initialize Edit Modal Events
+document.addEventListener("DOMContentLoaded", () => {
+    const editModal = document.getElementById("edit-product-modal");
+    const editForm = document.getElementById("edit-product-form");
+    const cancelBtn = document.getElementById("edit-cancel-btn");
+
+    if (cancelBtn && editModal) {
+        cancelBtn.addEventListener("click", () => {
+            editModal.style.display = "none";
+        });
+    }
+
+    if (editForm) {
+        editForm.addEventListener("submit", async (e) => {
+            e.preventDefault();
+            const id = document.getElementById("edit-product-id").value;
+            const product = products.find(p => String(p.id) === String(id));
+            if (!product) return;
+
+            const updatedData = {
+                name: document.getElementById("edit-product-name").value.trim(),
+                description: document.getElementById("edit-product-description").value.trim(),
+                price: parseFloat(document.getElementById("edit-product-price").value) || 0,
+                image: document.getElementById("edit-product-image").value.trim(),
+                category: document.getElementById("edit-product-category").value,
+                stock: parseInt(document.getElementById("edit-product-stock").value, 10) || 0,
+                featured: document.getElementById("edit-featured-product").checked
+            };
+
+            try {
+                const response = await AppUtils.apiRequest(`/products/${id}`, {
+                    method: "PUT",
+                    body: JSON.stringify(updatedData)
+                });
+
+                if (response.success) {
+                    Object.assign(product, updatedData);
+                    renderProducts();
+                    renderStats();
+                    AppUtils.notify("Product updated successfully!", "success");
+                    editModal.style.display = "none";
+                } else {
+                    AppUtils.notify(response.message || "Failed to update product.", "error");
+                }
+            } catch (error) {
+                console.error("EDIT PRODUCT ERROR:", error);
+                AppUtils.notify("Failed to update product.", "error");
+            }
+        });
+    }
+});

--- a/frontend/styles/admin.css
+++ b/frontend/styles/admin.css
@@ -214,3 +214,75 @@ ADVANCED ADMIN PANEL
     display: flex;
     gap: 10px;
 }
+
+/* =============================
+MODAL STYLES
+============================= */
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: #fff;
+    padding: 30px;
+    border-radius: 10px;
+    width: 90%;
+    max-width: 600px;
+    box-shadow: 0 5px 25px rgba(0,0,0,0.2);
+    max-height: 90vh;
+    overflow-y: auto;
+}
+
+.modal-content h2 {
+    margin-bottom: 20px;
+    color: #333;
+}
+
+#edit-product-form input,
+#edit-product-form textarea,
+#edit-product-form select {
+    width: 100%;
+    padding: 14px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    outline: none;
+    margin-bottom: 10px;
+    background: #fff;
+}
+
+#edit-product-form textarea {
+    min-height: 100px;
+    resize: vertical;
+}
+
+.modal-actions button {
+    padding: 12px 20px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: 600;
+    color: #fff;
+    transition: 0.3s;
+}
+
+.modal-actions button[type="submit"] {
+    background: #088178;
+}
+
+.modal-actions button[type="submit"]:hover {
+    background: #066b63;
+}
+
+.modal-actions button#edit-cancel-btn:hover {
+    background: #5a6268;
+}


### PR DESCRIPTION

## Description
This PR resolves the issue where the `editProduct()` function in the admin dashboard relied on sequential, browser-blocking native `prompt()` dialogs. The native prompts have been replaced with a styled, DOM-based modal that matches the "Add Product" interface, providing a significantly improved user experience and accessibility.

## Changes Made
- Added a new `edit-product-modal` structure to `frontend/admin.html` located just before the footer.
- Added corresponding styling for the modal overlay and content in `frontend/styles/admin.css` to ensure it is centered and responsive.
- Refactored `editProduct()` in `frontend/scripts/admin.js` to parse product data into the modal fields and display the modal rather than utilizing sequential `prompt`s.
- Bound a `submit` listener to the new form to execute the `PUT` request to update the product and refresh the table correctly.
- Added a `cancel` button listener to close the modal gracefully.

## Related Issues
Closes #259
