### PR TITLE
feat: add Amazon-style mega menu with category items

### DIFF
--- a/frontend/components/navbar.html
+++ b/frontend/components/navbar.html
@@ -39,38 +39,203 @@
           <i class="fas fa-bars" aria-hidden="true"></i>
           Menu
         </button>
-        <ul id="category-menu-dropdown" class="category-menu-dropdown">
-          <li>
-            <a class="category-menu-link" href="shop.html?category=Fashion">Fashion</a>
-          </li>
-          <li>
-            <a class="category-menu-link" href="shop.html?category=Grocery">Grocery</a>
-          </li>
-          <li>
-            <a class="category-menu-link" href="shop.html?category=Toys">Toys</a>
-          </li>
-          <li>
-            <a class="category-menu-link" href="shop.html?category=Electronics">Electronics</a>
-          </li>
-          <li>
-            <a class="category-menu-link" href="shop.html?category=Stationery">Stationery</a>
-          </li>
-          <li>
-            <a class="category-menu-link" href="shop.html?category=Home%20%26%20Kitchen">Home &amp; Kitchen</a>
-          </li>
-          <li>
-            <a class="category-menu-link" href="shop.html?category=Beauty">Beauty</a>
-          </li>
-          <li>
-            <a class="category-menu-link" href="shop.html?category=Sports">Sports</a>
-          </li>
-          <li>
-            <a class="category-menu-link" href="shop.html?category=Pet%20Supplies">Pet Supplies</a>
-          </li>
-          <li>
-            <a class="category-menu-link" href="shop.html?category=Automotive">Automotive</a>
-          </li>
-        </ul>
+        <div
+          id="category-menu-dropdown"
+          class="category-menu-dropdown"
+          aria-label="Product categories"
+        >
+          <div class="mega-menu-sidebar" aria-label="Categories">
+            <button class="mega-menu-category is-active" type="button" data-mega-category="fashion" aria-expanded="true" aria-controls="mega-panel-fashion">
+              <i class="fas fa-tshirt" aria-hidden="true"></i>
+              <span>Fashion</span>
+            </button>
+            <button class="mega-menu-category" type="button" data-mega-category="electronics" aria-expanded="false" aria-controls="mega-panel-electronics">
+              <i class="fas fa-laptop" aria-hidden="true"></i>
+              <span>Electronics</span>
+            </button>
+            <button class="mega-menu-category" type="button" data-mega-category="grocery" aria-expanded="false" aria-controls="mega-panel-grocery">
+              <i class="fas fa-shopping-basket" aria-hidden="true"></i>
+              <span>Grocery</span>
+            </button>
+            <button class="mega-menu-category" type="button" data-mega-category="toys" aria-expanded="false" aria-controls="mega-panel-toys">
+              <i class="fas fa-puzzle-piece" aria-hidden="true"></i>
+              <span>Toys</span>
+            </button>
+            <button class="mega-menu-category" type="button" data-mega-category="stationery" aria-expanded="false" aria-controls="mega-panel-stationery">
+              <i class="fas fa-pencil-alt" aria-hidden="true"></i>
+              <span>Stationery</span>
+            </button>
+            <button class="mega-menu-category" type="button" data-mega-category="home-kitchen" aria-expanded="false" aria-controls="mega-panel-home-kitchen">
+              <i class="fas fa-home" aria-hidden="true"></i>
+              <span>Home &amp; Kitchen</span>
+            </button>
+            <button class="mega-menu-category" type="button" data-mega-category="beauty" aria-expanded="false" aria-controls="mega-panel-beauty">
+              <i class="fas fa-spa" aria-hidden="true"></i>
+              <span>Beauty</span>
+            </button>
+            <button class="mega-menu-category" type="button" data-mega-category="sports" aria-expanded="false" aria-controls="mega-panel-sports">
+              <i class="fas fa-running" aria-hidden="true"></i>
+              <span>Sports</span>
+            </button>
+            <button class="mega-menu-category" type="button" data-mega-category="pet-supplies" aria-expanded="false" aria-controls="mega-panel-pet-supplies">
+              <i class="fas fa-paw" aria-hidden="true"></i>
+              <span>Pet Supplies</span>
+            </button>
+            <button class="mega-menu-category" type="button" data-mega-category="automotive" aria-expanded="false" aria-controls="mega-panel-automotive">
+              <i class="fas fa-car" aria-hidden="true"></i>
+              <span>Automotive</span>
+            </button>
+          </div>
+
+          <div class="mega-menu-content">
+            <section id="mega-panel-fashion" class="mega-menu-panel is-active" data-mega-panel="fashion" aria-labelledby="mega-title-fashion">
+              <div class="mega-menu-panel-header">
+                <h3 id="mega-title-fashion">Fashion</h3>
+                <a href="shop.html?category=Fashion">Shop all Fashion</a>
+              </div>
+              <div class="mega-menu-grid">
+                <a class="category-menu-link" href="shop.html?category=Fashion&amp;subcategory=Men%27s%20Clothing">Men's Clothing</a>
+                <a class="category-menu-link" href="shop.html?category=Fashion&amp;subcategory=Women%27s%20Clothing">Women's Clothing</a>
+                <a class="category-menu-link" href="shop.html?category=Fashion&amp;subcategory=Kids%20Wear">Kids Wear</a>
+                <a class="category-menu-link" href="shop.html?category=Fashion&amp;subcategory=Footwear">Footwear</a>
+                <a class="category-menu-link" href="shop.html?category=Fashion&amp;subcategory=Watches">Watches</a>
+                <a class="category-menu-link" href="shop.html?category=Fashion&amp;subcategory=Bags">Bags</a>
+                <a class="category-menu-link" href="shop.html?category=Fashion&amp;subcategory=Accessories">Accessories</a>
+              </div>
+            </section>
+
+            <section id="mega-panel-electronics" class="mega-menu-panel" data-mega-panel="electronics" aria-labelledby="mega-title-electronics">
+              <div class="mega-menu-panel-header">
+                <h3 id="mega-title-electronics">Electronics</h3>
+                <a href="shop.html?category=Electronics">Shop all Electronics</a>
+              </div>
+              <div class="mega-menu-grid">
+                <a class="category-menu-link" href="shop.html?category=Electronics&amp;subcategory=Mobiles">Mobiles</a>
+                <a class="category-menu-link" href="shop.html?category=Electronics&amp;subcategory=Laptops">Laptops</a>
+                <a class="category-menu-link" href="shop.html?category=Electronics&amp;subcategory=Tablets">Tablets</a>
+                <a class="category-menu-link" href="shop.html?category=Electronics&amp;subcategory=Smart%20Watches">Smart Watches</a>
+                <a class="category-menu-link" href="shop.html?category=Electronics&amp;subcategory=Headphones">Headphones</a>
+                <a class="category-menu-link" href="shop.html?category=Electronics&amp;subcategory=Cameras">Cameras</a>
+                <a class="category-menu-link" href="shop.html?category=Electronics&amp;subcategory=Gaming">Gaming</a>
+              </div>
+            </section>
+
+            <section id="mega-panel-grocery" class="mega-menu-panel" data-mega-panel="grocery" aria-labelledby="mega-title-grocery">
+              <div class="mega-menu-panel-header">
+                <h3 id="mega-title-grocery">Grocery</h3>
+                <a href="shop.html?category=Grocery">Shop all Grocery</a>
+              </div>
+              <div class="mega-menu-grid">
+                <a class="category-menu-link" href="shop.html?category=Grocery&amp;subcategory=Fruits%20%26%20Vegetables">Fruits &amp; Vegetables</a>
+                <a class="category-menu-link" href="shop.html?category=Grocery&amp;subcategory=Dairy">Dairy</a>
+                <a class="category-menu-link" href="shop.html?category=Grocery&amp;subcategory=Snacks">Snacks</a>
+                <a class="category-menu-link" href="shop.html?category=Grocery&amp;subcategory=Beverages">Beverages</a>
+                <a class="category-menu-link" href="shop.html?category=Grocery&amp;subcategory=Cooking%20Essentials">Cooking Essentials</a>
+                <a class="category-menu-link" href="shop.html?category=Grocery&amp;subcategory=Household%20Supplies">Household Supplies</a>
+              </div>
+            </section>
+
+            <section id="mega-panel-toys" class="mega-menu-panel" data-mega-panel="toys" aria-labelledby="mega-title-toys">
+              <div class="mega-menu-panel-header">
+                <h3 id="mega-title-toys">Toys</h3>
+                <a href="shop.html?category=Toys">Shop all Toys</a>
+              </div>
+              <div class="mega-menu-grid">
+                <a class="category-menu-link" href="shop.html?category=Toys&amp;subcategory=Educational%20Toys">Educational Toys</a>
+                <a class="category-menu-link" href="shop.html?category=Toys&amp;subcategory=Building%20Blocks">Building Blocks</a>
+                <a class="category-menu-link" href="shop.html?category=Toys&amp;subcategory=Dolls">Dolls</a>
+                <a class="category-menu-link" href="shop.html?category=Toys&amp;subcategory=RC%20Toys">RC Toys</a>
+                <a class="category-menu-link" href="shop.html?category=Toys&amp;subcategory=Outdoor%20Toys">Outdoor Toys</a>
+              </div>
+            </section>
+
+            <section id="mega-panel-stationery" class="mega-menu-panel" data-mega-panel="stationery" aria-labelledby="mega-title-stationery">
+              <div class="mega-menu-panel-header">
+                <h3 id="mega-title-stationery">Stationery</h3>
+                <a href="shop.html?category=Stationery">Shop all Stationery</a>
+              </div>
+              <div class="mega-menu-grid">
+                <a class="category-menu-link" href="shop.html?category=Stationery&amp;subcategory=Notebooks">Notebooks</a>
+                <a class="category-menu-link" href="shop.html?category=Stationery&amp;subcategory=Pens">Pens</a>
+                <a class="category-menu-link" href="shop.html?category=Stationery&amp;subcategory=Pencils">Pencils</a>
+                <a class="category-menu-link" href="shop.html?category=Stationery&amp;subcategory=School%20Bags">School Bags</a>
+                <a class="category-menu-link" href="shop.html?category=Stationery&amp;subcategory=Office%20Supplies">Office Supplies</a>
+                <a class="category-menu-link" href="shop.html?category=Stationery&amp;subcategory=Art%20Supplies">Art Supplies</a>
+              </div>
+            </section>
+
+            <section id="mega-panel-home-kitchen" class="mega-menu-panel" data-mega-panel="home-kitchen" aria-labelledby="mega-title-home-kitchen">
+              <div class="mega-menu-panel-header">
+                <h3 id="mega-title-home-kitchen">Home &amp; Kitchen</h3>
+                <a href="shop.html?category=Home%20%26%20Kitchen">Shop all Home &amp; Kitchen</a>
+              </div>
+              <div class="mega-menu-grid">
+                <a class="category-menu-link" href="shop.html?category=Home%20%26%20Kitchen&amp;subcategory=Furniture">Furniture</a>
+                <a class="category-menu-link" href="shop.html?category=Home%20%26%20Kitchen&amp;subcategory=Cookware">Cookware</a>
+                <a class="category-menu-link" href="shop.html?category=Home%20%26%20Kitchen&amp;subcategory=Storage">Storage</a>
+                <a class="category-menu-link" href="shop.html?category=Home%20%26%20Kitchen&amp;subcategory=Home%20Decor">Home Decor</a>
+                <a class="category-menu-link" href="shop.html?category=Home%20%26%20Kitchen&amp;subcategory=Bedding">Bedding</a>
+                <a class="category-menu-link" href="shop.html?category=Home%20%26%20Kitchen&amp;subcategory=Kitchen%20Appliances">Kitchen Appliances</a>
+              </div>
+            </section>
+
+            <section id="mega-panel-beauty" class="mega-menu-panel" data-mega-panel="beauty" aria-labelledby="mega-title-beauty">
+              <div class="mega-menu-panel-header">
+                <h3 id="mega-title-beauty">Beauty</h3>
+                <a href="shop.html?category=Beauty">Shop all Beauty</a>
+              </div>
+              <div class="mega-menu-grid">
+                <a class="category-menu-link" href="shop.html?category=Beauty&amp;subcategory=Skincare">Skincare</a>
+                <a class="category-menu-link" href="shop.html?category=Beauty&amp;subcategory=Haircare">Haircare</a>
+                <a class="category-menu-link" href="shop.html?category=Beauty&amp;subcategory=Makeup">Makeup</a>
+                <a class="category-menu-link" href="shop.html?category=Beauty&amp;subcategory=Fragrances">Fragrances</a>
+                <a class="category-menu-link" href="shop.html?category=Beauty&amp;subcategory=Personal%20Care">Personal Care</a>
+              </div>
+            </section>
+
+            <section id="mega-panel-sports" class="mega-menu-panel" data-mega-panel="sports" aria-labelledby="mega-title-sports">
+              <div class="mega-menu-panel-header">
+                <h3 id="mega-title-sports">Sports</h3>
+                <a href="shop.html?category=Sports">Shop all Sports</a>
+              </div>
+              <div class="mega-menu-grid">
+                <a class="category-menu-link" href="shop.html?category=Sports&amp;subcategory=Cricket">Cricket</a>
+                <a class="category-menu-link" href="shop.html?category=Sports&amp;subcategory=Football">Football</a>
+                <a class="category-menu-link" href="shop.html?category=Sports&amp;subcategory=Gym%20Equipment">Gym Equipment</a>
+                <a class="category-menu-link" href="shop.html?category=Sports&amp;subcategory=Cycling">Cycling</a>
+                <a class="category-menu-link" href="shop.html?category=Sports&amp;subcategory=Outdoor%20Sports">Outdoor Sports</a>
+              </div>
+            </section>
+
+            <section id="mega-panel-pet-supplies" class="mega-menu-panel" data-mega-panel="pet-supplies" aria-labelledby="mega-title-pet-supplies">
+              <div class="mega-menu-panel-header">
+                <h3 id="mega-title-pet-supplies">Pet Supplies</h3>
+                <a href="shop.html?category=Pet%20Supplies">Shop all Pet Supplies</a>
+              </div>
+              <div class="mega-menu-grid">
+                <a class="category-menu-link" href="shop.html?category=Pet%20Supplies&amp;subcategory=Dog%20Food">Dog Food</a>
+                <a class="category-menu-link" href="shop.html?category=Pet%20Supplies&amp;subcategory=Cat%20Food">Cat Food</a>
+                <a class="category-menu-link" href="shop.html?category=Pet%20Supplies&amp;subcategory=Pet%20Toys">Pet Toys</a>
+                <a class="category-menu-link" href="shop.html?category=Pet%20Supplies&amp;subcategory=Grooming">Grooming</a>
+                <a class="category-menu-link" href="shop.html?category=Pet%20Supplies&amp;subcategory=Accessories">Accessories</a>
+              </div>
+            </section>
+
+            <section id="mega-panel-automotive" class="mega-menu-panel" data-mega-panel="automotive" aria-labelledby="mega-title-automotive">
+              <div class="mega-menu-panel-header">
+                <h3 id="mega-title-automotive">Automotive</h3>
+                <a href="shop.html?category=Automotive">Shop all Automotive</a>
+              </div>
+              <div class="mega-menu-grid">
+                <a class="category-menu-link" href="shop.html?category=Automotive&amp;subcategory=Car%20Accessories">Car Accessories</a>
+                <a class="category-menu-link" href="shop.html?category=Automotive&amp;subcategory=Bike%20Accessories">Bike Accessories</a>
+                <a class="category-menu-link" href="shop.html?category=Automotive&amp;subcategory=Helmets">Helmets</a>
+                <a class="category-menu-link" href="shop.html?category=Automotive&amp;subcategory=Engine%20Oil">Engine Oil</a>
+                <a class="category-menu-link" href="shop.html?category=Automotive&amp;subcategory=Cleaning%20Kits">Cleaning Kits</a>
+              </div>
+            </section>
+          </div>
+        </div>
       </li>
       <li><a href="index.html">Home</a></li>
       <li><a href="shop.html">Shop</a></li>
