### PR TITLE
fix: resolve backend startup syntax error and incorrect import path

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -9,7 +9,7 @@ const morgan = require("morgan");
 const timeout = require("connect-timeout");
 const fs = require("fs");
 const path = require("path");
-const setupGracefulShutdown = require('./src/utils/gracefulShutdown');
+const setupGracefulShutdown = require('./utils/gracefulShutdown');
 
 const { apiLimiter, adminLimiter, mcpLimiter } = require('./config/rateLimiters');
 const dotenv = require("dotenv");
@@ -61,7 +61,7 @@ const { outboxService } = require('./services/outboxService');
 
 
 // Initialize outbox service
-await outboxService.initialize();
+outboxService.initialize().catch(err => console.error('Outbox initialization failed:', err));
 
 // Add outbox routes
 app.use('/api/outbox', outboxRoutes);
@@ -82,7 +82,7 @@ const flagRoutes = require('./routes/flagRoutes');
 const { featureFlagService } = require('./services/featureFlagService');
 
 // Initialize feature flag service
-await featureFlagService.initialize();
+featureFlagService.initialize().catch(err => console.error('Feature flag initialization failed:', err));
 
 // Add flag routes
 app.use('/api/flags', flagRoutes);
@@ -117,7 +117,7 @@ const pluginRoutes = require('./routes/pluginRoutes');
 const { pluginSystem } = require('./services/pluginSystemService');
 
 // Initialize plugin system
-await pluginSystem.initialize();
+pluginSystem.initialize().catch(err => console.error('Plugin system initialization failed:', err));
 
 // Add plugin routes
 app.use('/api/plugins', pluginRoutes);


### PR DESCRIPTION

### **PR Description**

#### **📌 Description**
This PR fixes two critical startup bugs in `backend/server.js` that caused the backend server to crash instantly on boot.

#### **🔍 Cause of the Bugs**
1. **Module Syntax Conflict (`ERR_AMBIGUOUS_MODULE_SYNTAX`):** The backend is configured as a CommonJS project (using `require()`). However, the developer used three top-level `await` statements (lines 64, 85, and 120) which are only valid in ES Modules. This caused Node.js to fail parsing the entrypoint file and crash.
2. **Missing Module (`MODULE_NOT_FOUND`):** The import on line 12 tried to require `gracefulShutdown.js` from `./src/utils/gracefulShutdown`, but the file is actually located in `./utils/gracefulShutdown`.

#### **🛠️ Solution**
1. Removed the top-level `await` keywords and converted the initialization calls to standard asynchronous promise chains with `.catch()` error handlers.
2. Corrected the import path on line 12 of `backend/server.js` to point to `./utils/gracefulShutdown`.

---

#### **✅ Verification/Testing**
- Started the backend server using `npm run dev`.
- Verified that the server boots up successfully, initializes the services without errors, and listens on port 5000.

Closes #924