### PR TITLE
fix: prevent queue starvation in expired review cleanup

### DIFF
--- a/backend/services/agentCheckoutService.js
+++ b/backend/services/agentCheckoutService.js
@@ -435,7 +435,7 @@ class AgentCheckoutService extends EventEmitter {
 
         // Check for expired reviews (auto-reject after 24 hours)
         const now = new Date();
-        const pending = this.getPendingReviews();
+        const pending = this.reviewQueue.map(id => this.checkoutSessions.get(id)).filter(Boolean);
 
         for (const session of pending) {
             const created = new Date(session.createdAt);


### PR DESCRIPTION
**Fixes #1145**

### Description
This pull request fixes a critical logical flaw in `backend/services/agentCheckoutService.js` that caused queue starvation for pending checkout reviews.

Previously, `processQueue()` only fetched the first 20 pending reviews via `getPendingReviews(20)` to prune expired reviews (those older than 24 hours). This meant that if the queue backed up to more than 20 items, any item beyond index 19 would never be evaluated for expiration until the first 20 were processed, causing permanent queue starvation.

### Proposed Changes
* **Expiration Pruning:** Refactored `processQueue` to map over the entire length of `this.reviewQueue` for expiration checks.
* **Preserved Limits:** The generic `getPendingReviews()` still returns up to 20 items, preserving pagination for UI limits, but the background expiration worker now comprehensively checks the entire internal map.

### Verification & Testing
* **Logic Verification:** Verified that instances beyond the 20th index correctly trigger the 24-hour expiration check during the 30-second interval cycle.