@@ -149,55 +314,142 @@
             <i class="fas fa-bars"></i> Categories
           </span>
         </li>
-        <li>
-          <a href="shop.html?category=Fashion" class="mobile-link mobile-category-link"
-            ><i class="fas fa-tshirt"></i> Fashion</a
-          >
+        <li class="mobile-category-accordion">
+          <button class="mobile-category-toggle" type="button" aria-expanded="false" aria-controls="mobile-category-fashion">
+            <span><i class="fas fa-tshirt" aria-hidden="true"></i> Fashion</span>
+            <i class="fas fa-chevron-down" aria-hidden="true"></i>
+          </button>
+          <div id="mobile-category-fashion" class="mobile-subcategory-panel">
+            <a href="shop.html?category=Fashion&amp;subcategory=Men%27s%20Clothing">Men's Clothing</a>
+            <a href="shop.html?category=Fashion&amp;subcategory=Women%27s%20Clothing">Women's Clothing</a>
+            <a href="shop.html?category=Fashion&amp;subcategory=Kids%20Wear">Kids Wear</a>
+            <a href="shop.html?category=Fashion&amp;subcategory=Footwear">Footwear</a>
+            <a href="shop.html?category=Fashion&amp;subcategory=Watches">Watches</a>
+            <a href="shop.html?category=Fashion&amp;subcategory=Bags">Bags</a>
+            <a href="shop.html?category=Fashion&amp;subcategory=Accessories">Accessories</a>
+          </div>
         </li>
