### PR TITLE
Add custom 404 page (closes #917)

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+
+    <meta charset="UTF-8">
+
+    <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1.0"
+    >
+
+    <!-- SEO -->
+    <link rel="canonical" href="https://www.bhuvansh.xyz/404.html">
+    <meta
+        name="description"
+        content="Page not found at AnthropicBots E-Commerce."
+    >
+
+    <meta
+        name="robots"
+        content="noindex, follow"
+    >
+
+    <meta
+        name="author"
+        content="AnthropicBots E-Commerce"
+    >
+
+    <title>
+        Page Not Found | AnthropicBots E-Commerce
+    </title>
+
+    <!-- Favicon -->
+
+    <link
+        rel="icon"
+        type="image/png"
+        href="assets/images/logo.png"
+    >
+
+    <!-- Styles -->
+
+    <link
+        rel="stylesheet"
+        href="styles/base.css"
+    >
+
+    <link
+        rel="stylesheet"
+        href="styles/layout.css"
+    >
+
+    <link
+        rel="stylesheet"
+        href="styles/components.css"
+    >
+
+    <link
+        rel="stylesheet"
+        href="styles/hero.css"
+    >
+
+    <link
+        rel="stylesheet"
+        href="styles/product-card.css"
+    >
+
+    <link
+        rel="stylesheet"
+        href="styles/style.css"
+    >
+
+    <link
+        rel="stylesheet"
+        href="styles/back-to-top.css"
+    >
+
+    <link
+        rel="stylesheet"
+        href="styles/404.css"
+    >
+
+    <!-- Icons -->
+
+    <link
+        rel="stylesheet"
+        href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css"
+    >
+
+</head>
+
+<body>
+
+    <!-- Navbar -->
+
+    <div id="navbar"></div>
+
+    <!-- 404 Section -->
+
+    <section id="notfound-page">
+
+        <div class="notfound-box">
+
+            <!-- Icon -->
+
+            <div class="notfound-icon">
+
+                <i class="fas fa-compass"></i>
+
+            </div>
+
+            <!-- Code -->
+
+            <p class="notfound-code">
+
+                404
+
+            </p>
+
+            <!-- Title -->
+
+            <h2>
+
+                Page Not Found
+
+            </h2>
+
+            <p>
+
+                The page you're looking for doesn't exist
+                or may have been moved. Let's get you
+                back on track.
+
+            </p>
+
+            <!-- Buttons -->
+
+            <div class="notfound-buttons">
+
+                <a href="index.html">
+
+                    Go to Homepage
+
+                </a>
+
+                <a href="shop.html" class="notfound-secondary">
+
+                    Browse Shop
+
+                </a>
+
+            </div>
+
+        </div>
+
+    </section>
+
+    <!-- Footer -->
+
+    <div id="footer"></div>
+
+    <!-- Core Scripts -->
+
+    <script
+        defer
+        src="scripts/config.js"
+    ></script>
+
+    <script
+        defer
+        src="scripts/toast.js"
+    ></script>
+
+    <script
+        defer
+        src="scripts/utils.js"
+    ></script>
+
+    <script
+        defer
+        src="scripts/auth.js"
+    ></script>
+
+    <script
+        defer
+        src="scripts/script.js"
+    ></script>
+
+    <script
+        defer
+        src="scripts/components.js"
+    ></script>
+
+    <script defer src="scripts/ui.js"></script>
+
+    <script
+        defer
+        src="scripts/back-to-top.js"
+    ></script>
+
+</body>
+
+</html>

--- a/frontend/styles/404.css
+++ b/frontend/styles/404.css
@@ -1,0 +1,126 @@
+#notfound-page{
+    min-height: 80vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f8f8f8;
+    padding: 40px 20px;
+}
+
+.notfound-box{
+    width: 100%;
+    max-width: 650px;
+    background: #fff;
+    padding: 50px;
+    border-radius: 12px;
+    text-align: center;
+    box-shadow: 0 5px 25px rgba(0,0,0,0.08);
+}
+
+.notfound-icon{
+    width: 100px;
+    height: 100px;
+    margin: auto;
+    border-radius: 50%;
+    background: #088178;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 25px;
+}
+
+.notfound-icon i{
+    color: #fff;
+    font-size: 40px;
+}
+
+.notfound-code{
+    font-size: 64px;
+    font-weight: 800;
+    color: #088178;
+    line-height: 1;
+    margin-bottom: 10px;
+}
+
+.notfound-box h2{
+    margin-bottom: 15px;
+    font-size: 34px;
+}
+
+.notfound-box p{
+    color: #555;
+    line-height: 28px;
+}
+
+.notfound-buttons{
+    margin-top: 35px;
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+}
+
+.notfound-buttons a{
+    background: #088178;
+    color: #fff;
+    text-decoration: none;
+    padding: 14px 24px;
+    border-radius: 6px;
+    transition: 0.3s ease;
+}
+
+.notfound-buttons a:hover{
+    background: #066e67;
+}
+
+.notfound-buttons a.notfound-secondary{
+    background: #fff;
+    color: #088178;
+    border: 2px solid #088178;
+    padding: 12px 22px;
+}
+
+.notfound-buttons a.notfound-secondary:hover{
+    background: #088178;
+    color: #fff;
+}
+
+/* Dark theme support, using the site's existing CSS variables */
+body.dark-theme #notfound-page{
+    background: var(--bg-light);
+}
+
+body.dark-theme .notfound-box{
+    background: var(--card-bg);
+    box-shadow: 0 5px 25px rgba(0,0,0,0.4);
+}
+
+body.dark-theme .notfound-box h2{
+    color: var(--text-dark);
+}
+
+body.dark-theme .notfound-box p{
+    color: var(--text-body);
+}
+
+body.dark-theme .notfound-buttons a.notfound-secondary{
+    background: transparent;
+    color: #88c9c0;
+    border-color: #88c9c0;
+}
+
+body.dark-theme .notfound-buttons a.notfound-secondary:hover{
+    background: #88c9c0;
+    color: var(--white);
+}
+
+@media (max-width: 1024px){
+
+    .notfound-box{
+        padding: 35px 25px;
+    }
+
+    .notfound-buttons{
+        flex-direction: column;
+    }
+
+}


### PR DESCRIPTION
Add custom 404 page
What this does
Adds a custom-styled 404 (Not Found) page so users get a proper branded error page instead of a blank/default browser error when they hit a broken or nonexistent route.
Changes

frontend/404.html - new 404 page markup, consistent with the site's existing layout and navigation
frontend/styles/404.css - styling for the 404 page matching the site's visual theme

Why
Previously there was no custom 404 page, so broken links or mistyped URLs would show the browser's default error page - inconsistent with the rest of the site's design and a poor user experience.
Testing

Verified the page renders correctly and matches site styling
Verified navigation/links on the page work as expected

Notes
This PR only touches the 404 page files - kept scoped intentionally to avoid mixing in unrelated changes.
