### PR TITLE
fix: correct math logic preventing removal of idle puppeteer instances

### DIFF
--- a/backend/services/puppeteerPoolService.js
+++ b/backend/services/puppeteerPoolService.js
@@ -307,8 +307,7 @@ class PuppeteerPoolService extends EventEmitter {
         }
 
         // Keep minimum instances
-        const remaining = this.pool.length - toRemove.length;
-        const removeCount = Math.min(toRemove.length, remaining - this.config.minInstances);
+        const removeCount = Math.min(toRemove.length, this.pool.length - this.config.minInstances);
 
         for (let i = 0; i < removeCount && i < toRemove.length; i++) {
             await this.removeInstance(toRemove[i]);


### PR DESCRIPTION

**Fixes #1144**

### Description
This pull request resolves a resource leak in `backend/services/puppeteerPoolService.js` where idle Puppeteer browser instances would indefinitely stack up without being garbage collected.

The `cleanupIdleInstances()` method contained a mathematical error in calculating `removeCount`:
`Math.min(toRemove.length, remaining - this.config.minInstances)`.
Because `remaining` was `pool.length - toRemove.length`, `removeCount` could evaluate to a negative number if the total pool was small. The loop `for (let i = 0; i < removeCount; ...)` would then bypass execution, permanently leaking idle instances over time.

### Proposed Changes
* **Corrected Pool Math:** Updated the `removeCount` logic to calculate against the total pool: `Math.min(toRemove.length, this.pool.length - this.config.minInstances)`.
* This guarantees that idle instances are safely purged down to `minInstances` while avoiding negative array iteration counts.

### Verification & Testing
* **Logic Verification:** Verified that removing more items than `minInstances` strictly truncates to positive numbers, ensuring correct garbage collection.