-        <li>
-          <a href="shop.html?category=Grocery" class="mobile-link mobile-category-link"
-            ><i class="fas fa-shopping-basket"></i> Grocery</a
-          >
+        <li class="mobile-category-accordion">
+          <button class="mobile-category-toggle" type="button" aria-expanded="false" aria-controls="mobile-category-electronics">
+            <span><i class="fas fa-laptop" aria-hidden="true"></i> Electronics</span>
+            <i class="fas fa-chevron-down" aria-hidden="true"></i>
+          </button>
+          <div id="mobile-category-electronics" class="mobile-subcategory-panel">
+            <a href="shop.html?category=Electronics&amp;subcategory=Mobiles">Mobiles</a>
+            <a href="shop.html?category=Electronics&amp;subcategory=Laptops">Laptops</a>
+            <a href="shop.html?category=Electronics&amp;subcategory=Tablets">Tablets</a>
+            <a href="shop.html?category=Electronics&amp;subcategory=Smart%20Watches">Smart Watches</a>
+            <a href="shop.html?category=Electronics&amp;subcategory=Headphones">Headphones</a>
+            <a href="shop.html?category=Electronics&amp;subcategory=Cameras">Cameras</a>
+            <a href="shop.html?category=Electronics&amp;subcategory=Gaming">Gaming</a>
+          </div>
         </li>
