### PR TITLE
fix: remove old purple conflicting css and apply teal theme #753

### DIFF
--- a/frontend/styles/contact.css
+++ b/frontend/styles/contact.css
@@ -417,37 +417,43 @@ body.dark-theme .ratings-right h2 {
     }
 }
 
-/* Universal Form Field Override - Smooth Pastel Lilac */
-.form-left input, 
+
+/* LIGHT MODE Inputs & Textareas */
+.form-left input,
 .form-left textarea,
 .form-left .form-control,
 .form-left .input-field {
-    background: #ebdfff !important;       
-    background-color: #ebdfff !important; 
-    border: 1px solid #dcd0f0 !important; 
-    color: #222222 !important;            
+    background: #f0fcfb !important;
+    /* Very light teal background */
+    background-color: #f0fcfb !important;
+    border: 1px solid #b2dfdb !important;
+    /* Soft teal border */
+    color: #222222 !important;
 }
 
-.form-left input:focus, 
+.form-left input:focus,
 .form-left textarea:focus {
-    background: #e2d4f7 !important;       
-    background-color: #e2d4f7 !important;
-    border-color: #c4b3e6 !important;     
+    background: #e0f2f1 !important;
+    /* Slightly darker teal on focus */
+    background-color: #e0f2f1 !important;
+    border-color: #80cbc4 !important;
+    /* Darker teal border on focus */
 }
 
-/* Update the Submit Feedback Button to a Sleek Purple Palette */
+/* Update the Submit Feedback Button to match Teal theme */
 .form-left button,
 .form-left input[type="submit"],
 .form-left .btn,
 #submit-feedback,
 .form-left button[type="submit"] {
-    background-color: #6d44b8 !important; 
-    color: #ffffff !important;             
+    background-color: #088178 !important;
+    /* Updated to website's primary teal */
+    color: #ffffff !important;
     border: none !important;
     padding: 12px 30px !important;
     font-size: 16px !important;
     font-weight: 600 !important;
-    border-radius: 8px !important;         
+    border-radius: 8px !important;
     cursor: pointer !important;
     transition: background-color 0.3s ease, transform 0.2s ease !important;
 }
@@ -456,10 +462,32 @@ body.dark-theme .ratings-right h2 {
 .form-left input[type="submit"]:hover,
 .form-left .btn:hover,
 .form-left button[type="submit"]:hover {
-    background-color: #855cd6 !important; 
-    transform: translateY(-1px) !important; 
+    background-color: #06655e !important;
+    /* Darker teal on hover */
+    transform: translateY(-1px) !important;
 }
 
+body.dark-theme .form-left input,
+body.dark-theme .form-left textarea {
+    background: #1a2e2c !important;
+    /* Very dark teal background */
+    background-color: #1a2e2c !important;
+    border-color: #2f5d58 !important;
+    /* Dark teal border */
+    color: #f0f0f0 !important;
+}
+
+body.dark-theme .form-left input::placeholder,
+body.dark-theme .form-left textarea::placeholder {
+    color: #8aa8a5 !important;
+}
+
+body.dark-theme .form-left input:focus,
+body.dark-theme .form-left textarea:focus {
+    background: #24403d !important;
+    /* Slightly lighter dark teal on focus */
+    border-color: #429188 !important;
+}
 /* ========================================================
    LIGHT THEME STYLES (Default / Standard Page View)
 ======================================================== */
@@ -571,6 +599,7 @@ body.dark-theme #contact-details .details span {
 body.dark-theme #contact-details .details li p,
 body.dark-theme #contact-details .details li i {
     color: #c0c0c0 !important;
+}
 /* ── DARK MODE MISSING FIXES ── */
 body.dark-theme #contact-details {
     background: #121212 !important;


### PR DESCRIPTION
## Description
Closes #753

Aligned the contact form input background and border colors with the website's existing green/teal color palette. The previous purple/lilac inputs were visually inconsistent with the rest of the UI and made the section feel disconnected from the overall design system.

## Changes Made
- **Removed conflicting old styles**: Deleted the hardcoded "Smooth Pastel Lilac" (`#ebdfff`) and dark purple (`#2a2a3e`) CSS blocks that were conflicting with the new theme.
- **Updated Light Mode Inputs**: Replaced the purple input background with a soft light teal (`#f0fcfb`) and updated the border color to a matching soft teal (`#b2dfdb`).
- **Updated Focus States**: Modified the input focus background to a slightly darker teal (`#e0f2f1`) and the focus border to a stronger teal (`#80cbc4`).
- **Updated Dark Mode Inputs**: Created dedicated dark teal styles for dark mode, using a deep teal background (`#1a2e2c`), teal borders (`#2f5d58`), and high-contrast text/placeholder colors.
- **Updated Button Color**: Changed the "Submit Feedback" button from purple (`#6d44b8`) to the primary teal (`#088178`), making it consistent with the rest of the website's call-to-action buttons.

## Benefits
- ✅ **Design consistency**: The contact form now perfectly matches the green/teal aesthetic of the website.
- ✅ **Improved UX**: Focus states are clearly visible and maintain a premium, cohesive look.
- ✅ **Dark mode support**: Inputs have been carefully optimized for readability in both light and dark themes.
- ✅ **Cleaner code**: Removed redundant and conflicting CSS rules using `!important`.

## screenshot
<img width="1543" height="771" alt="image" src="https://github.com/user-attachments/assets/08e18cce-04f0-4d4e-a180-68743660c29a" />
