### PR TITLE
fix: handle non-existent chat conversations in update and assignment flows

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -46,13 +46,24 @@ const updateStatus = async (req, res) => {
         }
 
         await chatService.updateConversationStatus(id, status);
-        
+
         // Emit socket event if needed, handled in socket logic usually
         // but we return REST success
         res.status(200).json({ success: true, message: `Conversation ${status}` });
     } catch (error) {
         console.error("UPDATE CONV STATUS ERROR:", error);
-        res.status(500).json({ success: false, message: "Server error" });
+
+        if (error.message === "Conversation not found") {
+            return res.status(404).json({
+                success: false,
+                message: "Conversation not found"
+            });
+        }
+
+        return res.status(500).json({
+            success: false,
+            message: "Server error"
+        });
     }
 };
 
@@ -65,7 +76,18 @@ const assignAdmin = async (req, res) => {
         res.status(200).json({ success: true, message: "Conversation assigned successfully" });
     } catch (error) {
         console.error("ASSIGN CONV ERROR:", error);
-        res.status(500).json({ success: false, message: "Server error" });
+
+        if (error.message === "Conversation not found") {
+            return res.status(404).json({
+                success: false,
+                message: "Conversation not found"
+            });
+        }
+
+        return res.status(500).json({
+            success: false,
+            message: "Server error"
+        });
     }
 };
 

--- a/backend/services/chat.service.js
+++ b/backend/services/chat.service.js
@@ -36,7 +36,7 @@ const getConversationList = async (filters, page = 1, limit = 20) => {
         query += ` AND c.status = ?`;
         params.push(filters.status);
     }
-    
+
     if (filters.assigned_to) {
         if (filters.assigned_to === 'unassigned') {
             query += ` AND c.assigned_admin_id IS NULL`;
@@ -85,12 +85,12 @@ const saveMessage = async (conversationId, senderId, senderType, message) => {
         `INSERT INTO chat_messages (conversation_id, sender_id, sender_type, message) VALUES (?, ?, ?, ?)`,
         [conversationId, senderId, senderType, message]
     );
-    
+
     // Update conversation updated_at implicitly
     await db.query(`UPDATE chat_conversations SET updated_at = CURRENT_TIMESTAMP WHERE id = ?`, [conversationId]);
-    
+
     const [newMsg] = await db.query(
-        `SELECT m.*, u.name as sender_name FROM chat_messages m JOIN users u ON m.sender_id = u.id WHERE m.id = ?`, 
+        `SELECT m.*, u.name as sender_name FROM chat_messages m JOIN users u ON m.sender_id = u.id WHERE m.id = ?`,
         [result.insertId]
     );
     return newMsg[0];
@@ -99,30 +99,40 @@ const saveMessage = async (conversationId, senderId, senderType, message) => {
 const updateConversationStatus = async (conversationId, status) => {
     let query = `UPDATE chat_conversations SET status = ?`;
     const params = [status];
-    
-    if (status === 'closed') {
+
+    if (status === "closed") {
         query += `, closed_at = CURRENT_TIMESTAMP`;
     } else {
         query += `, closed_at = NULL`;
     }
-    
+
     query += ` WHERE id = ?`;
     params.push(conversationId);
-    
-    await db.query(query, params);
+
+    const [result] = await db.query(query, params);
+
+    if (result.affectedRows === 0) {
+        throw new Error("Conversation not found");
+    }
 };
 
 const assignConversation = async (conversationId, adminId) => {
-    await db.query(
-        `UPDATE chat_conversations SET assigned_admin_id = ?, status = 'pending' WHERE id = ?`,
+    const [result] = await db.query(
+        `UPDATE chat_conversations
+         SET assigned_admin_id = ?, status = 'pending'
+         WHERE id = ?`,
         [adminId, conversationId]
     );
+
+    if (result.affectedRows === 0) {
+        throw new Error("Conversation not found");
+    }
 };
 
 const verifyConversationAccess = async (conversationId, userId, role) => {
     const [conv] = await db.query(`SELECT * FROM chat_conversations WHERE id = ?`, [conversationId]);
     if (!conv.length) return false;
-    
+
     if (role === 'admin') return true;
     return conv[0].customer_id === userId;
 };


### PR DESCRIPTION
## Summary

This PR fixes chat conversation update and assignment flows so they no longer return a false success response when the target conversation does not exist.

Previously, the service executed update queries without checking whether any row was actually modified. As a result, invalid conversation IDs could still produce successful API responses.

## Changes Made

- Added `affectedRows` validation to `updateConversationStatus()`.
- Added `affectedRows` validation to `assignConversation()`.
- Throw a `"Conversation not found"` error when no matching conversation exists.
- Updated chat controller error handling to return `404 Not Found` for non-existent conversations.
- Preserved existing `500` handling for unexpected server errors.

## Benefits

- Prevents false-success responses for invalid conversation IDs.
- Improves API correctness.
- Makes chat update and assignment behavior more predictable.
- Provides clearer error handling for clients.

## Testing

- Verified that updating an existing conversation still succeeds.
- Verified that assigning an existing conversation still succeeds.
- Verified that updating a non-existent conversation returns `404`.
- Verified that assigning a non-existent conversation returns `404`.

Closes #387