### PR TITLE
fix: resolve SQL syntax error in removeFromWishlist

### DIFF
--- a/backend/controllers/wishlistController.js
+++ b/backend/controllers/wishlistController.js
@@ -96,7 +96,7 @@ const wishlistController = {
             }
 
             const [result] = await promisePool.query(`
-                DeleteE FROM wishlist_items 
+                DELETE FROM wishlist_items 
                 WHERE user_id = ? AND product_id = ?
             `, [userId, productId]);
 

--- a/issues.md
+++ b/issues.md
@@ -1,0 +1,25 @@
+## 1. Bug: Fatal SQL Syntax Error in Wishlist Deletion
+
+### Description
+The `removeFromWishlist` function in `backend/controllers/wishlistController.js` contains a hardcoded typo in the SQL query: it uses `DeleteE FROM wishlist_items` instead of `DELETE FROM wishlist_items`. This breaks the endpoint.
+
+---
+
+## 2. Bug: Information Disclosure via DB Error Leak (Products)
+
+### Description
+In `backend/controllers/productController.js`, when fetching products fails, the raw `error.message` is passed directly into the JSON response at line 169. This can expose sensitive database details.
+
+---
+
+## 3. Bug: Typo in Exported Function Name (Products)
+
+### Description
+In `backend/controllers/productController.js`, the product deletion function is named `DeleteeProduct` (with an extra 'e') at line 421. It should be `deleteProduct`.
+
+---
+
+## 4. Bug: XSS Fallback in Blog Rendering
+
+### Description
+In `frontend/scripts/blog.js`, the code uses `textDiv.innerHTML = window.DOMPurify ? DOMPurify.sanitize(post.content) : post.content;`. This fallback is insecure and allows DOM-based XSS if DOMPurify fails to load.


### PR DESCRIPTION
### Description
This PR fixes a critical SQL syntax typo in `backend/controllers/wishlistController.js` where the query used `DeleteE FROM wishlist_items` instead of `DELETE FROM wishlist_items`.
Fixes #370 
### Changes Made
* Corrected `DeleteE` to `DELETE` in `removeFromWishlist`, allowing users to successfully remove items from their wishlist.