### PR TITLE
fix: prevent duplicate product creation by validating product names

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -243,6 +243,8 @@ const createProduct = async (req, res) => {
         });
     }
 
+    const normalizedName = sanitizeString(name).trim();
+
     if (
         safeNumber(price) <= 0
     ) {
@@ -259,10 +261,28 @@ const createProduct = async (req, res) => {
     `;
 
     try {
+    // Prevent duplicate product names (case-insensitive)
+        const [existingProducts] = await db.query(
+            `
+        SELECT id
+        FROM products
+        WHERE LOWER(TRIM(name)) = LOWER(TRIM(?))
+        LIMIT 1
+    `,
+            [normalizedName]
+        );
+
+        if (safeArray(existingProducts).length) {
+            return res.status(409).json({
+                success: false,
+                message: "A product with this name already exists."
+            });
+        }
+        
         const [result] = await db.query(
             query,
             [
-                sanitizeString(name),
+                normalizedName,
                 description || "",
                 safeNumber(price),
                 sanitizeString(image),
@@ -272,8 +292,8 @@ const createProduct = async (req, res) => {
                     safeInteger(stock)
                 ),
                 featured === true
-                || featured === 1
-                || featured === "1"
+                    || featured === 1
+                    || featured === "1"
                     ? 1
                     : 0
             ]
@@ -364,8 +384,8 @@ const updateProduct = async (req, res) => {
                     safeInteger(stock)
                 ),
                 featured === true
-                || featured === 1
-                || featured === "1"
+                    || featured === 1
+                    || featured === "1"
                     ? 1
                     : 0,
                 id


### PR DESCRIPTION
## Summary

This PR improves the product creation flow by preventing duplicate products with the same name from being created.

Before inserting a new product into the database, the controller now performs a case-insensitive lookup to determine whether a product with the same normalized name already exists. If a duplicate is found, the API returns a `409 Conflict` response instead of creating another record.

## Changes Made

- Normalize the product name before validation using `sanitizeString()` and `trim()`.
- Add a case-insensitive duplicate product check before inserting a new product.
- Return a `409 Conflict` response when a product with the same name already exists.
- Reuse the normalized product name during insertion to ensure consistent data storage.
- Execute the duplicate validation inside the existing `try...catch` block for proper database error handling.

## Benefits

- Prevents accidental duplicate product creation.
- Improves product catalog consistency.
- Reduces redundant product records.
- Provides a more predictable API response for duplicate creation attempts.
- Maintains proper error handling for all database operations.

## Testing

- Verified that a new product can be created successfully.
- Verified that attempting to create a product with the same name (case-insensitive) returns a `409 Conflict` response.
- Verified that product names are normalized before being stored.
- Verified that existing product creation behavior remains unchanged for unique products.

Closes #342