### PR TITLE
fix: resolve memory leak in mcp rate limiter causing DoS

### DIFF
--- a/backend/middleware/mcpSecurity.js
+++ b/backend/middleware/mcpSecurity.js
@@ -29,6 +29,20 @@ const RATE_LIMIT_MAX = 10; // 10 requests per minute
 // In-memory rate limiter
 const rateLimiter = new Map();
 
+// Periodic garbage collection to prevent memory leaks (OOM/DoS)
+const cleanupInterval = setInterval(() => {
+    const windowStart = Date.now() - RATE_LIMIT_WINDOW;
+    for (const [ip, requests] of rateLimiter.entries()) {
+        const recentRequests = requests.filter(time => time > windowStart);
+        if (recentRequests.length === 0) {
+            rateLimiter.delete(ip);
+        } else {
+            rateLimiter.set(ip, recentRequests);
+        }
+    }
+}, RATE_LIMIT_WINDOW);
+cleanupInterval.unref();
+
 // ============================================
 // VALIDATION FUNCTIONS
 // ============================================


### PR DESCRIPTION

### Description
This PR fixes a critical Denial of Service (DoS) vulnerability in the new `mcpSecurity.js` rate limiter. The previous implementation used an in-memory `Map()` to cache IP addresses but never explicitly deleted entries for inactive IPs. This allowed an attacker using IP spoofing to permanently exhaust the Node.js memory heap by creating thousands of stale entries, eventually resulting in an Out-of-Memory (OOM) crash.
Fixes #436
### Changes Made
* Added a periodic garbage collection routine (`setInterval`) to the `mcpSecurity.js` module. 
* The interval runs every `RATE_LIMIT_WINDOW` and actively deletes (`rateLimiter.delete(ip)`) any IPs that haven't made requests recently, effectively preventing the memory leak.
