### PR TITLE
Add courier webhook ingestion for automatic shipment status updates

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -202,6 +202,12 @@ STRIPE_WEBHOOK_SECRET=
 STRIPE_PUBLISHABLE_KEY=
 
 # ============================================
+# COURIER WEBHOOKS (shipment tracking)
+# ============================================
+
+COURIER_WEBHOOK_SECRET=
+
+# ============================================
 # EXTERNAL SERVICES
 # ============================================
 

--- a/backend/controllers/courierWebhookController.js
+++ b/backend/controllers/courierWebhookController.js
@@ -1,0 +1,80 @@
+// HTTP handlers for courier shipment webhooks (Issue #1157).
+//
+// The receive endpoint is intentionally forgiving: once a well-formed payload is
+// durably stored we answer 200/202 so the courier stops retrying, even if the
+// downstream shipment update failed (those rows are retried by the background
+// job). Only malformed/unauthorized deliveries get 4xx.
+
+const courierWebhookService = require("../services/courierWebhookService");
+const { WebhookError } = courierWebhookService;
+const logger = require("../utils/logger");
+
+const SIGNATURE_HEADER = "x-courier-signature";
+
+const receiveWebhook = async (req, res) => {
+    const provider = req.params.provider;
+    const signature = req.get(SIGNATURE_HEADER);
+
+    try {
+        const result = await courierWebhookService.ingestWebhook({
+            provider,
+            payload: req.body,
+            signature
+        });
+
+        if (result.duplicate) {
+            return res.status(200).json({
+                success: true,
+                message: "Duplicate webhook ignored",
+                webhookId: result.webhookId
+            });
+        }
+
+        // 202 Accepted: payload is stored; the shipment update may still be
+        // pending if it failed and will be retried by the background job.
+        const statusCode = result.processed ? 200 : 202;
+        return res.status(statusCode).json({
+            success: true,
+            message: result.processed
+                ? "Webhook processed"
+                : "Webhook accepted; processing deferred",
+            webhookId: result.webhookId,
+            shipmentId: result.shipmentId,
+            status: result.status,
+            error: result.error
+        });
+    } catch (error) {
+        if (error instanceof WebhookError) {
+            return res.status(error.statusCode).json({
+                success: false,
+                message: error.message
+            });
+        }
+
+        logger.error(`Courier webhook ingestion error: ${error.message}`);
+        return res.status(500).json({
+            success: false,
+            message: "Failed to ingest courier webhook"
+        });
+    }
+};
+
+// Admin/cron trigger to reprocess webhooks that were stored but not applied.
+const processPending = async (req, res) => {
+    try {
+        const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 50, 1), 200);
+        const summary = await courierWebhookService.processPendingWebhooks(limit);
+        return res.status(200).json({ success: true, ...summary });
+    } catch (error) {
+        logger.error(`Courier webhook batch processing error: ${error.message}`);
+        return res.status(500).json({
+            success: false,
+            message: "Failed to process pending courier webhooks"
+        });
+    }
+};
+
+module.exports = {
+    receiveWebhook,
+    processPending
+};

--- a/backend/routes/courierWebhookRoutes.js
+++ b/backend/routes/courierWebhookRoutes.js
@@ -1,0 +1,45 @@
+// routes/courierWebhookRoutes.js
+// Courier shipment webhook endpoints (Issue #1157).
+
+const express = require("express");
+const router = express.Router();
+const authMiddleware = require("../middleware/authMiddleware");
+const { authorizeRoles } = require("../middleware/rbacMiddleware");
+const courierWebhookController = require("../controllers/courierWebhookController");
+const courierWebhookService = require("../services/courierWebhookService");
+
+const MAX_PROVIDER_LENGTH = 50;
+
+// Validate the provider path segment before the payload is touched, so an
+// unknown/oversized provider is rejected with a clear 400.
+router.param("provider", (req, res, next, provider) => {
+    if (typeof provider !== "string" || provider.length > MAX_PROVIDER_LENGTH) {
+        return res.status(400).json({
+            success: false,
+            message: "Invalid courier provider"
+        });
+    }
+    if (!courierWebhookService.isSupportedProvider(provider)) {
+        return res.status(400).json({
+            success: false,
+            message: `Unsupported courier provider: ${provider}`,
+            supportedProviders: [...courierWebhookService.SUPPORTED_PROVIDERS]
+        });
+    }
+    next();
+});
+
+// Admin/cron: retry webhooks that were stored but not yet applied. Declared
+// before the "/:provider" route so it isn't captured as a provider name.
+router.post(
+    "/process-pending",
+    authMiddleware,
+    authorizeRoles("admin", "superadmin"),
+    courierWebhookController.processPending
+);
+
+// Public ingestion endpoint hit by the courier provider. Authenticated by an
+// optional per-provider HMAC signature header rather than a user session.
+router.post("/:provider", courierWebhookController.receiveWebhook);
+
+module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -12,6 +12,7 @@ const recommendationRoutes = require("./recommendationRoutes");
 const cartRoutes = require("./cartRoutes");
 const pincodeRoutes = require("./pincodeRoutes");
 const subscriptionRoutes = require("./subscriptionRoutes");
