### PR TITLE
fix: prevent statistics inflation for blocked crawler traffic

### DIFF
--- a/backend/services/aiCrawlerProtectionService.js
+++ b/backend/services/aiCrawlerProtectionService.js
@@ -160,7 +160,6 @@ class AICrawlerProtectionService extends EventEmitter {
         const windowStart = now - CRAWLER_CONFIG.rateLimit.windowMs;
         traffic.requests = traffic.requests.filter(t => t > windowStart);
         traffic.lastSeen = now;
-        traffic.totalRequests++;
 
         // Check rate limit
         if (traffic.requests.length >= CRAWLER_CONFIG.rateLimit.maxRequests) {
@@ -172,6 +171,8 @@ class AICrawlerProtectionService extends EventEmitter {
                 ip
             };
         }
+
+        traffic.totalRequests++;
 
         // Add current request
         traffic.requests.push(now);


### PR DESCRIPTION

**Fixes #1146**

### Description
This pull request prevents malicious or rate-limited requests from artificially inflating the crawler traffic metrics in `backend/services/aiCrawlerProtectionService.js`.

Previously, `traffic.totalRequests++` was incremented before the `traffic.requests.length >= CRAWLER_CONFIG.rateLimit.maxRequests` block. This meant blocked requests still counted towards successful analytics.

### Proposed Changes
* Moved the `traffic.totalRequests++` statement after the rate-limit verification barrier.
* Blocked traffic now correctly returns an error without falsely pushing into the metrics arrays.

### Verification & Testing
* **Logic Verification:** Verified that once a bot exceeds the `maxRequests` threshold, further spam no longer counts towards `totalRequests` analytics.