### PR TITLE
fix: deduplicate product IDs in batch wishlist additions

### DIFF
--- a/backend/controllers/wishlistController.js
+++ b/backend/controllers/wishlistController.js
@@ -262,12 +262,14 @@ const wishlistController = {
     // ==================== BATCH ADD TO WISHLIST ====================
     batchAddToWishlist: async (req, res) => {
         const connection = await promisePool.getConnection();
+
         try {
             const userId = req.user.id;
             const { productIds } = req.body;
+            const uniqueProductIds = [...new Set(productIds.map((id) => safeNumber(id)))];
 
             // Validate batch
-            const validation = validateBatchOperation(productIds);
+            const validation = validateBatchOperation(uniqueProductIds);
             if (!validation.valid) {
                 return res.status(400).json({
                     success: false,
@@ -277,17 +279,17 @@ const wishlistController = {
 
             await connection.beginTransaction();
 
-            const results = [];
             const added = [];
             const alreadyExist = [];
             const notFound = [];
 
-            for (const productId of productIds) {
+            for (const productId of uniqueProductIds) {
                 // Check if product exists and is active
                 const [product] = await connection.query(
                     'SELECT id FROM products WHERE id = ? AND is_active = 1',
                     [productId]
                 );
+
                 if (!product.length) {
                     notFound.push(productId);
                     continue;
@@ -298,6 +300,7 @@ const wishlistController = {
                     'SELECT id FROM wishlist_items WHERE user_id = ? AND product_id = ?',
                     [userId, productId]
                 );
+
                 if (existing.length) {
                     alreadyExist.push(productId);
                     continue;
@@ -308,6 +311,7 @@ const wishlistController = {
                     'INSERT INTO wishlist_items (user_id, product_id, created_at) VALUES (?, ?, NOW())',
                     [userId, productId]
                 );
+
                 added.push(productId);
             }
 
@@ -316,22 +320,25 @@ const wishlistController = {
             // Invalidate cache
             invalidateCache(userId);
 
-            logger.info(`Batch add: ${added.length} added, ${alreadyExist.length} existing, ${notFound.length} not found`);
+            logger.info(
+                `Batch add: ${added.length} added, ${alreadyExist.length} existing, ${notFound.length} not found`
+            );
 
             return res.status(200).json({
                 success: true,
                 message: `Added ${added.length} products to wishlist`,
                 data: {
-                    added: added,
-                    alreadyExist: alreadyExist,
-                    notFound: notFound,
-                    totalProcessed: productIds.length
+                    added,
+                    alreadyExist,
+                    notFound,
+                    totalProcessed: uniqueProductIds.length
                 }
             });
 
         } catch (error) {
             await connection.rollback();
             logger.error(`BATCH ADD TO WISHLIST ERROR: ${error.message}`);
+
             return res.status(500).json({
                 success: false,
                 message: "Failed to add products to wishlist"
@@ -812,7 +819,7 @@ const wishlistController = {
         try {
             const userId = req.user.id;
             invalidateCache(userId);
-            
+
             return res.status(200).json({
                 success: true,
                 message: 'Wishlist cache cleared'


### PR DESCRIPTION
## Summary

This PR updates the batch wishlist add flow to deduplicate incoming product IDs before processing them.

Previously, `batchAddToWishlist()` iterated over the raw `productIds` array, which meant the same product could be processed multiple times in a single request if duplicate IDs were submitted.

## Changes Made

- Normalized and deduplicated incoming `productIds` before processing
- Ran batch validation against the deduplicated product ID list
- Updated the batch add loop to process each unique product ID at most once per request
- Updated `totalProcessed` to reflect the deduplicated input set

## Benefits

- Prevents repeated processing of the same product in a single batch request
- Reduces unnecessary product existence and wishlist existence queries
- Makes batch wishlist results cleaner and more predictable
- Improves efficiency of the batch wishlist add flow

## Testing

- Verified that duplicate product IDs in the same request are processed only once
- Verified that valid unique product IDs still behave as before
- Verified that response fields such as `added`, `alreadyExist`, `notFound`, and `totalProcessed` remain aligned with the deduplicated input set

Closes #613