### PR TITLE
fix: resolve shop page category cards filtering bug

### DIFF
--- a/frontend/scripts/shop.js
+++ b/frontend/scripts/shop.js
@@ -1295,11 +1295,28 @@ document.addEventListener(
         document.querySelectorAll(".fashion-card").forEach((card) => {
             card.addEventListener("click", () => {
                 const category = card.dataset.category;
-                const checkbox = document.querySelector(
+                let checkbox = document.querySelector(
                     `input[name="category-filter"][value="${category}"]`
                 );
+
+                resetCategoryCheckboxes();
+
+                if (!checkbox && elements.categoryList) {
+                    // Create checkbox dynamically if it doesn't exist
+                    const label = document.createElement("label");
+                    label.innerHTML = `
+                        <input
+                            type="checkbox"
+                            name="category-filter"
+                            value="${AppUtils.escapeHTML(category)}"
+                        >
+                        ${AppUtils.escapeHTML(category)}
+                    `;
+                    elements.categoryList.appendChild(label);
+                    checkbox = label.querySelector("input");
+                }
+
                 if (checkbox) {
-                    resetCategoryCheckboxes();
                     checkbox.checked = true;
                     applyFilters({ resetPage: true });
                     document.getElementById("product-container")


### PR DESCRIPTION
### **PR Description**

#### **📌 Description**
This PR resolves a bug on the Shop page (`frontend/shop.html`) where clicking on the category cards ("T-SHIRTS", "HOODIES", "JACKETS", "DENIM") at the top of the page did not filter the products or scroll to the products container.

#### **🔍 Cause of the Bug**
The click event listener for `.fashion-card` elements relied on querying the category filter checkbox directly from the DOM using:
```javascript
const checkbox = document.querySelector(`input[name="category-filter"][value="${category}"]`);
```
If the checkbox was not present in the DOM (which happens when no products of that category are loaded, e.g., using the default schema/database data), the `checkbox` variable was `null`, causing the click handler to silently fail and do nothing.

#### **🛠️ Solution**
Updated `frontend/scripts/shop.js` to dynamically create the category checkbox in the sidebar if it is missing when the card is clicked. Once ensured to exist, it is checked, the filters are applied, and the page scrolls smoothly down to the product list.

---

#### **✅ Verification/Testing**
- Clicked on all category cards ("T-SHIRTS", "HOODIES", "JACKETS", "DENIM") on the Shop page.
- Verified that categories without initially loaded products now correctly create the filter checkbox, check it, filter the page (displaying a "No products found" message or the filtered list), and scroll smoothly down to the product list container.

Closes #861 
