### PR TITLE
Use the FULLTEXT index for product search with a LIKE fallback

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -14,6 +14,13 @@ const MAX_PRODUCT_LIMIT = 50;
 const NORMALIZED_CATEGORY_SQL =
     "LOWER(REPLACE(REPLACE(category, '-', ''), ' ', ''))";
 
+const FULLTEXT_SEARCH_COLUMNS = "name, description, short_description, meta_keywords";
+
+const FULLTEXT_UNAVAILABLE_CODES = new Set([
+    "ER_FT_MATCHING_KEY_NOT_FOUND",
+    "ER_BAD_FIELD_ERROR"
+]);
+
 // Whitelisted sort keys → ORDER BY clause. Keys mirror the frontend shop
 // sort control so the same value round-trips through the API. A stable
 // `id DESC` tie-breaker keeps pagination free of overlaps/gaps when the
@@ -61,6 +68,23 @@ function parsePaginationValue(value, defaultValue, fieldName) {
     return parsedValue;
 }
 
+function escapeLikeTerm(value) {
+    return value.replace(/[%_\\]/g, "\\$&");
+}
+
+function toBooleanModeQuery(value) {
+    return value
+        .split(/\s+/)
+        .map((token) => token.replace(/[+\-<>()~*"@]/g, ""))
+        .filter(Boolean)
+        .map((token) => `+${token}*`)
+        .join(" ");
+}
+
+function isFulltextUnavailable(error) {
+    return Boolean(error) && FULLTEXT_UNAVAILABLE_CODES.has(error.code);
+}
+
 // ---------- Get all products ----------
 const getProducts = async (req, res) => {
     try {
@@ -69,23 +93,22 @@ const getProducts = async (req, res) => {
         const limit = Math.min(requestedLimit, MAX_PRODUCT_LIMIT);
         const offset = (page - 1) * limit;
 
-        const search =
-            req.query.search
-                ? `%${sanitizeString(
-                    req.query.search
-                )}%`
-                : null;
+        const rawSearch = req.query.search
+            ? sanitizeString(req.query.search)
+            : "";
+        const likeSearch = rawSearch
+            ? `%${escapeLikeTerm(rawSearch)}%`
+            : null;
+        const booleanSearch = rawSearch
+            ? toBooleanModeQuery(rawSearch)
+            : "";
 
         // Resolve sort against the whitelist; unknown/empty falls back to newest.
         const orderByClause =
             SORT_CLAUSES[sanitizeString(req.query.sort)] || DEFAULT_SORT_CLAUSE;
 
-        let baseQuery = `
-            FROM products
-        `;
-
-        const conditions = [];
-        const params = [];
+        const filterConditions = [];
+        const filterParams = [];
 
         // category filter (case/format-insensitive)
         if (req.query.category) {
@@ -106,17 +129,17 @@ const getProducts = async (req, res) => {
                     ? TOYS_CATEGORY_VALUES
                     : STATIONERY_CATEGORY_VALUES;
 
-                conditions.push(
+                filterConditions.push(
                     `${NORMALIZED_CATEGORY_SQL} IN (${categoryValues.map(
                         () => "LOWER(REPLACE(REPLACE(?, '-', ''), ' ', ''))"
                     ).join(", ")})`
                 );
-                params.push(...categoryValues);
+                filterParams.push(...categoryValues);
             } else {
-                conditions.push(
+                filterConditions.push(
                     `${NORMALIZED_CATEGORY_SQL} = LOWER(REPLACE(REPLACE(?, '-', ''), ' ', ''))`
                 );
-                params.push(sanitizedCategory);
+                filterParams.push(sanitizedCategory);
             }
         }
 
@@ -124,75 +147,89 @@ const getProducts = async (req, res) => {
         if (
             req.query.featured === "true"
         ) {
-            conditions.push(
+            filterConditions.push(
                 "featured = 1"
             );
         }
 
-        // search filter
-        if (search) {
-            conditions.push(
-                "name LIKE ?"
-            );
-            params.push(search);
-        }
+        const runProductQuery = async (useFulltext) => {
+            const conditions = [...filterConditions];
+            const params = [...filterParams];
 
-        // build where clause
-        if (conditions.length) {
-            baseQuery += `
-                WHERE ${conditions.join(" AND ")}
+            if (rawSearch) {
+                if (useFulltext) {
+                    conditions.push(
+                        `MATCH(${FULLTEXT_SEARCH_COLUMNS}) AGAINST (? IN BOOLEAN MODE)`
+                    );
+                    params.push(booleanSearch);
+                } else {
+                    conditions.push("name LIKE ?");
+                    params.push(likeSearch);
+                }
+            }
+
+            const whereClause = conditions.length
+                ? `WHERE ${conditions.join(" AND ")}`
+                : "";
+
+            const countQuery = `
+                SELECT COUNT(*) AS total
+                FROM products
+                ${whereClause}
             `;
-        }
 
-        // count query
-        const countQuery = `
-            SELECT COUNT(*) AS total
-            ${baseQuery}
-        `;
+            const productQuery = `
+                SELECT
+                    id,
+                    name,
+                    description,
+                    price,
+                    image,
+                    category,
+                    stock,
+                    featured,
+                    rating,
+                    num_reviews
+                FROM products
+                ${whereClause}
+                ORDER BY ${orderByClause}
+                LIMIT ?
+                OFFSET ?
+            `;
 
-        // product query
-        const productQuery = `
-            SELECT
-                id,
-                name,
-                description,
-                price,
-                image,
-                category,
-                stock,
-                featured,
-                rating,
-                num_reviews
-            ${baseQuery}
-            ORDER BY ${orderByClause}
-            LIMIT ?
-            OFFSET ?
-        `;
+            const [countResults] = await db.query(countQuery, params);
+            const total = Number(countResults?.[0]?.total || 0);
 
-        // get total count
-        const [
-            countResults
-        ] = await db.query(
-            countQuery,
-            params
-        );
-
-        const total =
-            Number(
-                countResults?.[0]?.total || 0
-            );
-
-        // fetch products
-        const [
-            results
-        ] = await db.query(
-            productQuery,
-            [
+            const [results] = await db.query(productQuery, [
                 ...params,
                 limit,
                 offset
-            ]
-        );
+            ]);
+
+            return { total, results };
+        };
+
+        const shouldUseFulltext = Boolean(rawSearch) && booleanSearch.length > 0;
+
+        let queryResult;
+        if (shouldUseFulltext) {
+            try {
+                queryResult = await runProductQuery(true);
+            } catch (error) {
+                if (isFulltextUnavailable(error)) {
+                    console.warn(
+                        `FULLTEXT search unavailable (${error.code}); falling back to LIKE`
+                    );
+                    queryResult = await runProductQuery(false);
+                } else {
+                    throw error;
+                }
+            }
+        } else {
+            queryResult = await runProductQuery(false);
+        }
+
+        const { total, results } = queryResult;
 
         return res.status(200)
             .json({

--- a/backend/tests/productSearch.test.js
+++ b/backend/tests/productSearch.test.js
@@ -1,0 +1,109 @@
+jest.mock("../config/db", () => ({ query: jest.fn() }));
+
+const db = require("../config/db");
+const { getProducts } = require("../controllers/productController");
+
+function mockRes() {
+    return {
+        statusCode: null,
+        body: null,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        }
+    };
+}
+
+function ftError() {
+    const err = new Error("Can't find FULLTEXT index matching the column list");
+    err.code = "ER_FT_MATCHING_KEY_NOT_FOUND";
+    return err;
+}
+
+function calls() {
+    return db.query.mock.calls.map(([sql]) => sql);
+}
+
+describe("getProducts — full-text search", () => {
+    beforeEach(() => {
+        db.query.mockReset();
+    });
+
+    test("uses the FULLTEXT index (MATCH...AGAINST) for both count and product queries", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT COUNT/.test(sql)) return [[{ total: 3 }]];
+            return [[{ id: 1 }]];
+        });
+        const res = mockRes();
+
+        await getProducts({ query: { search: "wireless mouse" } }, res);
+
+        expect(res.statusCode).toBe(200);
+        const sqls = calls();
+        expect(sqls.every((sql) => /MATCH\(.*\) AGAINST \(\? IN BOOLEAN MODE\)/.test(sql))).toBe(true);
+        expect(sqls.some((sql) => /LIKE/.test(sql))).toBe(false);
+    });
+
+    test("passes a boolean-mode expression with required + prefix tokens", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT COUNT/.test(sql)) return [[{ total: 0 }]];
+            return [[]];
+        });
+        const res = mockRes();
+
+        await getProducts({ query: { search: "red shoes" } }, res);
+
+        const [, params] = db.query.mock.calls[0];
+        expect(params).toContain("+red* +shoes*");
+    });
+
+    test("falls back to LIKE when the FULLTEXT index is unavailable", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/MATCH/.test(sql)) throw ftError();
+            if (/SELECT COUNT/.test(sql)) return [[{ total: 1 }]];
+            return [[{ id: 7 }]];
+        });
+        const res = mockRes();
+
+        await getProducts({ query: { search: "laptop" } }, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.total).toBe(1);
+        const sqls = calls();
+        expect(sqls.some((sql) => /LIKE/.test(sql))).toBe(true);
+    });
+
+    test("does not add a search predicate when no search term is given", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT COUNT/.test(sql)) return [[{ total: 5 }]];
+            return [[{ id: 1 }]];
+        });
+        const res = mockRes();
+
+        await getProducts({ query: {} }, res);
+
+        const sqls = calls();
+        expect(sqls.some((sql) => /MATCH|LIKE/.test(sql))).toBe(false);
+    });
+
+    test("keeps category filter and search predicate together (count mirrors product query)", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT COUNT/.test(sql)) return [[{ total: 2 }]];
+            return [[{ id: 1 }]];
+        });
+        const res = mockRes();
+
+        await getProducts({ query: { search: "toy car", category: "toys" } }, res);
+
+        const [countSql] = db.query.mock.calls.find(([sql]) => /SELECT COUNT/.test(sql));
+        const [productSql] = db.query.mock.calls.find(([sql]) => /FROM products[\s\S]*LIMIT/.test(sql));
+        for (const sql of [countSql, productSql]) {
+            expect(sql).toMatch(/MATCH\(.*\) AGAINST/);
+            expect(sql).toMatch(/IN \(/); // category IN (...) clause
+        }
+    });
+});


### PR DESCRIPTION
Product search ran a `name LIKE '%term%'` scan, ignoring the FULLTEXT index already defined on the products table and missing matches in description and other indexed fields.

Search now issues a boolean-mode `MATCH ... AGAINST` query against the indexed columns. If the index (or its columns) is unavailable on a given deployment, it falls back to the previous LIKE behaviour so search never hard-fails.
Category/featured filters, sorting, pagination, and the count-vs-results consistency are all preserved.

Test plan
- Unit coverage for: MATCH used for both count and product queries, boolean-mode token construction, fallback to LIKE when the index is missing, no search predicate when no term is given, and filters combining with search.
- Full backend suite passes (pre-existing unrelated suites that need missing dev deps still fail as before).

Closes #1142.