### PR TITLE
feat: add confirm password validation to signup flow

### DIFF
--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -61,10 +61,10 @@ router.post(
     applyCaptchaCheck,
     detectSyntheticIdentity,  // ✅ FRAUD DETECTION ADDED
     (req, res, next) => {
-        const { name, email, password, age } = req.body;
+        const { name, email, password, confirmPassword, age } = req.body;
 
         // Validate all required fields
-        const validationError = validateRequiredFields(req, res, ['name', 'email', 'password']);
+        const validationError = validateRequiredFields(req, res, ['name', 'email', 'password', 'confirmPassword']);
         if (validationError) return validationError;
 
         // Additional validations
@@ -79,6 +79,13 @@ router.post(
             return res.status(400).json({
                 success: false,
                 message: "Password must be at least 6 characters long"
+            });
+        }
+
+        if (password !== confirmPassword) {
+            return res.status(400).json({
+                success: false,
+                message: "Passwords do not match"
             });
         }
 

--- a/frontend/scripts/auth.js
+++ b/frontend/scripts/auth.js
@@ -20,6 +20,7 @@ const elements = {
     signupName: document.getElementById("signup-name"),
     signupEmail: document.getElementById("signup-email"),
     signupPassword: document.getElementById("signup-password"),
+    signupConfirmPassword: document.getElementById("signup-confirm-password"),
     signinEmail: document.getElementById("signin-email"),
     signinPassword: document.getElementById("signin-password"),
     authLink: document.getElementById("auth-link"),
@@ -206,10 +207,10 @@ function resetOtpTimer(buttonId, timerId) {
 }
 
 // ==================== API CALLS ====================
-async function signupUser(name, email, password) {
+async function signupUser(name, email, password, confirmPassword) {
     return await AppUtils.apiRequest("/auth/signup", {
         method: "POST",
-        body: JSON.stringify({ name, email, password })
+        body: JSON.stringify({ name, email, password, confirmPassword })
     });
 }
 
@@ -305,6 +306,7 @@ if (elements.signupForm) {
         const name = elements.signupName.value.trim();
         const email = elements.signupEmail.value.trim();
         const password = elements.signupPassword.value;
+        const confirmPassword = elements.signupConfirmPassword?.value || "";
 
         if (!name) {
             AppUtils.notify("Name is required.", "error");
@@ -313,6 +315,11 @@ if (elements.signupForm) {
 
         if (!emailRegex.test(email)) {
             AppUtils.notify("Enter a valid email.", "error");
+            return;
+        }
+
+        if (password !== confirmPassword) {
+            AppUtils.notify("Passwords do not match. Please try again.", "error");
             return;
         }
 
@@ -327,7 +334,7 @@ if (elements.signupForm) {
         toggleFormLoading(submitBtn, true, "Sending OTP...");
 
         try {
-            const response = await signupUser(name, email, password);
+            const response = await signupUser(name, email, password, confirmPassword);
 
             if (response.success) {
                 AppUtils.notify("OTP sent to your email!", "success");
@@ -408,7 +415,7 @@ if (otpForm) {
             const password = elements.signupPassword.value;
             
             try {
-                const response = await signupUser(name, email, password);
+                const response = await signupUser(name, email, password, elements.signupConfirmPassword?.value || "");
                 if (response.success) {
                     AppUtils.notify("OTP resent successfully!", "success");
                     startOtpTimer('resend-signup-otp-link', 'resend-signup-timer');

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -145,6 +145,27 @@
                     <div id="password-strength-tips" style="font-size: 0.8rem; color: #888; margin-top: 4px; min-height: 20px;"></div>
                 </div>
 
+                <!-- Confirm Password -->
+                <div class="password-field">
+                    <input
+                        type="password"
+                        id="signup-confirm-password"
+                        name="confirmPassword"
+                        placeholder="Confirm Password"
+                        autocomplete="new-password"
+                        required
+                    >
+                    <button
+                        type="button"
+                        class="password-toggle"
+                        aria-label="Show password"
+                        aria-pressed="false"
+                    >
+                        <i class="fas fa-eye" aria-hidden="true"></i>
+                    </button>
+                    <span class="countdown-indicator" style="display:none;"></span>
+                </div>
+
                 <button
                     type="submit"
                     class="auth-btn"


### PR DESCRIPTION
## Summary

This PR adds a Confirm Password field to the sign-up form and validates that both password entries match before account registration can proceed.
Fixes #677

## What Changed

- Added a **Confirm Password** input below the Password field.
- Implemented client-side validation to prevent form submission when passwords do not match.
- Displayed a clear validation message for mismatched passwords.
- Sent `confirmPassword` in the signup request.
- Added server-side validation to ensure passwords match before account creation.

## Why

This prevents accidental password typos during registration, improves user experience, and enforces validation on both the client and server.

## Testing

- Verified matching passwords allow registration.
- Verified mismatched passwords block registration with an appropriate error message.
- Confirmed there are no editor-reported issues in the modified files.