### PR TITLE
feat: add Amazon-style category navigation menu

### DIFF
--- a/frontend/components/navbar.html
+++ b/frontend/components/navbar.html
@@ -28,6 +28,50 @@
   <!-- Desktop Navigation -->
   <nav class="desktop-nav">
     <ul id="navbar-links" class="nav-links">
+      <li class="category-menu-item">
+        <button
+          id="category-menu-toggle"
+          class="category-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="category-menu-dropdown"
+        >
+          <i class="fas fa-bars" aria-hidden="true"></i>
+          Menu
+        </button>
+        <ul id="category-menu-dropdown" class="category-menu-dropdown">
+          <li>
+            <a class="category-menu-link" href="shop.html?category=Fashion">Fashion</a>
+          </li>
+          <li>
+            <a class="category-menu-link" href="shop.html?category=Grocery">Grocery</a>
+          </li>
+          <li>
+            <a class="category-menu-link" href="shop.html?category=Toys">Toys</a>
+          </li>
+          <li>
+            <a class="category-menu-link" href="shop.html?category=Electronics">Electronics</a>
+          </li>
+          <li>
+            <a class="category-menu-link" href="shop.html?category=Stationery">Stationery</a>
+          </li>
+          <li>
+            <a class="category-menu-link" href="shop.html?category=Home%20%26%20Kitchen">Home &amp; Kitchen</a>
+          </li>
+          <li>
+            <a class="category-menu-link" href="shop.html?category=Beauty">Beauty</a>
+          </li>
+          <li>
+            <a class="category-menu-link" href="shop.html?category=Sports">Sports</a>
+          </li>
+          <li>
+            <a class="category-menu-link" href="shop.html?category=Pet%20Supplies">Pet Supplies</a>
+          </li>
+          <li>
+            <a class="category-menu-link" href="shop.html?category=Automotive">Automotive</a>
+          </li>
+        </ul>
+      </li>
       <li><a href="index.html">Home</a></li>
       <li><a href="shop.html">Shop</a></li>
       <li><a href="blog.html">Blog</a></li>
@@ -100,6 +144,62 @@
     <!-- Mobile Menu Links -->
     <nav class="mobile-nav">
       <ul class="mobile-nav-links">
+        <li>
+          <span class="mobile-menu-label">
+            <i class="fas fa-bars"></i> Categories
+          </span>
+        </li>
+        <li>
+          <a href="shop.html?category=Fashion" class="mobile-link mobile-category-link"
+            ><i class="fas fa-tshirt"></i> Fashion</a
+          >
+        </li>
+        <li>
+          <a href="shop.html?category=Grocery" class="mobile-link mobile-category-link"
+            ><i class="fas fa-shopping-basket"></i> Grocery</a
+          >
+        </li>
+        <li>
+          <a href="shop.html?category=Toys" class="mobile-link mobile-category-link"
+            ><i class="fas fa-puzzle-piece"></i> Toys</a
+          >
+        </li>
+        <li>
+          <a href="shop.html?category=Electronics" class="mobile-link mobile-category-link"
+            ><i class="fas fa-laptop"></i> Electronics</a
+          >
+        </li>
+        <li>
+          <a href="shop.html?category=Stationery" class="mobile-link mobile-category-link"
+            ><i class="fas fa-pencil-alt"></i> Stationery</a
+          >
+        </li>
+        <li>
+          <a href="shop.html?category=Home%20%26%20Kitchen" class="mobile-link mobile-category-link"
+            ><i class="fas fa-home"></i> Home &amp; Kitchen</a
+          >
+        </li>
+        <li>
+          <a href="shop.html?category=Beauty" class="mobile-link mobile-category-link"
+            ><i class="fas fa-spa"></i> Beauty</a
+          >
+        </li>
+        <li>
+          <a href="shop.html?category=Sports" class="mobile-link mobile-category-link"
+            ><i class="fas fa-running"></i> Sports</a
+          >
+        </li>
+        <li>
+          <a href="shop.html?category=Pet%20Supplies" class="mobile-link mobile-category-link"
+            ><i class="fas fa-paw"></i> Pet Supplies</a
+          >
+        </li>
+        <li>
+          <a href="shop.html?category=Automotive" class="mobile-link mobile-category-link"
+            ><i class="fas fa-car"></i> Automotive</a
+          >
+        </li>
+        <li class="mobile-divider"></li>
         <li>
           <a href="index.html" class="mobile-link"
             ><i class="fas fa-home"></i> Home</a

--- a/frontend/scripts/components.js
+++ b/frontend/scripts/components.js
@@ -232,6 +232,79 @@ navLinks.forEach(link => {
         link.setAttribute('aria-current', 'page');
     }
 });
