### PR TITLE
fix: add 3s auto-hide timeout to password visibility toggle

### DIFF
--- a/frontend/scripts/auth.js
+++ b/frontend/scripts/auth.js
@@ -822,67 +822,87 @@ document.addEventListener(
     }
 );
 
-// password visibility toggle
+// password visibility toggle with auto-hide security
 document.querySelectorAll(
     ".password-toggle"
 ).forEach((toggle) => {
 
-    toggle.addEventListener(
-        "click",
-        () => {
+    let autoHideTimer = null;
+    let countdownTimer = null;
+    let secondsLeft = 3;
 
-            const field =
-                toggle.closest(
-                    ".password-field"
-                );
+    const field = toggle.closest(".password-field");
+    const countdown = field?.querySelector(".countdown-indicator");
 
-            const input =
-                field?.querySelector(
-                    "input"
-                );
-
-            if (
-                !input
-            ) {
-                return;
-            }
-
-            const isHidden =
-                input.type === "password";
-
-            input.type =
-                isHidden
-                    ? "text"
-                    : "password";
-
-            toggle.setAttribute(
-                "aria-pressed",
-                String(isHidden)
-            );
-
-            toggle.setAttribute(
-                "aria-label",
-                isHidden
-                    ? "Hide password"
-                    : "Show password"
-            );
-
-            const icon =
-                toggle.querySelector("i");
-
-            if (icon) {
-                icon.classList.toggle(
-                    "fa-eye",
-                    !isHidden
-                );
-
-                icon.classList.toggle(
-                    "fa-eye-slash",
-                    isHidden
-                );
-            }
+    function resetToggle(input, icon) {
+        input.type = "password";
+        toggle.setAttribute("aria-pressed", "false");
+        toggle.setAttribute("aria-label", "Show password");
+        if (icon) {
+            icon.classList.add("fa-eye");
+            icon.classList.remove("fa-eye-slash");
         }
-    );
+        if (countdown) {
+            countdown.style.display = "none";
+            countdown.textContent = "";
+        }
+        clearTimeout(autoHideTimer);
+        clearInterval(countdownTimer);
+        autoHideTimer = null;
+        countdownTimer = null;
+        secondsLeft = 3;
+    }
+
+    function startCountdown(input, icon) {
+        secondsLeft = 3;
+        if (countdown) {
+            countdown.style.display = "inline";
+            countdown.textContent = "Hiding in " + secondsLeft + "s";
+        }
+
+        countdownTimer = setInterval(() => {
+            secondsLeft--;
+            if (countdown) {
+                countdown.textContent = "Hiding in " + secondsLeft + "s";
+            }
+            if (secondsLeft <= 0) {
+                clearInterval(countdownTimer);
+            }
+        }, 1000);
+
+        autoHideTimer = setTimeout(() => {
+            resetToggle(input, icon);
+        }, 3000);
+    }
+
+    toggle.addEventListener("click", () => {
+
+        const input = field?.querySelector("input");
+        if (!input) return;
+
+        const isHidden = input.type === "password";
+        const icon = toggle.querySelector("i");
+
+        // If currently visible — hide immediately and cancel timer
+        if (!isHidden) {
+            resetToggle(input, icon);
+            return;
+        }
+
+        // Show password and start auto-hide countdown
+        input.type = "text";
+        toggle.setAttribute("aria-pressed", "true");
+        toggle.setAttribute("aria-label", "Hide password");
+        if (icon) {
+            icon.classList.remove("fa-eye");
+            icon.classList.add("fa-eye-slash");
+        }
+
+        // Clear any existing timers before starting new ones
+        clearTimeout(autoHideTimer);
+        clearInterval(countdownTimer);
+        startCountdown(input, icon);
+    });
 });
 
 // Password Strength Meter

--- a/frontend/signin.html
+++ b/frontend/signin.html
@@ -106,13 +106,25 @@
                     autocomplete="email"
                     required
                 >
-                <input
-                    type="password"
-                    id="signin-password"
-                    placeholder="Password"
-                    autocomplete="current-password"
-                    required
-                >
+                <div class="password-field">
+                    <input
+                        type="password"
+                        id="signin-password"
+                        placeholder="Password"
+                        autocomplete="current-password"
+                        required
+                    >
+                    <button
+                        type="button"
+                        class="password-toggle"
+                        aria-label="Show password"
+                        aria-pressed="false"
+                    >
+                        <i class="fas fa-eye" aria-hidden="true"></i>
+                    </button>
+                    <span class="countdown-indicator" style="display:none;"></span>
+                </div>
+                
                 <div style="text-align: right; margin-bottom: 15px;">
                     <a href="#" id="forgot-password-link" style="color: #088178; font-size: 14px; text-decoration: none;">Forgot Password?</a>
                 </div>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -133,6 +133,7 @@
                     >
                         <i class="fas fa-eye" aria-hidden="true"></i>
                     </button>
+                    <span class="countdown-indicator" style="display:none;"></span>
                 </div>
 
                 <!-- Password Strength Meter -->

--- a/frontend/styles/style.css
+++ b/frontend/styles/style.css
@@ -270,11 +270,14 @@
     }
 }
 
-#password-strength-tips {
-    font-size: 0.8rem;
-    color: #888;
-    margin-top: 4px;
-    min-height: 20px;
+/* Password toggle countdown indicator */
+.countdown-indicator {
+    font-size: 0.75rem;
+    color: #088178;
+    margin-left: 8px;
+    font-weight: 500;
+    vertical-align: middle;
+    transition: opacity 0.3s ease;
 }
 
 #password-strength-bar {


### PR DESCRIPTION
## Summary

Closes #314

Adds a 3-second auto-hide security timeout to the password visibility 
toggle on both signup and signin pages. When the eye icon is clicked to 
reveal the password, a countdown shows and the password automatically 
hides after 3 seconds.

## Problem

The eye icon toggle had no timeout — once clicked, the password stayed 
visible indefinitely, creating a shoulder-surfing security risk.

## Changes

**`frontend/signin.html`**
- Added the eye toggle button entirely (it was missing on signin page)
- Wrapped password input in `.password-field` div to match signup structure
- Added `.countdown-indicator` span for the timer display

**`frontend/signup.html`**
- Added `.countdown-indicator` span inside the existing `.password-field`

**`frontend/scripts/auth.js`**
- Rewrote password toggle with `resetToggle()` and `startCountdown()` 
  functions
- On eye click → password revealed + "Hiding in 3s" countdown starts
- After 3 seconds → password auto-hides, eye icon resets
- Clicking eye again before 3s → timer cancelled, hides immediately

**`frontend/styles/style.css`**
- Added `.countdown-indicator` styles (teal color, small font)

## Testing

- [x] Click eye on signup → password visible + countdown shows
- [x] Countdown ticks 3s → 2s → 1s → password hides automatically
- [x] Click eye again before 3s → hides immediately, timer cancelled
- [x] Same behavior on signin page
- [x] No backend required — purely frontend

##Screenshot
<img width="1106" height="505" alt="image" src="https://github.com/user-attachments/assets/1962aa42-5c2d-41f5-ba78-611f370d000d" />
