### PR TITLE
fix(certificate): generate certificateId before validation

### DIFF
--- a/backend/models/CertificateOfAction.js
+++ b/backend/models/CertificateOfAction.js
@@ -69,8 +69,8 @@ const certificateSchema = new mongoose.Schema({
     timestamps: true
 });
 
-// Generate certificate ID
-certificateSchema.pre('save', function(next) {
+// Generate certificate ID before validation so required validation does not fail
+certificateSchema.pre('validate', function(next) {
     if (this.isNew && !this.certificateId) {
         this.certificateId = `CERT-${crypto.randomBytes(8).toString('hex').toUpperCase()}`;
     }


### PR DESCRIPTION
## Summary

This PR fixes a validation-order bug in `CertificateOfAction` where `certificateId` was marked as required in the schema but only generated later in a `pre("save")` hook.

## Problem

`certificateId` is defined as a required field, but Mongoose runs validation before `pre("save")` middleware. As a result, new `CertificateOfAction` documents created without an explicit `certificateId` could fail validation before the model had a chance to auto-generate the ID.

## What changed

* Moved automatic `certificateId` generation from `pre("save")` to `pre("validate")`
* Kept `certificateId` as a required schema field
* Preserved the existing certificate ID format and generation behavior

## Why this fix

Using `pre("validate")` ensures the model-generated `certificateId` is populated before required-field validation runs. This keeps the schema contract consistent while allowing callers to create certificates without manually supplying an ID.

## Result

* New certificates can be created without explicitly passing `certificateId`
* Required validation no longer fails before ID generation
* The schema and middleware behavior are now aligned

closes #831 