### PR TITLE
fix: validate product stock before syncing cart quantities

### DIFF
--- a/backend/controllers/cartController.js
+++ b/backend/controllers/cartController.js
@@ -69,38 +69,54 @@ const cartController = {
 
             await connection.beginTransaction();
 
-            // clear existing cart
+            let placeholders = [];
+            let values = [];
+
+            if (quantities.size) {
+                const ids = [...quantities.keys()];
+
+                const [products] = await connection.query(
+                    `SELECT id, stock FROM products WHERE id IN (${ids.map(() => "?").join(",")})`,
+                    ids
+                );
+
+                const productMap = new Map(
+                    products.map((product) => [
+                        safeNumber(product.id),
+                        safeNumber(product.stock)
+                    ])
+                );
+
+                for (const [productId, qty] of quantities) {
+                    if (!productMap.has(productId)) continue;
+
+                    const availableStock = productMap.get(productId);
+
+                    if (qty > availableStock) {
+                        await connection.rollback();
+
+                        return res.status(400).json({
+                            success: false,
+                            message: `Requested quantity exceeds available stock for product ${productId}`
+                        });
+                    }
+
+                    placeholders.push("(?, ?, ?)");
+                    values.push(userId, productId, qty);
+                }
+            }
+
+            // clear existing cart only after validation succeeds
             await connection.query(
                 "DELETE FROM cart_items WHERE user_id = ?",
                 [userId]
             );
 
-            if (quantities.size) {
-                const ids = [...quantities.keys()];
-
-                // keep only products that still exist
-                const [products] = await connection.query(
-                    `SELECT id FROM products WHERE id IN (${ids.map(() => "?").join(",")})`,
-                    ids
+            if (placeholders.length) {
+                await connection.query(
+                    `INSERT INTO cart_items (user_id, product_id, quantity) VALUES ${placeholders.join(",")}`,
+                    values
                 );
-
-                const validIds = new Set(products.map((p) => p.id));
-
-                const placeholders = [];
-                const values = [];
-
-                for (const [productId, qty] of quantities) {
-                    if (!validIds.has(productId)) continue;
-                    placeholders.push("(?, ?, ?)");
-                    values.push(userId, productId, qty);
-                }
-
-                if (placeholders.length) {
-                    await connection.query(
-                        `INSERT INTO cart_items (user_id, product_id, quantity) VALUES ${placeholders.join(",")}`,
-                        values
-                    );
-                }
             }
 
             await connection.commit();


### PR DESCRIPTION
## Summary

This PR updates the cart sync flow to validate requested cart quantities against current product stock before inserting cart items.

Previously, `syncCart()` only checked whether the referenced products existed and then inserted the requested quantities directly. This allowed cart items to be stored with quantities greater than the available stock.

## Changes Made

- Updated the cart sync product lookup to fetch both `id` and `stock`
- Added stock validation for each requested cart item before insertion
- Return a `400` response when a requested quantity exceeds available stock
- Preserve transaction safety by rolling back the sync when stock validation fails

## Benefits

- Prevents invalid cart quantities from being stored
- Keeps cart contents aligned with current inventory
- Improves checkout reliability by catching stock issues earlier
- Makes cart state more trustworthy for users and clients

## Testing

- Verified that valid cart sync requests still succeed
- Verified that syncing a quantity greater than available stock returns a `400` response
- Verified that the transaction is rolled back and the cart is not partially overwritten when stock validation fails

Closes #609