### PR TITLE
fix(shop): remove duplicate search bar from shop page (#372)

### DIFF
--- a/frontend/shop.html
+++ b/frontend/shop.html
@@ -95,7 +95,7 @@
 
     <!-- Navbar -->
 
-    <div id="navbar"></div>
+    <div id="navbar" data-hide-global-search="true"></div>
 
     <!-- Shop Banner -->
 


### PR DESCRIPTION
The global navbar search bar (.search-container) was visible on the shop page alongside the dedicated shop search bar (#shop-controls). This caused a redundant UI with two search inputs shown simultaneously.

The components.js loader already supports a data-hide-global-search attribute on the #navbar element to suppress the global search on specific pages. Apply this attribute to shop.html so the navbar search is removed on load, leaving only the shop-specific search which includes autocomplete suggestions, category filters, price filters, rating filters, availability filters, and sort controls.

No JS or CSS changes required — the fix is a single HTML attribute using the existing suppression mechanism.

Fixes #372