### PR TITLE
fix(compliance): generate recordId before validation

### DIFF
--- a/backend/models/ComplianceRecord.js
+++ b/backend/models/ComplianceRecord.js
@@ -137,8 +137,8 @@ const complianceRecordSchema = new mongoose.Schema({
     timestamps: true
 });
 
-// Generate record ID (Bilkul waisa hi)
-complianceRecordSchema.pre('save', function (next) {
+// Generate record ID before validation so required validation does not fail
+complianceRecordSchema.pre('validate', function (next) {
     if (this.isNew && !this.recordId) {
         const crypto = require('crypto');
         this.recordId = `COMPLY-${crypto.randomBytes(4).toString('hex').toUpperCase()}`;


### PR DESCRIPTION
## Summary

This PR fixes a validation-order bug in `ComplianceRecord` where `recordId` was marked as required in the schema but generated only later in a `pre("save")` hook.

## Problem

`recordId` is a required field, but Mongoose runs validation before `pre("save")` middleware. Because of that, creating a new compliance record without explicitly providing `recordId` could fail validation before the model had a chance to auto-generate it.

## What changed

* Moved automatic `recordId` generation from `pre("save")` to `pre("validate")`
* Kept `recordId` as a required field in the schema
* Preserved the existing record ID format and generation behavior

## Why this fix

Using `pre("validate")` ensures `recordId` is populated before required-field validation runs. This keeps the schema contract intact while allowing the model to continue generating IDs automatically for new documents.

## Result

* New compliance records can be created without manually supplying `recordId`
* Required validation no longer fails before ID generation
* The schema and middleware behavior are now aligned


closes #833 