### PR TITLE
Feat: Add downloadable PDF invoices for orders

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -7,6 +7,7 @@ const {
     "../services/order.service"
 );
 
+const { generateInvoicePdf } = require("../services/invoice.service");
 const inventoryReservationService = require("../services/inventoryReservationService");
 
 const {
@@ -629,5 +630,38 @@ module.exports = {
     updateOrderStatus,
     cancelUserOrder,
     validateOrder,
-    getOrderSummary
+    getOrderSummary,
+    downloadInvoice
+};
+
+// download invoice
+const downloadInvoice = async (req, res) => {
+    try {
+        const orderId = req.params.id;
+        
+        // Fetch order details
+        const [orders] = await db.query("SELECT * FROM orders WHERE id = ?", [orderId]);
+        if (!orders || orders.length === 0) {
+            return res.status(404).json({ success: false, message: "Order not found" });
+        }
+        const order = orders[0];
+
+        // Authorization: Ensure user is admin or the order belongs to them
+        if (req.user && req.user.role !== 'admin' && order.user_id !== req.user.id) {
+            return res.status(403).json({ success: false, message: "Unauthorized access to order" });
+        }
+
+        // Fetch order items
+        const [items] = await db.query("SELECT * FROM order_items WHERE order_id = ?", [orderId]);
+
+        // Generate PDF
+        const pdfBuffer = await generateInvoicePdf(order, items);
+
+        res.setHeader('Content-Type', 'application/pdf');
+        res.setHeader('Content-Disposition', `attachment; filename="invoice-${orderId}.pdf"`);
+        return res.status(200).send(pdfBuffer);
+    } catch (error) {
+        console.error("Error generating invoice:", error);
+        return res.status(500).json({ success: false, message: "Failed to generate invoice" });
+    }
 };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -31,6 +31,7 @@
         "helmet": "^8.2.0",
         "ioredis": "^5.11.1",
         "joi": "^18.2.3",
+        "json2csv": "^6.0.0-alpha.2",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.7.4",
         "morgan": "^1.11.0",
@@ -40,6 +41,8 @@
         "node-cron": "^4.6.0",
         "nodemailer": "^9.0.0",
         "opossum": "^10.0.0",
+        "otplib": "^13.4.1",
+        "pdfkit": "^0.19.1",
         "prom-client": "^15.1.3",
         "rate-limiter-flexible": "^11.2.0",
         "socket.io": "^4.8.3",
@@ -107,7 +110,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1110,11 +1112,22 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmmirror.com/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1128,7 +1141,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1422,6 +1434,74 @@
         "@opentelemetry/api": "^1.1.0"
       }
     },
