### PR TITLE
test: Add tests for auth middleware and product sanitization (fixes #664, #666)

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+    testEnvironment: 'node',
+    coverageDirectory: 'coverage',
+    collectCoverageFrom: [
+        '**/*.js',
+        '!node_modules/**'
+    ],
+    testMatch: [
+        '**/tests/**/*.test.js'
+    ]
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "jest --coverage"
   },
   "keywords": [],
   "author": "",
@@ -29,6 +30,7 @@
     "socket.io": "^4.8.3"
   },
   "devDependencies": {
+    "jest": "^29.7.0",
     "nodemon": "^3.1.14"
   }
 }

--- a/backend/tests/authMiddleware.test.js
+++ b/backend/tests/authMiddleware.test.js
@@ -1,0 +1,72 @@
+const { authMiddleware, optionalAuth } = require('../middleware/authMiddleware');
+const jwt = require('jsonwebtoken');
+
+describe('authMiddleware', () => {
+    let mockReq, mockRes, mockNext;
+
+    beforeEach(() => {
+        mockReq = { headers: {} };
+        mockRes = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn().mockReturnThis()
+        };
+        mockNext = jest.fn();
+    });
+
+    it('should reject request without authorization header', () => {
+        authMiddleware(mockReq, mockRes, mockNext);
+        expect(mockRes.status).toHaveBeenCalledWith(401);
+        expect(mockRes.json).toHaveBeenCalledWith({
+            success: false,
+            message: 'Authorization header required'
+        });
+        expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should accept valid Bearer token', () => {
+        const token = jwt.sign({ userId: 1 }, 'test-secret');
+        mockReq.headers.authorization = `Bearer ${token}`;
+        
+        authMiddleware(mockReq, mockRes, mockNext);
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockReq.user).toBeDefined();
+    });
+
+    it('should reject invalid token', () => {
+        mockReq.headers.authorization = 'Bearer invalid-token';
+        
+        authMiddleware(mockReq, mockRes, mockNext);
+        expect(mockRes.status).toHaveBeenCalledWith(401);
+        expect(mockRes.json).toHaveBeenCalledWith({
+            success: false,
+            message: 'Invalid or expired token'
+        });
+    });
+});
+
+describe('optionalAuth', () => {
+    let mockReq, mockRes, mockNext;
+
+    beforeEach(() => {
+        mockReq = { headers: {} };
+        mockRes = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn().mockReturnThis()
+        };
+        mockNext = jest.fn();
+    });
+
+    it('should call next without token', () => {
+        optionalAuth(mockReq, mockRes, mockNext);
+        expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('should attach user with valid token', () => {
+        const token = jwt.sign({ userId: 1 }, 'test-secret');
+        mockReq.headers.authorization = `Bearer ${token}`;
+        
+        optionalAuth(mockReq, mockRes, mockNext);
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockReq.user).toBeDefined();
+    });
+});

--- a/backend/tests/productSanitization.test.js
+++ b/backend/tests/productSanitization.test.js
@@ -1,0 +1,60 @@
+describe('Product Search Input Sanitization', () => {
+    // Test the sanitization logic used in getProductSuggestions
+    
+    function sanitizeSearchInput(keyword) {
+        if (!keyword || keyword.trim() === '') {
+            return null;
+        }
+        const sanitized = keyword.trim().slice(0, 100).replace(/[%_\\]/g, '\\$&');
+        return `%${sanitized}%`;
+    }
+
+    describe('Input Validation', () => {
+        test('should return null for empty input', () => {
+            expect(sanitizeSearchInput('')).toBeNull();
+        });
+
+        test('should return null for whitespace only', () => {
+            expect(sanitizeSearchInput('   ')).toBeNull();
+        });
+
+        test('should return null for null input', () => {
+            expect(sanitizeSearchInput(null)).toBeNull();
+        });
+    });
+
+    describe('Basic Sanitization', () => {
+        test('should trim whitespace', () => {
+            const result = sanitizeSearchInput('  laptop  ');
+            expect(result).toBe('%laptop%');
+        });
+
+        test('should limit to 100 characters', () => {
+            const longInput = 'a'.repeat(150);
+            const result = sanitizeSearchInput(longInput);
+            expect(result.length).toBeLessThanOrEqual(102); // % + 100 chars + %
+        });
+    });
+
+    describe('LIKE Special Character Escaping', () => {
+        test('should escape percent sign', () => {
+            const result = sanitizeSearchInput('100%');
+            expect(result).toBe('%100\\%%');
+        });
+
+        test('should escape underscore', () => {
+            const result = sanitizeSearchInput('laptop_2024');
+            expect(result).toBe('%laptop\\_2024%');
+        });
+
+        test('should escape backslash', () => {
+            const result = sanitizeSearchInput('path\\file');
+            expect(result).toBe('%path\\\\file%');
+        });
+
+        test('should escape multiple special chars', () => {
+            const result = sanitizeSearchInput('%_\\%_');
+            expect(result).toBe('%\\%\\_\\\\%_');
+        });
+    });
+});


### PR DESCRIPTION
Add test files for the fixes:
- backend/tests/authMiddleware.test.js - JWT authentication tests
- backend/tests/productSanitization.test.js - Search input validation tests

References: #666, #664

Signed-off-by: saidai-bhuvanesh <saidai.bhuvanesh@gmail.com>