### PR TITLE
fix: remove allowed module details from public MCP status response

### DIFF
--- a/backend/routes/mcpRoutes.js
+++ b/backend/routes/mcpRoutes.js
@@ -97,9 +97,9 @@ router.post(
 router.get('/status', (req, res) => {
     res.json({
         success: true,
-        status: 'online',
+        service: "MCP",
+        status: "active",
         version: '2.0.0-secure',
-        allowedModules: require('../middleware/mcpSecurity').ALLOWED_MODULES,
         timestamp: new Date().toISOString()
     });
 });


### PR DESCRIPTION
## Summary

This PR updates the public MCP status endpoint to avoid exposing internal allowed module configuration.

Previously, the `/status` endpoint returned internal MCP module allowlist details. This exposed internal security-related configuration through a public route.

## Changes Made

- Removed internal allowed module information from the public MCP status response.
- Kept the endpoint focused on minimal operational metadata such as service name, status, version, and timestamp.

## Benefits

- Reduces exposure of internal MCP configuration.
- Keeps the public status endpoint minimal and safer by default.
- Improves separation between health/status information and internal security configuration.

## Testing

- Verified that `/api/mcp/status` still returns a successful status response.
- Verified that internal allowed module configuration is no longer exposed in the response.

Closes #458