### PR TITLE
fix: resolve fashion subcategories mapping in filter utility

### DIFF
--- a/frontend/scripts/shop-filter-utils.js
+++ b/frontend/scripts/shop-filter-utils.js
@@ -44,7 +44,12 @@
             "women",
             "Women",
             "men",
-            "Men"
+            "Men",
+            "Footwear",
+            "Kids Wear",
+            "Watches",
+            "Bags",
+            "Accessories"
         ],
         electronics: [
             "Electronics",


### PR DESCRIPTION


### **PR Description**

#### **📌 Description**
This PR fixes a category mapping bug where clicking subcategories under the **Fashion** menu dropdown (such as **Footwear**, **Watches**, **Bags**, **Accessories**, or **Kids Wear**) displayed no products despite having matching items in the database.

#### **🔍 Cause of the Bug**
In `frontend/scripts/shop-filter-utils.js`, the `megaCategoryMap.fashion` list was missing several subcategory names. When selecting a subcategory page under Fashion (e.g. `shop.html?category=Fashion&subcategory=Footwear`), the products in those subcategories (like "White Sneakers") were incorrectly filtered out since their category (`Footwear`) was not associated with the `Fashion` mega-category.

#### **🛠️ Solution**
Added `"Footwear"`, `"Kids Wear"`, `"Watches"`, `"Bags"`, and `"Accessories"` to the `fashion` array inside `megaCategoryMap` in `frontend/scripts/shop-filter-utils.js`.

---

#### **✅ Verification/Testing**
- Clicked on **Fashion ➔ Footwear** in the Menu dropdown.
- Verified that footwear products (like "White Sneakers" and "Running Sneakers" from the database) are now correctly displayed on the Shop page instead of showing an empty list.

Closes #919