+    "node_modules/@otplib/core": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-13.4.1.tgz",
+      "integrity": "sha512-KIXgK1hNtWJEBMTastbe1bpmuais+3f+ATeO8TkMs2rNkfGO1FbQy8+/UWVEu3TR/iTJerU0idkPudaPmLP2BA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/hotp": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/hotp/-/hotp-13.4.1.tgz",
+      "integrity": "sha512-g9q04SwpG5ZtMnVkUcgcoAlwCH4YLROZN1qhyBwgkBzqYYVSYhpP6gSGaxGHwePLt1c+e6NqDlgIZN+e1/XPuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1",
+        "@otplib/uri": "13.4.1"
+      }
+    },
+    "node_modules/@otplib/plugin-base32-scure": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-base32-scure/-/plugin-base32-scure-13.4.1.tgz",
+      "integrity": "sha512-Fs/r5qisC05SRhT6xWXaypB6PVC0vgWf6zztmi0J5RnQ09OJiPDWCJFH6cDm6ANsrdvB9di7X+Jb7L13BoEbUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1",
+        "@scure/base": "^2.2.0"
+      }
+    },
+    "node_modules/@otplib/plugin-crypto-noble": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto-noble/-/plugin-crypto-noble-13.4.1.tgz",
+      "integrity": "sha512-PJfVW8/1hdS6CfxLheKPZSLTwDq4TijZbN4yRjxlv0ODdzmxpM+wGwWr1JXMdy0xJPxLziydQD5gdVqrR4/gAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.2.0",
+        "@otplib/core": "13.4.1"
+      }
+    },
+    "node_modules/@otplib/plugin-crypto-noble/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@otplib/totp": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/totp/-/totp-13.4.1.tgz",
+      "integrity": "sha512-QOkBVPrf6AM4qZaReZPSk9/I8ATVdZpIISJz115MqeVtcrbcr5llPZ0J7804tpnjnp1vCRkI5Qjd47HhgVteBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1",
+        "@otplib/hotp": "13.4.1",
+        "@otplib/uri": "13.4.1"
+      }
+    },
+    "node_modules/@otplib/uri": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/uri/-/uri-13.4.1.tgz",
+      "integrity": "sha512-xaIm7bvICMhoB2rZIR5luiaMdssWR5nY5nXnR1fdezUgZuEO58D6zrGzLp7pQuBmlpmL0HagnscDQFoskp9yiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmmirror.com/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -1430,6 +1510,15 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1485,6 +1574,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@streamparser/json": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.6.tgz",
+      "integrity": "sha512-vL9EVn/v+OhZ+Wcs6O4iKE9EUpwHUqHmCtNUMWjqp+6dr85+XPOSGTEsqYNq1Vn04uk9SWlOVmx9J48ggJVT2Q==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1604,7 +1699,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
       "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1674,6 +1768,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/acorn-import-assertions": {
@@ -2059,6 +2166,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/base64id": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
@@ -2203,6 +2330,24 @@
         "object.entries": "^1.0.4"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.5",
       "resolved": "https://registry.npmmirror.com/browserslist/-/browserslist-4.28.5.tgz",
@@ -2223,7 +2368,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -2652,6 +2796,15 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmmirror.com/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -3073,6 +3226,12 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -3669,7 +3828,6 @@
       "resolved": "https://registry.npmmirror.com/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3725,6 +3883,12 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3884,6 +4048,23 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/form-data": {
@@ -5320,6 +5501,12 @@
         "node": ">= 20"
       }
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5389,6 +5576,24 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/json2csv": {
+      "version": "6.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-6.0.0-alpha.2.tgz",
+      "integrity": "sha512-nJ3oP6QxN8z69IT1HmrJdfVxhU1kLTBVgMfRnNZc37YEY+jZ4nU27rBGxT4vaqM/KUCavLRhntmTuBFqZLBUcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@streamparser/json": "^0.0.6",
+        "commander": "^6.2.0",
+        "lodash.get": "^4.4.2"
+      },
+      "bin": {
+        "json2csv": "bin/json2csv.js"
+      },
+      "engines": {
+        "node": ">= 12",
+        "npm": ">= 6.13.0"
       }
     },
     "node_modules/json5": {
@@ -5482,6 +5687,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmmirror.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -5512,6 +5736,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -6275,6 +6506,20 @@
         "forwarded-parse": "^2.1.0"
       }
     },
