### PR TITLE
Fix broken outgoing coupling logic

### DIFF
--- a/backend/services/architecturalRiskService.js
+++ b/backend/services/architecturalRiskService.js
@@ -278,12 +278,15 @@ class ArchitecturalRiskService extends EventEmitter {
                 if (deps.some(d => d.includes(moduleName))) {
                     incoming++;
                 }
-                
-                // Check if target module depends on this module
-                if (modulePath === mod) {
-                    outgoing += deps.length;
-                }
             }
+        }
+        
+        // Calculate outgoing separately
+        const targetFiles = this.findFilesInModule(modulePath);
+        for (const file of targetFiles) {
+            const content = fs.readFileSync(file, 'utf8');
+            const deps = this.extractDependencies(content);
+            outgoing += deps.length;
         }
 
         return {


### PR DESCRIPTION
### Description
Fixes a dead logic bug in `architecturalRiskService.js` where the `outgoing` coupling metric for all modules was always incorrectly calculated as `0`.
FIxes #1087 
### Changes Made
- Separated the calculation of outgoing dependencies into a distinct loop that evaluates the target module's own files.
- Maintained the existing incoming dependencies logic within the `allModules` iteration.
- Resolves the issue where the `continue` statement bypassed the outgoing logic block entirely.