+
+const categoryMenuItem = document.querySelector(".category-menu-item");
+const categoryMenuToggle = document.getElementById("category-menu-toggle");
+const categoryMenuLinks = document.querySelectorAll(
+    ".category-menu-link, .mobile-category-link"
+);
+const currentUrl = new URL(window.location.href);
+const currentCategory = currentUrl.searchParams.get("category");
+
+const setCategoryMenuOpen = (isOpen) => {
+    if (!categoryMenuItem || !categoryMenuToggle) {
+        return;
+    }
+
+    categoryMenuItem.classList.toggle("is-open", isOpen);
+    categoryMenuToggle.setAttribute("aria-expanded", String(isOpen));
+};
+
+categoryMenuToggle?.addEventListener("click", (event) => {
+    event.stopPropagation();
+    setCategoryMenuOpen(true);
+});
+
+categoryMenuItem?.addEventListener("mouseenter", () => {
+    if (window.matchMedia("(min-width: 1025px)").matches) {
+        setCategoryMenuOpen(true);
+    }
+});
+
+categoryMenuItem?.addEventListener("mouseleave", () => {
+    if (window.matchMedia("(min-width: 1025px)").matches) {
+        setCategoryMenuOpen(false);
+    }
+});
+
+categoryMenuItem?.addEventListener("focusout", (event) => {
+    if (!categoryMenuItem.contains(event.relatedTarget)) {
+        setCategoryMenuOpen(false);
+    }
+});
+
+document.addEventListener("click", (event) => {
+    if (categoryMenuItem && !categoryMenuItem.contains(event.target)) {
+        setCategoryMenuOpen(false);
+    }
+});
+
+document.addEventListener("keydown", (event) => {
+    if (
+        event.key === "Escape" &&
+        categoryMenuItem?.classList.contains("is-open")
+    ) {
+        setCategoryMenuOpen(false);
+        categoryMenuToggle?.focus();
+    }
+});
+
+categoryMenuLinks.forEach((link) => {
+    const linkUrl = new URL(link.href);
+
+    if (
+        currentUrl.pathname.endsWith(linkUrl.pathname.split("/").pop()) &&
+        currentCategory &&
+        linkUrl.searchParams.get("category") === currentCategory
+    ) {
+        link.classList.add("active");
+        link.setAttribute("aria-current", "page");
+    }
+});
+
+if (currentCategory) {
+    categoryMenuToggle?.classList.add("active");
+}
     // notify components ready
     document.dispatchEvent(new CustomEvent("componentsLoaded"));
 }

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -105,6 +105,118 @@ html, body {
     background-color: var(--primary-color, #088178);
 }
 
+/* CATEGORY DROPDOWN */
+.category-menu-item {
+    position: relative;
+}
+
+.category-menu-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 38px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    line-height: 1;
+    transition:
+        background-color 0.3s ease,
+        color 0.3s ease,
+        box-shadow 0.3s ease,
+        transform 0.3s ease;
+}
+
+.category-menu-toggle:hover,
+.category-menu-toggle:focus-visible,
+.category-menu-toggle.active,
+.category-menu-item.is-open .category-menu-toggle {
+    background: rgba(8, 129, 120, 0.1);
+    color: var(--primary-color, #088178);
+    box-shadow: 0 6px 14px rgba(8, 129, 120, 0.12);
+}
+
+.category-menu-toggle:hover {
+    transform: translateY(-1px);
+}
+
+.category-menu-toggle:focus-visible {
+    outline: 2px solid var(--primary-color, #088178);
+    outline-offset: 2px;
+}
+
+.category-menu-dropdown {
+    position: absolute;
+    top: calc(100% + 16px);
+    left: 0;
+    width: min(300px, 86vw);
+    padding: 10px;
+    border: 1px solid rgba(8, 129, 120, 0.14);
+    border-radius: 8px;
+    background: var(--white, #ffffff);
+    box-shadow: 0 18px 36px rgba(0, 0, 0, 0.14);
+    list-style: none;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(8px) scale(0.98);
+    transform-origin: top left;
+    transition:
+        opacity 0.22s ease,
+        transform 0.22s ease,
+        visibility 0.22s ease;
+    visibility: hidden;
+    z-index: 10001;
+}
+
+.category-menu-dropdown::before {
+    content: "";
+    position: absolute;
+    top: -7px;
+    left: 20px;
+    width: 14px;
+    height: 14px;
+    border-top: 1px solid rgba(8, 129, 120, 0.14);
+    border-left: 1px solid rgba(8, 129, 120, 0.14);
+    background: var(--white, #ffffff);
+    transform: rotate(45deg);
+}
+
+.category-menu-item.is-open .category-menu-dropdown,
+.category-menu-item:hover .category-menu-dropdown,
+.category-menu-item:focus-within .category-menu-dropdown {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0) scale(1);
+    visibility: visible;
+}
+
+.category-menu-link {
+    display: flex;
+    align-items: center;
+    min-height: 40px;
+    padding: 10px 12px;
+    border-radius: 6px;
+    color: var(--text-dark, #222);
+    font-size: 14px;
+    font-weight: 600;
+    text-decoration: none;
+    transition:
+        background-color 0.25s ease,
+        color 0.25s ease,
+        transform 0.25s ease;
+}
+
+.category-menu-link:hover,
+.category-menu-link:focus-visible,
+.category-menu-link.active {
+    background: rgba(8, 129, 120, 0.1);
+    color: var(--primary-color, #088178);
+    transform: translateX(3px);
+}
+
+.category-menu-link:focus-visible {
+    outline: 2px solid var(--primary-color, #088178);
+    outline-offset: 1px;
+}
+
 
 /* Hide Hamburger Button on Desktop */
 #mobile-menu-btn {
@@ -255,12 +367,32 @@ html, body {
     margin: 16px 0;
 }
 
+.mobile-menu-label {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 8px 20px 4px;
+    color: #606a68;
+    font-size: 13px;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.mobile-menu-label i {
+    width: 24px;
+    text-align: center;
+}
+
+.mobile-category-link {
+    padding-block: 12px;
+}
+
 /* ==================== RESPONSIVE (TABLET & MOBILE) ==================== */
 @media (max-width: 1024px) {
     #header {
         padding: 16px 24px;
     }
-    
+
     .desktop-nav {
         display: none;
     }
@@ -578,6 +710,36 @@ body.dark-theme #header {
   box-shadow: 0 5px 15px rgba(0,0,0,0.4);
 }
 
+body.dark-theme .category-menu-toggle:hover,
+body.dark-theme .category-menu-toggle:focus-visible,
+body.dark-theme .category-menu-toggle.active,
+body.dark-theme .category-menu-item.is-open .category-menu-toggle {
+  background: rgba(57, 164, 214, 0.16);
+  color: #39a4d6;
+}
+
+body.dark-theme .category-menu-dropdown {
+  background: #1a1a1a;
+  border-color: #333;
+  box-shadow: 0 18px 36px rgba(0,0,0,0.45);
+}
+
+body.dark-theme .category-menu-dropdown::before {
+  background: #1a1a1a;
+  border-color: #333;
+}
+
+body.dark-theme .category-menu-link {
+  color: #e0e0e0;
+}
+
+body.dark-theme .category-menu-link:hover,
+body.dark-theme .category-menu-link:focus-visible,
+body.dark-theme .category-menu-link.active {
+  background: rgba(57, 164, 214, 0.16);
+  color: #39a4d6;
+}
+
 /* Desktop nav links */
 body.dark-theme .desktop-nav #navbar-links li a,
 body.dark-theme .desktop-nav #navbar-links li button {
@@ -603,6 +765,10 @@ body.dark-theme .mobile-link {
   background: #1e1e1e;
   color: #e0e0e0;
   border-color: #333;
+}
+
+body.dark-theme .mobile-menu-label {
+  color: #b8c4c2;
 }
 
 body.dark-theme #mobile-close-btn {


### PR DESCRIPTION
Closes #538

## Summary
- Added a first-position `Menu` item to the existing desktop navbar.
- Added a modern category dropdown with the requested product categories.
- Integrated the same category links into the existing mobile slide-out navigation.
- Added hover, click, outside-click close, Escape close, focus, active state, dark-mode, and responsive styling.
- Removed the always-visible second category navigation row.

## Verification
- `node --check frontend/scripts/components.js`
- `git diff --check upstream/main..HEAD`
- Playwright check at `http://localhost:5501/`:
  - no second category nav exists
  - desktop `Menu` dropdown opens and closes
  - outside click and Escape close the dropdown
  - active category state sets `aria-current="page"`
  - mobile categories appear inside the existing mobile menu
  - no horizontal page overflow on mobile
##Screenshot 

<img width="1433" height="821" alt="Screenshot 2026-07-06 at 11 13 31 AM" src="https://github.com/user-attachments/assets/486cdc43-055b-4442-b044-33dfcd01ab1c" />


## Note
- Browser console still reports pre-existing unrelated errors from upstream files containing conflict markers (`frontend/scripts/product-actions.js`, `frontend/scripts/recentlyViewed.js`) and product API calls when the backend is not running/available for `localhost:5501`. These files are outside Issue #538 and were not modified.
