### PR TITLE
fix(ai): return 501 response for unimplemented protected chat route

### DIFF
--- a/backend/routes/aiProtectRoutes.js
+++ b/backend/routes/aiProtectRoutes.js
@@ -10,7 +10,10 @@ router.use(promptInjectionGuard);
 
 // Your protected AI routes here
 router.post('/chat', async (req, res) => {
-    // Your chat handler
+    return res.status(501).json({
+        success: false,
+        message: 'AI protected chat endpoint is not implemented yet'
+    });
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary

This PR fixes the protected AI chat route so it always completes the request lifecycle instead of leaving requests hanging.

## Problem

`POST /chat` in `backend/routes/aiProtectedRoutes.js` defined an async route handler with an empty body. After the authentication and prompt-injection middlewares ran, requests reaching this handler would not receive a response and could remain open until timeout.

## What changed

* Replaced the empty `/chat` handler with an explicit `501 Not Implemented` JSON response
* Ensured the route always returns a response instead of hanging

## Why this fix

Until the actual protected chat functionality is implemented, the route should fail clearly and consistently rather than appearing usable while never completing. Returning a `501` response makes the endpoint state explicit for clients and avoids timeout-based failures.

## Result

* `POST /chat` no longer hangs
* Clients receive a clear and predictable response
* The route remains safe to expose until full chat logic is implemented


closes #834 