### PR TITLE
fix: stop exposing internal chat controller errors in API responses

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -59,8 +59,6 @@ const getConversations = async (req, res) => {
     res.status(500).json({
       success: false,
       message: "Failed to fetch conversations",
-      details:
-        process.env.NODE_ENV === "development" ? error.message : undefined,
     });
   }
 };
@@ -106,8 +104,6 @@ const getConversationDetails = async (req, res) => {
     res.status(500).json({
       success: false,
       message: "Failed to fetch conversation details",
-      details:
-        process.env.NODE_ENV === "development" ? error.message : undefined,
     });
   }
 };
@@ -157,9 +153,7 @@ const updateStatus = async (req, res) => {
 
     return res.status(500).json({
       success: false,
-      message: "Failed to update conversation status",
-      details:
-        process.env.NODE_ENV === "development" ? error.message : undefined,
+      message: "Failed to update conversation status"
     });
   }
 };
@@ -214,8 +208,6 @@ const assignAdmin = async (req, res) => {
     return res.status(500).json({
       success: false,
       message: "Failed to assign conversation",
-      details:
-        process.env.NODE_ENV === "development" ? error.message : undefined,
     });
   }
 };


### PR DESCRIPTION
## Summary

This PR updates the chat controller to avoid exposing raw internal error details in API responses.

Previously, several chat controller actions included a `details` field in 500 responses when `NODE_ENV === "development"`, which could return raw `error.message` values to API consumers.

## Changes Made

- Removed the `details` field from 500 responses in the chat controller.
- Kept detailed error information in server-side logs through the existing `console.error(...)` calls.
- Preserved the existing client-facing error messages for chat controller actions.

## Affected Actions

- `getConversations()`
- `getConversationDetails()`
- `updateStatus()`
- `assignAdmin()`

## Benefits

- Reduces exposure of internal backend details in API responses
- Improves security hygiene for chat-related endpoints
- Makes controller error responses more consistent
- Keeps debugging information limited to server-side logs

## Testing

- Verified that chat controller actions still return the same 500 status codes and client-facing error messages on failure
- Verified that internal `error.message` values are no longer included in API responses
- Verified that detailed error information is still available in server logs

Closes #610