-        <li>
-          <a href="shop.html?category=Toys" class="mobile-link mobile-category-link"
-            ><i class="fas fa-puzzle-piece"></i> Toys</a
-          >
+        <li class="mobile-category-accordion">
+          <button class="mobile-category-toggle" type="button" aria-expanded="false" aria-controls="mobile-category-grocery">
+            <span><i class="fas fa-shopping-basket" aria-hidden="true"></i> Grocery</span>
+            <i class="fas fa-chevron-down" aria-hidden="true"></i>
+          </button>
+          <div id="mobile-category-grocery" class="mobile-subcategory-panel">
+            <a href="shop.html?category=Grocery&amp;subcategory=Fruits%20%26%20Vegetables">Fruits &amp; Vegetables</a>
+            <a href="shop.html?category=Grocery&amp;subcategory=Dairy">Dairy</a>
+            <a href="shop.html?category=Grocery&amp;subcategory=Snacks">Snacks</a>
+            <a href="shop.html?category=Grocery&amp;subcategory=Beverages">Beverages</a>
+            <a href="shop.html?category=Grocery&amp;subcategory=Cooking%20Essentials">Cooking Essentials</a>
+            <a href="shop.html?category=Grocery&amp;subcategory=Household%20Supplies">Household Supplies</a>
+          </div>
         </li>
-        <li>
-          <a href="shop.html?category=Electronics" class="mobile-link mobile-category-link"
-            ><i class="fas fa-laptop"></i> Electronics</a
-          >
+        <li class="mobile-category-accordion">
+          <button class="mobile-category-toggle" type="button" aria-expanded="false" aria-controls="mobile-category-toys">
+            <span><i class="fas fa-puzzle-piece" aria-hidden="true"></i> Toys</span>
+            <i class="fas fa-chevron-down" aria-hidden="true"></i>
+          </button>
+          <div id="mobile-category-toys" class="mobile-subcategory-panel">
+            <a href="shop.html?category=Toys&amp;subcategory=Educational%20Toys">Educational Toys</a>
+            <a href="shop.html?category=Toys&amp;subcategory=Building%20Blocks">Building Blocks</a>
+            <a href="shop.html?category=Toys&amp;subcategory=Dolls">Dolls</a>
+            <a href="shop.html?category=Toys&amp;subcategory=RC%20Toys">RC Toys</a>
+            <a href="shop.html?category=Toys&amp;subcategory=Outdoor%20Toys">Outdoor Toys</a>
+          </div>
         </li>
-        <li>
-          <a href="shop.html?category=Stationery" class="mobile-link mobile-category-link"
-            ><i class="fas fa-pencil-alt"></i> Stationery</a
-          >
+        <li class="mobile-category-accordion">
+          <button class="mobile-category-toggle" type="button" aria-expanded="false" aria-controls="mobile-category-stationery">
+            <span><i class="fas fa-pencil-alt" aria-hidden="true"></i> Stationery</span>
+            <i class="fas fa-chevron-down" aria-hidden="true"></i>
+          </button>
+          <div id="mobile-category-stationery" class="mobile-subcategory-panel">
+            <a href="shop.html?category=Stationery&amp;subcategory=Notebooks">Notebooks</a>
+            <a href="shop.html?category=Stationery&amp;subcategory=Pens">Pens</a>
+            <a href="shop.html?category=Stationery&amp;subcategory=Pencils">Pencils</a>
+            <a href="shop.html?category=Stationery&amp;subcategory=School%20Bags">School Bags</a>
+            <a href="shop.html?category=Stationery&amp;subcategory=Office%20Supplies">Office Supplies</a>
+            <a href="shop.html?category=Stationery&amp;subcategory=Art%20Supplies">Art Supplies</a>
+          </div>
         </li>
