### PR TITLE
fix: profile icon navigates to profile.html when dropdown is absent on dashboard

### DIFF
--- a/frontend/scripts/auth.js
+++ b/frontend/scripts/auth.js
@@ -753,23 +753,18 @@ function initializeAuthUI() {
     ) {
         authLink.innerHTML =
             `<i class="fas fa-user"></i>`;
-
-        authLink.href =
-            "#";
-
+            
+        authLink.href = "profile.html";
         authLink.classList.add(
             "profile-active"
         );
-
-        authLink.addEventListener(
-            "click",
-            (event) => {
-                event.preventDefault();
-                dropdown?.classList.toggle(
-                    "active"
-                );
-            }
-        );
+authLink.addEventListener("click", (event) => {
+    if (dropdown) {
+        event.preventDefault();
+        dropdown.classList.toggle("active");
+    }
+    // if no dropdown exists, href="profile.html" handles navigation
+});
 
         logoutBtn?.addEventListener(
             "click",


### PR DESCRIPTION
Fixes #417 

## Problem
The profile/account icon in the navbar was completely unresponsive 
on the dashboard page.

Root cause: When a user is logged in, auth.js sets the icon's 
href to "#" and tries to toggle a #profile-dropdown element. 
That dropdown does not exist in navbar.html or dashboard.html, 
so the click event is silently consumed with no action taken.

## Fix
Updated the click handler in auth.js to check if the dropdown 
exists before trying to toggle it. If no dropdown is present 
(as on the dashboard page), the link falls back to navigating 
to profile.html via its href.

## Behavior After Fix
- Pages with dropdown - dropdown toggles as before 
- Dashboard page - clicking icon navigates to profile.html 

## Screenshot
<img width="1361" height="597" alt="Screenshot 2026-07-03 152411" src="https://github.com/user-attachments/assets/8a124239-6ad7-4b85-8c60-8bee42eb9d15" />
