### PR TITLE
fix: resolve delete button class selector typo in admin.css

### DIFF
--- a/frontend/styles/admin.css
+++ b/frontend/styles/admin.css
@@ -130,7 +130,7 @@ table td{
     color: #fff;
 }
 
-.Deletee-btn{
+.delete-btn{
     background: red;
 }
 


### PR DESCRIPTION


### **PR Description**

#### **📌 Description**
This PR fixes a CSS class selector typo in the admin panel stylesheet that prevented delete buttons from being styled correctly.

#### **🔍 Cause of the Bug**
On line 133 of `frontend/styles/admin.css`, the class name for delete buttons was defined as `.Deletee-btn` instead of `.delete-btn`. This prevented it from matching the standard class used in admin components.

#### **🛠️ Solution**
Renamed `.Deletee-btn` to `.delete-btn` in the stylesheet.

---

#### **✅ Verification/Testing**
- Verified that delete buttons in the admin panel table and lists are now properly styled with their red backgrounds as specified in the CSS rules.

Closes #866