### PR TITLE
fix(admin-approval): verify update result before committing approval decision

### DIFF
--- a/backend/controllers/adminApprovalController.js
+++ b/backend/controllers/adminApprovalController.js
@@ -113,12 +113,26 @@ exports.decideApproval = async (req, res) => {
 
     try {
       // Step 1: Update the approval request status
-      await connection.query(
-        `UPDATE admin_approval_requests 
-               SET status = ?, admin_id = ?, admin_notes = ?
-               WHERE id = ? AND status = 'pending'`,
-        [action === 'approve' ? 'approved' : 'rejected', req.user.id, sanitizedNotes, id]
+      const [updateResult] = await connection.query(
+        `UPDATE admin_approval_requests
+     SET status = ?, admin_id = ?, admin_notes = ?
+     WHERE id = ? AND status = 'pending'`,
+        [
+          status,
+          req.user.id,
+          adminNotes,
+          id
+        ]
       );
+
+      if (updateResult.affectedRows === 0) {
+        await connection.rollback();
+
+        return res.status(409).json({
+          success: false,
+          message: "This approval request has already been processed by another administrator."
+        });
+      }
 
       // Step 2: If approved, proceed with associated business logic within the SAME transaction
       if (action === 'approve') {


### PR DESCRIPTION
## Summary

This PR improves the reliability of the admin approval decision flow by verifying that the approval request was actually updated before committing the transaction.

Previously, the controller validated that the request existed and was still pending before starting the transaction. However, after executing the `UPDATE` statement, it immediately committed the transaction and returned a success response without checking whether any row was actually modified.

Under concurrent requests, another administrator could process the same approval request before the current transaction completed, causing the update to affect zero rows while still returning a successful response.

## Changes Made

- Captured the result of the approval `UPDATE` query.
- Verified `affectedRows` before committing the transaction.
- Rolled back the transaction when no rows were updated.
- Returned a `409 Conflict` response when the approval request had already been processed by another administrator.

## Before

- Executed the update query.
- Committed the transaction regardless of whether any row was updated.
- Returned a success response even when the update affected zero rows.

## After

- Executes the update query.
- Verifies `affectedRows`.
- Rolls back the transaction if no row was updated.
- Returns a conflict response instead of a false-success response.

## Benefits

- Prevents false-success responses.
- Improves correctness under concurrent admin actions.
- Makes approval decisions more predictable.
- Keeps API responses aligned with actual database changes.

Closes #1074 