### PR TITLE
feat(wishlist): validate sync payload structure and unique IDs (Close…

### DIFF
--- a/backend/routes/wishlistRoutes.js
+++ b/backend/routes/wishlistRoutes.js
@@ -7,7 +7,63 @@ const { authorizeRoles } = require("../middleware/rbacMiddleware");
 const wishlistController = require("../controllers/wishlistController");
 const { safeNumber, safeInteger } = require("../utils/helpers");
 
+
 // ==================== VALIDATION MIDDLEWARE ====================
+// ==================== SYNC VALIDATION MIDDLEWARE ====================
+const validateSyncPayload = (req, res, next) => {
+  const { productIds } = req.body;
+
+  // 1. Array hona chahiye
+  if (!Array.isArray(productIds)) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid payload format. 'productIds' must be an array.",
+    });
+  }
+
+  // 2. Non-empty check
+  if (productIds.length === 0) {
+    return res.status(400).json({
+      success: false,
+      message: "Product IDs array cannot be empty for synchronization.",
+    });
+  }
+
+  // 3. Max limit check (Sync operation heavy hoti hai, isliye 200 limit rakhi hai)
+  const MAX_SYNC_LIMIT = 200;
+  if (productIds.length > MAX_SYNC_LIMIT) {
+    return res.status(400).json({
+      success: false,
+      message: `Maximum ${MAX_SYNC_LIMIT} products allowed in a single synchronization request.`,
+    });
+  }
+
+  // 4. Validate individual IDs aur duplicates check
+  const seenIds = new Set();
+  for (const id of productIds) {
+    const validId = safeNumber(id);
+    if (!validId || validId < 1) {
+      return res.status(400).json({
+        success: false,
+        message: `Invalid product ID provided: ${id}. All IDs must be positive integers.`,
+      });
+    }
+
+    // Duplicate check
+    if (seenIds.has(validId)) {
+      return res.status(400).json({
+        success: false,
+        message: `Duplicate product ID found: ${id}. Synchronization payload must contain unique IDs.`,
+      });
+    }
+    seenIds.add(validId);
+  }
+
+  // 5. Validated data ko request mein attach karein (Controller ise use kar sakta hai)
+  req.validatedProductIds = Array.from(seenIds);
+
+  next();
+};
 const validateProductId = (req, res, next) => {
   const productId = safeNumber(req.params.productId || req.body.productId);
   if (!productId || productId < 1) {
@@ -95,7 +151,7 @@ router.post(
 router.post("/share", authMiddleware, wishlistController.generateShareLink);
 
 // Sync wishlist (replace entire wishlist)
-router.post("/sync", authMiddleware, wishlistController.syncWishlist);
+router.post("/sync", authMiddleware,validateSyncPayload, wishlistController.syncWishlist);
 
 // Remove from wishlist (using body)
 router.post(


### PR DESCRIPTION
## Closes #931

### Problem description
The `/sync` endpoint in `wishlist.routes.js` currently forwards the request directly to `wishlistController.syncWishlist` without validating the payload. This allows malformed data (like non-array inputs), invalid/negative product IDs, duplicates, or excessively large arrays to reach the service layer, leading to potential database corruption and unnecessary load.

### Proposed solution
Introduced a dedicated `validateSyncPayload` middleware and applied it to the `/sync` route before the controller.

**The middleware performs the following validations:**
- ✅ Checks if `productIds` exists and is a valid array.
- ✅ Ensures the array is not empty.
- ✅ Enforces a maximum limit of **200 items** per sync request to prevent abuse.
- ✅ Validates every ID using `safeNumber` to ensure they are positive integers.
- ✅ Rejects duplicate product IDs using a `Set`.
- ✅ Attaches `req.validatedProductIds` to the request for the controller to use.

### Benefits
- ✅ Prevents Database Abuse by rejecting overly large requests early.
- ✅ Ensures Data Integrity by preventing duplicate IDs.
- ✅ Provides consistent, user-friendly error messages.
- ✅ Follows the existing pattern used in `validateBatchProducts`.

### Testing instructions
1. Send a POST request to `/sync` with an empty array `{ "productIds": [] }`. Should return a 400 error.
2. Send a request with duplicate IDs `[1, 2, 1]`. Should return a 400 error.
3. Send a request with an array of 300 items. Should return a "Maximum 200 products" error.
4. Send a valid array. The request should pass middleware and hit the controller.