+const courierWebhookRoutes = require("./courierWebhookRoutes");
 
 router.use("/products", productRoutes);
 router.use("/auth", authRoutes);
@@ -24,5 +25,6 @@ router.use("/recommendations", recommendationRoutes);
 router.use("/cart", cartRoutes);
 router.use("/pincode", pincodeRoutes);
 router.use("/subscriptions", subscriptionRoutes);
+router.use("/courier-webhooks", courierWebhookRoutes);
 
 module.exports = router;

--- a/backend/services/courierWebhookService.js
+++ b/backend/services/courierWebhookService.js
@@ -1,0 +1,417 @@
+// Courier webhook ingestion pipeline (Issue #1157).
+//
+// Turns raw courier-provider webhook deliveries into shipment status updates,
+// backed by the existing `shipments`, `shipment_tracking` and `courier_webhooks`
+// tables. The flow for each delivery is:
+//
+//   1. Verify the provider is supported (and the signature, if a secret is set).
+//   2. Normalize the provider-specific payload into a common event shape.
+//   3. Skip deliveries already processed (idempotency via a per-event dedupe key).
+//   4. Persist the raw payload in `courier_webhooks` for audit/debugging.
+//   5. Apply the event: append a `shipment_tracking` row and advance the
+//      `shipments` status. Processing failures are recorded on the webhook row
+//      (error_message) and never bubble up as an unhandled crash.
+//
+// `processPendingWebhooks` lets a background worker / scheduled job retry rows
+// that were persisted but not yet processed (e.g. the shipment did not exist
+// when the event first arrived).
+
+const crypto = require("crypto");
+const db = require("../config/db");
+const logger = require("../utils/logger");
+const { verifyClaudeSignature } = require("../utils/signatureVerification");
+const { safeArray, sanitizeString } = require("../utils/helpers");
+
+// Providers we accept webhooks from. Unknown providers are rejected up front so
+// a typo in the URL doesn't silently store junk.
+const SUPPORTED_PROVIDERS = new Set([
+    "shiprocket",
+    "delhivery",
+    "bluedart",
+    "generic"
+]);
+
+// Valid values for shipments.status (see backend/schema.sql).
+const SHIPMENT_STATUSES = new Set([
+    "pending",
+    "picked",
+    "in_transit",
+    "out_for_delivery",
+    "delivered",
+    "failed",
+    "returned"
+]);
+
+// Maps the many status strings couriers use onto our shipment status enum.
+// Keys are normalized (lowercased, spaces/hyphens → underscore) before lookup.
+const COURIER_STATUS_MAP = {
+    pending: "pending",
+    created: "pending",
+    manifested: "pending",
+    label_generated: "pending",
+    ready_to_ship: "pending",
+
+    picked: "picked",
+    picked_up: "picked",
+    pickup: "picked",
+    pickup_complete: "picked",
+    pickup_scheduled: "picked",
+
+    in_transit: "in_transit",
+    intransit: "in_transit",
+    shipped: "in_transit",
+    dispatched: "in_transit",
+    at_hub: "in_transit",
+
+    out_for_delivery: "out_for_delivery",
+    ofd: "out_for_delivery",
+
+    delivered: "delivered",
+    completed: "delivered",
+
+    failed: "failed",
+    failed_delivery: "failed",
+    undelivered: "failed",
+    delivery_failed: "failed",
+    exception: "failed",
+
+    returned: "returned",
+    rto: "returned",
+    rto_delivered: "returned",
+    return_to_origin: "returned"
+};
+
+// Reserved envelope key added to the stored payload so we can resolve the
+// provider / dedupe key when reprocessing a persisted webhook without a schema
+// change. The original provider fields are preserved alongside it.
+const META_KEY = "__meta";
+
+class WebhookError extends Error {
+    constructor(message, statusCode) {
+        super(message);
+        this.name = "WebhookError";
+        this.statusCode = statusCode;
+    }
+}
+
+function normalizeStatusKey(value) {
+    return sanitizeString(value)
+        .toLowerCase()
+        .replace(/[\s-]+/g, "_");
+}
+
+// Resolve a courier status string to a shipment enum value, or null if we don't
+// recognize it (the raw value is still stored on the tracking row).
+function mapCourierStatus(rawStatus) {
+    return COURIER_STATUS_MAP[normalizeStatusKey(rawStatus)] || null;
+}
+
+function isSupportedProvider(provider) {
+    return SUPPORTED_PROVIDERS.has(sanitizeString(provider).toLowerCase());
+}
+
+// Pull a value from the payload trying several common field aliases so one
+// normalizer copes with slightly different provider schemas.
+function pick(payload, keys) {
+    for (const key of keys) {
+        if (payload[key] !== undefined && payload[key] !== null && payload[key] !== "") {
+            return payload[key];
+        }
+    }
+    return undefined;
+}
+
+// Convert a raw provider payload into the common event shape. Throws a 400
+// WebhookError when required fields are missing.
+function normalizeEvent(provider, payload) {
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+        throw new WebhookError("Webhook payload must be a JSON object", 400);
+    }
+
+    const trackingNumber = sanitizeString(
+        pick(payload, ["tracking_number", "trackingNumber", "awb", "awb_code", "waybill"])
+    );
+    const status = sanitizeString(
+        pick(payload, ["status", "current_status", "shipment_status", "event"])
+    );
+
+    const missing = [];
+    if (!trackingNumber) missing.push("tracking_number");
+    if (!status) missing.push("status");
+    if (missing.length > 0) {
+        throw new WebhookError(
+            `Webhook payload missing required field(s): ${missing.join(", ")}`,
+            400
+        );
+    }
+
+    const occurredAtRaw = pick(payload, [
+        "occurred_at",
+        "timestamp",
+        "event_time",
+        "status_time",
+        "updated_at"
+    ]);
+    const occurredAt = occurredAtRaw ? new Date(occurredAtRaw) : new Date();
+
+    // A stable per-event id keeps duplicate deliveries idempotent. When the
+    // provider gives us one we use it; otherwise we derive a deterministic hash
+    // from the event's identifying fields.
+    const providerEventId = sanitizeString(
+        pick(payload, ["event_id", "eventId", "id", "webhook_id"])
+    );
+    const eventId = providerEventId || deriveEventId(trackingNumber, status, occurredAt);
+
+    return {
+        provider: provider.toLowerCase(),
+        eventId,
+        trackingNumber,
+        rawStatus: status,
+        mappedStatus: mapCourierStatus(status),
+        description: sanitizeString(pick(payload, ["description", "message", "activity", "remark"])) || null,
+        location: sanitizeString(pick(payload, ["location", "city", "current_location"])) || null,
+        latitude: toNumberOrNull(pick(payload, ["latitude", "lat"])),
+        longitude: toNumberOrNull(pick(payload, ["longitude", "lng", "lon"])),
+        carrierStatusCode: sanitizeString(pick(payload, ["status_code", "carrier_status_code", "code"])) || null,
+        estimatedDelivery: toDateStringOrNull(pick(payload, ["estimated_delivery", "edd", "expected_delivery"])),
+        occurredAt: Number.isNaN(occurredAt.getTime()) ? new Date() : occurredAt
+    };
+}
+
+function deriveEventId(trackingNumber, status, occurredAt) {
+    const basis = `${trackingNumber}|${status}|${occurredAt instanceof Date ? occurredAt.toISOString() : occurredAt}`;
+    return crypto.createHash("sha256").update(basis).digest("hex");
+}
+
+function toNumberOrNull(value) {
+    if (value === undefined || value === null || value === "") return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toDateStringOrNull(value) {
+    if (!value) return null;
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString().slice(0, 10);
+}
+
+function verifySignature(provider, payload, signature) {
+    const secret = process.env[`COURIER_WEBHOOK_SECRET_${provider.toUpperCase()}`]
+        || process.env.COURIER_WEBHOOK_SECRET;
+
+    // No secret configured → signature checks are disabled (local/dev). This is
+    // intentional so the pipeline works without per-provider secrets, matching
+    // how the rest of the project treats optional integrations.
+    if (!secret) return;
+
+    if (!verifyClaudeSignature(signature, payload, secret)) {
+        throw new WebhookError("Invalid webhook signature", 401);
+    }
+}
+
+async function findWebhookByDedupeKey(dedupeKey) {
+    const [rows] = await db.query(
+        `SELECT id, processed
+         FROM courier_webhooks
+         WHERE JSON_UNQUOTE(JSON_EXTRACT(payload, '$.${META_KEY}.dedupeKey')) = ?
+         ORDER BY id DESC
+         LIMIT 1`,
+        [dedupeKey]
+    );
+    return safeArray(rows)[0] || null;
+}
+
+async function findShipmentByTracking(trackingNumber) {
+    const [rows] = await db.query(
+        `SELECT id, status FROM shipments
+         WHERE tracking_number = ? AND deleted_at IS NULL
+         LIMIT 1`,
+        [trackingNumber]
+    );
+    return safeArray(rows)[0] || null;
+}
+
+async function insertWebhookRow({ shipmentId, eventType, payload }) {
+    const [result] = await db.query(
+        `INSERT INTO courier_webhooks (shipment_id, event_type, payload, processed)
+         VALUES (?, ?, ?, 0)`,
+        [shipmentId || null, eventType, JSON.stringify(payload)]
+    );
+    return result.insertId;
+}
+
+async function markWebhookProcessed(webhookId, shipmentId) {
+    await db.query(
+        `UPDATE courier_webhooks
+         SET processed = 1, processed_at = NOW(), error_message = NULL, shipment_id = ?
+         WHERE id = ?`,
+        [shipmentId || null, webhookId]
+    );
+}
+
+async function recordWebhookError(webhookId, message) {
+    await db.query(
+        `UPDATE courier_webhooks
+         SET processed = 0, error_message = ?
+         WHERE id = ?`,
+        [String(message).slice(0, 1000), webhookId]
+    );
+}
+
+// Append a tracking event and advance the parent shipment. Assumes the shipment
+// exists; the caller resolves it first.
+async function applyEventToShipment(shipment, event) {
+    const isDelivered = event.mappedStatus === "delivered";
+
+    await db.query(
+        `INSERT INTO shipment_tracking
+            (shipment_id, status, location, description, latitude, longitude,
+             carrier_status_code, estimated_delivery, is_delivered, \`timestamp\`)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+            shipment.id,
+            event.mappedStatus || event.rawStatus,
+            event.location,
+            event.description,
+            event.latitude,
+            event.longitude,
+            event.carrierStatusCode,
+            event.estimatedDelivery,
+            isDelivered ? 1 : 0,
+            event.occurredAt
+        ]
+    );
+
+    // Only touch shipments.status when we could map the courier status onto our
+    // enum; an unrecognized status is still recorded on the tracking row above.
+    if (event.mappedStatus && SHIPMENT_STATUSES.has(event.mappedStatus)) {
+        if (isDelivered) {
+            await db.query(
+                `UPDATE shipments
+                 SET status = ?, actual_delivery_date = ?
+                 WHERE id = ?`,
+                [event.mappedStatus, event.occurredAt.toISOString().slice(0, 10), shipment.id]
+            );
+        } else {
+            await db.query(
+                `UPDATE shipments SET status = ? WHERE id = ?`,
+                [event.mappedStatus, shipment.id]
+            );
+        }
+    }
+}
+
+async function processEvent(webhookId, event) {
+    const shipment = await findShipmentByTracking(event.trackingNumber);
+    if (!shipment) {
+        throw new WebhookError(
+            `No shipment found for tracking number ${event.trackingNumber}`,
+            422
+        );
+    }
+    await applyEventToShipment(shipment, event);
+    await markWebhookProcessed(webhookId, shipment.id);
+    return shipment.id;
+}
+
+// Entry point for a single inbound webhook delivery.
+async function ingestWebhook({ provider, payload, signature }) {
+    if (!isSupportedProvider(provider)) {
+        throw new WebhookError(`Unsupported courier provider: ${provider}`, 400);
+    }
+
+    verifySignature(provider, payload, signature);
+
+    const event = normalizeEvent(provider, payload);
+    const dedupeKey = `${event.provider}:${event.eventId}`;
+
+    const existing = await findWebhookByDedupeKey(dedupeKey);
+    if (existing && existing.processed) {
+        logger.info(`Duplicate courier webhook ignored (dedupeKey=${dedupeKey})`);
+        return { duplicate: true, processed: true, webhookId: existing.id };
+    }
+
+    const storedPayload = {
+        ...payload,
+        [META_KEY]: {
+            provider: event.provider,
+            dedupeKey,
+            eventId: event.eventId,
+            trackingNumber: event.trackingNumber,
+            receivedAt: new Date().toISOString()
+        }
+    };
+
+    // Reuse the earlier failed row on retry instead of piling up duplicates.
+    let webhookId = existing ? existing.id : null;
+    const shipment = await findShipmentByTracking(event.trackingNumber);
+    if (webhookId === null) {
+        webhookId = await insertWebhookRow({
+            shipmentId: shipment ? shipment.id : null,
+            eventType: event.rawStatus,
+            payload: storedPayload
+        });
+    }
+
+    try {
+        const shipmentId = await processEvent(webhookId, event);
+        return {
+            duplicate: false,
+            processed: true,
+            webhookId,
+            shipmentId,
+            status: event.mappedStatus
+        };
+    } catch (error) {
+        // Persisted-but-unprocessed: log it on the row so a later retry (fresh
+        // delivery or processPendingWebhooks) can pick it up, and don't crash.
+        await recordWebhookError(webhookId, error.message);
+        logger.warn(`Courier webhook ${webhookId} stored but not processed: ${error.message}`);
+        return {
+            duplicate: false,
+            processed: false,
+            webhookId,
+            error: error.message
+        };
+    }
+}
+
+// Reprocess webhooks that were persisted but never applied (background job).
+async function processPendingWebhooks(limit = 50) {
+    const [rows] = await db.query(
+        `SELECT id, payload FROM courier_webhooks
+         WHERE processed = 0
+         ORDER BY received_at ASC
+         LIMIT ?`,
+        [limit]
+    );
+
+    const summary = { total: safeArray(rows).length, processed: 0, failed: 0 };
+
+    for (const row of safeArray(rows)) {
+        try {
+            const payload = typeof row.payload === "string" ? JSON.parse(row.payload) : row.payload;
+            const provider = payload?.[META_KEY]?.provider || "generic";
+            const event = normalizeEvent(provider, payload);
+            await processEvent(row.id, event);
+            summary.processed += 1;
+        } catch (error) {
+            await recordWebhookError(row.id, error.message);
+            summary.failed += 1;
+            logger.warn(`Retry of courier webhook ${row.id} failed: ${error.message}`);
+        }
+    }
+
+    return summary;
+}
+
+module.exports = {
+    ingestWebhook,
+    processPendingWebhooks,
+    normalizeEvent,
+    mapCourierStatus,
+    isSupportedProvider,
+    WebhookError,
+    SUPPORTED_PROVIDERS,
+    SHIPMENT_STATUSES
+};

--- a/backend/tests/courierWebhook.test.js
+++ b/backend/tests/courierWebhook.test.js
@@ -1,0 +1,191 @@
+// Tests for the courier webhook ingestion pipeline (#1157). The DB and logger
+// are mocked so we can assert the persist → apply → mark-processed flow, status
+// mapping, idempotency and graceful failure handling without a live MySQL.
+
+jest.mock("../config/db", () => ({ query: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+const db = require("../config/db");
+const service = require("../services/courierWebhookService");
+
+// Configurable fake DB. `state` controls what the SELECTs return; INSERT/UPDATE
+// calls are recorded so tests can assert side effects.
+function installDb(state = {}) {
+    const calls = [];
+    let webhookAutoId = state.newWebhookId || 100;
+
+    db.query.mockImplementation(async (sql, params = []) => {
+        calls.push({ sql, params });
+
+        if (/FROM courier_webhooks\s+WHERE JSON_UNQUOTE/i.test(sql)) {
+            return [state.existingWebhook ? [state.existingWebhook] : []];
+        }
+        if (/FROM shipments\s+WHERE tracking_number/i.test(sql)) {
+            return [state.shipment ? [state.shipment] : []];
+        }
+        if (/SELECT id, payload FROM courier_webhooks\s+WHERE processed = 0/i.test(sql)) {
+            return [state.pending || []];
+        }
+        if (/^\s*INSERT INTO courier_webhooks/i.test(sql)) {
+            return [{ insertId: webhookAutoId++ }];
+        }
+        if (/^\s*INSERT INTO shipment_tracking/i.test(sql)) {
+            return [{ insertId: 1 }];
+        }
+        // UPDATE shipments / UPDATE courier_webhooks
+        return [{ affectedRows: 1 }];
+    });
+
+    return { calls };
+}
+
+function sqlsMatching(calls, regex) {
+    return calls.filter(({ sql }) => regex.test(sql));
+}
+
+const basePayload = {
+    tracking_number: "AWB123",
+    status: "in_transit",
+    location: "Mumbai Hub",
+    description: "Package in transit"
+};
+
+afterEach(() => {
+    db.query.mockReset();
+    delete process.env.COURIER_WEBHOOK_SECRET;
+    delete process.env.COURIER_WEBHOOK_SECRET_SHIPROCKET;
+});
+
+describe("status mapping + normalization", () => {
+    test("maps courier status vocabularies onto the shipment enum", () => {
+        expect(service.mapCourierStatus("OUT FOR DELIVERY")).toBe("out_for_delivery");
+        expect(service.mapCourierStatus("RTO")).toBe("returned");
+        expect(service.mapCourierStatus("picked-up")).toBe("picked");
+        expect(service.mapCourierStatus("Delivered")).toBe("delivered");
+    });
+
+    test("returns null for unknown courier statuses", () => {
+        expect(service.mapCourierStatus("teleported")).toBeNull();
+    });
+
+    test("normalizeEvent requires tracking_number and status", () => {
+        expect(() => service.normalizeEvent("generic", { status: "delivered" }))
+            .toThrow(/tracking_number/);
+        expect(() => service.normalizeEvent("generic", { tracking_number: "X" }))
+            .toThrow(/status/);
+    });
+
+    test("normalizeEvent reads provider field aliases", () => {
+        const event = service.normalizeEvent("delhivery", {
+            awb: "WAY9",
+            current_status: "Delivered",
+            edd: "2026-08-01"
+        });
+        expect(event.trackingNumber).toBe("WAY9");
+        expect(event.mappedStatus).toBe("delivered");
+        expect(event.estimatedDelivery).toBe("2026-08-01");
+    });
+});
+
+describe("ingestWebhook", () => {
+    test("rejects unsupported providers with a 400 WebhookError", async () => {
+        installDb();
+        await expect(
+            service.ingestWebhook({ provider: "notacourier", payload: basePayload })
+        ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    test("persists the webhook, appends tracking and advances shipment status", async () => {
+        const { calls } = installDb({ shipment: { id: 7, status: "pending" } });
+
+        const result = await service.ingestWebhook({
+            provider: "shiprocket",
+            payload: basePayload
+        });
+
+        expect(result).toMatchObject({ duplicate: false, processed: true, shipmentId: 7, status: "in_transit" });
+        expect(sqlsMatching(calls, /INSERT INTO courier_webhooks/i)).toHaveLength(1);
+        expect(sqlsMatching(calls, /INSERT INTO shipment_tracking/i)).toHaveLength(1);
+        const [shipmentUpdate] = sqlsMatching(calls, /UPDATE shipments SET status/i);
+        expect(shipmentUpdate.params).toEqual(["in_transit", 7]);
+        expect(sqlsMatching(calls, /UPDATE courier_webhooks\s+SET processed = 1/i)).toHaveLength(1);
+    });
+
+    test("sets actual_delivery_date when the shipment is delivered", async () => {
+        const { calls } = installDb({ shipment: { id: 9, status: "in_transit" } });
+
+        await service.ingestWebhook({
+            provider: "generic",
+            payload: { tracking_number: "AWB9", status: "delivered", occurred_at: "2026-08-05T10:00:00Z" }
+        });
+
+        const [deliveredUpdate] = sqlsMatching(calls, /UPDATE shipments\s+SET status = \?, actual_delivery_date/i);
+        expect(deliveredUpdate.params).toEqual(["delivered", "2026-08-05", 9]);
+    });
+
+    test("is idempotent: a duplicate of an already-processed event is skipped", async () => {
+        const { calls } = installDb({ existingWebhook: { id: 42, processed: 1 } });
+
+        const result = await service.ingestWebhook({
+            provider: "shiprocket",
+            payload: basePayload
+        });
+
+        expect(result).toMatchObject({ duplicate: true, webhookId: 42 });
+        expect(sqlsMatching(calls, /INSERT INTO courier_webhooks/i)).toHaveLength(0);
+        expect(sqlsMatching(calls, /INSERT INTO shipment_tracking/i)).toHaveLength(0);
+    });
+
+    test("stores the payload and records an error when no shipment matches (no throw)", async () => {
+        const { calls } = installDb({ shipment: null });
+
+        const result = await service.ingestWebhook({
+            provider: "shiprocket",
+            payload: basePayload
+        });
+
+        expect(result).toMatchObject({ duplicate: false, processed: false });
+        expect(result.error).toMatch(/No shipment found/);
+        expect(sqlsMatching(calls, /INSERT INTO courier_webhooks/i)).toHaveLength(1);
+        expect(sqlsMatching(calls, /UPDATE courier_webhooks\s+SET processed = 0/i)).toHaveLength(1);
+        expect(sqlsMatching(calls, /INSERT INTO shipment_tracking/i)).toHaveLength(0);
+    });
+
+    test("rejects an invalid signature with a 401 when a secret is configured", async () => {
+        process.env.COURIER_WEBHOOK_SECRET = "super-secret-value-1234567890";
+        installDb({ shipment: { id: 1, status: "pending" } });
+
+        await expect(
+            service.ingestWebhook({
+                provider: "shiprocket",
+                payload: basePayload,
+                signature: "deadbeef".repeat(8)
+            })
+        ).rejects.toMatchObject({ statusCode: 401 });
+    });
+});
+
+describe("processPendingWebhooks", () => {
+    test("reprocesses stored rows and reports a summary", async () => {
+        const pending = [
+            {
+                id: 201,
+                payload: JSON.stringify({
+                    tracking_number: "AWB123",
+                    status: "delivered",
+                    __meta: { provider: "shiprocket" }
+                })
+            }
+        ];
+        installDb({ pending, shipment: { id: 5, status: "in_transit" } });
+
+        const summary = await service.processPendingWebhooks(10);
+
+        expect(summary).toEqual({ total: 1, processed: 1, failed: 0 });
+    });
+});


### PR DESCRIPTION
The shipments, shipment_tracking, and courier_webhooks tables existed but there was no way to ingest courier events, so shipment status had to be updated by hand.

Adds a webhook pipeline: `POST /api/courier-webhooks/:provider` validates the provider (and an optional per-provider HMAC signature), normalizes provider payloads to a common event shape, persists the raw payload for audit, then updates the shipment and appends a tracking row. Duplicate deliveries are idempotent via a per-event dedupe key, and processing failures are recorded on the webhook row without failing the request. An admin-only `POST /api/courier-webhooks/process-pending` endpoint retries stored-but-unprocessed events for a background job/cron.

Test plan
- Unit coverage for: status-vocabulary mapping and payload normalization, persist→apply→mark-processed happy path, delivered-status setting the delivery date, idempotent skip of already-processed duplicates, graceful handling when no shipment matches, signature rejection, and batch reprocessing.

Closes #1157.