### PR TITLE
fix: normalize interaction type before recommendation validation

### DIFF
--- a/backend/controllers/recommendationController.js
+++ b/backend/controllers/recommendationController.js
@@ -1,17 +1,18 @@
 const { asyncHandler, safeInteger, sanitizeString } = require("../utils/helpers");
 const interactionService = require("../services/interactionService");
 const recommendationService = require("../services/recommendationService");
-const {INTERACTION_TYPES} = require("../constants/interactionTypes");
+const { INTERACTION_TYPES } = require("../constants/interactionTypes");
 
 const recordInteraction = asyncHandler(async (req, res) => {
   const userId = req.user.id;
-  const { productId, type } = req.body;
+  const { productId } = req.body;
+  const normalizedType = sanitizeString(req.body.type || "").trim().toLowerCase();
 
-  if (!Object.values(INTERACTION_TYPES).includes(type)) {
+  if (!Object.values(INTERACTION_TYPES).includes(normalizedType)) {
     return res.status(400).json({
       success: false,
-      message: "Invalid interaction type"
-    })
+      message: "Invalid interaction type",
+    });
   }
 
   if (!productId) {
@@ -21,7 +22,7 @@ const recordInteraction = asyncHandler(async (req, res) => {
     });
   }
 
-  await interactionService.recordInteraction(userId, productId, type);
+  await interactionService.recordInteraction(userId, productId, normalizedType);
 
   return res.status(200).json({
     success: true,


### PR DESCRIPTION
## Summary

This PR updates the recommendation controller to normalize interaction type input before validating it against the shared interaction type constants.

Previously, `recordInteraction()` validated the raw `req.body.type` value directly, which made validation sensitive to harmless formatting differences such as extra whitespace or casing differences.

## Changes Made

- Normalized the incoming interaction type using the existing sanitization helper
- Trimmed surrounding whitespace from the interaction type
- Converted the interaction type to lowercase before validation
- Validated the normalized value against `INTERACTION_TYPES`
- Passed the normalized interaction type to `interactionService.recordInteraction()`

## Benefits

- Prevents unnecessary validation failures caused by harmless formatting differences
- Makes recommendation interaction validation more robust
- Reuses the project’s existing sanitization pattern
- Improves consistency in request validation behavior

## Testing

- Verified that valid interaction types like `"purchase"` still work
- Verified that inputs such as `"purchase "` and `"VIEW"` are normalized and accepted correctly
- Verified that invalid interaction types still return a `400` response

Closes #611