### PR TITLE
fix: remove localhost bypass from admin rate limiter

### DIFF
--- a/backend/middleware/authLimiter.js
+++ b/backend/middleware/authLimiter.js
@@ -27,10 +27,6 @@ const adminLimiter = rateLimit({
         success: false,
         errorCode: "ADMIN_RATE_LIMIT_EXCEEDED",
         message: "Too many requests. Please try again after 15 minutes."
-    },
-    skip: (req) => {
-        // Skip rate limiting for localhost in development
-        return process.env.NODE_ENV === "development" && req.ip === "::1";
     }
 });
 


### PR DESCRIPTION
## Summary

This PR removes the localhost development bypass from the admin rate limiter so that admin endpoints remain rate-limited consistently across environments.

Previously, the admin limiter skipped rate limiting entirely for localhost requests in development mode. This created inconsistent behavior between development and production and left admin endpoints unprotected during local testing.

## Changes Made

- Removed the `skip` function from `adminLimiter`.
- Ensured that admin rate limiting now applies consistently in development and production.
- Preserved the existing rate limit window, max request count, and error response structure.

## Benefits

- Keeps admin rate-limiting behavior consistent across environments.
- Ensures admin endpoints remain protected during development and testing.
- Reduces environment-specific behavior in security middleware.
- Makes admin rate-limiter behavior easier to reason about.

## Testing

- Verified that the admin limiter still returns the expected `429` response after exceeding the limit.
- Verified that localhost requests in development are no longer exempt from admin rate limiting.
- Confirmed that existing limiter response format remains unchanged.

Closes #440