### PR TITLE
fix(delivery): apply dark mode via body.dark-theme instead of prefers-color-scheme

### DIFF
--- a/frontend/styles/delivery.css
+++ b/frontend/styles/delivery.css
@@ -13,20 +13,18 @@
     --delivery-table-text: #555555;
 }
 
-@media (prefers-color-scheme: dark) {
-    :root {
-        --delivery-bg-page: #0f0f0f;
-        --delivery-bg-card: #1e1e1e;
-        --delivery-bg-card-alt: #2a2a2a;
-        --delivery-border: #3a3a3a;
-        --delivery-text: #f0f0f0;
-        --delivery-text-muted: #c0c0c0;
-        --delivery-notice-bg: #1a3530;
-        --delivery-notice-text: #a0d8d0;
-        --delivery-shadow: rgba(0, 0, 0, 0.4);
-        --delivery-table-even: #252525;
-        --delivery-table-text: #c0c0c0;
-    }
+body.dark-theme {
+    --delivery-bg-page: #0f0f0f;
+    --delivery-bg-card: #1e1e1e;
+    --delivery-bg-card-alt: #2a2a2a;
+    --delivery-border: #3a3a3a;
+    --delivery-text: #f0f0f0;
+    --delivery-text-muted: #c0c0c0;
+    --delivery-notice-bg: #1a3530;
+    --delivery-notice-text: #a0d8d0;
+    --delivery-shadow: rgba(0, 0, 0, 0.4);
+    --delivery-table-even: #252525;
+    --delivery-table-text: #c0c0c0;
 }
 
 /* ── HEADER ── */


### PR DESCRIPTION
## Description
The Delivery/Shipping Policy page (delivery.html) stayed in a light/white theme even when Dark Mode was enabled — the page background, feature card descriptions, "Shipping Policy" heading, and intro paragraph remained low-contrast and barely readable. Only the header appeared dark, since it pulls its styling from a different (correctly implemented) source.

Fixes #1097

## Root Cause
Dark mode is toggled site-wide via a `body.dark-theme` class (see `ui.js`). `frontend/styles/delivery.css` defined its dark-mode variables inside an OS-level `@media (prefers-color-scheme: dark)` query instead — this only reacts to the user's system theme setting, not the site's own toggle. So the variables never updated when the toggle was clicked.

## Changes
- Replaced `@media (prefers-color-scheme: dark) { :root { ... } }` with `body.dark-theme { ... }` in `frontend/styles/delivery.css`
- No color values changed — same dark palette as before (`#0f0f0f` / `#1e1e1e` / `#f0f0f0` etc.), only the trigger mechanism now matches the rest of the site (`product-card.css`, `base.css`)

## Screenshot
<img width="1918" height="892" alt="image" src="https://github.com/user-attachments/assets/2fe3208e-ba1b-4351-b8fc-08cc5ba84f95" />

## How to Test

1. Go to the Delivery/Shipping Policy page (`delivery.html`).
2. Toggle Dark Mode from the site settings.
3. Scroll through the Free Shipping / Fast Processing / Easy Returns cards, Shipping Policy section, and Shipping Method table.
4. Confirm the background, headings, paragraph text, and table all switch to dark styling and remain clearly readable, consistent with the header.

## Test Coverage Note
This is a CSS-only visual fix. The `frontend/` directory has no automated test framework set up (only `backend/tests/` uses Jest), so this was verified manually via browser dark-mode toggle rather than an automated test.

## Checklist
- [x] Commit signed off with DCO (`git commit -s`)
- [x] Tested locally in both light and dark mode
- [x] No JS changes required (reuses existing dark-theme class toggle)
- [x] Follows existing CSS convention used in `product-card.css` / `base.css`