### PR TITLE
fix: return 404 when deciding a non-existent admin approval request

### DIFF
--- a/backend/routes/adminApprovalRoutes.js
+++ b/backend/routes/adminApprovalRoutes.js
@@ -55,12 +55,19 @@ router.post('/approvals/:id/decide', authMiddleware, async (req, res) => {
             });
         }
 
-        await db.query(
+        const [result] = await db.query(
             `UPDATE admin_approval_requests 
              SET status = ?, admin_id = ?, admin_notes = ?
              WHERE id = ?`,
             [action === 'approve' ? 'approved' : 'rejected', req.user.id, notes, id]
         );
+
+        if (result.affectedRows === 0) {
+            return res.status(404).json({
+                success: false,
+                error: 'Approval request not found'
+            });
+        }
 
         // If approved, proceed with order
         if (action === 'approve') {
@@ -68,13 +75,13 @@ router.post('/approvals/:id/decide', authMiddleware, async (req, res) => {
             // ... order processing logic
         }
 
-        res.json({
+        return res.json({
             success: true,
             message: `Request ${action}d successfully`
         });
     } catch (error) {
         console.error('Error updating approval:', error);
-        res.status(500).json({
+        return res.status(500).json({
             success: false,
             error: 'Failed to update approval'
         });


### PR DESCRIPTION
## Summary

This PR fixes the admin approval decision route so it no longer returns a false success response when the target approval request does not exist.

Previously, the `/approvals/:id/decide` route executed an update query without checking whether any row was actually modified. As a result, invalid approval request IDs could still return a successful response.

## Changes Made

- Captured the database result from the approval request update query.
- Added an `affectedRows` check after updating `admin_approval_requests`.
- Return `404 Not Found` when the target approval request does not exist.
- Preserve the existing success response for valid approval/rejection actions.

## Benefits

- Prevents false-success responses for invalid approval request IDs.
- Improves API correctness for admin approval workflows.
- Makes approval actions easier to debug and more predictable.

## Testing

- Verified that approving an existing approval request still succeeds.
- Verified that rejecting an existing approval request still succeeds.
- Verified that a non-existent approval request ID now returns `404 Not Found`.

Closes #457