### PR TITLE
fix: apply dark mode consistently on About Us and Contact pages

### DIFF
--- a/frontend/styles/about.css
+++ b/frontend/styles/about.css
@@ -292,3 +292,46 @@ body.dark-theme .about-cta-btn {
     background: var(--primary-color);
     color: #fff;
 }
+
+/* ── DARK MODE MISSING FIXES ── */
+body.dark-theme #about-stats {
+    background: #121212 !important;
+}
+
+body.dark-theme .stat-card {
+    background: #1e1e2e !important;
+    border-color: #333 !important;
+}
+
+body.dark-theme .stat-card h3 {
+    color: var(--primary-color) !important;
+}
+
+body.dark-theme .stat-card p {
+    color: #aaaaaa !important;
+}
+
+body.dark-theme #about-head {
+    background: #121212 !important;
+}
+
+body.dark-theme .about-marquee-replace {
+    color: var(--primary-color) !important;
+}
+
+body.dark-theme #about-app {
+    background: #121212 !important;
+}
+
+body.dark-theme #feature {
+    background: #121212 !important;
+}
+
+body.dark-theme .fe-box {
+    background: #1e1e2e !important;
+    border-color: #333 !important;
+}
+
+body.dark-theme .fe-box h6 {
+    color: #cccccc !important;
+}

--- a/frontend/styles/contact.css
+++ b/frontend/styles/contact.css
@@ -521,3 +521,53 @@ body.dark-theme div[class*="feedback"] {
                 0 0 30px rgba(255, 255, 255, 0.6), 
                 0 0 60px rgba(255, 255, 255, 0.25) !important;
 }
+
+/* ── DARK MODE MISSING FIXES ── */
+body.dark-theme #contact-details {
+    background: #121212 !important;
+}
+
+/* feedback-container ka hardcoded white override */
+body.dark-theme .feedback-container,
+body.dark-theme section.feedback-container,
+body.dark-theme div[class*="feedback"] {
+    background: linear-gradient(145deg, #1a1a2e, #16162a) !important;
+    background-color: #1a1a2e !important;
+    border-color: #3a3a5a !important;
+    box-shadow: 0 15px 35px rgba(0,0,0,0.4),
+                0 0 25px rgba(168,85,247,0.2) !important;
+}
+
+body.dark-theme .form-left h2,
+body.dark-theme .ratings-heading,
+body.dark-theme .ratings-right h2 {
+    color: #ffffff !important;
+}
+
+body.dark-theme .metric-question,
+body.dark-theme .metric-row span {
+    color: #cccccc !important;
+}
+
+body.dark-theme .metric-controls > i.fal,
+body.dark-theme .metric-controls > i[class*="fa-"] {
+    color: #aaaaaa !important;
+}
+
+body.dark-theme .form-left input,
+body.dark-theme .form-left textarea {
+    background: #2a2a3e !important;
+    background-color: #2a2a3e !important;
+    border-color: #444 !important;
+    color: #f0f0f0 !important;
+}
+
+body.dark-theme .form-left input::placeholder,
+body.dark-theme .form-left textarea::placeholder {
+    color: #888 !important;
+}
+
+body.dark-theme #form-details {
+    background: #0d0d0d !important;
+    border-color: #2a2a2a !important;
+}


### PR DESCRIPTION
## 🐞 Issue
Dark mode was not fully applied on the About Us and Contact pages. Some sections retained light mode styling, causing poor text visibility and inconsistent UI.

## 🛠️ Changes Made

### `frontend/styles/about.css`
- Fixed `#about-stats` background in dark mode
- Fixed `.stat-card` background and text colors
- Fixed `#about-head` and `#about-app` section backgrounds
- Fixed `#feature` section and `.fe-box` cards dark mode styling

### `frontend/styles/contact.css`
- Fixed `.feedback-container` hardcoded white background override
- Fixed `#form-details` and `#contact-details` backgrounds
- Fixed `.form-left` input and textarea dark mode styles
- Fixed `.metric-question`, `.metric-controls` icon colors
- Fixed form heading colors in dark mode

## ✅ Testing
- Enabled dark mode and navigated to About Us page — all sections now follow dark theme
- Enabled dark mode and navigated to Contact page — feedback card, form inputs, rating section all consistent
- Verified no light mode breakage

## 📸 Screenshots
<img width="1918" height="906" alt="image" src="https://github.com/user-attachments/assets/ee200b1b-41c4-4d94-8f27-7f8c94f0451e" />
<img width="1918" height="912" alt="image" src="https://github.com/user-attachments/assets/1715d8fc-32fb-4f14-96c1-ee7666cc2bc8" />

Fixes #273