### PR TITLE
fix: remove insecure XSS fallback in blog rendering

### DIFF
--- a/frontend/scripts/blog.js
+++ b/frontend/scripts/blog.js
@@ -223,9 +223,9 @@ function openArticleModal(id) {
 
     const textDiv = document.createElement("div");
     textDiv.className = "modal-text";
-    
-    // Sanitize with DOMPurify to prevent XSS
-    textDiv.innerHTML = window.DOMPurify ? DOMPurify.sanitize(post.content) : post.content;
+    textDiv.innerHTML = window.DOMPurify 
+        ? DOMPurify.sanitize(post.content) 
+        : window.AppUtils ? AppUtils.escapeHTML(post.content) : post.content.replace(/</g, "&lt;").replace(/>/g, "&gt;");
     blogModalBody.appendChild(textDiv);
 
     const shareDiv = document.createElement("div");


### PR DESCRIPTION
### Description
This PR removes an insecure fallback mechanism in `frontend/scripts/blog.js`. The previous code attempted to use `DOMPurify.sanitize()`, but fell back to rendering raw `innerHTML` (`post.content`) if `DOMPurify` was unavailable. This opened up the possibility of DOM-based XSS if the library failed to load.
Fixes #381
### Changes Made
* Modified the fallback to use `AppUtils.escapeHTML()` or a regex-based HTML encoder, ensuring that even if `DOMPurify` fails, the application is protected against script injection.