+    "node_modules/otplib": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-13.4.1.tgz",
+      "integrity": "sha512-o5CxfDw6bh7hoDv0NUUIcc0RqzJ9ipfUrzeKheKJ+vs4rXZnDlA9n4a/7R1cDjpmLjKLix4BgNVRmoDkm5rLSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1",
+        "@otplib/hotp": "13.4.1",
+        "@otplib/plugin-base32-scure": "13.4.1",
+        "@otplib/plugin-crypto-noble": "13.4.1",
+        "@otplib/totp": "13.4.1",
+        "@otplib/uri": "13.4.1"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/p-limit/-/p-limit-3.1.0.tgz",
@@ -6329,6 +6574,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -6405,6 +6656,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pdfkit": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.19.1.tgz",
+      "integrity": "sha512-6Gzk+wDwTs4VSxsR5rCMTnIl5nlmkye1oWB0l2hDB1EX6ZNSIBroKQEv+2+fPPn+stVjyqzmsqRJVDfB9fo5DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
@@ -6472,6 +6737,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
       }
     },
     "node_modules/pretty-format": {
@@ -6798,6 +7071,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -7539,6 +7818,12 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmmirror.com/tmpl/-/tmpl-1.0.5.tgz",
@@ -7717,12 +8002,38 @@
         "unicode-substring": "^0.1.0"
       }
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/unicode-substring": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/unicode-substring/-/unicode-substring-0.1.0.tgz",
       "integrity": "sha512-36Xaw9wXi7MB/3/EQZZHkZyyiRNa9i3k9YtPAz2KfqMVH2xutdXyMHn4Igarmnvr+wOrfWa/6njhY+jPpXN2EQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -51,6 +51,7 @@
     "nodemailer": "^9.0.0",
     "opossum": "^10.0.0",
     "otplib": "^13.4.1",
+    "pdfkit": "^0.19.1",
     "prom-client": "^15.1.3",
     "rate-limiter-flexible": "^11.2.0",
     "socket.io": "^4.8.3",

--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -322,6 +322,9 @@ router.get("/:id/summary", authMiddleware, orderController.getOrderSummary);
 // Get single order with items
 router.get("/:id", authMiddleware, orderController.getOrderById);
 
