### PR TITLE
Feat : Add size guide modal to product detail page

### DIFF
--- a/frontend/product.html
+++ b/frontend/product.html
@@ -337,68 +337,58 @@
 
             <!-- Size Chart -->
 
-            <div class="size-chart-box">
+            <!-- Size Guide Link -->
+            <div class="size-guide-link-wrapper">
+                <button
+                    type="button"
+                    id="size-guide-btn"
+                    class="size-guide-btn"
+                    aria-haspopup="dialog"
+                    aria-controls="size-guide-modal"
+                >
+                    📏 Size Guide
+                </button>
+            </div>
 
-                <h4>
-
-                    Size Chart
-
-                </h4>
-
-                <table class="size-chart-table">
-
-                    <tr>
-
-                        <th>Size</th>
-
-                        <th>Chest</th>
-
-                        <th>Length</th>
-
-                    </tr>
-
-                    <tr>
-
-                        <td>M</td>
-
-                        <td>38</td>
-
-                        <td>27</td>
-
-                    </tr>
-
-                    <tr>
-
-                        <td>L</td>
-
-                        <td>40</td>
-
-                        <td>28</td>
-
-                    </tr>
-
-                    <tr>
-
-                        <td>XL</td>
-
-                        <td>42</td>
-
-                        <td>29</td>
-
-                    </tr>
-
-                    <tr>
-
-                        <td>XXL</td>
-
-                        <td>44</td>
-
-                        <td>30</td>
-
-                    </tr>
-
-                </table>
-
+            <!-- Size Guide Modal -->
+            <div
+                id="size-guide-modal"
+                class="size-guide-overlay"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="size-guide-title"
+                aria-hidden="true"
+            >
+                <div class="size-guide-modal">
+                    <div class="size-guide-header">
+                        <h3 id="size-guide-title">📏 Size Guide</h3>
+                        <button type="button" class="size-guide-close" id="size-guide-close" aria-label="Close size guide">&times;</button>
+                    </div>
+                    <p class="size-guide-subtitle">All measurements are in centimeters (cm) and inches (in)</p>
+                    <div class="size-guide-table-wrapper">
+                        <table class="size-guide-table">
+                            <thead>
+                                <tr>
+                                    <th>Size</th>
+                                    <th>Chest (cm)</th>
+                                    <th>Chest (in)</th>
+                                    <th>Waist (cm)</th>
+                                    <th>Waist (in)</th>
+                                    <th>Length (cm)</th>
+                                    <th>Length (in)</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr><td class="size-label">S</td><td>86–91</td><td>34–36</td><td>71–76</td><td>28–30</td><td>68</td><td>26.5</td></tr>
+                                <tr><td class="size-label">M</td><td>91–97</td><td>36–38</td><td>76–81</td><td>30–32</td><td>70</td><td>27.5</td></tr>
+                                <tr><td class="size-label">L</td><td>97–102</td><td>38–40</td><td>81–86</td><td>32–34</td><td>72</td><td>28.5</td></tr>
+                                <tr><td class="size-label">XL</td><td>107–112</td><td>42–44</td><td>91–97</td><td>36–38</td><td>74</td><td>29</td></tr>
+                                <tr><td class="size-label">XXL</td><td>117–122</td><td>46–48</td><td>102–107</td><td>40–42</td><td>76</td><td>30</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <p class="size-guide-tip">💡 <strong>Tip:</strong> Measure yourself and compare to the chart above. When between sizes, size up for a relaxed fit.</p>
+                </div>
             </div>
 
             <!-- Color Variants -->
@@ -854,6 +844,41 @@
     <script defer src="scripts/ui.js"></script>
 
     <script defer src="scripts/recommendations.js"></script>
+
+    <script>
+    (function () {
+        var modal = document.getElementById('size-guide-modal');
+        var openBtn = document.getElementById('size-guide-btn');
+        var closeBtn = document.getElementById('size-guide-close');
+
+        function openModal() {
+            modal.classList.add('active');
+            modal.setAttribute('aria-hidden', 'false');
+            closeBtn.focus();
+            document.body.style.overflow = 'hidden';
+        }
+
+        function closeModal() {
+            modal.classList.remove('active');
+            modal.setAttribute('aria-hidden', 'true');
+            openBtn.focus();
+            document.body.style.overflow = '';
+        }
+
+        openBtn.addEventListener('click', openModal);
+        closeBtn.addEventListener('click', closeModal);
+
+        modal.addEventListener('click', function (e) {
+            if (e.target === modal) closeModal();
+        });
+
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && modal.classList.contains('active')) {
+                closeModal();
+            }
+        });
+        })();
+    </script>
 
 </body>
 </html>

--- a/frontend/styles/product.css
+++ b/frontend/styles/product.css
@@ -701,3 +701,196 @@ body.dark-theme .review-container p {
     margin-top: 8px;
     font-size: 14px;
 }
