### PR TITLE
Persist authenticated carts through the backend cart API

### DIFF
--- a/frontend/scripts/recommendations.js
+++ b/frontend/scripts/recommendations.js
@@ -389,15 +389,20 @@ const Recommendations = (() => {
             // Record interaction
             await postInteraction(productId, 'cart_add');
             
-            // Add to cart
-            const response = await window.AppUtils.apiRequest('/api/cart', {
+            // Add to cart via the backend cart API (apiRequest already
+            // prefixes API_BASE, so the path is /cart/add, not /api/cart).
+            const response = await window.AppUtils.apiRequest('/cart/add', {
                 method: 'POST',
                 body: JSON.stringify({ productId, quantity: 1 })
             });
             
             if (response && response.success) {
                 showToast('✅ Product added to cart!', 'success');
-                // Update cart count
+                // Pull the authoritative cart back into the local mirror so the
+                // navbar count and cart page reflect the new item.
+                if (typeof window.AppUtils.loadUserCollections === 'function') {
+                    await window.AppUtils.loadUserCollections();
+                }
                 if (typeof window.updateCartCount === 'function') {
                     window.updateCartCount();
                 }

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -822,7 +822,8 @@ const getCart = () => {
 };
 
 const saveCart = (
-    cart
+    cart,
+    { sync = true } = {}
 ) => {
 
     const normalizedCart =
@@ -855,6 +856,13 @@ const saveCart = (
                 }
             )
         );
+    }
+
+    // Signed-in users: mirror every mutation to the persistent backend cart.
+    // `sync: false` is used when the local mirror is being hydrated FROM the
+    // backend, to avoid an echo write.
+    if (sync && isAuthenticated()) {
+        syncCartWithBackend(normalizedCart);
     }
 
     return normalizedCart;
@@ -919,6 +927,27 @@ const addCartItem = (
         );
     }
 
+    // Signed-in users: reserve stock through the backend. This is the only
+    // endpoint that creates the 15-minute inventory lock the checkout flow
+    // later validates, so add must route through it (not just /cart/sync).
+    if (isAuthenticated()) {
+        apiRequest(
+            "/cart/add",
+            {
+                method: "POST",
+                body: JSON.stringify({
+                    productId: item.id,
+                    quantity: item.qty
+                })
+            }
+        ).catch((error) => {
+            console.warn(
+                "Cart reservation failed:",
+                error
+            );
+        });
+    }
+
     return saveCart(
         cart
     );
@@ -980,6 +1009,117 @@ const clearCart = () => {
     return saveCart(
         []
     );
+};
+
+// ---------- Backend cart integration (authenticated users) ----------
+// Guests keep using localStorage only. For signed-in users every cart mutation
+// is mirrored to the persistent backend cart (/api/cart) so carts survive
+// across devices/sessions and the inventory-reservation workflow is exercised.
+
+const isAuthenticated = () =>
+    Boolean(getToken() && getUser());
+
+// Collapse the local cart (which keys lines by id|color|size) into the
+// product-level shape the backend cart stores (one row per product).
+const aggregateCartForBackend = (cart) => {
+    const totals = new Map();
+
+    safeArray(cart).forEach((item) => {
+        if (item?.id === undefined || item?.id === null) {
+            return;
+        }
+
+        const key = String(item.id);
+        const qty = Math.max(1, safeInteger(item.qty, 1));
+
+        totals.set(key, (totals.get(key) || 0) + qty);
+    });
+
+    return Array.from(
+        totals,
+        ([productId, qty]) => ({ productId, qty })
+    );
+};
+
+// Debounced full-cart push. /cart/sync is replace-all, so it reconciles the
+// server with the authoritative local cart after any mutation — including bulk
+// edits made directly through saveCart outside the helpers above.
+const syncCartWithBackend = debounce((cart) => {
+    if (!isAuthenticated()) {
+        return;
+    }
+
+    apiRequest("/cart/sync", {
+        method: "POST",
+        body: JSON.stringify({
+            items: aggregateCartForBackend(cart)
+        })
+    }).catch((error) => {
+        console.warn("Cart backend sync failed:", error);
+    });
+}, 600);
+
+// Merge two carts by line key, summing quantities. Folds a guest cart into the
+// account cart on login.
+const mergeCarts = (primary, secondary) => {
+    const merged = safeArray(primary)
+        .map(normalizeCartItem)
+        .filter(Boolean);
+
+    safeArray(secondary)
+        .map(normalizeCartItem)
+        .filter(Boolean)
+        .forEach((item) => {
+            const existing = merged.find(
+                (candidate) =>
+                    getCartItemKey(candidate) === getCartItemKey(item)
+            );
+
+            if (existing) {
+                existing.qty += item.qty;
+            } else {
+                merged.push(item);
+            }
+        });
+
+    return merged;
+};
+
+// Hydrate the local cart mirror from the persistent backend cart. Called on
+// login and on page load for signed-in users. `retry` is disabled on the fetch
+// so an expired session never force-redirects a browsing user off a public
+// page; a real mutation will trigger the normal refresh/redirect flow instead.
+const loadUserCollections = async () => {
+    if (!isAuthenticated()) {
+        return getCart();
+    }
+
+    let serverCart = [];
+
+    try {
+        const data = await apiRequest("/cart", {}, false);
+
+        if (data && data.success) {
+            serverCart = safeArray(data.cart);
+        }
+    } catch (error) {
+        console.warn("Failed to load backend cart:", error);
+        return getCart();
+    }
+
+    const guestCart = getCart();
+    const merged = mergeCarts(serverCart, guestCart);
+
+    // Persist the merged view locally without echoing it straight back.
+    saveCart(merged, { sync: false });
+
+    // If the user brought a guest cart, push the merge so other devices
+    // converge on the combined state.
+    if (guestCart.length) {
+        syncCartWithBackend(merged);
+    }
+
+    return merged;
 };
 
 const getCartCount = (
@@ -1190,6 +1330,9 @@ window.AppUtils = {
     removeCartItem,
     clearCart,
     getCartCount,
+    isAuthenticated,
+    syncCartWithBackend,
+    loadUserCollections,
     validateCoupon,
     calculateCartTotals,
     getWishlist,
@@ -1209,3 +1352,12 @@ window.requireAuth = requireAuth;
 window.defaultImage = defaultImage;
 window.safeForEach = safeForEach;
 window.safeMap = safeMap;
+
+// Hydrate the persistent backend cart for already–signed-in users on load, so
+// a cart created on another device/session follows them here. Listeners on
+// CART_UPDATED_EVENT (cart page, drawer, navbar count) refresh automatically.
+if (getToken() && getUser()) {
+    loadUserCollections().catch((error) => {
+        console.warn("Initial cart hydration failed:", error);
+    });
+}

--- a/frontend/scripts/wishlist.js
+++ b/frontend/scripts/wishlist.js
@@ -296,6 +296,9 @@ async function addToCartFromWishlist(
         qty: 1
     };
 
+    // addCartItem now routes signed-in users through the backend cart
+    // (including the inventory reservation), so no separate /cart/add call is
+    // needed here — a manual one previously sent the wrong payload shape.
     cart =
         AppUtils.addCartItem(
             item
@@ -306,31 +309,6 @@ async function addToCartFromWishlist(
         "success"
     );
 
-    const token =
-        AppUtils.getToken();
-
-    if (
-        token
-    ) {
-        try {
-            await AppUtils.apiRequest(
-                "/cart/add",
-                {
-                    method: "POST",
-                    body:
-                        JSON.stringify(
-                            item
-                        )
-                }
-            );
-        } catch (error) {
-            console.error(
-                "CART ADD ERROR:",
-                error
-            );
-        }
-    }
-    
     // Remove from wishlist
     await removeWishlist(index);
 }


### PR DESCRIPTION
The frontend managed the cart entirely in `localStorage`, so the backend cart, cross-device persistence, and the inventory-reservation workflow were never reached. Signed-in users now route cart operations through the cart API: adding an item reserves stock, every mutation mirrors to the server, and the cart is loaded (merging any existing guest cart) on login and on page load. Guests continue to use `localStorage` with no change.

Also corrects two callers that used a wrong cart endpoint path and sent a malformed add payload.

**Test plan**

- Verified guests make no backend cart calls; an authenticated add sends the correct reservation payload and mirrors the cart; login merges server and guest carts into one.
- Manually add/update/remove/clear as a logged-in user, then re-login in a fresh session and confirm the cart is restored.

Closes #1140.