### PR TITLE
fix: resolve zombie promise state corruption in saga orchestrator timeouts

### DIFF
--- a/backend/services/sagaOrchestratorService.js
+++ b/backend/services/sagaOrchestratorService.js
@@ -150,10 +150,17 @@ class SagaOrchestrator extends EventEmitter {
             return { skipped: true };
         }
 
-        // Execute step with timeout
+        // Execute step with timeout and AbortController
         const timeout = step.timeout || 30000;
+        const controller = new AbortController();
+        const signal = controller.signal;
+        
+        let timeoutId;
         const timeoutPromise = new Promise((_, reject) => {
-            setTimeout(() => reject(new Error(`Step timeout: ${step.name}`)), timeout);
+            timeoutId = setTimeout(() => {
+                controller.abort();
+                reject(new Error(`Step timeout: ${step.name}`));
+            }, timeout);
         });
 
         // Get step handler
@@ -163,10 +170,15 @@ class SagaOrchestrator extends EventEmitter {
         }
 
         // Execute step
-        const result = await Promise.race([
-            handler(saga.context, saga.results),
-            timeoutPromise
-        ]);
+        let result;
+        try {
+            result = await Promise.race([
+                handler(saga.context, saga.results, signal),
+                timeoutPromise
+            ]);
+        } finally {
+            clearTimeout(timeoutId);
+        }
 
         // Store compensation if available
         if (step.compensation) {


### PR DESCRIPTION
Closes #1001 
### Description
This PR resolves a critical architectural flaw in `SagaOrchestrator` (`backend/services/sagaOrchestratorService.js`) where step timeouts were implemented using a simple `Promise.race()`. 

Since Node.js does not cancel losing promises in a race, if a step timed out, the Saga would initiate compensation (e.g., refund) while the original step handler continued executing in the background. If the background handler eventually succeeded, it would commit its changes, leading to a fatally corrupted system state (e.g., both a refund and an order completion occurring simultaneously).

### Changes Made
* Introduced an `AbortController` in `executeStep()` to propagate native cancellation signals.
* Modified the timeout logic to call `controller.abort()` when the timeout is reached.
* Passed the `signal` down to the step handler so that active database queries or network requests are proactively aborted rather than left running in the background as zombie promises.