### PR TITLE
fix: resolve Stored XSS vulnerability across promotional category pages

### DIFF
--- a/frontend/scripts/Buy1Get1.js
+++ b/frontend/scripts/Buy1Get1.js
@@ -155,10 +155,10 @@
         
         div.innerHTML = `
             <span class = "bogo-badge">BUY 1<br>GET 1<br>FREE</span>
-            <img src="${product.image || 'assets/images/default.jpg'}" alt="${product.name}" onerror="this.src='assets/images/default.jpg';">
+            <img src="${product.image || 'assets/images/default.jpg'}" alt="${AppUtils.escapeHTML(product.name)}" onerror="this.src='assets/images/default.jpg';">
             <div class="des">
-                <span>${product.brand || 'Adidas'}</span>
-                <h5>${product.name}</h5>
+                <span>${AppUtils.escapeHTML(product.brand || 'Adidas')}</span>
+                <h5>${AppUtils.escapeHTML(product.name)}</h5>
                 <div class="star">
                     ${starsHtml}
                 </div>

--- a/frontend/scripts/early_summer.js
+++ b/frontend/scripts/early_summer.js
@@ -158,10 +158,10 @@
         const starsHtml = '<i class="fas fa-star"></i>'.repeat(product.rating || 5);
         
         div.innerHTML = `
-            <img src="${product.image || 'assets/images/default.jpg'}" alt="${product.name}" onerror="this.src='assets/images/default.jpg';">
+            <img src="${product.image || 'assets/images/default.jpg'}" alt="${AppUtils.escapeHTML(product.name)}" onerror="this.src='assets/images/default.jpg';">
             <div class="des">
-                <span>${product.brand || 'Adidas'}</span>
-                <h5>${product.name}</h5>
+                <span>${AppUtils.escapeHTML(product.brand || 'Adidas')}</span>
+                <h5>${AppUtils.escapeHTML(product.name)}</h5>
                 <div class="star">
                     ${starsHtml}
                 </div>

--- a/frontend/scripts/mens.js
+++ b/frontend/scripts/mens.js
@@ -148,10 +148,10 @@
         const starsHtml = '<i class="fas fa-star"></i>'.repeat(product.rating || 5);
         
         div.innerHTML = `
-            <img src="${product.image || 'assets/images/default.jpg'}" alt="${product.name}" onerror="this.src='assets/images/default.jpg';">
+            <img src="${product.image || 'assets/images/default.jpg'}" alt="${AppUtils.escapeHTML(product.name)}" onerror="this.src='assets/images/default.jpg';">
             <div class="des">
-                <span>${product.brand || 'Adidas'}</span>
-                <h5>${product.name}</h5>
+                <span>${AppUtils.escapeHTML(product.brand || 'Adidas')}</span>
+                <h5>${AppUtils.escapeHTML(product.name)}</h5>
                 <div class="star">
                     ${starsHtml}
                 </div>

--- a/frontend/scripts/seasonal.js
+++ b/frontend/scripts/seasonal.js
@@ -142,10 +142,10 @@
         const starsHtml = '<i class="fas fa-star"></i>'.repeat(product.rating || 5);
         
         div.innerHTML = `
-            <img src="${product.image || 'assets/images/default.jpg'}" alt="${product.name}" onerror="this.src='assets/images/default.jpg';">
+            <img src="${product.image || 'assets/images/default.jpg'}" alt="${AppUtils.escapeHTML(product.name)}" onerror="this.src='assets/images/default.jpg';">
             <div class="des">
-                <span>${product.brand || 'Adidas'}</span>
-                <h5>${product.name}</h5>
+                <span>${AppUtils.escapeHTML(product.brand || 'Adidas')}</span>
+                <h5>${AppUtils.escapeHTML(product.name)}</h5>
                 <div class="star">
                     ${starsHtml}
                 </div>

--- a/frontend/scripts/tshirt.js
+++ b/frontend/scripts/tshirt.js
@@ -158,10 +158,10 @@
         const starsHtml = '<i class="fas fa-star"></i>'.repeat(product.rating || 5);
         
         div.innerHTML = `
-            <img src="${product.image || 'assets/images/default.jpg'}" alt="${product.name}" onerror="this.src='assets/images/default.jpg';">
+            <img src="${product.image || 'assets/images/default.jpg'}" alt="${AppUtils.escapeHTML(product.name)}" onerror="this.src='assets/images/default.jpg';">
             <div class="des">
-                <span>${product.brand || 'Adidas'}</span>
-                <h5>${product.name}</h5>
+                <span>${AppUtils.escapeHTML(product.brand || 'Adidas')}</span>
+                <h5>${AppUtils.escapeHTML(product.name)}</h5>
                 <div class="star">
                     ${starsHtml}
                 </div>

--- a/frontend/scripts/womens.js
+++ b/frontend/scripts/womens.js
@@ -148,10 +148,10 @@
         const starsHtml = '<i class="fas fa-star"></i>'.repeat(product.rating || 5);
         
         div.innerHTML = `
-            <img src="${product.image || 'assets/images/default.jpg'}" alt="${product.name}" onerror="this.src='assets/images/default.jpg';">
+            <img src="${product.image || 'assets/images/default.jpg'}" alt="${AppUtils.escapeHTML(product.name)}" onerror="this.src='assets/images/default.jpg';">
             <div class="des">
-                <span>${product.brand || 'Adidas'}</span>
-                <h5>${product.name}</h5>
+                <span>${AppUtils.escapeHTML(product.brand || 'Adidas')}</span>
+                <h5>${AppUtils.escapeHTML(product.name)}</h5>
                 <div class="star">
                     ${starsHtml}
                 </div>


### PR DESCRIPTION
Description
Similar to the Compare page, several category-specific frontend scripts were rendering product cards by interpolating raw, unsanitized strings directly into innerHTML. This PR ensures all product names and brands are properly escaped.
FIxes #286 
Changes:

Applied AppUtils.escapeHTML() to product.name and product.brand inside the innerHTML string interpolation for the following scripts:
frontend/scripts/womens.js
frontend/scripts/mens.js
frontend/scripts/tshirt.js
frontend/scripts/seasonal.js
frontend/scripts/early_summer.js
frontend/scripts/Buy1Get1.js
Mitigates XSS risks when rendering dynamic product grids across all promotional categories.