### PR TITLE
feat(product): add WhatsApp share + Copy Link buttons on product detail page

### DIFF
--- a/frontend/product.html
+++ b/frontend/product.html
@@ -516,6 +516,35 @@
                     Wishlist
 
                 </button>
+                                <!-- Share Buttons (WhatsApp + Copy Link) -->
+
+                <button
+                    id="whatsapp-share-btn"
+                    type="button"
+                    aria-label="Share this product on WhatsApp"
+                    title="Share on WhatsApp"
+                >
+
+                    <i class="fab fa-whatsapp"></i>
+
+                    WhatsApp
+
+                </button>
+
+                <button
+                    id="copy-link-btn"
+                    type="button"
+                    aria-label="Copy product link to clipboard"
+                    title="Copy product link"
+                >
+
+                    <i class="fas fa-link"></i>
+
+                    Copy Link
+
+                </button>
+
+
 
             </div>
 

--- a/frontend/scripts/product-actions.js
+++ b/frontend/scripts/product-actions.js
@@ -345,6 +345,92 @@ async function toggleProductWishlist() {
     }
 }
 
+// =====================================
+// SHARE FEATURE (WhatsApp + Copy Link)
+// =====================================
+
+// build the share text used by WhatsApp / clipboard
+function buildProductShareText() {
+    const productName =
+        (currentProduct && currentProduct.name)
+            ? currentProduct.name
+            : (document.title || "Check out this product");
+
+    const productUrl = window.location.href;
+
+    return `Check out ${productName} on AnthropicBots E-Commerce: ${productUrl}`;
+}
+
+// share product on WhatsApp via https://wa.me/?text=
+function shareOnWhatsApp() {
+    const text = buildProductShareText();
+
+    const whatsappUrl =
+        `https://wa.me/?text=${encodeURIComponent(text)}`;
+
+    // open in a new tab so the user keeps the product page open
+    const win = window.open(whatsappUrl, "_blank", "noopener,noreferrer");
+
+    if (!win) {
+        // pop-up was blocked — fall back to navigation in same tab
+        window.location.href = whatsappUrl;
+    }
+
+    if (typeof AppUtils !== "undefined" && AppUtils.notify) {
+        AppUtils.notify("Opening WhatsApp...", "info");
+    }
+}
+
+// copy current product URL to clipboard using navigator.clipboard
+async function copyProductLink() {
+    const url = window.location.href;
+
+    // prefer the modern async Clipboard API
+    if (
+        navigator.clipboard &&
+        typeof navigator.clipboard.writeText === "function"
+    ) {
+        try {
+            await navigator.clipboard.writeText(url);
+
+            if (typeof AppUtils !== "undefined" && AppUtils.notify) {
+                AppUtils.notify("Product link copied to clipboard!", "success");
+            }
+            return;
+        } catch (err) {
+            console.warn("Clipboard API failed, falling back to legacy copy:", err);
+            // fall through to legacy method
+        }
+    }
+
+    // legacy fallback for non-secure contexts / older browsers
+    try {
+        const textarea = document.createElement("textarea");
+        textarea.value = url;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "absolute";
+        textarea.style.left = "-9999px";
+        document.body.appendChild(textarea);
+
+        textarea.select();
+        const ok = document.execCommand("copy");
+        document.body.removeChild(textarea);
+
+        if (typeof AppUtils !== "undefined" && AppUtils.notify) {
+            if (ok) {
+                AppUtils.notify("Product link copied to clipboard!", "success");
+            } else {
+                AppUtils.notify("Could not copy link. Please copy manually.", "error");
+            }
+        }
+    } catch (err) {
+        console.error("Legacy copy failed:", err);
+        if (typeof AppUtils !== "undefined" && AppUtils.notify) {
+            AppUtils.notify("Could not copy link. Please copy manually.", "error");
+        }
+    }
+}
+
 // action bindings
 document.addEventListener(
     "DOMContentLoaded",
@@ -362,6 +448,16 @@ document.addEventListener(
         const wishlistBtn =
             document.getElementById(
                 "wishlist-btn"
+            );
+
+        const whatsappShareBtn =
+            document.getElementById(
+                "whatsapp-share-btn"
+            );
+
+        const copyLinkBtn =
+            document.getElementById(
+                "copy-link-btn"
             );
 
         if (
@@ -409,6 +505,26 @@ document.addEventListener(
                 }
             );
         }
+
+        if (whatsappShareBtn) {
+            whatsappShareBtn.addEventListener(
+                "click",
+                (event) => {
+                    event.preventDefault();
+                    shareOnWhatsApp();
+                }
+            );
+        }
+
+        if (copyLinkBtn) {
+            copyLinkBtn.addEventListener(
+                "click",
+                (event) => {
+                    event.preventDefault();
+                    copyProductLink();
+                }
+            );
+        }
     }
 );
 
@@ -424,3 +540,9 @@ window.buyNow =
 
 window.toggleProductWishlist =
     toggleProductWishlist;
+
+window.shareOnWhatsApp =
+    shareOnWhatsApp;
+
+window.copyProductLink =
+    copyProductLink;

--- a/frontend/styles/product.css
+++ b/frontend/styles/product.css
@@ -431,8 +431,9 @@ PRODUCT VARIANTS
     color: #088178;
 }
 
-#share-btn{
-    background: #444;
+#share-btn,
+#whatsapp-share-btn,
+#copy-link-btn{
     color: #fff;
     border: none;
     padding: 14px 22px;
@@ -441,7 +442,21 @@ PRODUCT VARIANTS
     transition: 0.3s ease;
 }
 
-#share-btn:hover{
+#share-btn{
+    background: #444;
+}
+
+#whatsapp-share-btn{
+    background: #25D366;
+}
+
+#copy-link-btn{
+    background: #2563eb;
+}
+
+#share-btn:hover,
+#whatsapp-share-btn:hover,
+#copy-link-btn:hover{
     opacity: 0.9;
     transform: translateY(-2px);
 }
@@ -468,7 +483,9 @@ PRODUCT VARIANTS
     }
 
     .product-buttons button,
-    #share-btn{
+    #share-btn,
+    #whatsapp-share-btn,
+    #copy-link-btn{
         width: 100%;
     }
 


### PR DESCRIPTION
This PR implements the feature requested in issue #809 — adding a Share Product button on the product detail page (/product.html).

Currently the product page has no way to share a product, which is a common conversion driver for a fashion storefront. This change adds:

1. WhatsApp share button → opens https://wa.me/?text=<encoded-message> in a new tab with the product name + URL prefilled

2. Copy Link button → uses navigator.clipboard.writeText() to copy the product URL to clipboard, with a legacy             document.execCommand('copy') fallback for older browsers / non-secure contexts

3. Both buttons show toast confirmations via the existing AppUtils.notify() helper

4. Responsive — both buttons go full-width on mobile (≤1024px)

5. Dark-mode aware (inherits existing dark-theme styling)

Closes #809
