### PR TITLE
fix: 6 homepage promotional banner links returning 404 on live site #396

### DIFF
--- a/frontend/sitemap.xml
+++ b/frontend/sitemap.xml
@@ -48,4 +48,16 @@
     <loc>https://www.bhuvansh.xyz/tshirt.html</loc>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://www.bhuvansh.xyz/mens.html</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.bhuvansh.xyz/womens.html</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.bhuvansh.xyz/Buy1Get1.html</loc>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,4 +1,14 @@
 {
+  
+  "routes": [
+    { "src": "/Buy1Get1.html", "dest": "/Buy1Get1.html" },
+    { "src": "/mens.html", "dest": "/mens.html" },
+    { "src": "/womens.html", "dest": "/womens.html" },
+    { "src": "/seasonal.html", "dest": "/seasonal.html" },
+    { "src": "/early_summer.html", "dest": "/early_summer.html" },
+    { "src": "/tshirt.html", "dest": "/tshirt.html" }
+  ],
+  
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary

Closes #396

Fixes all 6 promotional banner/CTA links on the homepage returning 404
on the live Vercel deployment.

## Root Cause

All 6 pages exist in the repository (`Buy1Get1.html`, `mens.html`,
`womens.html`, `seasonal.html`, `early_summer.html`, `tshirt.html`)
and work correctly locally. The 404s on the live site are caused by
Vercel not having explicit routes defined for these pages in
`vercel.json` — without explicit routes, Vercel's router doesn't
resolve them correctly from the `frontend/` root directory.

Additionally, `sitemap.xml` was missing 3 of the 6 pages (`mens.html`,
`womens.html`, `Buy1Get1.html`), meaning they were invisible to search
engines.

## Changes

**`frontend/vercel.json`**
- Added explicit `routes` array mapping all 6 promotional pages to
  their correct destinations so Vercel resolves them correctly

**`frontend/sitemap.xml`**
- Added missing `mens.html`, `womens.html`, `Buy1Get1.html` entries
  with appropriate priority values

## Testing

- [x] All 6 pages open correctly on `localhost:5500`
- [x] Homepage banner links navigate to correct pages locally
- [x] `vercel.json` is valid JSON
- [x] Live 404 fix will be confirmed after merge and Vercel redeploy