### PR TITLE
fix: prevent duplicate signal listeners in graceful shutdown

### DIFF
--- a/backend/utils/gracefulShutdown.js
+++ b/backend/utils/gracefulShutdown.js
@@ -1,24 +1,35 @@
 // src/utils/gracefulShutdown.js
 
+let isShutdownSetup = false;  // Flag to track if already set up
+
 /**
  * Sets up graceful shutdown handlers for SIGINT and SIGTERM signals.
  * @param {http.Server} server - The HTTP server instance to shut down.
  */
 const setupGracefulShutdown = (server) => {
+  // Check if already set up
+  if (isShutdownSetup) {
+    console.warn(' Graceful shutdown already set up, skipping duplicate registration');
+    return;
+  }
+
   const shutdown = () => {
-    console.log("\nShutting down server gracefully...");
+    console.log("\n Shutting down server gracefully...");
     server.close(() => {
       console.log("HTTP server closed");
       process.exit(0);
     });
     setTimeout(() => {
-      console.error("Force shutdown after timeout");
+      console.error(" Force shutdown after timeout");
       process.exit(1);
     }, 10000);
   };
 
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
+  
+  isShutdownSetup = true;  // Mark as set up
+  console.log(" Graceful shutdown handlers registered");
 };
 
 module.exports = setupGracefulShutdown;


### PR DESCRIPTION
## What does this PR do?
- Adds `isShutdownSetup` flag to prevent duplicate signal listener registration
- Fixes issue where SIGINT/SIGTERM handlers were registered multiple times
- Prevents multiple shutdown executions on single signal

## Related Issue
Fixes #868

## Testing
- Tested by calling setupGracefulShutdown() multiple times
- Only one shutdown handler executes on Ctrl+C