### PR TITLE
fix #765: Wishlist cache invalidation broken

### DIFF
--- a/backend/controllers/wishlistController.js
+++ b/backend/controllers/wishlistController.js
@@ -38,8 +38,13 @@ function setCache(userId, page, limit, data) {
 }
 
 function invalidateCache(userId) {
-    const key = getCacheKey(userId);
-    cache.delete(key);
+    // Delete all cache keys that match this user's prefix
+    const prefix = `wishlist:${userId}:`;
+    for (const key of cache.keys()) {
+        if (key.startsWith(prefix)) {
+            cache.delete(key);
+        }
+    }
     logger.debug(`Cache invalidated for user: ${userId}`);
 }
 


### PR DESCRIPTION
## Issue #765: Wishlist Cache Invalidation is Broken

### Bug Description
The `invalidateCache` function in `wishlistController.js` doesn't properly clear cached wishlist data.

### Root Cause
```javascript
// getCacheKey requires 3 parameters
function getCacheKey(userId, page, limit) {
    return `wishlist:${userId}:page:${page}:limit:${limit}`;
}

// invalidateCache only passes userId - WRONG!
function invalidateCache(userId) {
    const key = getCacheKey(userId);  // ❌ Missing page and limit!
    cache.delete(key);
}
```

### Solution
```javascript
function invalidateCache(userId) {
    // Delete all cache keys matching user's prefix
    const prefix = `wishlist:${userId}:`;
    for (const key of cache.keys()) {
        if (key.startsWith(prefix)) {
            cache.delete(key);
        }
    }
}
```

### Impact
- **Before**: Users see stale wishlist data after adding/removing items
- **After**: Cache is properly invalidated, users see fresh data

### Changes Made
- `backend/controllers/wishlistController.js`: Fixed cache invalidation

---
Closes #765