### PR TITLE
fix(signature): guard invalid signature preview logging

### DIFF
--- a/backend/utils/signatureVerification.js
+++ b/backend/utils/signatureVerification.js
@@ -74,7 +74,11 @@ function verifyClaudeSignature(signature, body, secret, options = {}) {
         validateBody(body);
 
         if (!validateSignature(signature)) {
-            console.warn('Invalid signature format', { signature: signature.substring(0, 10) });
+            console.warn('Invalid signature format', {
+                signature: typeof signature === 'string'
+                    ? signature.substring(0, 10)
+                    : 'invalid'
+            });
             return false;
         }
 
@@ -159,7 +163,7 @@ function isTrustedAgent(req) {
         }
 
         const signature = req.headers[config.signatureHeader] ||
-                         req.headers['x-claude-signature'];
+            req.headers['x-claude-signature'];
 
         if (!signature) {
             console.warn('Missing signature header', {


### PR DESCRIPTION
## Summary

This PR fixes invalid-signature logging in `backend/utils/signatureVerification.js`.

Previously, `verifyClaudeSignature()` rejected invalid signatures through `validateSignature(signature)`, but the invalid-signature log path still assumed `signature` was always a string:

```js
console.warn('Invalid signature format', { signature: signature.substring(0, 10) });
```

If `signature` was missing or non-string, calling `.substring()` could itself throw before the helper returned `false`.

## Changes Made

- Guarded the invalid-signature preview log with a string type check
- Added a safe fallback value for missing or non-string signatures

## Example

### Before
```js
if (!validateSignature(signature)) {
    console.warn('Invalid signature format', { signature: signature.substring(0, 10) });
    return false;
}
```

### After
```js
if (!validateSignature(signature)) {
    console.warn('Invalid signature format', {
        signature: typeof signature === 'string'
            ? signature.substring(0, 10)
            : 'invalid'
    });
    return false;
}
```

## Benefits

- Prevents avoidable runtime errors during invalid-signature logging
- Keeps malformed signature handling on the intended `return false` path
- Makes the logging branch consistent with the helper’s defensive validation behavior

## Testing

- Verified that valid signatures are unaffected
- Verified that missing or non-string signatures no longer cause `.substring()` errors in the logging path
- Verified that invalid signatures still return `false` as expected

Closes #726