### PR TITLE
fix(negotiation): generate negotiationId before validation

### DIFF
--- a/backend/models/Negotiation.js
+++ b/backend/models/Negotiation.js
@@ -184,8 +184,8 @@ const negotiationSchema = new mongoose.Schema({
     timestamps: true
 });
 
-// Generate negotiation ID (Bilkul waisa hi)
-negotiationSchema.pre('save', function (next) {
+// Generate negotiation ID before validation so required validation does not fail
+negotiationSchema.pre('validate', function (next) {
     if (this.isNew && !this.negotiationId) {
         const crypto = require('crypto');
         this.negotiationId = `NEG-${crypto.randomBytes(6).toString('hex').toUpperCase()}`;


### PR DESCRIPTION
## Summary

This PR fixes a validation-order bug in the `Negotiation` model where `negotiationId` was marked as required in the schema but generated only later in a `pre("save")` hook.

## Problem

`negotiationId` is a required field, but Mongoose runs validation before `pre("save")` middleware. Because of that, creating a new negotiation without explicitly providing `negotiationId` could fail validation before the model had a chance to auto-generate it.

## What changed

* Moved automatic `negotiationId` generation from `pre("save")` to `pre("validate")`
* Kept `negotiationId` as a required field in the schema
* Preserved the existing negotiation ID format and generation behavior

## Why this fix

Using `pre("validate")` ensures `negotiationId` is populated before required-field validation runs. This keeps the schema contract intact while allowing the model to continue generating IDs automatically for new documents.

## Result

* New negotiations can be created without manually supplying `negotiationId`
* Required validation no longer fails before ID generation
* The schema and middleware behavior are now aligned

closes #832 