+// Download order invoice
+router.get("/:id/invoice", authMiddleware, orderController.downloadInvoice);
+
 // Cancel order with reason
 router.patch("/:id/cancel", authMiddleware, (req, res, next) => {
     const reasonValidation = validateReason(req.body.reason);

--- a/backend/services/invoice.service.js
+++ b/backend/services/invoice.service.js
@@ -1,0 +1,118 @@
+const PDFDocument = require('pdfkit');
+
+function generateInvoicePdf(order, items) {
+    return new Promise((resolve, reject) => {
+        try {
+            const doc = new PDFDocument({ margin: 50 });
+            let buffers = [];
+            
+            doc.on('data', buffers.push.bind(buffers));
+            doc.on('end', () => {
+                const pdfData = Buffer.concat(buffers);
+                resolve(pdfData);
+            });
+            doc.on('error', reject);
+
+            // Generate Header
+            doc.fillColor('#444444')
+                .fontSize(20)
+                .text('INVOICE', 50, 50, { align: 'right' });
+            
+            const orderIdText = order.order_number || order.id;
+            doc.fontSize(10)
+                .text(`Order ID: ${orderIdText}`, 50, 80, { align: 'right' })
+                .text(`Order Date: ${new Date(order.created_at).toLocaleDateString()}`, 50, 95, { align: 'right' });
+            
+            // Customer Info
+            doc.fontSize(14).text('Billed To:', 50, 130);
+            doc.fontSize(10)
+                .text(order.customer_name || 'N/A', 50, 150)
+                .text(order.customer_email || 'N/A', 50, 165)
+                .text(order.customer_phone || '', 50, 180);
+                
+            let fullAddress = order.full_address || '';
+            if (!fullAddress && order.shipping_address) {
+                const address = typeof order.shipping_address === 'string' ? JSON.parse(order.shipping_address) : order.shipping_address;
+                fullAddress = `${address.street || ''}, ${address.city || ''}, ${address.state || ''} ${address.zip || ''}`.trim();
+            }
+            if (fullAddress.startsWith(',')) fullAddress = fullAddress.substring(1).trim();
+            doc.text(fullAddress, 50, 195);
+
+            // Table Header
+            const tableTop = 250;
+            doc.font('Helvetica-Bold');
+            doc.text('Item', 50, tableTop);
+            doc.text('Qty', 300, tableTop, { width: 50, align: 'right' });
+            doc.text('Price', 380, tableTop, { width: 50, align: 'right' });
+            doc.text('Total', 480, tableTop, { width: 50, align: 'right' });
+            
+            doc.moveTo(50, tableTop + 15).lineTo(530, tableTop + 15).stroke();
+            
+            // Table Rows
+            doc.font('Helvetica');
+            let y = tableTop + 25;
+            (items || []).forEach(item => {
+                // Handle pagination if needed
+                if (y > 700) {
+                    doc.addPage();
+                    y = 50;
+                }
+                const name = item.name || 'Unknown Product';
+                const qty = Number(item.qty) || 1;
+                const price = Number(item.price) || 0;
+                const lineTotal = price * qty;
+
+                doc.text(name, 50, y, { width: 230 });
+                doc.text(qty.toString(), 300, y, { width: 50, align: 'right' });
+                doc.text(`$${price.toFixed(2)}`, 380, y, { width: 50, align: 'right' });
+                doc.text(`$${lineTotal.toFixed(2)}`, 480, y, { width: 50, align: 'right' });
+                y += 20;
+            });
+            
+            doc.moveTo(50, y).lineTo(530, y).stroke();
+            y += 15;
+            
+            // Summary
+            const subtotal = Number(order.subtotal) || 0;
+            let discount = Number(order.discount) || 0;
+            if (!discount && order.discount_amount) {
+                discount = Number(order.discount_amount);
+            }
+            const tax = Number(order.tax) || 0;
+            const shipping = Number(order.shipping_cost) || 0;
+            let total = Number(order.total) || 0;
+            if (order.final_amount) {
+                total = Number(order.final_amount);
+            }
+
+            doc.text(`Subtotal: $${subtotal.toFixed(2)}`, 380, y, { align: 'right' });
+            y += 15;
+            if (discount > 0) {
+                doc.text(`Discount: -$${discount.toFixed(2)}`, 380, y, { align: 'right' });
+                y += 15;
+            }
+            if (tax > 0) {
+                doc.text(`Tax: $${tax.toFixed(2)}`, 380, y, { align: 'right' });
+                y += 15;
+            }
+            if (shipping > 0) {
+                doc.text(`Shipping: $${shipping.toFixed(2)}`, 380, y, { align: 'right' });
+                y += 15;
+            }
+            
+            doc.font('Helvetica-Bold');
+            doc.text(`Total: $${total.toFixed(2)}`, 380, y, { align: 'right' });
+            y += 15;
+            doc.font('Helvetica');
+            doc.text(`Payment Method: ${order.payment_method || 'N/A'}`, 380, y, { align: 'right' });
+
+            doc.end();
+        } catch (error) {
+            reject(error);
+        }
+    });
+}
+
+module.exports = {
+    generateInvoicePdf
+};


### PR DESCRIPTION
## Summary

This PR adds support for generating downloadable PDF invoices for completed orders.

A new authenticated endpoint has been introduced that generates invoices on demand, allowing customers (or authorized administrators) to download a PDF containing their order details without storing invoice files on the server.

Closes #1042

## Changes

### PDF Invoice Generation

* Added a dedicated invoice service to generate PDF invoices on demand.
* Generates invoices containing:

  * Order information
  * Customer details
  * Shipping address
  * Itemized products with quantities and pricing
  * Order summary (subtotal, discounts, taxes, shipping, and final total)
  * Payment method

### Order Download Endpoint

* Added an authenticated endpoint to download invoices:

  * `GET /api/orders/:id/invoice`
* Retrieves the requested order and its associated items.
* Returns the generated PDF with the appropriate response headers for file download.

### Authorization

* Restricts invoice downloads to authorized users.
* Ensures only the order owner or an administrator can access an invoice.

## Why

This feature provides customers with a convenient way to download invoices for completed purchases while keeping invoice generation stateless. PDFs are generated on demand, avoiding the need to persist invoice files or introduce additional storage.