### PR TITLE
fix: password strength indicator hidden on empty field

### DIFF
--- a/frontend/scripts/auth.js
+++ b/frontend/scripts/auth.js
@@ -900,36 +900,43 @@ function evaluatePasswordStrength(password) {
     let color = 'strength-weak';
     let percent = 25;
     if (score === 4) { level = 'Strong'; color = 'strength-strong'; percent = 100; }
-    else if (score === 3) { level = 'Medium'; color = 'strength-medium'; percent = 70; }
-    else if (score === 2) { level = 'Weak'; color = 'strength-weak'; percent = 45; }
-    else { percent = 20; }
+    else if (score === 3) { level = 'Medium'; color = 'strength-medium'; percent = 60; }
+    else if (score === 2) { level = 'Weak'; color = 'strength-weak'; percent = 30; }
+    else { percent = 30; }
 
     return { level, color, percent, tips };
 }
 
 function updatePasswordStrength() {
     const passwordInput = document.getElementById('signup-password');
+    const container = document.getElementById('password-strength-container');
     const fill = document.getElementById('password-strength-fill');
     const text = document.getElementById('password-strength-text');
     const tips = document.getElementById('password-strength-tips');
     const signupBtn = document.getElementById('signup-btn');
 
-    if (!passwordInput || !fill || !text || !tips) return;
+    if (!passwordInput || !fill || !text || !tips || !container) return;
 
     const password = passwordInput.value;
-    const result = evaluatePasswordStrength(password);
 
-    fill.style.width = result.percent + '%';
-    fill.className = result.color;
-    text.textContent = result.level;
-    text.style.color = result.level === 'Strong' ? '#28a745' : result.level === 'Medium' ? '#ffa500' : '#ff4d4d';
-
+    // Hide entire container when field is empty
     if (password.length === 0) {
+        container.style.display = 'none';
         tips.textContent = '';
         if (signupBtn) signupBtn.disabled = true;
         return;
     }
 
+    // Show container once user starts typing
+    container.style.display = 'block';
+
+    const result = evaluatePasswordStrength(password);
+
+    fill.style.width = result.percent + '%';
+    fill.className = result.color;
+    text.textContent = result.level;
+    //text.style.color = result.level === 'Strong' ? '#28a745' : result.level === 'Medium' ? '#ffa500' : '#ff4d4d';
+    text.className = result.color;
     tips.textContent = result.tips.join(' • ');
     if (signupBtn) signupBtn.disabled = (result.level === 'Weak');
 }
@@ -939,7 +946,5 @@ document.addEventListener('DOMContentLoaded', function() {
     const passwordInput = document.getElementById('signup-password');
     if (passwordInput) {
         passwordInput.addEventListener('input', updatePasswordStrength);
-        // Initial check
-        updatePasswordStrength();
     }
 });

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -136,11 +136,11 @@
                 </div>
 
                 <!-- Password Strength Meter -->
-                <div id="password-strength-container" style="margin-top: 8px;">
+                <div id="password-strength-container" style="margin-top: 8px; display: none;">
                     <div id="password-strength-bar" style="height: 6px; border-radius: 4px; background: #e0e0e0; overflow: hidden;">
                         <div id="password-strength-fill" style="height: 100%; width: 0%; border-radius: 4px; transition: width 0.3s ease;"></div>
                     </div>
-                    <div id="password-strength-text" style="font-size: 0.85rem; margin-top: 4px; font-weight: 500; color: #666;">Weak</div>
+                    <div id="password-strength-text" style="font-size: 0.85rem; margin-top: 4px; font-weight: 500; color: #666;"></div>
                     <div id="password-strength-tips" style="font-size: 0.8rem; color: #888; margin-top: 4px; min-height: 20px;"></div>
                 </div>
 

--- a/frontend/styles/style.css
+++ b/frontend/styles/style.css
@@ -277,5 +277,42 @@
     min-height: 20px;
 }
 
+#password-strength-bar {
+    height: 6px;
+    border-radius: 4px;
+    background: #e0e0e0;
+    overflow: hidden;
+}
+
+#password-strength-fill {
+    height: 100%;
+    border-radius: 4px;
+    transition: width 0.4s ease, background-color 0.4s ease;
+}
+
+#password-strength-fill.strength-weak {
+    background-color: #e74c3c;
+}
+
+#password-strength-fill.strength-medium {
+    background-color: #f39c12;
+}
+
+#password-strength-fill.strength-strong {
+    background-color: #27ae60;
+}
+
+#password-strength-text.strength-weak {
+    color: #e74c3c !important;
+}
+
+#password-strength-text.strength-medium {
+    color: #f39c12 !important;
+}
+
+#password-strength-text.strength-strong {
+    color: #27ae60 !important;
+}
+
 /* =============================
 Breadcrumb Navigation (Issue #344)


### PR DESCRIPTION
## Summary

Closes #313

Fixes the password strength indicator showing "Weak" on page load before 
the user has typed anything. The bar and label now only appear once the 
user starts typing, and hide again if the field is cleared.

## Root Cause

Two issues were causing this:

1. `signup.html` had hardcoded `Weak` as default text in 
   `#password-strength-text`, visible on page load
2. `auth.js` called `updatePasswordStrength()` immediately on 
   `DOMContentLoaded` (marked as `// Initial check`), which ran the 
   strength evaluation on an empty field and rendered the bar/label

## Changes

**`frontend/signup.html`**
- Added `display: none` to `#password-strength-container` so it's 
  hidden by default on page load
- Removed hardcoded `Weak` text from `#password-strength-text`

**`frontend/scripts/auth.js`**
- Added `container` reference inside `updatePasswordStrength()`
- When field is empty → `container.style.display = 'none'`
- When user starts typing → `container.style.display = 'block'`
- Removed the `// Initial check` + `updatePasswordStrength()` call 
  from `DOMContentLoaded` listener

**`frontend/styles/style.css`**
- Added `.strength-weak`, `.strength-medium`, `.strength-strong` CSS 
  classes for both `#password-strength-fill` and `#password-strength-text`
- Weak → red `#e74c3c`, bar at 30%
- Medium → orange `#f39c12`, bar at 60%
- Strong → green `#27ae60`, bar at 100%

##Screenshot
<img width="1548" height="727" alt="image" src="https://github.com/user-attachments/assets/4a72ebf0-7d4c-49ce-80c4-0c6167b5913a" />
