### PR TITLE
fix: resolve SyntaxError caused by duplicate const declarations in script.js

### DIFF
--- a/frontend/scripts/script.js
+++ b/frontend/scripts/script.js
@@ -141,8 +141,6 @@ function renderProducts(container, products = []) {
   const fragment = document.createDocumentFragment();
   const wishlistIds = new Set(AppUtils.getWishlist().map((item) => String(item.id)));
 
-  const wishlistIds = new Set(AppUtils.getWishlist().map(item => String(item.id)));
-
   AppUtils.safeArray(products).forEach((product) => {
     if (!product || !product.id) return;
 


### PR DESCRIPTION
Description
This PR fixes a critical script execution failure on the homepage caused by a duplicate constant declaration.
Fixes #284 
Changes:

Removed the duplicate const wishlistIds = new Set(...) declaration at line 144 of frontend/scripts/script.js.
Restores the rendering of "Featured Products" and "New Arrivals" which were failing to load due to the SyntaxError halting the script