### PR TITLE
fix: make specific crawler matching case-insensitive

### DIFF
--- a/backend/middleware/aiCrawlerMiddleware.js
+++ b/backend/middleware/aiCrawlerMiddleware.js
@@ -1,6 +1,6 @@
 // backend/middleware/aiCrawlerMiddleware.js
 const aiCrawlerVerification = require('../services/aiCrawlerVerificationService');
-const {db} = require("../config/db");
+const { db } = require("../config/db");
 
 /**
  * Middleware to verify AI crawlers
@@ -54,15 +54,17 @@ async function verifyAICrawler(req, res, next) {
  * Middleware to verify specific crawlers
  */
 async function verifySpecificCrawler(crawlerType) {
-    return async function(req, res, next) {
+    return async function (req, res, next) {
         try {
             const userAgent = req.headers['user-agent'] || '';
-            
+
             // Check if User-Agent matches target crawler
-            if (!userAgent.includes(crawlerType)) {
+            const normalizedUserAgent = String(userAgent || "").toLowerCase();
+            const normalizedCrawlerType = String(crawlerType || "").toLowerCase();
+
+            if (!normalizedUserAgent.includes(normalizedCrawlerType)) {
                 return next();
             }
-
             // Verify the crawler
             const verification = await aiCrawlerVerification.verifyCrawler(req);
 
@@ -90,7 +92,7 @@ async function verifySpecificCrawler(crawlerType) {
 async function blockSuspiciousIPs(req, res, next) {
     try {
         const ip = req.ip || req.connection.remoteAddress || 'unknown';
-        
+
         // Check if IP is blocked
         const [blocked] = await db.query(
             'SELECT * FROM blocked_ips WHERE ip_address = ? AND blocked_at > DATE_SUB(NOW(), INTERVAL 7 DAY)',


### PR DESCRIPTION
## Summary

This PR updates `verifySpecificCrawler(crawlerType)` to perform case-insensitive crawler matching.

Previously, the middleware used a case-insensitive regular expression in `verifyAICrawler()` but relied on a case-sensitive `userAgent.includes(crawlerType)` check in `verifySpecificCrawler()`. This could cause valid crawler user agents to be skipped when letter casing differed.

## Changes Made

- Normalized the request user-agent string before matching
- Normalized the expected `crawlerType` before matching
- Updated `verifySpecificCrawler()` to use a case-insensitive substring comparison

## Benefits

- Makes crawler matching behavior consistent across the middleware
- Prevents valid crawler matches from being skipped due to case differences
- Improves reliability of specific crawler verification
- Makes the matching logic easier to understand and maintain

## Testing

- Verified that crawler matching still works for exact-case inputs
- Verified that case variations such as `chatgpt`, `ChatGPT`, and `CHATGPT` now match consistently
- Verified that non-matching user agents still pass through unchanged

Closes #682