-        <li>
-          <a href="shop.html?category=Home%20%26%20Kitchen" class="mobile-link mobile-category-link"
-            ><i class="fas fa-home"></i> Home &amp; Kitchen</a
-          >
+        <li class="mobile-category-accordion">
+          <button class="mobile-category-toggle" type="button" aria-expanded="false" aria-controls="mobile-category-home-kitchen">
+            <span><i class="fas fa-home" aria-hidden="true"></i> Home &amp; Kitchen</span>
+            <i class="fas fa-chevron-down" aria-hidden="true"></i>
+          </button>
+          <div id="mobile-category-home-kitchen" class="mobile-subcategory-panel">
+            <a href="shop.html?category=Home%20%26%20Kitchen&amp;subcategory=Furniture">Furniture</a>
+            <a href="shop.html?category=Home%20%26%20Kitchen&amp;subcategory=Cookware">Cookware</a>
+            <a href="shop.html?category=Home%20%26%20Kitchen&amp;subcategory=Storage">Storage</a>
+            <a href="shop.html?category=Home%20%26%20Kitchen&amp;subcategory=Home%20Decor">Home Decor</a>
+            <a href="shop.html?category=Home%20%26%20Kitchen&amp;subcategory=Bedding">Bedding</a>
+            <a href="shop.html?category=Home%20%26%20Kitchen&amp;subcategory=Kitchen%20Appliances">Kitchen Appliances</a>
+          </div>
         </li>
-        <li>
-          <a href="shop.html?category=Beauty" class="mobile-link mobile-category-link"
-            ><i class="fas fa-spa"></i> Beauty</a
-          >
+        <li class="mobile-category-accordion">
+          <button class="mobile-category-toggle" type="button" aria-expanded="false" aria-controls="mobile-category-beauty">
+            <span><i class="fas fa-spa" aria-hidden="true"></i> Beauty</span>
+            <i class="fas fa-chevron-down" aria-hidden="true"></i>
+          </button>
+          <div id="mobile-category-beauty" class="mobile-subcategory-panel">
+            <a href="shop.html?category=Beauty&amp;subcategory=Skincare">Skincare</a>
+            <a href="shop.html?category=Beauty&amp;subcategory=Haircare">Haircare</a>
+            <a href="shop.html?category=Beauty&amp;subcategory=Makeup">Makeup</a>
+            <a href="shop.html?category=Beauty&amp;subcategory=Fragrances">Fragrances</a>
+            <a href="shop.html?category=Beauty&amp;subcategory=Personal%20Care">Personal Care</a>
+          </div>
         </li>
-        <li>
-          <a href="shop.html?category=Sports" class="mobile-link mobile-category-link"
-            ><i class="fas fa-running"></i> Sports</a
-          >
+        <li class="mobile-category-accordion">
+          <button class="mobile-category-toggle" type="button" aria-expanded="false" aria-controls="mobile-category-sports">
+            <span><i class="fas fa-running" aria-hidden="true"></i> Sports</span>
+            <i class="fas fa-chevron-down" aria-hidden="true"></i>
+          </button>
+          <div id="mobile-category-sports" class="mobile-subcategory-panel">
+            <a href="shop.html?category=Sports&amp;subcategory=Cricket">Cricket</a>
+            <a href="shop.html?category=Sports&amp;subcategory=Football">Football</a>
+            <a href="shop.html?category=Sports&amp;subcategory=Gym%20Equipment">Gym Equipment</a>
+            <a href="shop.html?category=Sports&amp;subcategory=Cycling">Cycling</a>
+            <a href="shop.html?category=Sports&amp;subcategory=Outdoor%20Sports">Outdoor Sports</a>
+          </div>
         </li>
-        <li>
-          <a href="shop.html?category=Pet%20Supplies" class="mobile-link mobile-category-link"
-            ><i class="fas fa-paw"></i> Pet Supplies</a
-          >
+        <li class="mobile-category-accordion">
+          <button class="mobile-category-toggle" type="button" aria-expanded="false" aria-controls="mobile-category-pet-supplies">
+            <span><i class="fas fa-paw" aria-hidden="true"></i> Pet Supplies</span>
+            <i class="fas fa-chevron-down" aria-hidden="true"></i>
+          </button>
+          <div id="mobile-category-pet-supplies" class="mobile-subcategory-panel">
+            <a href="shop.html?category=Pet%20Supplies&amp;subcategory=Dog%20Food">Dog Food</a>
+            <a href="shop.html?category=Pet%20Supplies&amp;subcategory=Cat%20Food">Cat Food</a>
+            <a href="shop.html?category=Pet%20Supplies&amp;subcategory=Pet%20Toys">Pet Toys</a>
+            <a href="shop.html?category=Pet%20Supplies&amp;subcategory=Grooming">Grooming</a>
+            <a href="shop.html?category=Pet%20Supplies&amp;subcategory=Accessories">Accessories</a>
+          </div>
         </li>
-        <li>
-          <a href="shop.html?category=Automotive" class="mobile-link mobile-category-link"
-            ><i class="fas fa-car"></i> Automotive</a
-          >
+        <li class="mobile-category-accordion">
+          <button class="mobile-category-toggle" type="button" aria-expanded="false" aria-controls="mobile-category-automotive">
+            <span><i class="fas fa-car" aria-hidden="true"></i> Automotive</span>
+            <i class="fas fa-chevron-down" aria-hidden="true"></i>
+          </button>
+          <div id="mobile-category-automotive" class="mobile-subcategory-panel">
+            <a href="shop.html?category=Automotive&amp;subcategory=Car%20Accessories">Car Accessories</a>
+            <a href="shop.html?category=Automotive&amp;subcategory=Bike%20Accessories">Bike Accessories</a>
+            <a href="shop.html?category=Automotive&amp;subcategory=Helmets">Helmets</a>
+            <a href="shop.html?category=Automotive&amp;subcategory=Engine%20Oil">Engine Oil</a>
+            <a href="shop.html?category=Automotive&amp;subcategory=Cleaning%20Kits">Cleaning Kits</a>
+          </div>
         </li>
         <li class="mobile-divider"></li>
         <li>

