### PR TITLE
Add server-side pagination and infinite scroll to product catalog

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -13,6 +13,21 @@ const {
 const MAX_PRODUCT_LIMIT = 50;
 const NORMALIZED_CATEGORY_SQL =
     "LOWER(REPLACE(REPLACE(category, '-', ''), ' ', ''))";
+
+// Whitelisted sort keys → ORDER BY clause. Keys mirror the frontend shop
+// sort control so the same value round-trips through the API. A stable
+// `id DESC` tie-breaker keeps pagination free of overlaps/gaps when the
+// primary sort column has duplicate values.
+const SORT_CLAUSES = {
+    newest: "id DESC",
+    oldest: "id ASC",
+    "price-low-high": "price ASC, id DESC",
+    "price-high-low": "price DESC, id DESC",
+    popularity: "num_reviews DESC, id DESC",
+    "highest-rated": "rating DESC, id DESC",
+    "alphabetical-az": "name ASC, id DESC"
+};
+const DEFAULT_SORT_CLAUSE = SORT_CLAUSES.newest;
 const TOYS_CATEGORY_VALUES = [
     "Toys",
     "Educational Toys",
@@ -60,6 +75,10 @@ const getProducts = async (req, res) => {
                     req.query.search
                 )}%`
                 : null;
+
+        // Resolve sort against the whitelist; unknown/empty falls back to newest.
+        const orderByClause =
+            SORT_CLAUSES[sanitizeString(req.query.sort)] || DEFAULT_SORT_CLAUSE;
 
         let baseQuery = `
             FROM products
@@ -145,7 +164,7 @@ const getProducts = async (req, res) => {
                 rating,
                 num_reviews
             ${baseQuery}
-            ORDER BY id DESC
+            ORDER BY ${orderByClause}
             LIMIT ?
             OFFSET ?
         `;

--- a/backend/tests/productPagination.test.js
+++ b/backend/tests/productPagination.test.js
@@ -1,0 +1,130 @@
+// Tests for server-side pagination + sort in productController.getProducts (#1139).
+// The DB module is mocked so the SQL and response envelope can be asserted
+// without a live MySQL connection.
+
+jest.mock("../config/db", () => ({ query: jest.fn() }));
+
+const db = require("../config/db");
+const { getProducts } = require("../controllers/productController");
+
+function mockRes() {
+    return {
+        statusCode: null,
+        body: null,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        }
+    };
+}
+
+function stubDb(total, rows) {
+    db.query.mockImplementation(async (sql) => {
+        if (/SELECT COUNT/.test(sql)) {
+            return [[{ total }]];
+        }
+        return [rows];
+    });
+}
+
+function lastProductQuery() {
+    const call = db.query.mock.calls.find(([sql]) =>
+        /FROM products[\s\S]*LIMIT/.test(sql)
+    );
+    return call || [null, null];
+}
+
+describe("getProducts — server-side pagination", () => {
+    beforeEach(() => {
+        db.query.mockReset();
+    });
+
+    test("returns pagination metadata (page/limit/total/totalPages)", async () => {
+        stubDb(42, [{ id: 2 }, { id: 1 }]);
+        const res = mockRes();
+
+        await getProducts({ query: { page: "2", limit: "12" } }, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toMatchObject({
+            success: true,
+            page: 2,
+            limit: 12,
+            total: 42,
+            totalPages: 4,
+            hasNextPage: true,
+            hasPrevPage: true
+        });
+        expect(Array.isArray(res.body.products)).toBe(true);
+    });
+
+    test("uses LIMIT/OFFSET derived from page and limit", async () => {
+        stubDb(42, [{ id: 1 }]);
+        const res = mockRes();
+
+        await getProducts({ query: { page: "3", limit: "10" } }, res);
+
+        const [, params] = lastProductQuery();
+        // page 3, limit 10 → LIMIT 10 OFFSET 20
+        expect(params.slice(-2)).toEqual([10, 20]);
+    });
+
+    test("caps limit at the maximum page size", async () => {
+        stubDb(500, [{ id: 1 }]);
+        const res = mockRes();
+
+        await getProducts({ query: { page: "1", limit: "999" } }, res);
+
+        expect(res.body.limit).toBe(50);
+    });
+
+    test("rejects invalid page with 400", async () => {
+        stubDb(0, []);
+        const res = mockRes();
+
+        await getProducts({ query: { page: "-1" } }, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+});
+
+describe("getProducts — sorting", () => {
+    beforeEach(() => {
+        db.query.mockReset();
+        stubDb(10, [{ id: 1 }]);
+    });
+
+    const cases = [
+        ["price-low-high", /ORDER BY\s+price ASC, id DESC/],
+        ["price-high-low", /ORDER BY\s+price DESC, id DESC/],
+        ["popularity", /ORDER BY\s+num_reviews DESC, id DESC/],
+        ["highest-rated", /ORDER BY\s+rating DESC, id DESC/],
+        ["alphabetical-az", /ORDER BY\s+name ASC, id DESC/]
+    ];
+
+    test.each(cases)("maps sort=%s to the expected ORDER BY", async (sort, pattern) => {
+        const res = mockRes();
+        await getProducts({ query: { sort } }, res);
+        const [sql] = lastProductQuery();
+        expect(sql).toMatch(pattern);
+    });
+
+    test("falls back to newest (id DESC) for an unknown sort", async () => {
+        const res = mockRes();
+        await getProducts({ query: { sort: "not-a-real-sort" } }, res);
+        const [sql] = lastProductQuery();
+        expect(sql).toMatch(/ORDER BY\s+id DESC\s+LIMIT/);
+    });
+
+    test("defaults to newest (id DESC) when no sort is given", async () => {
+        const res = mockRes();
+        await getProducts({ query: {} }, res);
+        const [sql] = lastProductQuery();
+        expect(sql).toMatch(/ORDER BY\s+id DESC\s+LIMIT/);
+    });
+});

--- a/frontend/scripts/shop.js
+++ b/frontend/scripts/shop.js
@@ -2,10 +2,21 @@
 (function(){
 let allProducts = [];
 let filteredProducts = [];
-// PAGINATION STATE
-let currentPage = 1;
-let totalPages = 1;
-let currentProducts = [];
+
+// SERVER PAGINATION / INFINITE SCROLL STATE
+// The catalog is streamed from the backend one page at a time and appended
+// to `allProducts`; all filtering/sorting still happens client-side over the
+// accumulated set. `sort` is the one dimension driven server-side so the
+// paginated order stays globally consistent across pages.
+let serverPage = 0;
+let serverTotalPages = 1;
+let serverHasNext = true;
+let isFetchingPage = false;
+let catalogExhausted = false;
+let lastServerSort = "";
+let priceTouched = false;
+let productObserver = null;
+const loadedProductIds = new Set();
 
 // Local fallback sample products (used when backend returns no products)
 const fallbackProducts = [
@@ -54,8 +65,9 @@ const SHOP_IMAGE_FALLBACK =
         </svg>`
     );
 
-const PRODUCTS_PER_PAGE =
-    globalThis.CONFIG?.PRODUCTS_PER_PAGE || 8;
+// Number of products requested per backend page (server-side pagination).
+const PAGE_SIZE =
+    globalThis.CONFIG?.PRODUCTS_PER_PAGE || 12;
 
 let filters = {
     search: "",
@@ -194,45 +206,151 @@ async function syncWishlistFallback(product) {
     updateWishlistButtons(product.id, !exists);
 }
 
-// FETCH PRODUCTS
-async function fetchProducts() {
-    if (elements.productContainer) {
-        elements.productContainer.innerHTML =
-            `
-                <div class="loading-products">
-                    Loading products...
-                </div>
-            `;
+// Reset accumulated catalog state so the next load starts from page 1.
+function resetCatalog() {
+    allProducts = [];
+    loadedProductIds.clear();
+    serverPage = 0;
+    serverTotalPages = 1;
+    serverHasNext = true;
+    catalogExhausted = false;
+}
+
+// Build the paginated products endpoint. `sort` round-trips to the backend so
+// each page is ordered consistently; search/category/price/rating/availability
+// stay client-side over the accumulated catalog.
+function buildProductsQuery(page) {
+    const params =
+        new URLSearchParams();
+
+    params.set("page", String(page));
+    params.set("limit", String(PAGE_SIZE));
+
+    if (filters.sort) {
+        params.set("sort", filters.sort);
     }
+
+    return `/products?${params.toString()}`;
+}
+
+// Append a freshly fetched page to the catalog, skipping ids already loaded so
+// a re-fetch can never duplicate cards.
+function appendProducts(products) {
+    AppUtils.safeArray(products).forEach((product) => {
+        const key = String(product.id);
+
+        if (loadedProductIds.has(key)) {
+            return;
+        }
+
+        loadedProductIds.add(key);
+        allProducts.push(product);
+    });
+}
+
+// Fetch the next backend page and merge it in. Guards against concurrent or
+// past-the-end requests so the IntersectionObserver can fire freely.
+async function loadNextProductsPage() {
+    if (isFetchingPage || !serverHasNext) {
+        return;
+    }
+
+    const isFirstPage = serverPage === 0;
+    isFetchingPage = true;
+    renderScrollStatus();
 
     try {
         const data =
             await AppUtils.apiRequest(
-                "/products?page=1&limit=50"
+                buildProductsQuery(serverPage + 1)
             );
 
-        allProducts =
-            data.success && Array.isArray(data.products) && data.products.length
-                ? data.products
-                : fallbackProducts;
+        const products =
+            data && data.success
+                ? AppUtils.safeArray(data.products)
+                : [];
 
+        if (isFirstPage && products.length === 0) {
+            // Backend reachable but empty (or unsuccessful) — fall back to the
+            // bundled sample catalog so the shop is never blank.
+            appendProducts(fallbackProducts);
+            serverHasNext = false;
+            catalogExhausted = true;
+        } else {
+            appendProducts(products);
+            serverPage += 1;
+            serverTotalPages =
+                Number(data.totalPages) || serverTotalPages;
+            serverHasNext =
+                data.hasNextPage === true
+                || serverPage < serverTotalPages;
+            catalogExhausted = !serverHasNext;
+        }
     } catch (error) {
-        console.error(
-            "SHOP FETCH ERROR:",
-            error
-        );
+        console.error("SHOP FETCH ERROR:", error);
 
-        allProducts =
-            fallbackProducts;
+        if (isFirstPage) {
+            appendProducts(fallbackProducts);
+        }
+
+        serverHasNext = false;
+        catalogExhausted = true;
+    } finally {
+        isFetchingPage = false;
     }
 
+    if (isFirstPage) {
+        initializeFilterControls();
+    } else {
+        refreshFilterControls();
+    }
+
+    applyFilters();
+
+    // Keep filling the viewport: when a client-side filter yields a short grid
+    // (or the first page is shorter than the screen) the sentinel stays visible,
+    // so pull the next page until the viewport is full or the catalog is drained.
+    maybeAutoLoadMore();
+}
+
+// Load more automatically while the sentinel is on screen. This is what makes
+// client-side search/category filtering work across the whole catalog: sparse
+// results leave the sentinel visible, which drains remaining pages.
+function maybeAutoLoadMore() {
+    if (!serverHasNext || isFetchingPage || !productObserver) {
+        return;
+    }
+
+    const sentinel =
+        document.getElementById("product-scroll-sentinel");
+
+    if (!sentinel) {
+        return;
+    }
+
+    requestAnimationFrame(() => {
+        const rect = sentinel.getBoundingClientRect();
+        const viewportHeight =
+            globalThis.innerHeight || document.documentElement.clientHeight;
+
+        if (rect.top <= viewportHeight + 200) {
+            loadNextProductsPage();
+        }
+    });
+}
+
+// FETCH PRODUCTS — entry point: reset and stream the catalog from page 1.
+function fetchProducts() {
     searchHistory =
         getStoredSearchHistory();
 
-    initializeFilterControls();
-    applyFilters({
-        resetPage: true
-    });
+    lastServerSort =
+        elements.sortSelect?.value || "newest";
+    filters.sort = lastServerSort;
+
+    resetCatalog();
+    setupProductObserver();
+    loadNextProductsPage();
 }
 
 // EMPTY STATE
@@ -615,6 +733,15 @@ function renderCategoryFilters() {
         return;
     }
 
+    // Preserve the user's ticked categories across catalog re-renders (the
+    // list grows as more pages stream in via infinite scroll).
+    const checkedValues =
+        new Set(
+            Array.from(
+                document.querySelectorAll('input[name="category-filter"]:checked')
+            ).map((input) => input.value)
+        );
+
     const categories =
         getFilterUtils().uniqueCategories(
             allProducts
@@ -628,11 +755,30 @@ function renderCategoryFilters() {
                         type="checkbox"
                         name="category-filter"
                         value="${AppUtils.escapeHTML(category)}"
+                        ${checkedValues.has(category) ? "checked" : ""}
                     >
                     ${AppUtils.escapeHTML(category)}
                 </label>
             `
         ).join("");
+}
+
+// Refresh derived controls after each streamed page without clobbering the
+// user's active selections. Price bounds only auto-widen while the user hasn't
+// manually adjusted the sliders.
+function refreshFilterControls() {
+    priceBounds =
+        getFilterUtils().getPriceBounds(
+            allProducts
+        );
+
+    if (!priceTouched) {
+        filters.minPrice = priceBounds.min;
+        filters.maxPrice = priceBounds.max;
+    }
+
+    renderCategoryFilters();
+    updatePriceControls();
 }
 
 function updatePriceControls() {
@@ -702,8 +848,14 @@ function applyFilters({ resetPage = false } = {}) {
 
     readFiltersFromControls();
 
-    if (resetPage) {
-        currentPage = 1;
+    // Sort is the server-driven dimension. When it changes, the accumulated
+    // pages are ordered by the old key, so restart streaming from page 1 with
+    // the new sort to keep pagination consistent.
+    if (filters.sort !== lastServerSort) {
+        lastServerSort = filters.sort;
+        resetCatalog();
+        loadNextProductsPage();
+        return;
     }
 
     filteredProducts =
@@ -715,39 +867,24 @@ function applyFilters({ resetPage = false } = {}) {
             filters.sort
         );
 
-    totalPages =
-        Math.max(
-            1,
-            Math.ceil(filteredProducts.length / PRODUCTS_PER_PAGE)
-        );
-
-    currentPage =
-        Math.min(
-            currentPage,
-            totalPages
-        );
-
-    const startIndex =
-        (currentPage - 1) * PRODUCTS_PER_PAGE;
-
-    currentProducts =
-        filteredProducts.slice(
-            startIndex,
-            startIndex + PRODUCTS_PER_PAGE
-        );
-
     updatePriceControls();
     updateResultsSummary();
     renderProducts(
-        currentProducts,
+        filteredProducts,
         {
             emptyMessage:
-                filters.megaCategory || filters.megaSubcategory
-                    ? "No products available in this category."
-                    : "No products found."
+                isFetchingPage
+                    ? "Loading products..."
+                    : filters.megaCategory || filters.megaSubcategory
+                        ? "No products available in this category."
+                        : "No products found."
         }
     );
-    renderPagination();
+    renderScrollStatus();
+
+    // A filter change can leave the sentinel on screen with more pages
+    // available; pull them so filtering reflects the full catalog.
+    maybeAutoLoadMore();
 }
 
 function updateResultsSummary() {
@@ -1062,9 +1199,12 @@ function setupFilterControls() {
     [elements.minPriceRange, elements.maxPriceRange].forEach((range) => {
         range?.addEventListener(
             "input",
-            () => applyFilters({
-                resetPage: true
-            })
+            () => {
+                priceTouched = true;
+                applyFilters({
+                    resetPage: true
+                });
+            }
         );
     });
 
@@ -1108,6 +1248,7 @@ function setupFilterControls() {
                 elements.sortSelect.value = "newest";
             }
 
+            priceTouched = false;
             filters.minPrice = priceBounds.min;
             filters.maxPrice = priceBounds.max;
             filters.megaCategory = "";
@@ -1165,115 +1306,79 @@ function setupFilterDrawer() {
     );
 }
 
-// PAGINATION UI
-function renderPagination() {
+// INFINITE SCROLL UI
+// The `#pagination` section holds the loading indicator, an end-of-results
+// note, and the sentinel element the IntersectionObserver watches.
+function renderScrollStatus() {
+    let statusBar =
+        document.getElementById("pagination");
 
-    let pagination =
-        document.getElementById(
-            "pagination"
-        );
-
-    // auto create pagination
-    if (
-        !pagination
-    ) {
-
-        pagination =
-            document.createElement(
-                "div"
-            );
-
-        pagination.id =
-            "pagination";
-
-        pagination.className =
-            "pagination";
-
-        elements.productContainer?.after(
-            pagination
-        );
+    if (!statusBar) {
+        statusBar =
+            document.createElement("section");
+        statusBar.id = "pagination";
+        elements.productContainer?.after(statusBar);
     }
 
-    pagination.innerHTML =
-        "";
+    const hasResults =
+        filteredProducts.length > 0;
 
-    // previous
-    const prevBtn =
-        document.createElement(
-            "button"
-        );
+    let statusMarkup = "";
 
-    prevBtn.innerText =
-        "← Prev";
+    if (isFetchingPage) {
+        statusMarkup = `
+            <div class="scroll-loader" role="status" aria-live="polite">
+                <span class="scroll-spinner" aria-hidden="true"></span>
+                <span>Loading more products…</span>
+            </div>
+        `;
+    } else if (catalogExhausted && !serverHasNext && hasResults) {
+        statusMarkup = `
+            <p class="scroll-end" role="status">
+                You've reached the end of the catalog.
+            </p>
+        `;
+    }
 
-    prevBtn.className =
-        "pagination-btn";
+    statusBar.innerHTML = `
+        ${statusMarkup}
+        <div id="product-scroll-sentinel" class="scroll-sentinel" aria-hidden="true"></div>
+    `;
 
-    prevBtn.disabled =
-        currentPage <= 1;
+    observeSentinel();
+}
 
-    prevBtn.onclick =
-        () => {
+// (Re)attach the observer to the current sentinel node. The sentinel is
+// recreated on every status render, so it must be re-observed each time.
+function observeSentinel() {
+    if (!productObserver) {
+        return;
+    }
 
-            if (
-                currentPage > 1
-            ) {
+    const sentinel =
+        document.getElementById("product-scroll-sentinel");
 
-                currentPage -= 1;
-                applyFilters();
+    if (sentinel) {
+        productObserver.observe(sentinel);
+    }
+}
+
+function setupProductObserver() {
+    if (productObserver || typeof IntersectionObserver === "undefined") {
+        return;
+    }
+
+    productObserver =
+        new IntersectionObserver(
+            (entries) => {
+                if (entries.some((entry) => entry.isIntersecting)) {
+                    loadNextProductsPage();
+                }
+            },
+            {
+                rootMargin: "200px 0px"
             }
-        };
-
-    pagination.appendChild(
-        prevBtn
-    );
-
-    // page info
-    const pageInfo =
-        document.createElement(
-            "span"
         );
-
-    pageInfo.className = 
-        "pagination-info";
-
-    pageInfo.innerText =
-        `Page ${currentPage} of ${totalPages}`;
-
-    pagination.appendChild(
-        pageInfo
-    );
-
-    // next
-    const nextBtn =
-        document.createElement(
-            "button"
-        );
-
-    nextBtn.innerText =
-        "Next →";
-
-    nextBtn.className = 
-        "pagination-btn";
-
-    nextBtn.disabled =
-        currentPage >= totalPages;
-
-    nextBtn.onclick =
-        () => {
-
-            if (
-                currentPage < totalPages
-            ) {
-
-                currentPage += 1;
-                applyFilters();
-            }
-        };
-
-    pagination.appendChild(
-        nextBtn
-    );
 }
 
 // INITIALIZATION

--- a/frontend/styles/shop.css
+++ b/frontend/styles/shop.css
@@ -399,6 +399,48 @@
   padding: 0 6px;
 }
 
+/* Infinite scroll status */
+.scroll-loader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #088178;
+}
+
+.scroll-spinner {
+  width: 20px;
+  height: 20px;
+  border: 3px solid rgba(8, 129, 120, 0.25);
+  border-top-color: #088178;
+  border-radius: 50%;
+  animation: scroll-spin 0.7s linear infinite;
+}
+
+@keyframes scroll-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.scroll-end {
+  font-size: 15px;
+  font-weight: 600;
+  color: #5f5f5f;
+}
+
+.scroll-sentinel {
+  width: 100%;
+  height: 1px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-spinner {
+    animation: none;
+  }
+}
+
 #product-container {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));


### PR DESCRIPTION
The shop page previously fetched the entire catalog in one request and paginated in the browser, which grows the initial payload and DOM as the catalog scales. It now loads one page at a time from the products API and appends results as the shopper nears the bottom of the grid, with a loading indicator while fetching and an end-of-catalog message when there are no more pages.

The products API also accepts a sort parameter (validated against a fixed set of orderings) so results are ordered server-side and stay consistent across pages.

Existing search, category, price, rating, and availability filters continue to work; when a filter narrows the results, remaining pages keep loading until the view is filled or the catalog is exhausted.

**Test plan**
- Verified the pagination metadata, limit/offset, and the sort whitelist (including fallback to newest for unknown/missing values) via targeted checks.
- Manually exercise scrolling, search, category selection, and each sort option on the shop page.

Closes #1139.