### PR TITLE
fix: compare page empty due to pagination bug

### DIFF
--- a/frontend/scripts/compare.js
+++ b/frontend/scripts/compare.js
@@ -17,26 +17,46 @@ async function renderCompare() {
 
     try {
 
-        const response =
-            await apiRequest(
-                "/products"
+        const results =
+            await Promise.allSettled(
+                compareProducts.map(id =>
+                    apiRequest(`/products/${id}`)
+                )
             );
-
-        const products =
-            Array.isArray(
-                response.products
-            )
-                ? response.products
-                : [];
 
         const selected =
-            products.filter(
-                product =>
-                    compareProducts.includes(
-                        String(product.id)
-                    )
-            );
+            results
+                .filter(
+                    result =>
+                        result.status === "fulfilled"
+                        &&
+                        result.value
+                        &&
+                        result.value.product
+                )
+                .map(
+                    result => result.value.product
+                );
 
+        const failedCount =
+            compareProducts.length - selected.length;
+
+        if (
+            selected.length === 0
+        ) {
+            compareContainer.innerHTML =
+                "<h3>No products selected</h3>";
+            return;
+        }
+
+        if (
+            failedCount > 0
+        ) {
+            AppUtils.notify(
+                `${failedCount} product(s) in your comparison are no longer available`,
+                "warning"
+            );
+        }
         compareContainer.innerHTML =
             selected.map(
                 product => `


### PR DESCRIPTION
## Description
Fixes the empty compare page reported in #920.

## Root Cause
`compare.js` fetched `GET /products` with no query params to build its
product list, then filtered client-side against the `compareProducts`
IDs stored in localStorage. The backend's `getProducts` controller
defaults to `limit=10, page=1`, so this call only ever returned the
first 10 products in the catalog. Any compared product outside that
first page was silently missing from the response, making the compare
page render as empty even though `compareProducts` in localStorage was
correct.

(Note: this differs slightly from the root cause guess in the original
issue - the stored IDs and full product objects weren't actually
mismatched, the product list itself was just incomplete due to
pagination.)

## Fix
`compare.js` now fetches each compared product individually via the
existing `GET /products/:id` endpoint, using `Promise.allSettled` so
one missing/deleted product doesn't break the whole page. If a
compared product can no longer be found (e.g. deleted since being
added), the user now gets a toast letting them know, instead of a
silent blank page.

## Testing
- Added 2+ products to compare (including ones outside the default
  first-page of 10) from both `shop.html` and `index.html`, confirmed
  all render correctly on `compare.html`.
- Manually injected an invalid/deleted product ID into
  `compareProducts` in localStorage and confirmed the page still
  renders the valid products plus a "no longer available" warning
  toast, instead of breaking.

Fixes #920