+
+/* ============================================
+   Size Guide Link + Modal
+   Feature: #312
+   ============================================ */
+
+.size-guide-link-wrapper {
+    margin-top: 8px;
+    margin-bottom: 4px;
+}
+
+.size-guide-btn {
+    background: none;
+    border: none;
+    color: var(--primary-color, #088178);
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 4px 0;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    transition: opacity 0.2s ease;
+}
+
+.size-guide-btn:hover {
+    opacity: 0.75;
+}
+
+.size-guide-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    background: rgba(0, 0, 0, 0.55);
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    backdrop-filter: blur(2px);
+}
+
+.size-guide-overlay.active {
+    display: flex;
+}
+
+.size-guide-modal {
+    background: var(--white, #fff);
+    border-radius: 12px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    width: 100%;
+    max-width: 680px;
+    max-height: 90vh;
+    overflow-y: auto;
+    padding: 2rem;
+    position: relative;
+    animation: sizeGuideIn 0.25s ease;
+}
+
+@keyframes sizeGuideIn {
+    from { opacity: 0; transform: translateY(-16px) scale(0.97); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.size-guide-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+
+.size-guide-header h3 {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--primary-color, #088178);
+    margin: 0;
+}
+
+.size-guide-close {
+    background: none;
+    border: none;
+    font-size: 1.75rem;
+    cursor: pointer;
+    color: #888;
+    line-height: 1;
+    padding: 4px 8px;
+    border-radius: 6px;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.size-guide-close:hover {
+    background: #f0f0f0;
+    color: #333;
+}
+
+.size-guide-subtitle {
+    font-size: 0.8rem;
+    color: #888;
+    margin-bottom: 1.25rem;
+}
+
+.size-guide-table-wrapper {
+    overflow-x: auto;
+    border-radius: 8px;
+    border: 1px solid #e5e5e5;
+}
+
+.size-guide-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+}
+
+.size-guide-table th {
+    background: var(--primary-color, #088178);
+    color: #fff;
+    padding: 10px 14px;
+    text-align: center;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.size-guide-table td {
+    padding: 10px 14px;
+    text-align: center;
+    border-bottom: 1px solid #f0f0f0;
+    color: #444;
+}
+
+.size-guide-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.size-guide-table tbody tr:hover {
+    background: #f9fafb;
+}
+
+.size-guide-table .size-label {
+    font-weight: 700;
+    color: var(--primary-color, #088178);
+}
+
+.size-guide-tip {
+    margin-top: 1.25rem;
+    font-size: 0.82rem;
+    color: #666;
+    background: #f9fafb;
+    border-left: 3px solid var(--primary-color, #088178);
+    padding: 10px 14px;
+    border-radius: 0 6px 6px 0;
+}
+
+body.dark-theme .size-guide-modal {
+    background: #1e1e1e;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+}
+
+body.dark-theme .size-guide-close:hover {
+    background: #2a2a2a;
+    color: #fff;
+}
+
+body.dark-theme .size-guide-table-wrapper {
+    border-color: #333;
+}
+
+body.dark-theme .size-guide-table td {
+    color: #ccc;
+    border-bottom-color: #2a2a2a;
+}
+
+body.dark-theme .size-guide-table tbody tr:hover {
+    background: #2a2a2a;
+}
+
+body.dark-theme .size-guide-tip {
+    background: #2a2a2a;
+    color: #aaa;
+}
+
+body.dark-theme .size-guide-subtitle {
+    color: #666;
+}
+
+@media (max-width: 600px) {
+    .size-guide-modal {
+        padding: 1.25rem;
+    }
+
+    .size-guide-table th,
+    .size-guide-table td {
+        padding: 8px 10px;
+        font-size: 0.8rem;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #312

Adds a "📏 Size Guide" button next to the size selector on the product 
detail page that opens a clean modal with a full measurement chart 
(S/M/L/XL/XXL) in both cm and inches.

## Problem

The product page had size buttons (S/M/L/XL/XXL) but no reference for 
what those sizes mean in measurements. There was a basic static 
`size-chart-box` with only 3 columns (Size, Chest, Length) and no 
styling — essentially invisible to users.

## Changes

**`frontend/product.html`**
- Removed the old unstyled inline `size-chart-box`
- Added `📏 Size Guide` trigger button below the size selector
- Added full modal markup with:
  - Header with title and × close button
  - Measurement table: S/M/L/XL/XXL × Chest/Waist/Length in cm + inches
  - Tip text for users between sizes
- Added minimal self-contained JS (IIFE) at bottom of body:
  - Opens modal on button click
  - Closes on × button, outside click, or Escape key
  - Manages `aria-hidden`, `body overflow`, and focus correctly

**`frontend/styles/product.css`**
- Added all size guide styles:
  - `.size-guide-btn` — underlined teal link-style button
  - `.size-guide-overlay` — fixed full-screen backdrop with blur
  - `.size-guide-modal` — centered card with slide-in animation
  - `.size-guide-table` — teal header, alternating hover rows
  - Dark theme overrides for all elements
  - Mobile responsive at `max-width: 600px`

## Testing

- [x] 📏 Size Guide button visible below size selector
- [x] Click button → modal opens with measurement table
- [x] Click × → modal closes
- [x] Click outside modal → modal closes
- [x] Press Escape → modal closes
- [x] Dark mode → modal styled correctly
- [x] Mobile — table scrolls horizontally, modal padded correctly
- [x] No backend required — pure frontend

##Screenshot
<img width="1918" height="1057" alt="image" src="https://github.com/user-attachments/assets/164ff19b-f739-4f92-bdfb-fe67cab6afa9" />