### PR TITLE
fix: resolve non-atomic service registration via database transactions

### DIFF
--- a/backend/services/capabilityDiscoveryService.js
+++ b/backend/services/capabilityDiscoveryService.js
@@ -92,27 +92,46 @@ class CapabilityDiscoveryService extends EventEmitter {
         // Validate service
         this.validateService(service);
 
-        this.services.set(service.id, service);
-        await this.storeService(service);
+        const connection = await db.getConnection();
+        await connection.beginTransaction();
 
-        // Register capabilities
-        for (const capability of service.capabilities) {
-            await this.registerCapability(service.id, capability);
+        try {
+            this.services.set(service.id, service);
+            await this.storeService(service, connection);
+
+            // Register capabilities
+            for (const capability of service.capabilities) {
+                await this.registerCapability(service.id, capability, connection);
+            }
+
+            await connection.commit();
+
+            // Rebuild dependency graph
+            this.buildDependencyGraph();
+
+            console.log(`📦 Service registered: ${service.name} (${service.id})`);
+            this.emit('service.registered', { serviceId: service.id, name: service.name });
+
+            return service;
+        } catch (error) {
+            await connection.rollback();
+            this.services.delete(service.id);
+            for (const capability of service.capabilities) {
+                const existing = this.getCapabilityByName(capability.name);
+                if (existing && existing.serviceId === service.id) {
+                    this.capabilities.delete(existing.id);
+                }
+            }
+            throw error;
+        } finally {
+            connection.release();
         }
-
-        // Rebuild dependency graph
-        this.buildDependencyGraph();
-
-        console.log(`📦 Service registered: ${service.name} (${service.id})`);
-        this.emit('service.registered', { serviceId: service.id, name: service.name });
-
-        return service;
     }
 
     /**
      * Register a capability
      */
-    async registerCapability(serviceId, capabilityData) {
+    async registerCapability(serviceId, capabilityData, connection = null) {
         const service = this.services.get(serviceId);
         if (!service) {
             throw new Error(`Service not found: ${serviceId}`);
@@ -147,7 +166,7 @@ class CapabilityDiscoveryService extends EventEmitter {
         }
 
         this.capabilities.set(capability.id, capability);
-        await this.storeCapability(capability);
+        await this.storeCapability(capability, connection || db);
 
         // Clear cache
         this.clearCache();
@@ -561,9 +580,9 @@ class CapabilityDiscoveryService extends EventEmitter {
         }
     }
 
-    async storeService(service) {
+    async storeService(service, connection = db) {
         try {
-            await db.query(
+            await connection.query(
                 `INSERT INTO services 
                  (service_id, name, version, description, category,
                   capabilities, dependencies, permissions, endpoints,
@@ -596,12 +615,13 @@ class CapabilityDiscoveryService extends EventEmitter {
             );
         } catch (error) {
             console.error('Store service error:', error);
+            throw error;
         }
     }
 
-    async storeCapability(capability) {
+    async storeCapability(capability, connection = db) {
         try {
-            await db.query(
+            await connection.query(
                 `INSERT INTO capabilities 
                  (capability_id, service_id, service_name, name, description,
                   version, category, operations, parameters, returns,
@@ -640,6 +660,7 @@ class CapabilityDiscoveryService extends EventEmitter {
             );
         } catch (error) {
             console.error('Store capability error:', error);
+            throw error;
         }
     }
 


### PR DESCRIPTION
Fixes #1035 
### Description
This PR fixes a data corruption and orphan bug in the `CapabilityDiscoveryService` (`backend/services/capabilityDiscoveryService.js`). The `registerService()` method was executing sequential `INSERT` queries for the Service and its multiple Capabilities without a transactional boundary. 

If any capability insertion failed (e.g., due to a duplicate key), the system crashed but left the initial Service and previous Capabilities partially committed in the database.

### Changes Made
* Refactored `registerService`, `registerCapability`, `storeService`, and `storeCapability` to accept an explicit `connection` parameter.
* Acquired a dedicated database connection (`await db.getConnection()`) and wrapped the entire registration flow inside a strict `START TRANSACTION` and `COMMIT` block.
* Added a `ROLLBACK` in the error catch block to guarantee ACID atomicity, ensuring services are either fully registered with all capabilities or not registered at all.
