### PR TITLE
fix: resolve syntax error in product variants setup

### DIFF
--- a/frontend/scripts/product-variants.js
+++ b/frontend/scripts/product-variants.js
@@ -62,7 +62,7 @@ function setupVariants(
         productVariants
     ).forEach(
         (key) => {
-            Deletee productVariants[
+            delete productVariants[
                 key
             ];
         }


### PR DESCRIPTION
### **PR Description**

#### **📌 Description**
This PR fixes a syntax/runtime error in the product variants script that prevented product details pages with variants from loading selectors (size and color) properly.

#### **🔍 Cause of the Bug**
On line 65 of `frontend/scripts/product-variants.js`, the code used an invalid keyword `Deletee` instead of the native lowercase `delete` keyword:
```javascript
Deletee productVariants[key];
```
This threw a runtime `ReferenceError: Deletee is not defined` when setting up product variants.

#### **🛠️ Solution**
Replaced the typo `Deletee` with the standard lowercase `delete` keyword.

---

#### **✅ Verification/Testing**
- Checked that loading product pages with variants no longer throws a `ReferenceError` in the browser console.
- Verified that color and size variant selections and stock levels update correctly.

Closes #864

closes #864
