### PR TITLE
feat(admin): validate admin log date range filters before processing …

### DIFF
--- a/backend/controllers/admin.controller.js
+++ b/backend/controllers/admin.controller.js
@@ -8,6 +8,8 @@ const {
 } = require("../utils/helpers");
 const logger = require("../utils/logger");
 
+const { validateDateRange } = require("../utils/dateRangeValidator");
+
 // =====================
 // DASHBOARD STATS
 // =====================
@@ -427,11 +429,22 @@ const getAdminLogs = async (req, res) => {
             50
         );
 
+        let startDate = req.query.startDate;
+        let endDate = req.query.endDate;
+        try {
+            validateDateRange(startDate, endDate, { maxRangeDays: 365 });
+        } catch (validationError) {
+            return res.status(400).json({
+                success: false,
+                message: validationError.message
+            });
+        }
+
         const filters = {
             action: sanitizeString(req.query.action),
             userId: req.query.userId ? safeNumber(req.query.userId) : undefined,
-            startDate: req.query.startDate,
-            endDate: req.query.endDate
+            startDate: startDate, 
+            endDate: endDate      
         };
 
         const result = await adminService.getAdminLogs(
@@ -440,7 +453,6 @@ const getAdminLogs = async (req, res) => {
             page,
             limit
         );
-
         return res.status(200).json({
             success: true,
             logs: result.logs,

--- a/backend/utils/dateRangeValidator.js
+++ b/backend/utils/dateRangeValidator.js
@@ -1,0 +1,45 @@
+// src/utils/dateRangeValidator.js
+
+const validateDateRange = (startDate, endDate, options = {}) => {
+  const { maxRangeDays = 365, allowFutureDates = false } = options;
+
+  // 1. Check if both dates are provided
+  if (!startDate || !endDate) {
+    throw new Error('Both startDate and endDate are required.');
+  }
+
+  // 2. Check if dates are valid date strings
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+
+  if (isNaN(start.getTime())) {
+    throw new Error(`Invalid startDate provided: "${startDate}". Please use a valid date format.`);
+  }
+  if (isNaN(end.getTime())) {
+    throw new Error(`Invalid endDate provided: "${endDate}". Please use a valid date format.`);
+  }
+
+  // 3. Check if start date is after end date
+  if (start.getTime() > end.getTime()) {
+    throw new Error('Start date cannot be later than end date.');
+  }
+
+  // 4. (Optional) Reject future dates for admin logs
+  if (!allowFutureDates) {
+    const now = new Date();
+    if (end.getTime() > now.getTime()) {
+      throw new Error('End date cannot be in the future.');
+    }
+  }
+
+  // 5. Check for maximum date range (Prevent overly expensive queries)
+  const diffTime = Math.abs(end.getTime() - start.getTime());
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  if (diffDays > maxRangeDays) {
+    throw new Error(`Date range cannot exceed ${maxRangeDays} days. You requested ${diffDays} days.`);
+  }
+
+  return { start, end };
+};
+
+module.exports = { validateDateRange };


### PR DESCRIPTION
## Closes #887

### Problem description
The `getAdminLogs` endpoint currently accepts `startDate` and `endDate` without performing comprehensive validation. Invalid dates, future dates, reversed ranges, or excessively large ranges (e.g., 10 years) reach the service layer, causing unnecessary database queries and inconsistent filtering behavior.

### Proposed solution
Implemented a reusable helper `src/utils/dateRangeValidator.js` responsible for validating admin log date filters.

The implementation:
- Validates that both `startDate` and `endDate` are valid dates.
- Rejects requests where the start date is later than the end date.
- Rejects invalid or malformed date values.
- Rejects future dates for admin logs.
- Enforces a maximum date range of **365 days** to prevent excessively expensive DB queries.
- Returns clear and consistent 400 Bad Request error messages.
- Keeps the validation reusable for future endpoints that accept date ranges.

### Testing instructions
1. Try calling the admin logs endpoint with an invalid date (e.g., `startDate=invalid` or `endDate=2026-99-99`). It should return a clear error.
2. Try with `startDate` later than `endDate` (e.g., `startDate=2025-01-01&endDate=2024-01-01`). Should return "Start date cannot be later than end date."
3. Try with a date range larger than 365 days. Should return "Date range cannot exceed 365 days."
4. Valid requests should continue to work perfectly.

### Additional context
All existing service layer logic remains untouched. Only input validation is added at the controller level to reject invalid/malicious queries before they hit the database, significantly improving performance and reliability.