### PR TITLE
feat(wishlist): reject duplicate product IDs in batch operations (Clo…

### DIFF
--- a/backend/routes/wishlistRoutes.js
+++ b/backend/routes/wishlistRoutes.js
@@ -22,26 +22,44 @@ const validateProductId = (req, res, next) => {
 
 const validateBatchProducts = (req, res, next) => {
   const { productIds } = req.body;
+
+  // 1. Check if array exists and is not empty
   if (!Array.isArray(productIds) || productIds.length === 0) {
     return res.status(400).json({
       success: false,
       message: "Product IDs array is required",
     });
   }
+
+  // 2. Check maximum limit
   if (productIds.length > 50) {
     return res.status(400).json({
       success: false,
       message: "Maximum 50 products per batch operation",
     });
   }
+
+  // 3. Validate individual IDs and check for DUPLICATES
+  const seenIds = new Set(); // Duplicate check ke liye Set use kiya
   for (const id of productIds) {
-    if (!safeNumber(id) || id < 1) {
+    const validId = safeNumber(id);
+    if (!validId || validId < 1) {
       return res.status(400).json({
         success: false,
         message: `Invalid product ID: ${id}`,
       });
     }
+
+    // 🔥 NEW: Agar ID pehle se Set mein hai, toh duplicate error return karo
+    if (seenIds.has(validId)) {
+      return res.status(400).json({
+        success: false,
+        message: `Duplicate product ID found: ${id}. Batch operations require unique IDs.`,
+      });
+    }
+    seenIds.add(validId);
   }
+
   next();
 };
 


### PR DESCRIPTION
## Closes #932

### Problem description
The `validateBatchProducts` middleware verifies that `productIds` is a non-empty array of valid integers. However, it currently allows duplicate product IDs (e.g., `[1, 2, 2, 3]`) to pass through to the controllers. This results in unnecessary database operations, inconsistent batch processing, and reduced efficiency.

### Proposed solution
Enhanced the existing `validateBatchProducts` middleware to reject duplicate product IDs before the request reaches the controller.

**Implementation details:**
- Added a `Set` named `seenIds` to track processed IDs during the validation loop.
- If a duplicate ID is found, the middleware immediately returns a `400 Bad Request` with a clear error message (`Duplicate product ID found: ${id}`).
- Preserved the existing validation for array structure, size limits (50 items), and positive integer validity.
- Reusable for both `POST /batch/add` and `DELETE /batch/remove` operations.

### Benefits
- ✅ Prevents inconsistent batch processing.
- ✅ Reduces unnecessary database queries.
- ✅ Provides immediate feedback to API consumers.
- ✅ Keeps controller logic clean and focused on business operations.

### Testing instructions
1. Send a request to `/batch/add` or `/batch/remove` with `productIds: [1, 2, 2, 3]`.
2. The API should return a 400 error: `Duplicate product ID found: 2`.
3. Send a valid request with unique IDs. It should pass through the validation successfully.