### PR TITLE
[BUG]: Cart item count number is clipped or cut off inside the header badge

### DIFF
--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -322,21 +322,22 @@ html, body {
 
 /* Desktop cart badge */
 #cart-badge {
-    display: none;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
     position: absolute;
     top: -8px;
     right: -10px;
+    width: auto;
     min-width: 18px;
     height: 18px;
-    padding: 0 4px;
+    padding: 0 6px;
     background: var(--primary-color, #088178);
     color: #ffffff;
     font-size: 11px;
     font-weight: 700;
-    border-radius: 50%;
-    align-items: center;
-    justify-content: center;
     line-height: 1;
+    border-radius: 9999px;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
     pointer-events: none;
 }


### PR DESCRIPTION
## 📋 Pull Request — Fix Cart Badge Number Alignment

### 🔗 Related Issue
Closes #412 — *[BUG]: Cart item count number is clipped or cut off inside the header badge*

### ✅ Changes Made
- **CSS Upgrade:** Added `display: flex !important`, `align-items: center !important`, and `justify-content: center !important` to force perfect centering, regardless of JavaScript interference.
- **JS Fix:** Updated `ui.js` by changing `desktopBadge.style.display = 'inline-block'` to `'flex'`. Because `inline-block` overrides Flexbox centering, this ensures the badge always remains perfectly centered.
- **Pill Shape:** Kept `border-radius: 9999px` which gives a perfect circle for single digits and a pill shape for 2+ digits.

### 🧪 Testing Checklist
- [ ] The number `3` (and any other number) is now perfectly centered both vertically and horizontally inside the green circle.
- [ ] Badge displays and aligns correctly on mobile and desktop.

## screen shot

<img width="1917" height="120" alt="image" src="https://github.com/user-attachments/assets/31c0bbc6-268c-438c-b941-6d19cdee7a78" />

