### PR TITLE
Fix WebSocket CORS issue

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -43,8 +43,6 @@ const app = express();
 const http = require("http");
 const server = http.createServer(app);
 const { initSocket } = require("./utils/socketManager");
-initSocket(server);
-
 // constants
 const PORT = Number(process.env.PORT) || 5000;
 
@@ -125,6 +123,9 @@ const allowedOrigins = [
 
     "https://www.bhuvansh.xyz"
 ];
+
+// initialize websocket server with CORS
+initSocket(server, allowedOrigins);
 
 // cors
 app.use(

--- a/backend/utils/socketManager.js
+++ b/backend/utils/socketManager.js
@@ -4,10 +4,10 @@ const chatService = require("../services/chat.service");
 
 let io;
 
-const initSocket = (server) => {
+const initSocket = (server, allowedOrigins) => {
     io = new Server(server, {
         cors: {
-            origin: ["http://localhost:5500", "http://127.0.0.1:5500"],
+            origin: allowedOrigins,
             methods: ["GET", "POST"],
             credentials: true
         }


### PR DESCRIPTION

**Description:**
This PR resolves an issue where the real-time customer support chat widget failed to connect via WebSocket in the production environment. The `Socket.IO` server initialization previously hardcoded localhost origins (`http://localhost:5500` and `http://127.0.0.1:5500`), which caused Cross-Origin Resource Sharing (CORS) policy violations when the application was accessed from the production domain.
Fixes #310 
**Changes Made:**
- Updated `initSocket` in `backend/utils/socketManager.js` to accept a dynamic `allowedOrigins` array parameter instead of hardcoding localhost addresses.
- Updated `backend/server.js` to pass the existing `allowedOrigins` array to `initSocket` after the array is initialized, ensuring that both local and production domains are permitted for WebSocket connections.

**Testing:**
- Verified that the chat widget connects successfully in local environments.
- Verified that CORS errors are resolved for production domains.
