### PR TITLE
fix(admin): deduplicate user IDs before bulk status updates

### DIFF
--- a/backend/controllers/admin.controller.js
+++ b/backend/controllers/admin.controller.js
@@ -59,8 +59,8 @@ const getUsers = async (req, res) => {
             search: sanitizeString(req.query.search),
             status: sanitizeString(req.query.status),
             role: sanitizeString(req.query.role),
-            emailVerified: req.query.emailVerified === 'true' ? true : 
-                          req.query.emailVerified === 'false' ? false : undefined
+            emailVerified: req.query.emailVerified === 'true' ? true :
+                req.query.emailVerified === 'false' ? false : undefined
         };
 
         const result = await adminService.getUsers(filters, page, limit);
@@ -152,9 +152,13 @@ const updateUserStatus = async (req, res) => {
 // =====================
 const bulkUpdateUserStatus = async (req, res) => {
     try {
-        const targetIds = safeArray(req.body.userIds)
-            .map(id => safeUUID(id))
-            .filter(id => id && id !== req.user.id);
+        const targetIds = [
+            ...new Set(
+                safeArray(req.body.userIds)
+                    .map(id => safeUUID(id))
+                    .filter(id => id && id !== req.user.id)
+            )
+        ];
 
         const status = sanitizeString(req.body.status);
 
@@ -464,8 +468,8 @@ const getAdminLogs = async (req, res) => {
         const filters = {
             action: sanitizeString(req.query.action),
             userId: req.query.userId ? safeUUID(req.query.userId) : undefined,
-            startDate: startDate, 
-            endDate: endDate      
+            startDate: startDate,
+            endDate: endDate
         };
 
         const result = await adminService.getAdminLogs(


### PR DESCRIPTION
## Summary

This PR prevents duplicate user IDs from being processed during bulk admin user status updates.

Previously, the controller validated incoming user IDs and removed invalid IDs and self-targets, but duplicate IDs were still forwarded to the service layer. This could lead to redundant processing and inconsistent reporting.

## Changes Made

- Deduplicated incoming `userIds` using `Set`
- Preserved existing validation for invalid IDs
- Preserved self-target filtering
- Ensured only unique user IDs are passed to the bulk update service

## Before

```js
const targetIds = safeArray(req.body.userIds)
    .map(id => safeUUID(id))
    .filter(id => id && id !== req.user.id);
```

## After

```js
const targetIds = [
    ...new Set(
        safeArray(req.body.userIds)
            .map(id => safeUUID(id))
            .filter(id => id && id !== req.user.id)
    )
];
```

## Benefits

- Prevents duplicate processing
- Improves efficiency for bulk updates
- Produces cleaner audit data
- Makes controller behavior deterministic

Closes #1072 