### PR TITLE
test: resolve typo in product sanitization test assertion

### DIFF
--- a/backend/tests/productSanitization.test.js
+++ b/backend/tests/productSanitization.test.js
@@ -54,7 +54,7 @@ describe('Product Search Input Sanitization', () => {
 
         test('should escape multiple special chars', () => {
             const result = sanitizeSearchInput('%_\\%_');
-            expect(result).toBe('%\\%\\_\\\\%_');
+            expect(result).toBe('%\\%\\_\\\\\\%\\_%');
         });
     });
 });


### PR DESCRIPTION


### **PR Description**

#### **📌 Description**
This PR fixes a typo in the unit test assertion for `sanitizeSearchInput` inside `backend/tests/productSanitization.test.js`.

#### **🔍 Cause of the Bug**
On line 57, the test expected the second wildcard character `%_` to remain unescaped:
```javascript
expect(result).toBe('%\\%\\_\\\\%_');
```
However, `sanitizeSearchInput` correctly escapes all wildcards globally, producing `%\\%\\_\\\\\\%\\_%`. The test failed due to a typo in its own expected value.

#### **🛠️ Solution**
Updated the assertion expected value to match the correct output: `'%\\%\\_\\\\\\%\\_%'`.

---

#### **✅ Verification/Testing**
- Ran `npx jest tests/productSanitization.test.js` from the `backend/` directory.
- All 9 tests passed successfully.

Closes #870
```