--- a/frontend/scripts/components.js
+++ b/frontend/scripts/components.js
@@ -235,11 +235,22 @@ navLinks.forEach(link => {
 
 const categoryMenuItem = document.querySelector(".category-menu-item");
 const categoryMenuToggle = document.getElementById("category-menu-toggle");
+const categoryMenuDropdown = document.getElementById("category-menu-dropdown");
+const megaMenuCategories = Array.from(
+    document.querySelectorAll(".mega-menu-category")
+);
+const megaMenuPanels = Array.from(
+    document.querySelectorAll(".mega-menu-panel")
+);
 const categoryMenuLinks = document.querySelectorAll(
-    ".category-menu-link, .mobile-category-link"
+    ".category-menu-link, .mega-menu-panel-header a, .mobile-subcategory-panel a"
+);
+const mobileCategoryAccordions = Array.from(
+    document.querySelectorAll(".mobile-category-accordion")
 );
 const currentUrl = new URL(window.location.href);
 const currentCategory = currentUrl.searchParams.get("category");
+const currentSubcategory = currentUrl.searchParams.get("subcategory");
 
 const setCategoryMenuOpen = (isOpen) => {
     if (!categoryMenuItem || !categoryMenuToggle) {
@@ -250,9 +261,38 @@ const setCategoryMenuOpen = (isOpen) => {
     categoryMenuToggle.setAttribute("aria-expanded", String(isOpen));
 };
 
+const activateMegaCategory = (categoryId) => {
+    megaMenuCategories.forEach((category) => {
+        const isActive = category.dataset.megaCategory === categoryId;
+
+        category.classList.toggle("is-active", isActive);
+        category.setAttribute("aria-expanded", String(isActive));
+    });
+
+    megaMenuPanels.forEach((panel) => {
+        panel.classList.toggle(
+            "is-active",
+            panel.dataset.megaPanel === categoryId
+        );
+    });
+};
+
+const focusMegaCategoryByOffset = (currentCategory, offset) => {
+    const currentIndex = megaMenuCategories.indexOf(currentCategory);
+    const nextIndex =
+        (currentIndex + offset + megaMenuCategories.length) %
+        megaMenuCategories.length;
+    const nextCategory = megaMenuCategories[nextIndex];
+
+    nextCategory?.focus();
+    activateMegaCategory(nextCategory?.dataset.megaCategory);
+};
+
 categoryMenuToggle?.addEventListener("click", (event) => {
     event.stopPropagation();
-    setCategoryMenuOpen(true);
+    setCategoryMenuOpen(
+        !categoryMenuItem?.classList.contains("is-open")
+    );
 });
 
 categoryMenuItem?.addEventListener("mouseenter", () => {
@@ -265,6 +305,49 @@ categoryMenuItem?.addEventListener("mouseleave", () => {
     if (window.matchMedia("(min-width: 1025px)").matches) {
         setCategoryMenuOpen(false);
     }
+});
+
+megaMenuCategories.forEach((category) => {
+    category.addEventListener("mouseenter", () => {
+        if (window.matchMedia("(min-width: 1025px)").matches) {
+            activateMegaCategory(category.dataset.megaCategory);
+        }
+    });
+
+    category.addEventListener("click", () => {
+        activateMegaCategory(category.dataset.megaCategory);
+        setCategoryMenuOpen(true);
+    });
+
+    category.addEventListener("keydown", (event) => {
+        if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+            event.preventDefault();
+            focusMegaCategoryByOffset(category, 1);
+        }
+
+        if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+            event.preventDefault();
+            focusMegaCategoryByOffset(category, -1);
+        }
+
+        if (event.key === "Home") {
+            event.preventDefault();
+            megaMenuCategories[0]?.focus();
+            activateMegaCategory(megaMenuCategories[0]?.dataset.megaCategory);
+        }
+
+        if (event.key === "End") {
+            event.preventDefault();
+            const lastCategory =
+                megaMenuCategories[megaMenuCategories.length - 1];
+            lastCategory?.focus();
+            activateMegaCategory(lastCategory?.dataset.megaCategory);
+        }
+    });
+});
+
+categoryMenuDropdown?.addEventListener("click", (event) => {
+    event.stopPropagation();
 });
 
 categoryMenuItem?.addEventListener("focusout", (event) => {
@@ -291,11 +374,14 @@ document.addEventListener("keydown", (event) => {
 
 categoryMenuLinks.forEach((link) => {
     const linkUrl = new URL(link.href);
+    const linkCategory = linkUrl.searchParams.get("category");
+    const linkSubcategory = linkUrl.searchParams.get("subcategory");
 
     if (
         currentUrl.pathname.endsWith(linkUrl.pathname.split("/").pop()) &&
         currentCategory &&
-        linkUrl.searchParams.get("category") === currentCategory
+        linkCategory === currentCategory &&
+        (!currentSubcategory || linkSubcategory === currentSubcategory)
     ) {
         link.classList.add("active");
         link.setAttribute("aria-current", "page");
@@ -304,7 +390,37 @@ categoryMenuLinks.forEach((link) => {
 
 if (currentCategory) {
     categoryMenuToggle?.classList.add("active");
+
+    const activeCategory = megaMenuCategories.find((category) => {
+        const panel = document.getElementById(
+            category.getAttribute("aria-controls")
+        );
+
+        return panel?.querySelector(
+            `a[href*="category=${encodeURIComponent(currentCategory).replace(/%20/g, "%20")}"]`
+        );
+    });
+
+    if (activeCategory?.dataset.megaCategory) {
+        activateMegaCategory(activeCategory.dataset.megaCategory);
+    }
 }
+
+mobileCategoryAccordions.forEach((accordion) => {
+    const toggle = accordion.querySelector(".mobile-category-toggle");
+    const panel = accordion.querySelector(".mobile-subcategory-panel");
+    const hasCurrentLink = Boolean(panel?.querySelector(".active"));
+
+    if (hasCurrentLink) {
+        accordion.classList.add("is-open");
+        toggle?.setAttribute("aria-expanded", "true");
+    }
+
+    toggle?.addEventListener("click", () => {
+        const isOpen = accordion.classList.toggle("is-open");
+        toggle.setAttribute("aria-expanded", String(isOpen));
+    });
+});
     // notify components ready
     document.dispatchEvent(new CustomEvent("componentsLoaded"));
 }

--- a/frontend/scripts/product-actions.js
+++ b/frontend/scripts/product-actions.js
@@ -276,17 +276,10 @@ async function toggleProductWishlist() {
                     )
             );
 
-<<<<<<< HEAD
-       AppUtils.notify(
-           "Added to wishlist ❤️",
-            "success"
-                    );
-=======
         AppUtils.notify(
           "Added to wishlist ❤️",
             "success"
                         );
->>>>>>> 709f3c7 (fix: improve wishlist toast and frontend scripts)
         
         if (token) {
             try {

--- a/frontend/scripts/recentlyViewed.js
+++ b/frontend/scripts/recentlyViewed.js
@@ -7,11 +7,7 @@ const recentlyViewed =
 // ELEMENTS
 const elements = {
     recentContainer:
-<<<<<<< HEAD
-        AppUtils.$("#recently-viewed-count")
-=======
        AppUtils.$("#recently-viewed-count"),
->>>>>>> 709f3c7 (fix: improve wishlist toast and frontend scripts)
 
     recentCount:
         AppUtils.$("#recently-viewed-count")

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -147,13 +147,16 @@ html, body {
     position: absolute;
     top: calc(100% + 16px);
     left: 0;
-    width: min(300px, 86vw);
-    padding: 10px;
+    display: grid;
+    grid-template-columns: minmax(190px, 0.8fr) minmax(420px, 1.6fr);
+    width: min(780px, calc(100vw - 48px));
+    min-height: 420px;
+    padding: 0;
     border: 1px solid rgba(8, 129, 120, 0.14);
     border-radius: 8px;
     background: var(--white, #ffffff);
     box-shadow: 0 18px 36px rgba(0, 0, 0, 0.14);
-    list-style: none;
+    overflow: hidden;
     opacity: 0;
     pointer-events: none;
     transform: translateY(8px) scale(0.98);
@@ -188,11 +191,116 @@ html, body {
     visibility: visible;
 }
 
+.mega-menu-sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 14px;
+    background: #f6faf9;
+    border-right: 1px solid rgba(8, 129, 120, 0.12);
+}
+
+.mega-menu-category {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    min-height: 40px;
+    padding: 10px 12px;
+    border-radius: 6px;
+    color: var(--text-dark, #222);
+    font-size: 14px;
+    font-weight: 700;
+    text-align: left;
+    white-space: nowrap;
+    transition:
+        background-color 0.2s ease,
+        color 0.2s ease,
+        transform 0.2s ease;
+}
+
+.mega-menu-category i {
+    width: 20px;
+    color: var(--primary-color, #088178);
+    text-align: center;
+}
+
+.mega-menu-category:hover,
+.mega-menu-category:focus-visible,
+.mega-menu-category.is-active {
+    background: #ffffff;
+    color: var(--primary-color, #088178);
+    box-shadow: 0 8px 18px rgba(8, 129, 120, 0.12);
+    transform: translateX(3px);
+}
+
+.mega-menu-category:focus-visible,
+.mega-menu-panel-header a:focus-visible,
+.mobile-category-toggle:focus-visible,
+.mobile-subcategory-panel a:focus-visible {
+    outline: 2px solid var(--primary-color, #088178);
+    outline-offset: 2px;
+}
+
+.mega-menu-content {
+    position: relative;
+    padding: 24px;
+    background:
+        linear-gradient(135deg, rgba(255, 153, 0, 0.08), transparent 34%),
+        #ffffff;
+}
+
+.mega-menu-panel {
+    display: none;
+    min-height: 100%;
+    animation: megaPanelIn 0.2s ease;
+}
+
+.mega-menu-panel.is-active {
+    display: block;
+}
+
+.mega-menu-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding-bottom: 14px;
+    margin-bottom: 18px;
+    border-bottom: 1px solid rgba(8, 129, 120, 0.14);
+}
+
+.mega-menu-panel-header h3 {
+    margin: 0;
+    color: var(--text-dark, #222);
+    font-size: 22px;
+    font-weight: 800;
+    line-height: 1.2;
+}
+
+.mega-menu-panel-header a {
+    color: var(--primary-color, #088178);
+    font-size: 13px;
+    font-weight: 700;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.mega-menu-panel-header a:hover {
+    color: #066663;
+}
+
+.mega-menu-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(150px, 1fr));
+    gap: 10px 14px;
+}
+
 .category-menu-link {
     display: flex;
     align-items: center;
-    min-height: 40px;
-    padding: 10px 12px;
+    min-height: 44px;
+    padding: 11px 12px;
     border-radius: 6px;
     color: var(--text-dark, #222);
     font-size: 14px;
@@ -215,6 +323,31 @@ html, body {
 .category-menu-link:focus-visible {
     outline: 2px solid var(--primary-color, #088178);
     outline-offset: 1px;
+}
+
+@keyframes megaPanelIn {
+    from {
+        opacity: 0;
+        transform: translateX(8px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .category-menu-toggle,
+    .category-menu-dropdown,
+    .mega-menu-category,
+    .mega-menu-panel,
+    .category-menu-link,
+    .mobile-category-toggle,
+    .mobile-subcategory-panel {
+        animation: none;
+        transition: none;
+    }
 }
 
 
@@ -385,6 +518,83 @@ html, body {
 
 .mobile-category-link {
     padding-block: 12px;
+}
+
+.mobile-category-accordion {
+    border: 1px solid rgba(8, 129, 120, 0.12);
+    border-radius: 8px;
+    background: #ffffff;
+    overflow: hidden;
+}
+
+.mobile-category-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    width: 100%;
+    min-height: 48px;
+    padding: 14px 16px;
+    border: 0;
+    background: transparent;
+    color: var(--text-dark, #222);
+    font-size: 15px;
+    font-weight: 700;
+    text-align: left;
+    cursor: pointer;
+}
+
+.mobile-category-toggle span {
+    display: inline-flex;
+    align-items: center;
+    gap: 14px;
+}
+
+.mobile-category-toggle span i {
+    width: 22px;
+    color: var(--primary-color, #088178);
+    text-align: center;
+}
+
+.mobile-category-toggle > i {
+    transition: transform 0.25s ease;
+}
+
+.mobile-category-accordion.is-open .mobile-category-toggle {
+    color: var(--primary-color, #088178);
+}
+
+.mobile-category-accordion.is-open .mobile-category-toggle > i {
+    transform: rotate(180deg);
+}
+
+.mobile-subcategory-panel {
+    max-height: 0;
+    overflow: hidden;
+    border-top: 1px solid transparent;
+    transition: max-height 0.25s ease, border-color 0.25s ease;
+}
+
+.mobile-category-accordion.is-open .mobile-subcategory-panel {
+    max-height: 360px;
+    border-top-color: rgba(8, 129, 120, 0.12);
+}
+
+.mobile-subcategory-panel a {
+    display: block;
+    min-height: 42px;
+    padding: 11px 16px 11px 52px;
+    color: #4f5c5a;
+    font-size: 14px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.mobile-subcategory-panel a:hover,
+.mobile-subcategory-panel a.active {
+    background: rgba(8, 129, 120, 0.1);
+    color: var(--primary-color, #088178);
 }
 
 /* ==================== RESPONSIVE (TABLET & MOBILE) ==================== */
@@ -740,6 +950,45 @@ body.dark-theme .category-menu-link.active {
   color: #39a4d6;
 }
 
+body.dark-theme .mega-menu-sidebar {
+  background: #151515;
+  border-right-color: #333;
+}
+
+body.dark-theme .mega-menu-category {
+  color: #e0e0e0;
+}
+
+body.dark-theme .mega-menu-category i {
+  color: #39a4d6;
+}
+
+body.dark-theme .mega-menu-category:hover,
+body.dark-theme .mega-menu-category:focus-visible,
+body.dark-theme .mega-menu-category.is-active {
+  background: #222;
+  color: #39a4d6;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+}
+
+body.dark-theme .mega-menu-content {
+  background:
+    linear-gradient(135deg, rgba(57, 164, 214, 0.12), transparent 34%),
+    #1a1a1a;
+}
+
+body.dark-theme .mega-menu-panel-header {
+  border-bottom-color: #333;
+}
+
+body.dark-theme .mega-menu-panel-header h3 {
+  color: #ffffff;
+}
+
+body.dark-theme .mega-menu-panel-header a {
+  color: #39a4d6;
+}
+
 /* Desktop nav links */
 body.dark-theme .desktop-nav #navbar-links li a,
 body.dark-theme .desktop-nav #navbar-links li button {
@@ -765,6 +1014,34 @@ body.dark-theme .mobile-link {
   background: #1e1e1e;
   color: #e0e0e0;
   border-color: #333;
+}
+
+body.dark-theme .mobile-category-accordion {
+  background: #1e1e1e;
+  border-color: #333;
+}
+
+body.dark-theme .mobile-category-toggle {
+  color: #e0e0e0;
+}
+
+body.dark-theme .mobile-category-toggle span i,
+body.dark-theme .mobile-category-accordion.is-open .mobile-category-toggle {
+  color: #39a4d6;
+}
+
+body.dark-theme .mobile-category-accordion.is-open .mobile-subcategory-panel {
+  border-top-color: #333;
+}
+
+body.dark-theme .mobile-subcategory-panel a {
+  color: #d0d0d0;
+}
+
+body.dark-theme .mobile-subcategory-panel a:hover,
+body.dark-theme .mobile-subcategory-panel a.active {
+  background: rgba(57, 164, 214, 0.16);
+  color: #39a4d6;
 }
 
 body.dark-theme .mobile-menu-label {


### PR DESCRIPTION
Closes #552

## Summary
- Replaced the existing Menu dropdown with an Amazon-style mega menu using the current navbar.
- Added desktop hover/click panel switching for 10 categories and 57 subcategory links.
- Added tablet/mobile category accordions inside the existing mobile navigation.
- Added keyboard, Escape, outside-click, ARIA state, focus, reduced-motion, and dark-theme support.
- Removed two existing conflict-marker artifacts that caused frontend script parse errors during verification.

## Testing
- node --check frontend/scripts/components.js
- node --check frontend/scripts/product-actions.js
- node --check frontend/scripts/recentlyViewed.js
- Playwright responsive verification on desktop/tablet/mobile: 10 categories, 57 subcategory links, 10 mobile accordions, one navbar, no console/page errors with product API mocked.