### PR TITLE
Fix #288: Styled Place Order button as a premium primary CTA with ful…

### DIFF
--- a/frontend/checkout.html
+++ b/frontend/checkout.html
@@ -305,7 +305,7 @@
 
                 <!-- Submit -->
 
-                <button type="submit">
+                <button type="submit" class="submit-btn">
 
                     Place Order
 

--- a/frontend/styles/checkout.css
+++ b/frontend/styles/checkout.css
@@ -178,22 +178,33 @@
     margin-bottom: 20px;
 }
 
-#checkout-form button{
+
+.submit-btn {
     width: 100%;
     background: #088178;
     color: #fff;
     border: none;
-    padding: 15px;
-    border-radius: 6px;
+    padding: 16px 20px;
+    border-radius: 8px;
     cursor: pointer;
     font-size: 16px;
-    transition: 0.3s ease;
+    font-weight: 700;
+    transition: all 0.3s ease;
+    margin-top: 25px;
+    box-shadow: 0 4px 14px rgba(8, 129, 120, 0.3);
+    box-sizing: border-box;
 }
 
-#checkout-form button:hover{
-    transform: translateY(-2px);
-    box-shadow: 0 10px 25px rgba(0,0,0,0.12);
+.submit-btn:hover {
+    background: #06655e;
+    transform: translateY(-3px);
+    box-shadow: 0 8px 25px rgba(8, 129, 120, 0.4);
 }
+
+.submit-btn:active {
+    transform: translateY(-1px);
+} 
+
 
 .checkout-item{
     display: flex;


### PR DESCRIPTION
## 📋 Pull Request — Style Place Order button as a premium CTA

### 🔗 Related Issue
Closes #288 — *[FEATURE]: [UI] Style the "Place Order" button with a premium, full-width primary CTA design*

### ✅ Changes Made
- Updated the `#checkout-form button` to have `width: 100%`, a bold `font-weight: 700`, and proper internal padding.
- Changed `border-radius` from `6px` to `8px` to perfectly align with the rounded corners of the Order Summary card.
- Added `margin-top: 25px` to properly separate the button from the form fields above it.
- Introduced a premium colored shadow (`box-shadow: 0 4px 14px rgba(8, 129, 120, 0.3)`).
- Enhanced the hover state with a darker teal background (`#06655e`), a stronger `translateY(-3px)` lift, and a deeper shadow.

### 🧪 Testing Checklist
- [ ] Button displays a solid Teal (`#088178`) primary background.
- [ ] Button uses bold white text for a strong CTA emphasis.
- [ ] Button is `width: 100%` and sits perfectly below the form with `margin-top: 25px`.
- [ ] `border-radius: 8px` matches the rest of the UI.
- [ ] Premium hover, lift, and shadow animations are smooth and polished.

##screenshot

<img width="1887" height="907" alt="image" src="https://github.com/user-attachments/assets/ef6c5d2f-9de2-4c6f-b84d-fed242caf9bb" />
