### PR TITLE
fix: return actual updated user count in bulk status updates

### DIFF
--- a/backend/services/admin.service.js
+++ b/backend/services/admin.service.js
@@ -211,7 +211,7 @@ const bulkUpdateUserStatus = async (adminId, targetIds, status, ip, userAgent) =
         }
 
         await connection.commit();
-        return { updatedCount: targetIds.length };
+        return { requestedCount: targetIds.length, updatedCount: result.affectedRows };
     } catch (e) {
         await connection.rollback();
         throw e;


### PR DESCRIPTION
## Summary

This PR fixes the bulk admin user status update service so it returns the actual number of users updated in the database instead of the number of requested target IDs.

Previously, the service returned `targetIds.length` as `updatedCount`, which could over-report the number of updated users when some of the provided IDs did not exist.

## Changes Made

- Updated `bulkUpdateUserStatus()` to return `result.affectedRows` as `updatedCount`.
- Preserved the existing zero-update guard for cases where no matching users are updated.

## Benefits

- Makes bulk update responses accurate.
- Improves admin-facing operational clarity.
- Keeps service metadata aligned with actual database changes.

## Testing

- Verified that valid bulk updates still succeed.
- Verified that `updatedCount` now reflects the actual number of updated rows.
- Verified that partially invalid user ID lists no longer over-report update counts.

Closes #498