### PR TITLE
fix(review): prevent SQL injection via sort allowlist

### DIFF
--- a/backend/models/Review.js
+++ b/backend/models/Review.js
@@ -6,6 +6,13 @@ const MAX_COMMENT_LENGTH = 1000;
 const MIN_RATING = 1;
 const MAX_RATING = 5;
 
+const REVIEW_SORT_OPTIONS = Object.freeze({
+  newest: "created_at DESC",
+  oldest: "created_at ASC",
+  rating_high: "rating DESC",
+  rating_low: "rating ASC",
+});
+
 class Review {
   constructor(review) {
     this.validate(review);
@@ -34,6 +41,14 @@ class Review {
     } catch (error) {
       return new Date();
     }
+  }
+
+  static getSafeSort(sort) {
+    if (typeof sort !== "string") {
+      return REVIEW_SORT_OPTIONS.newest;
+    }
+
+    return REVIEW_SORT_OPTIONS[sort] || REVIEW_SORT_OPTIONS.newest;
   }
 
   static validate(review) {
@@ -165,7 +180,8 @@ class Review {
 
   static async findByProduct(productId, options = {}) {
     try {
-      const { limit = 20, offset = 0, sort = 'created_at DESC', rating = null } = options;
+      const { limit = 20, offset = 0, sort = "newest", rating = null } = options;
+      const safeSort = Review.getSafeSort(sort);
 
       let query = `SELECT * FROM reviews WHERE product_id = ? AND is_deleted = FALSE`;
       const params = [productId];
@@ -175,29 +191,30 @@ class Review {
         params.push(rating);
       }
 
-      query += ` ORDER BY ${sort} LIMIT ? OFFSET ?`;
+      query += ` ORDER BY ${safeSort} LIMIT ? OFFSET ?`;
       params.push(limit, offset);
 
       const [rows] = await db.query(query, params);
-      return rows.map(row => new Review(row));
+      return rows.map((row) => new Review(row));
     } catch (error) {
-      console.error('Review.findByProduct error:', error.message);
+      console.error("Review.findByProduct error:", error.message);
       throw error;
     }
   }
 
   static async findByUser(userId, options = {}) {
     try {
-      const { limit = 20, offset = 0, sort = 'created_at DESC' } = options;
+      const { limit = 20, offset = 0, sort = "newest" } = options;
+      const safeSort = Review.getSafeSort(sort);
 
       const [rows] = await db.query(
-        `SELECT * FROM reviews WHERE user_id = ? AND is_deleted = FALSE ORDER BY ${sort} LIMIT ? OFFSET ?`,
+        `SELECT * FROM reviews WHERE user_id = ? AND is_deleted = FALSE ORDER BY ${safeSort} LIMIT ? OFFSET ?`,
         [userId, limit, offset]
       );
 
-      return rows.map(row => new Review(row));
+      return rows.map((row) => new Review(row));
     } catch (error) {
-      console.error('Review.findByUser error:', error.message);
+      console.error("Review.findByUser error:", error.message);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary

This PR fixes a SQL injection risk in `Review` query helpers by removing raw interpolation of caller-provided `sort` values in review listing queries.

## What changed

* Added a strict allowlist of supported review sort options in `Review.js`
* Introduced a helper to resolve incoming sort values to safe SQL fragments
* Updated `findByProduct()` to use a validated sort value instead of interpolating raw input
* Updated `findByUser()` to use the same safe sort resolution logic
* Added a safe fallback to `created_at DESC` / `newest` for invalid or unsupported sort values

## Why this change is needed

Previously, both `findByProduct()` and `findByUser()` directly interpolated `sort` into SQL `ORDER BY` clauses. Since SQL placeholders cannot parameterize identifiers or sort expressions, this created a risk of SQL injection if untrusted input reached these helpers.

## Security impact

This change prevents arbitrary SQL fragments from being injected through review sorting inputs and makes review query behavior predictable by restricting sorting to known-safe values only.

## Supported sort modes

* `newest` → `created_at DESC`
* `oldest` → `created_at ASC`
* `rating_high` → `rating DESC`
* `rating_low` → `rating ASC`

Backward-compatible aliases for existing sort strings can also be supported if needed.

## Testing notes

* Verified that valid sort modes still return correctly ordered review lists
* Verified that invalid sort values fall back to the default safe sort instead of being interpolated into SQL


closes #830 