### PR TITLE
fix: correct invalid HTML nesting of anchor inside button on homepage banner

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -337,11 +337,11 @@
             <span>
                 The best classic dress is on sale at cara
             </span>
-            <button class="banner-btn">
-                <a href="Buy1Get1.html">
-                View Products
-                </a>
-            </button>
+            <a href="Buy1Get1.html">
+    <button class="banner-btn">
+        View Products
+    </button>
+</a>
         </div>
 
         <div class="banner-box banner-box2">

--- a/frontend/scripts/shop.js
+++ b/frontend/scripts/shop.js
@@ -1073,7 +1073,7 @@ function renderPagination() {
     prevBtn.innerText =
         "← Prev";
 
-    prevBtn.className = 
+    prevBtn.className =
         "pagination-btn";
 
     prevBtn.disabled =


### PR DESCRIPTION
Fixes #481 

## Problem
The "View Products" button on the "Buy 1 Get 1 Free" homepage 
banner had an <a> tag nested inside a <button> tag which is 
invalid HTML per the HTML5 specification. This causes 
inconsistent click behavior across browsers.

## Fix
Swapped the nesting - moved the <a> tag outside the <button>:

Before (Wrong):
<button class="banner-btn">
    <a href="Buy1Get1.html">View Products</a>
</button>

After (Correct):
<a href="Buy1Get1.html">
    <button class="banner-btn">View Products</button>
</a>

## File Changed
- frontend/index.html