### PR TITLE
Fix: remove global search from sign-in page

### DIFF
--- a/frontend/scripts/components.js
+++ b/frontend/scripts/components.js
@@ -28,6 +28,13 @@ const loadComponent = async (id, file) => {
         const data = await response.text();
         element.innerHTML = data;
 
+        if (
+            id === "navbar" &&
+            element.dataset.hideGlobalSearch === "true"
+        ) {
+            element.querySelector(".search-container")?.remove();
+        }
+
         return true;
 
     } catch (error) {

--- a/frontend/signin.html
+++ b/frontend/signin.html
@@ -85,7 +85,7 @@
 
 <body>
     <!-- Navbar -->
-    <div id="navbar"></div>
+    <div id="navbar" data-hide-global-search="true"></div>
 
     <!-- Signin -->
     <section class="auth-container">


### PR DESCRIPTION
## Summary
- Hide the shared global product search bar on the Sign-In page only
- Keep the rest of the navbar intact, including logo, auth link, and theme toggle
- Leave Home, Shop, and other page search bars unchanged

## Verification
- Ran local frontend at http://localhost:5501
- Verified Sign-In no longer shows the global navbar search
- Verified Home and Shop still show usable search inputs
- Ran `git diff --check`
- Ran `node --check frontend/scripts/components.js`
##Screenshot 

<img width="1440" height="820" alt="Screenshot 2026-07-01 at 9 22 10 PM" src="https://github.com/user-attachments/assets/4cc25b92-3551-406f-b5e1-a4ff1eb75b30" />


Closes #373