### PR TITLE
fix(admin): prevent re-processing of already decided approval request…

### DIFF
--- a/backend/controllers/adminApprovalController.js
+++ b/backend/controllers/adminApprovalController.js
@@ -34,9 +34,7 @@ exports.getPendingApprovals = async (req, res) => {
   }
 };
 
-/**
- * Approve or reject discount (Admin only)
- */
+
 exports.decideApproval = async (req, res) => {
   try {
     if (req.user.role !== 'admin') {
@@ -56,17 +54,41 @@ exports.decideApproval = async (req, res) => {
       });
     }
 
+  
+    const [existingRequest] = await db.query(
+      `SELECT status FROM admin_approval_requests WHERE id = ?`,
+      [id]
+    );
+
+    if (existingRequest.length === 0) {
+      return res.status(404).json({
+        success: false,
+        error: 'Approval request not found'
+      });
+    }
+
+    if (existingRequest[0].status !== 'pending') {
+      // 409 Conflict HTTP status code use karein (Best practice for state conflicts)
+      return res.status(409).json({
+        success: false,
+        error: `Request already ${existingRequest[0].status}. Cannot re-process an already decided request.`
+      });
+    }
+    // ==========================================
+
+    // 2. Abhi status 'pending' hai, toh update karein
     const [result] = await db.query(
       `UPDATE admin_approval_requests 
              SET status = ?, admin_id = ?, admin_notes = ?
-             WHERE id = ?`,
+             WHERE id = ? AND status = 'pending'`, // Extra security: DB level pe bhi check
       [action === 'approve' ? 'approved' : 'rejected', req.user.id, notes, id]
     );
 
     if (result.affectedRows === 0) {
-      return res.status(404).json({
+      // Extra safety check if DB didn't update due to some race condition
+      return res.status(409).json({
         success: false,
-        error: 'Approval request not found'
+        error: 'Request status was modified by another admin. Please refresh and try again.'
       });
     }
 


### PR DESCRIPTION
## Closes #953

### Problem description
The `decideApproval` controller currently allows an admin to change the status of an approval request regardless of its current state. This means an already `approved` or `rejected` request can be overwritten by a subsequent request.
**Example Scenario:** Admin A approves a request, changing status to `approved`. Admin B later sends a `reject` action for the same ID. Because the update query lacks a state check, the request is overwritten to `rejected`, corrupting the approval history.

### Proposed solution
Modified the `decideApproval` logic to include a state verification step before performing the update.

**Implementation details:**
- Added a `SELECT` query at the start to check the current `status` of the request.
- If the request is not found, returns `404 Not Found`.
- If the current `status` is **not** `pending`, it immediately returns a `409 Conflict` error with a descriptive message: *`Request already ${status}. Cannot re-process an already decided request.`*
- The final `UPDATE` query also includes the condition `AND status = 'pending'` for atomic database-level safety.
- Prevents accidental overwrites and ensures consistency in the approval workflow.

### Benefits
- ✅ Prevents duplicate processing and inconsistent approval history.
- ✅ Provides clear and specific error messages (404 for missing, 409 for conflict).
- ✅ Improves data integrity for critical admin actions.
- ✅ Follows REST best practices by using appropriate HTTP status codes.

### Testing instructions
1. Approve a pending request (status becomes `approved`).
2. Immediately try to send a `reject` action using the same request ID.
3. The API should return a `409 Conflict` error: `Request already approved. Cannot re-process an already decided request.`
4. Valid pending requests should pass successfully.