### PR TITLE
fix(ai-financial): restrict financial limits endpoint to admins

### DIFF
--- a/backend/controllers/aiFinancialController.js
+++ b/backend/controllers/aiFinancialController.js
@@ -163,7 +163,14 @@ exports.getAuditLogs = async (req, res) => {
  * Get financial limits configuration
  */
 exports.getLimits = (req, res) => {
-  res.json({
+  if (req.user.role !== "admin") {
+    return res.status(403).json({
+      success: false,
+      error: "Admin access required"
+    });
+  }
+
+  return res.json({
     success: true,
     limits: FINANCIAL_LIMITS
   });


### PR DESCRIPTION
## Summary

This PR restricts access to the financial limits endpoint by requiring administrator privileges before returning the internal AI financial configuration.

Previously, `getLimits()` exposed the `FINANCIAL_LIMITS` configuration without performing any authorization checks, while the other financial controller actions already required admin access.

## Changes Made

- Added an admin role check to `getLimits()`.
- Returned `403 Forbidden` for unauthorized users.
- Kept the existing response format unchanged for authorized administrators.

## Before

- Any caller reaching the endpoint could retrieve the financial limits configuration.

## After

- Only administrators can access the financial limits configuration.

## Benefits

- Protects internal financial thresholds.
- Makes authorization consistent across the controller.
- Reduces exposure of operational configuration.

Closes #1082 