### PR TITLE
fix: rating stars inconsistent styling across light and dark themes

### DIFF
--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -384,15 +384,23 @@
             let currentLockedRating = 0; 
 
             // Common helper function to apply the beautiful golden neon light emission
+            function isDarkTheme() {
+                return document.body.classList.contains('dark-theme');
+            }
+
             function applyGlow(element) {
-                element.style.color = '#ffcc00';
-                // Layered shadows: tight crisp core glow + wide diffused ambient bloom
-                element.style.textShadow = '0 0 4px #ffcc00, 0 0 10px #ffbb00, 0 0 20px #ffaa00';
+                if (isDarkTheme()) {
+                    element.style.color = '#ffd700';
+                    element.style.textShadow = '0 0 6px rgba(255, 215, 0, 0.8), 0 0 12px rgba(255, 165, 0, 0.5)';
+                } else {
+                    element.style.color = '#f5a623';
+                    element.style.textShadow = '0 0 4px rgba(245, 166, 35, 0.4)';
+                }
                 element.style.transform = 'scale(1.1)';
             }
 
             function removeGlow(element) {
-                element.style.color = '#e2e8f0';
+                element.style.color = isDarkTheme() ? '#666666' : '#cccccc';
                 element.style.textShadow = 'none';
                 element.style.transform = 'scale(1)';
             }
@@ -457,6 +465,27 @@
 
     forceInitStars();
     window.onload = forceInitStars;
+    // Re-apply star colors when theme toggles
+const themeToggleBtn = document.getElementById('theme-toggle');
+if (themeToggleBtn) {
+    themeToggleBtn.addEventListener('click', function() {
+        setTimeout(() => {
+            document.querySelectorAll('.stars').forEach(row => {
+                row.querySelectorAll('i').forEach(s => {
+                    if (s.className.includes('fas')) {
+                        s.style.color = document.body.classList.contains('dark-theme') ? '#ffd700' : '#f5a623';
+                        s.style.textShadow = document.body.classList.contains('dark-theme')
+                            ? '0 0 6px rgba(255, 215, 0, 0.8), 0 0 12px rgba(255, 165, 0, 0.5)'
+                            : '0 0 4px rgba(245, 166, 35, 0.4)';
+                    } else {
+                        s.style.color = document.body.classList.contains('dark-theme') ? '#666666' : '#cccccc';
+                        s.style.textShadow = 'none';
+                    }
+                });
+            });
+        }, 50);
+    });
+}
 </script>
 </body>
 </html>

--- a/frontend/styles/contact.css
+++ b/frontend/styles/contact.css
@@ -465,35 +465,26 @@ body.dark-theme .ratings-right h2 {
 ======================================================== */
 
 /* Empty / Standard state for stars only */
+/* Empty stars — light theme */
 .stars i {
-    color: #cccccc !important; 
-    transition: color 0.3s ease;
+    color: #cccccc;
+    transition: color 0.2s ease, text-shadow 0.2s ease, transform 0.2s ease;
 }
 
-/* FILLED State for Light Theme - Changes to solid black */
-.stars i.active,
-.stars i.filled,
-.stars i.selected,
-.stars i.fas { 
-    color: #000000 !important; 
+/* Filled stars — light theme: golden orange */
+.stars i.fas {
+    color: #f5a623;
 }
 
-/* ========================================================
-   DARK THEME STYLES (Triggers when .dark-theme is on body)
-======================================================== */
-
-/* Empty state for stars inside dark mode frame */
+/* Empty stars — dark theme */
 body.dark-theme .stars i {
-    color: #555555 !important; 
+    color: #555555;
 }
 
-/* FILLED State for Dark Theme - Changes to bright white */
-body.dark-theme .stars i.active,
-body.dark-theme .stars i.filled,
-body.dark-theme .stars i.selected,
+/* Filled stars — dark theme: bright gold */
 body.dark-theme .stars i.fas {
-    color: #ffffff !important; 
-    text-shadow: 0 0 8px rgba(255, 255, 255, 0.5); 
+    color: #ffd700;
+    text-shadow: 0 0 6px rgba(255, 215, 0, 0.8), 0 0 12px rgba(255, 165, 0, 0.5);
 }
 
 /* ========================================================


### PR DESCRIPTION
## Summary

Closes #316

Fixes the star rating component on the Contact page not adapting to 
light and dark themes. Stars now show golden colors in both themes with 
proper contrast for empty and filled states.

## Root Cause

Two separate issues were stacking against each other:

1. **CSS `!important` overrides** — `contact.css` had hardcoded 
   `color: #000000 !important` for filled stars in light mode and 
   `color: #ffffff !important` for dark mode. These values were wrong 
   (black/white instead of golden) and couldn't be overridden by JS.

2. **JS inline styles ignored theme** — `applyGlow()` hardcoded 
   `#ffcc00` and `removeGlow()` hardcoded `#e2e8f0` regardless of 
   active theme, so switching themes had no effect on already-rendered 
   stars.

## Changes

**`frontend/styles/contact.css`**
- Removed all `!important` overrides on star colors
- Light theme filled stars → `#f5a623` (golden orange)
- Dark theme filled stars → `#ffd700` (bright gold) with soft glow
- Empty stars → `#cccccc` light / `#555555` dark for proper contrast

**`frontend/contact.html`**
- `isDarkTheme()` helper checks `body.dark-theme` class at call time
- `applyGlow()` applies correct gold shade per active theme
- `removeGlow()` applies correct empty star color per active theme
- Added theme toggle listener that refreshes all star colors after 
  theme switches (50ms delay to let class apply first)

## Testing

- [x] Light mode — filled stars golden orange, empty stars light grey
- [x] Dark mode — filled stars bright gold

##Screenshot
<img width="1439" height="778" alt="image" src="https://github.com/user-attachments/assets/56a61177-ebdd-4f6d-adac-bfdf18b7567a" />
