### PR TITLE
feat: add chevron dropdown indicator icon to Menu button #752

### DIFF
--- a/frontend/components/navbar.html
+++ b/frontend/components/navbar.html
@@ -28,7 +28,7 @@
   <!-- Desktop Navigation -->
   <nav class="desktop-nav">
     <ul id="navbar-links" class="nav-links">
-      <li class="category-menu-item">
+      <li class="category-menu-item">  
         <button
           id="category-menu-toggle"
           class="category-menu-toggle"
@@ -38,7 +38,9 @@
         >
           <i class="fas fa-bars" aria-hidden="true"></i>
           Menu
+          <i class="fas fa-chevron-down dropdown-indicator" aria-hidden="true"></i>
         </button>
+     
         <div
           id="category-menu-dropdown"
           class="category-menu-dropdown"

--- a/frontend/styles/style.css
+++ b/frontend/styles/style.css
@@ -317,5 +317,13 @@
     color: #27ae60 !important;
 }
 
-/* =============================
-Breadcrumb Navigation (Issue #344)
+
+.category-menu-toggle .dropdown-indicator {
+    margin-left: 8px;
+    font-size: 11px;
+    color: #666;
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.category-menu-toggle[aria-expanded="true"] .dropdown-indicator {
+    transform: rotate(180deg);
+}


### PR DESCRIPTION
## Description
Closes #752

Added a dropdown indicator icon (Chevron Down) next to the "Menu" label in the navigation bar. This provides a clear visual cue to users that the menu item expands into a dropdown, improving discoverability and making the navigation more intuitive.

## Changes Made
- **HTML**: Added a `<i class="fas fa-chevron-down dropdown-indicator"></i>` icon inside the `#category-menu-toggle` button, placed immediately after the "Menu" text.
- **CSS**:
  - Styled the dropdown indicator with proper spacing (`margin-left: 8px`), size, and color.
  - Added a smooth `0.3s` transition for rotation.
  - Leveraged the existing `aria-expanded` attribute to control the icon's state. When `aria-expanded="true"`, the icon smoothly rotates `180deg` to point upwards, visually signaling that the menu is open.
- **No Functional Changes**: Existing menu toggle behavior and JavaScript logic remain intact.

## Benefits
- ✅ **Improved discoverability**: Users can immediately recognize that the "Menu" item contains a dropdown.
- ✅ **Better UX**: Provides instant visual feedback when the menu is opened/closed via the animated chevron.
- ✅ **Cleaner interface**: The icon matches the existing design and aligns perfectly with the navbar layout.