### PR TITLE
fix: resolve dark mode contrast defects across home, blog, and shop selectors

### DIFF
--- a/frontend/styles/base.css
+++ b/frontend/styles/base.css
@@ -39,7 +39,7 @@ body.dark-theme {
     color: #ffffff;
 }
 /* reset */
-*{
+*{   
     margin: 0;
     padding: 0;
     box-sizing: border-box;
@@ -238,8 +238,13 @@ body.dark-theme label,
 body.dark-theme .form-group,
 body.dark-theme p,
 body.dark-theme a {
-    color: var(--text-light);
+    color: var(--text-dark); /*description index page visiblein dark mode*/
 }
+--------
+body.dark-theme h2 {
+    color: var(--text-dark);
+}
+-------
 body.dark-theme footer {
     background-color: #1a1a1a;
     color: #ffffff;
@@ -297,7 +302,7 @@ body.dark-theme .order-content {
     border: 1px solid #333 !important;
 }
 body.dark-theme h3 {
-    color:#000 ! important;
+    color: var(--text-dark) !important; /*making h3 visible in dark mode*/
 }
 body.dark-theme .toast-container,
 body.dark-theme .toast,
@@ -353,4 +358,8 @@ body.dark-theme #profile-dropdown {
     background-color: #1e1e1e !important;
     border: 1px solid #333 !important;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.6) !important;
+}
+/*Recommended For You title being visible in dark mode*/
+body.dark-theme #recommended h2 { 
+    color: #ffffff !important;
 }

--- a/frontend/styles/blog.css
+++ b/frontend/styles/blog.css
@@ -228,7 +228,7 @@
 }
 
 .read-time {
-    color: var(--text-light);
+    color: var(--text-dark); /*making read-time visible in dark mode*/
     font-weight: 600;
     font-size: 12px;
     display: flex;
@@ -420,7 +420,7 @@
     gap: 15px;
     align-items: center;
     font-size: 13px;
-    color: var(--text-light);
+    color: var(--text-dark); /*making modal-meta visible in dark mode*/
     margin-bottom: 15px;
     font-weight: 600;
 }
@@ -463,9 +463,9 @@
     font-size: 15px;
 }
 
-.author-title {
+.author-title { 
     font-size: 13px;
-    color: var(--text-light);
+    color: var(--text-dark); /*making author-title visible in dark mode*/
     font-weight: 500;
 }
 


### PR DESCRIPTION
### Target Issue
Closes #241

### Brief Summary of Changes
Resolved low-contrast text visibility defects occurring within dark theme mode across several frontend view modules:
- **Home Module**: Fixed the color contrast for the `<h2>` "Recommended for You" section header to ensure clear readability against the dark background.
- **Blog Module**: Updated text color variables for the `4 min read` time tracker, publication date metadata, and the author's professional designation subtitle (.author-title).
- **Shop Module**: Restructured the category overlay hierarchy (`body.dark-theme h3`) to override global constraints and maintain bright typography visibility over dark product card layers.
- **Code Cleanliness**: Added contextual maintainer comments directly inside `base.css` and `blog.css` to prevent future styling regressions.

### Visual Proof (Screenshots)
| Before Change | After Change |
| --- | --- |
| 
<img width="1918" height="972" alt="Screenshot 2026-06-22 224102" src="https://github.com/user-attachments/assets/64f4abac-488c-49e2-9ebf-ac979448ea03" />
   | 
<img width="1918" height="1008" alt="Screenshot 2026-06-23 224947" src="https://github.com/user-attachments/assets/20b3a639-5e24-4ecb-a82b-e1df2337d9f1" />
   |
| 
<img width="1073" height="912" alt="Screenshot 2026-06-23 003701" src="https://github.com/user-attachments/assets/7a275cd6-ecbb-4977-83cc-974a02c9d5e2" />
    |
<img width="1705" height="1023" alt="Screenshot 2026-06-23 225010" src="https://github.com/user-attachments/assets/3ea1da3d-443a-4183-8de4-f0b43cefd96b" />
    |
|  
<img width="1016" height="798" alt="Screenshot 2026-06-23 232036" src="https://github.com/user-attachments/assets/ad2099d0-8244-415a-be4b-ae1d9a2b502c" />
  | 
<img width="1057" height="893" alt="Screenshot 2026-06-23 225044" src="https://github.com/user-attachments/assets/c05f449e-8099-4937-a599-b1b9efcbee50" />
  |
|   
<img width="547" height="730" alt="Screenshot 2026-06-23 232210" src="https://github.com/user-attachments/assets/3f7a2705-134a-4c76-81b0-55acd03c2fe8" />
 |  
<img width="435" height="582" alt="Screenshot 2026-06-23 232316" src="https://github.com/user-attachments/assets/aa06db93-94b2-4cdc-a515-6ce6747afc42" />
  |