### PR TITLE
fix: display toy products and images in mega menu (#860)

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -10,6 +10,16 @@ const {
 } = require("../utils/helpers");
 
 const MAX_PRODUCT_LIMIT = 50;
+const NORMALIZED_CATEGORY_SQL =
+    "LOWER(REPLACE(REPLACE(category, '-', ''), ' ', ''))";
+const TOYS_CATEGORY_VALUES = [
+    "Toys",
+    "Educational Toys",
+    "Building Blocks",
+    "Dolls",
+    "RC Toys",
+    "Outdoor Toys"
+];
 
 function parsePaginationValue(value, defaultValue, fieldName) {
     if (value === undefined || value === null || value === "") {
@@ -50,14 +60,27 @@ const getProducts = async (req, res) => {
 
         // category filter (case/format-insensitive)
         if (req.query.category) {
-            conditions.push(
-                "LOWER(REPLACE(REPLACE(category, '-', ''), ' ', '')) = LOWER(REPLACE(REPLACE(?, '-', ''), ' ', ''))"
+            const sanitizedCategory = sanitizeString(
+                req.query.category
             );
-            params.push(
-                sanitizeString(
-                    req.query.category
-                )
-            );
+            const isToysCategory =
+                sanitizedCategory
+                    .toLowerCase()
+                    .replace(/[-\s]+/g, "") === "toys";
+
+            if (isToysCategory) {
+                conditions.push(
+                    `${NORMALIZED_CATEGORY_SQL} IN (${TOYS_CATEGORY_VALUES.map(
+                        () => "LOWER(REPLACE(REPLACE(?, '-', ''), ' ', ''))"
+                    ).join(", ")})`
+                );
+                params.push(...TOYS_CATEGORY_VALUES);
+            } else {
+                conditions.push(
+                    `${NORMALIZED_CATEGORY_SQL} = LOWER(REPLACE(REPLACE(?, '-', ''), ' ', ''))`
+                );
+                params.push(sanitizedCategory);
+            }
         }
 
         // featured filter

--- a/frontend/components/navbar.html
+++ b/frontend/components/navbar.html
@@ -201,12 +201,17 @@
                 <h3 id="mega-title-toys">Toys</h3>
                 <a href="shop.html?category=Toys">Shop all Toys</a>
               </div>
-              <div class="mega-menu-grid">
-                <a class="category-menu-link" href="shop.html?category=Toys&amp;subcategory=Educational%20Toys">Educational Toys</a>
-                <a class="category-menu-link" href="shop.html?category=Toys&amp;subcategory=Building%20Blocks">Building Blocks</a>
-                <a class="category-menu-link" href="shop.html?category=Toys&amp;subcategory=Dolls">Dolls</a>
-                <a class="category-menu-link" href="shop.html?category=Toys&amp;subcategory=RC%20Toys">RC Toys</a>
-                <a class="category-menu-link" href="shop.html?category=Toys&amp;subcategory=Outdoor%20Toys">Outdoor Toys</a>
+              <div class="mega-menu-grid grocery-mega-menu-grid toy-mega-menu-grid">
+                <div class="grocery-subcategory-list toy-subcategory-list" aria-label="Toys subcategories">
+                  <a class="category-menu-link toy-subcategory-link is-active" href="shop.html?category=Toys&amp;subcategory=Educational%20Toys" data-toy-subcategory="Educational Toys" aria-controls="toy-product-preview">Educational Toys</a>
+                  <a class="category-menu-link toy-subcategory-link" href="shop.html?category=Toys&amp;subcategory=Building%20Blocks" data-toy-subcategory="Building Blocks" aria-controls="toy-product-preview">Building Blocks</a>
+                  <a class="category-menu-link toy-subcategory-link" href="shop.html?category=Toys&amp;subcategory=Dolls" data-toy-subcategory="Dolls" aria-controls="toy-product-preview">Dolls</a>
+                  <a class="category-menu-link toy-subcategory-link" href="shop.html?category=Toys&amp;subcategory=RC%20Toys" data-toy-subcategory="RC Toys" aria-controls="toy-product-preview">RC Toys</a>
+                  <a class="category-menu-link toy-subcategory-link" href="shop.html?category=Toys&amp;subcategory=Outdoor%20Toys" data-toy-subcategory="Outdoor Toys" aria-controls="toy-product-preview">Outdoor Toys</a>
+                </div>
+                <div id="toy-product-preview" class="grocery-product-preview toy-product-preview" aria-live="polite">
+                  <p class="grocery-menu-empty toy-menu-empty">Loading products...</p>
+                </div>
               </div>
             </section>
 

--- a/frontend/scripts/components.js
+++ b/frontend/scripts/components.js
@@ -257,6 +257,12 @@ const grocerySubcategoryLinks = Array.from(
 const groceryProductPreview = document.getElementById(
     "grocery-product-preview"
 );
+const toySubcategoryLinks = Array.from(
+    document.querySelectorAll(".toy-subcategory-link")
+);
+const toyProductPreview = document.getElementById(
+    "toy-product-preview"
+);
 
 const grocerySubcategoryKeywords = {
     "Fruits & Vegetables": [
@@ -328,6 +334,58 @@ const grocerySubcategoryKeywords = {
     ]
 };
 
+const toySubcategoryKeywords = {
+    "Educational Toys": [
+        "educational",
+        "learning",
+        "stem",
+        "science",
+        "math",
+        "puzzle",
+        "flash",
+        "activity"
+    ],
+    "Building Blocks": [
+        "building",
+        "blocks",
+        "block",
+        "brick",
+        "bricks",
+        "construction",
+        "lego",
+        "stack"
+    ],
+    Dolls: [
+        "doll",
+        "dolls",
+        "plush",
+        "figure",
+        "figurine",
+        "pretend",
+        "playset"
+    ],
+    "RC Toys": [
+        "rc",
+        "remote",
+        "control",
+        "controlled",
+        "car",
+        "drone",
+        "robot",
+        "vehicle"
+    ],
+    "Outdoor Toys": [
+        "outdoor",
+        "scooter",
+        "ball",
+        "frisbee",
+        "water",
+        "garden",
+        "sports",
+        "ride"
+    ]
+};
+
 const normalizeMenuValue = (value) =>
     String(value || "")
         .toLowerCase()
@@ -350,6 +408,11 @@ const stringifyProductValue = (value) => {
 
     return String(value);
 };
+
+const escapeMenuHTML = (value) =>
+    window.AppUtils?.escapeHTML
+        ? AppUtils.escapeHTML(value)
+        : String(value || "");
 
 const getProductSearchText = (product) =>
     [
@@ -400,14 +463,74 @@ const matchesGrocerySubcategory = (product, subcategory) => {
     );
 };
 
-const getProductLink = (product, fallbackSubcategory) => {
+const matchesToySubcategory = (product, subcategory) => {
+    const normalizedSubcategory = normalizeMenuValue(subcategory);
+    const category = normalizeMenuValue(product?.category);
+    const productSubcategory = normalizeMenuValue(
+        getProductSubcategory(product)
+    );
+    const searchText = normalizeMenuValue(
+        getProductSearchText(product)
+    );
+    const keywords = toySubcategoryKeywords[subcategory] || [];
+
+    if (productSubcategory) {
+        return productSubcategory === normalizedSubcategory;
+    }
+
+    if (category === normalizedSubcategory) {
+        return true;
+    }
+
+    if (
+        category !== "toys" &&
+        !searchText.includes("toy")
+    ) {
+        return false;
+    }
+
+    return keywords.some((keyword) =>
+        searchText.includes(normalizeMenuValue(keyword))
+    );
+};
+
+const getProductLink = (
+    product,
+    fallbackCategory,
+    fallbackSubcategory
+) => {
     if (product?.id !== undefined && product?.id !== null) {
         return `product.html?id=${encodeURIComponent(product.id)}`;
     }
 
-    return `shop.html?category=Grocery&subcategory=${encodeURIComponent(
+    return `shop.html?category=${encodeURIComponent(
+        fallbackCategory
+    )}&subcategory=${encodeURIComponent(
         fallbackSubcategory
     )}`;
+};
+
+const renderMenuRating = (rating) => {
+    const normalizedRating = Number(rating);
+
+    if (!Number.isFinite(normalizedRating) || normalizedRating <= 0) {
+        return "";
+    }
+
+    const starCount = Math.max(
+        1,
+        Math.min(5, Math.round(normalizedRating))
+    );
+    const stars = Array.from(
+        { length: starCount },
+        () => `<i class="fas fa-star" aria-hidden="true"></i>`
+    ).join("");
+
+    return `
+        <span class="grocery-menu-product-rating toy-menu-product-rating" aria-label="${starCount} out of 5 stars">
+            ${stars}
+        </span>
+    `;
 };
 
 const renderGroceryProducts = (products, subcategory) => {
@@ -432,7 +555,7 @@ const renderGroceryProducts = (products, subcategory) => {
             const escapedName = AppUtils.escapeHTML(name);
             const image = AppUtils.defaultImage(product?.image);
             const price = AppUtils.formatPrice(product?.price || 0);
-            const href = getProductLink(product, subcategory);
+            const href = getProductLink(product, "Grocery", subcategory);
 
             return `
                 <a class="grocery-menu-product" href="${href}">
@@ -451,6 +574,49 @@ const renderGroceryProducts = (products, subcategory) => {
         .join("");
 };
 
+const renderToyProducts = (products, subcategory) => {
+    if (!toyProductPreview) {
+        return;
+    }
+
+    const safeProducts = Array.isArray(products)
+        ? products
+        : [];
+
+    if (!safeProducts.length) {
+        toyProductPreview.innerHTML =
+            `<p class="grocery-menu-empty toy-menu-empty">No toys available for ${escapeMenuHTML(subcategory)} yet.</p>`;
+        return;
+    }
+
+    toyProductPreview.innerHTML = safeProducts
+        .slice(0, 4)
+        .map((product) => {
+            const name = product?.name || "Toy";
+            const escapedName = AppUtils.escapeHTML(name);
+            const image = AppUtils.defaultImage(product?.image);
+            const price = AppUtils.formatPrice(product?.price || 0);
+            const href = getProductLink(product, "Toys", subcategory);
+            const rating = renderMenuRating(product?.rating);
+
+            return `
+                <a class="grocery-menu-product toy-menu-product" href="${href}">
+                    <img
+                        src="${AppUtils.escapeHTML(image)}"
+                        alt="${escapedName}"
+                        loading="lazy"
+                    />
+                    <span class="grocery-menu-product-info toy-menu-product-info">
+                        <span class="grocery-menu-product-name toy-menu-product-name">${escapedName}</span>
+                        <span class="grocery-menu-product-price toy-menu-product-price">${price}</span>
+                        ${rating}
+                    </span>
+                </a>
+            `;
+        })
+        .join("");
+};
+
 const setActiveGrocerySubcategory = (activeLink) => {
     grocerySubcategoryLinks.forEach((link) => {
         const isActive = link === activeLink;
@@ -459,26 +625,64 @@ const setActiveGrocerySubcategory = (activeLink) => {
     });
 };
 
-const fetchGroceryProducts = async () => {
-    if (!groceryProductPreview || !window.AppUtils) {
+const setActiveToySubcategory = (activeLink) => {
+    toySubcategoryLinks.forEach((link) => {
+        const isActive = link === activeLink;
+
+        link.classList.toggle("is-active", isActive);
+    });
+};
+
+let megaMenuProductsCache;
+
+const fetchMegaMenuProducts = async () => {
+    if (!window.AppUtils) {
         return [];
+    }
+
+    if (megaMenuProductsCache) {
+        return megaMenuProductsCache;
     }
 
     try {
-        const data = await AppUtils.apiRequest(
-            "/products?page=1&limit=200"
+        const requestedLimit = 200;
+        const firstPage = await AppUtils.apiRequest(
+            `/products?page=1&limit=${requestedLimit}`
+        );
+        const products = firstPage.success && Array.isArray(firstPage.products)
+            ? [...firstPage.products]
+            : [];
+        const pageLimit = Number(firstPage.limit) || products.length || 50;
+        const totalPages = Number(firstPage.totalPages) || 1;
+        const pagesToFetch = Math.min(
+            totalPages,
+            Math.ceil(requestedLimit / pageLimit)
         );
 
-        return data.success && Array.isArray(data.products)
-            ? data.products
-            : [];
+        for (let page = 2; page <= pagesToFetch; page += 1) {
+            if (products.length >= requestedLimit) {
+                break;
+            }
+
+            const data = await AppUtils.apiRequest(
+                `/products?page=${page}&limit=${requestedLimit}`
+            );
+
+            if (data.success && Array.isArray(data.products)) {
+                products.push(...data.products);
+            }
+        }
+
+        megaMenuProductsCache = products.slice(0, requestedLimit);
     } catch (error) {
         console.error(
-            "GROCERY MEGA MENU FETCH ERROR:",
+            "MEGA MENU PRODUCTS FETCH ERROR:",
             error
         );
-        return [];
+        megaMenuProductsCache = [];
     }
+
+    return megaMenuProductsCache;
 };
 
 const initializeGroceryMegaMenu = async () => {
@@ -510,12 +714,51 @@ const initializeGroceryMegaMenu = async () => {
         });
     });
 
-    groceryProducts = await fetchGroceryProducts();
+    groceryProducts = await fetchMegaMenuProducts();
 
     const defaultLink =
         grocerySubcategoryLinks.find((link) =>
             link.dataset.grocerySubcategory === currentSubcategory
         ) || grocerySubcategoryLinks[0];
+
+    showSubcategoryProducts(defaultLink);
+};
+
+const initializeToyMegaMenu = async () => {
+    if (!toySubcategoryLinks.length || !toyProductPreview) {
+        return;
+    }
+
+    let toyProducts = [];
+
+    const showSubcategoryProducts = (link) => {
+        const subcategory =
+            link.dataset.toySubcategory ||
+            link.textContent.trim();
+        const products = toyProducts.filter((product) =>
+            matchesToySubcategory(product, subcategory)
+        );
+
+        setActiveToySubcategory(link);
+        renderToyProducts(products, subcategory);
+    };
+
+    toySubcategoryLinks.forEach((link) => {
+        link.addEventListener("mouseenter", () => {
+            showSubcategoryProducts(link);
+        });
+
+        link.addEventListener("focus", () => {
+            showSubcategoryProducts(link);
+        });
+    });
+
+    toyProducts = await fetchMegaMenuProducts();
+
+    const defaultLink =
+        toySubcategoryLinks.find((link) =>
+            link.dataset.toySubcategory === currentSubcategory
+        ) || toySubcategoryLinks[0];
 
     showSubcategoryProducts(defaultLink);
 };
@@ -765,6 +1008,7 @@ mobileCategoryAccordions.forEach((accordion) => {
     });
 });
     await initializeGroceryMegaMenu();
+    await initializeToyMegaMenu();
     // notify components ready
     document.dispatchEvent(new CustomEvent("componentsLoaded"));
 }

--- a/frontend/scripts/shop-filter-utils.js
+++ b/frontend/scripts/shop-filter-utils.js
@@ -175,6 +175,21 @@
         ],
         accessories: [
             "Accessories"
+        ],
+        educationaltoys: [
+            "Educational Toys"
+        ],
+        buildingblocks: [
+            "Building Blocks"
+        ],
+        dolls: [
+            "Dolls"
+        ],
+        rctoys: [
+            "RC Toys"
+        ],
+        outdoortoys: [
+            "Outdoor Toys"
         ]
     };
 
@@ -195,6 +210,9 @@
 
         const productKeys = toKeySet([
             getProductCategory(product),
+            product?.subcategory,
+            product?.sub_category,
+            product?.subCategory,
             getProductBrand(product),
             ...(Array.isArray(product?.tags) ? product.tags : [])
         ]);

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -337,7 +337,8 @@ html, body {
     gap: 8px;
 }
 
-.grocery-subcategory-link.is-active {
+.grocery-subcategory-link.is-active,
+.toy-subcategory-link.is-active {
     background: rgba(8, 129, 120, 0.1);
     color: var(--primary-color, #088178);
     transform: translateX(3px);
@@ -409,6 +410,14 @@ html, body {
     color: var(--primary-color, #088178);
     font-size: 13px;
     font-weight: 800;
+}
+
+.toy-menu-product-rating {
+    display: flex;
+    gap: 2px;
+    color: #f5a623;
+    font-size: 11px;
+    line-height: 1;
 }
 
 .grocery-menu-empty {
@@ -1048,7 +1057,8 @@ body.dark-theme .category-menu-link.active {
   color: #39a4d6;
 }
 
-body.dark-theme .grocery-subcategory-link.is-active {
+body.dark-theme .grocery-subcategory-link.is-active,
+body.dark-theme .toy-subcategory-link.is-active {
   background: rgba(57, 164, 214, 0.16);
   color: #39a4d6;
 }


### PR DESCRIPTION
## Summary
- Add dynamic Toys mega menu product preview by subcategory
- Match Toys products by exact category/subcategory and Toys-specific keywords
- Align shop/backend Toys category filtering with Toys subcategory product categories

## Verification
- npm install
- node --check frontend/scripts/components.js
- node --check frontend/scripts/shop-filter-utils.js
- node --check backend/controllers/productController.js
- git diff --check

#860 solved
## Notes
- Full Jest suite currently fails in existing auth/signature/product sanitization tests unrelated to this change.
- npm start is currently blocked by an existing server.js ambiguous module syntax error under Node v25.6.1.