### PR TITLE
feat: add "Continue Shopping" button on cart page #398

### DIFF
--- a/frontend/cart.html
+++ b/frontend/cart.html
@@ -271,6 +271,10 @@
                 Empty Cart
             </button>
 
+            <button id="continue-shopping-btn" onclick="window.location.href='shop.html'">
+                ← Continue Shopping
+            </button>
+
             <button id="checkout-btn">
 
                 Proceed to Checkout

--- a/frontend/styles/cart.css
+++ b/frontend/styles/cart.css
@@ -227,6 +227,37 @@
     box-shadow: 0 10px 25px rgba(0,0,0,0.12);
 }
 
+#continue-shopping-btn {
+    width: 100%;
+    background: transparent;
+    color: #088178;
+    border: 2px solid #088178;
+    padding: 13px;
+    border-radius: 6px;
+    cursor: pointer;
+    margin-top: 12px;
+    font-size: 16px;
+    font-weight: 500;
+    transition: 0.3s ease;
+}
+
+#continue-shopping-btn:hover {
+    background: #088178;
+    color: #fff;
+    transform: translateY(-2px);
+    box-shadow: 0 10px 25px rgba(0,0,0,0.12);
+}
+
+body.dark-theme #continue-shopping-btn {
+    color: #088178;
+    border-color: #088178;
+}
+
+body.dark-theme #continue-shopping-btn:hover {
+    background: #088178;
+    color: #fff;
+}
+
 .empty-cart{
     text-align: center;
     padding: 50px 20px;


### PR DESCRIPTION
## Summary

Closes #398

Adds a "← Continue Shopping" button on the cart page that navigates
back to the shop, giving users a clear secondary action alongside
"Proceed to Checkout".

## Problem

The cart page only had one action — "Proceed to Checkout". Users who
wanted to keep browsing had to use the browser back button or manually
navigate, breaking the natural shopping flow.

## Changes

**`frontend/cart.html`**
- Added `#continue-shopping-btn` above the checkout button
- Uses `onclick="window.location.href='shop.html'"` for navigation

**`frontend/styles/cart.css`**
- Styled as a secondary outline button (transparent background,
  teal border) so it doesn't compete visually with the primary
  checkout button
- Hover state fills with teal to match site theme
- Dark theme aware

## Testing

- [x] Button visible on cart page above "Proceed to Checkout"
- [x] Click navigates to shop.html
- [x] Outline style doesn't compete with primary checkout button
- [x] Hover fills correctly in both light and dark mode