### PR TITLE
fix: apply dark theme styles to filters sidebar

### DIFF
--- a/frontend/styles/shop.css
+++ b/frontend/styles/shop.css
@@ -805,3 +805,37 @@
   color: #111;
   font-weight: 600;
 }
+
+/* Dark mode fixes for Filters sidebar */
+body.dark-theme .filter-sidebar {
+    background: #1e1e1e;
+    border-color: #333;
+}
+
+body.dark-theme .filter-sidebar__header h2,
+body.dark-theme .filter-group legend {
+    color: #ffffff;
+}
+
+body.dark-theme .filter-group {
+    border-top-color: #333;
+}
+
+body.dark-theme .filter-options label,
+body.dark-theme .price-filter label {
+    color: #e0e0e0;
+}
+
+body.dark-theme .price-range-output {
+    color: #0fbfa5; /* slightly brighter teal for contrast on dark bg */
+}
+
+body.dark-theme .filter-close {
+    background: #2a2a2a;
+    color: #e0e0e0;
+}
+
+body.dark-theme .clear-filters-btn {
+    background: #088178;
+    color: #ffffff;
+}


### PR DESCRIPTION
## Description
The Filters sidebar (Category, Price, Rating) on the Shop page stayed in a light/white theme even when Dark Mode was enabled, making checkbox labels and price text low-contrast and hard to read. Every other component (product cards, navbar, footer) already had `body.dark-theme` overrides in its respective CSS file, but `shop.css` was missing them entirely for the filter sidebar.

Fixes #1096

## Root Cause
Dark mode is toggled site-wide via a `body.dark-theme` class (see `components.js` / `ui.js`). `frontend/styles/shop.css` never defined matching dark-theme rules for `.filter-sidebar`, `.filter-group`, `.filter-options label`, `.price-filter label`, etc. — they were hardcoded to light colors (`#fff`, `#17211f`, `#313d3a`) with no dark variant.

## Changes
- Added `body.dark-theme` overrides in `frontend/styles/shop.css` for:
  - `.filter-sidebar` background/border
  - `.filter-sidebar__header h2` and `.filter-group legend` text color
  - `.filter-group` border-top color
  - `.filter-options label` / `.price-filter label` text color
  - `.price-range-output` accent color
  - `.filter-close` button
  - `.clear-filters-btn` button
- Colors match the existing dark palette used elsewhere in the codebase (`#1e1e1e` bg, `#333` borders, `#e0e0e0`/`#ffffff` text) for visual consistency.

## How to Test
1. Go to the Shop / Products page.
2. Toggle Dark Mode from the site settings.
3. Open the Filters sidebar (Category, Price, Rating).
4. Confirm the sidebar background is dark and all labels/text are clearly readable with good contrast.

## Screenshot
<img width="1918" height="911" alt="image" src="https://github.com/user-attachments/assets/f029604d-ac67-4466-91da-88bcea221da7" />

## Test Coverage Note
This is a CSS-only visual fix. The `frontend/` directory has no automated test framework set up (only `backend/tests/` uses Jest), so this was verified manually via browser dark-mode toggle rather than an automated test.

## Checklist
- [x] Commit signed off with DCO (`git commit -s`)
- [x] Tested locally in both light and dark mode
- [x] No JS changes required (reuses existing `dark-theme` class toggle)
- [x] Follows existing CSS convention used in `product-card.css` / `base.css`