### PR TITLE
fix(auth): Apply rate limiter to forgot-password

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -224,6 +224,8 @@ app.use("/api/auth/login", authLimiter);
 
 app.use("/api/auth/signup", authLimiter);
 
+app.use("/api/auth/forgot-password", authLimiter);
+
 // health route
 app.get("/health", (req, res) => {
   return res.status(200).json({


### PR DESCRIPTION
**Description**:
### What does this PR do?
This PR mitigates an email-bombing/spam vulnerability on the `/api/auth/forgot-password` endpoint. The endpoint previously lacked any rate limiting, allowing malicious actors to spam the API with unlimited password reset requests, potentially exhausting email quotas and causing annoyance to users.
Fixes #295 
### Changes Made:
- Applied the existing `authLimiter` middleware to the `forgot-password` route in `backend/server.js`.

### Testing:
- Sent multiple requests to the forgot-password endpoint and verified that the `authLimiter` correctly restricts excessive requests (HTTP 429 Too Many Requests) while allowing normal usage.