### PR TITLE
fix(socket): enforce max connections by tracking multiple socket ids per user

### DIFF
--- a/backend/utils/socketManager.js
+++ b/backend/utils/socketManager.js
@@ -52,10 +52,9 @@ const initSocket = (server, allowedOrigins) => {
             socket.userId = decoded.id;
             socket.userRole = decoded.role || 'customer';
 
-            const userConnections = Array.from(userSockets.entries())
-                .filter(([userId]) => userId === socket.userId);
+            const existingSockets = userSockets.get(socket.userId) || new Set();
 
-            if (userConnections.length >= MAX_CONNECTIONS_PER_USER) {
+            if (existingSockets.size >= MAX_CONNECTIONS_PER_USER) {
                 logger.warn(`User ${socket.userId} exceeded max connections`);
                 return next(new Error("Too many connections"));
             }
@@ -73,9 +72,19 @@ const initSocket = (server, allowedOrigins) => {
 
         logger.info(`User connected: ${userId} (${userRole}) - Socket: ${socket.id}`);
 
-        userSockets.set(userId, socket.id);
+        if (!userSockets.has(userId)) {
+            userSockets.set(userId, new Set());
+        }
+
+        const userSocketSet = userSockets.get(userId);
+        userSocketSet.add(socket.id);
+
         socketUsers.set(socket.id, userId);
-        userStatus.set(userId, { status: 'online', lastSeen: new Date(), socketId: socket.id });
+        userStatus.set(userId, {
+            status: 'online',
+            lastSeen: new Date(),
+            socketId: socket.id
+        });
 
         io.emit('user_status_change', { userId, status: 'online' });
         io.emit('users_online', userSockets.size);
@@ -415,15 +424,28 @@ function handleDisconnect(socket) {
     if (userId) {
         cleanupPreviousRooms(socket);
 
-        userSockets.delete(userId);
-        socketUsers.delete(socket.id);
-        userStatus.set(userId, { status: 'offline', lastSeen: new Date() });
+        const userSocketSet = userSockets.get(userId);
 
+        if (userSocketSet) {
+            userSocketSet.delete(socket.id);
+
+            if (userSocketSet.size === 0) {
+                userSockets.delete(userId);
+                userStatus.set(userId, { status: 'offline', lastSeen: new Date() });
+                io.emit('user_status_change', { userId, status: 'offline' });
+            } else {
+                userStatus.set(userId, {
+                    status: 'online',
+                    lastSeen: new Date(),
+                    socketId: Array.from(userSocketSet)[0]
+                });
+            }
+        }
+
+        socketUsers.delete(socket.id);
         clearTypingForUser(userId);
 
-        io.emit('user_status_change', { userId, status: 'offline' });
         io.emit('users_online', userSockets.size);
-
         logger.info(`User disconnected: ${userId}`);
     }
 
@@ -439,9 +461,11 @@ function getIo() {
 }
 
 function sendToUser(userId, event, data) {
-    const socketId = userSockets.get(userId);
-    if (socketId) {
-        io.to(socketId).emit(event, data);
+    const socketIds = userSockets.get(userId);
+    if (socketIds && socketIds.size > 0) {
+        socketIds.forEach((socketId) => {
+            io.to(socketId).emit(event, data);
+        });
         return true;
     }
     return false;


### PR DESCRIPTION
## Summary

This PR fixes max socket connection enforcement in `backend/utils/socketManager.js` by changing `userSockets` from a single-socket map into a per-user set of socket IDs.

Previously, the socket manager attempted to limit each user to `MAX_CONNECTIONS_PER_USER`, but `userSockets` stored only one socket ID per user:

```js
userSockets.set(userId, socket.id);
```

Because of that, every new socket for the same user overwrote the previous one, which caused the connection-count check to undercount active sockets and prevented the max-connection limit from being enforced correctly.

## Changes Made

- Updated `userSockets` usage to store a `Set` of socket IDs per user
- Replaced the connection-count logic to use the per-user socket set size
- Added new sockets to the user’s socket set on connection
- Updated disconnect cleanup to remove only the disconnected socket ID
- Removed the user entry only when no sockets remain for that user
- Updated `sendToUser()` to emit to all active socket IDs for a user instead of assuming a single socket ID

## Why this fix is needed

The socket manager is designed to support `MAX_CONNECTIONS_PER_USER`, but the previous `Map<userId, socketId>` structure could not track multiple simultaneous sockets for the same user. As a result, max connection enforcement and cleanup behavior were inconsistent with the intended design.

## Benefits

- Makes max connection enforcement actually work
- Preserves all active socket IDs for a user
- Prevents newer sockets from overwriting older ones
- Improves disconnect cleanup when users have multiple active sockets
- Keeps direct user emits working across all active sockets for that user

## Testing

- Verified that multiple sockets for the same user are now tracked together
- Verified that connection count checks use the actual number of active sockets for the user
- Verified that disconnecting one socket does not remove the user if other sockets are still active
- Verified that `sendToUser()` emits to all active sockets for a user

Closes #727