### PR TITLE
fix: Add Railway URL to CORS allowed origins (#665)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -165,7 +165,8 @@ const allowedOrigins = [
     "http://172.18.208.1:5502",
     FRONTEND_URL,
     "https://e-commerce-git-main-bhuvanshs-projects.vercel.app",
-    "https://www.bhuvansh.xyz"
+    "https://www.bhuvansh.xyz",
+    "https://e-commerce-production-d546.up.railway.app"
 ];
 
 // initialize websocket server with CORS


### PR DESCRIPTION
## Fixes #665

**Bug:** CORS URL mismatch - Frontend uses Railway API but backend only allows Vercel origin.

**Fix:** Added Railway production URL to backend CORS allowedOrigins:
- Added: https://e-commerce-production-d546.up.railway.app

**Files changed:** backend/server.js