### PR TITLE
fix: resolve polling re-entrancy leak using recursive setTimeout

### DIFF
--- a/backend/services/healthScoreService.js
+++ b/backend/services/healthScoreService.js
@@ -128,15 +128,22 @@ class HealthScoreService extends EventEmitter {
      */
     startHealthChecks() {
         for (const [moduleType, config] of this.healthChecks) {
+            const scheduleNext = () => {
+                const timer = setTimeout(async () => {
+                    await this.performHealthCheck(moduleType);
+                    if (this.isRunning) {
+                        scheduleNext();
+                    }
+                }, config.interval);
+                this.checkTimers.set(moduleType, timer);
+            };
+
             // Initial check
-            this.performHealthCheck(moduleType);
-
-            // Schedule periodic checks
-            const timer = setInterval(() => {
-                this.performHealthCheck(moduleType);
-            }, config.interval);
-
-            this.checkTimers.set(moduleType, timer);
+            this.performHealthCheck(moduleType).then(() => {
+                if (this.isRunning) {
+                    scheduleNext();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Fixes #1033 
### Description
This PR addresses a severe "Re-entrancy Leak" vulnerability in `HealthScoreService` (`backend/services/healthScoreService.js`). Previously, the periodic health checks were scheduled using `setInterval()`, which fired off asynchronous `performHealthCheck()` calls indiscriminately.

If a check hung or exceeded the interval duration, the loop would spawn duplicate, overlapping checks for the same module. This rapidly exhausted database connections and network sockets, ultimately crashing the Node.js process. 

### Changes Made
* Replaced `setInterval` with a recursive `setTimeout` pattern inside `startHealthChecks()`.
* The next health check is now only scheduled *after* the previous asynchronous check has fully resolved, ensuring exactly zero overlap and preventing connection pool exhaustion.
