### PR TITLE
fix: improve section header text visibility in dark mode (#1156)

### DIFF
--- a/frontend/styles/style.css
+++ b/frontend/styles/style.css
@@ -241,6 +241,19 @@
     margin: 0;
 }
 
+body.dark-theme .section-header-card {
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+body.dark-theme .section-header-card h2 {
+    color: #f8fafc;
+}
+
+body.dark-theme .section-header-card p {
+    color: #e2e8f0;
+}
+
 /* New Arrivals */
 .arrivals-card {
     background: linear-gradient(
@@ -249,6 +262,11 @@
         #ffe8d9
     );
     border-left: 8px solid #f4a261;
+}
+
+body.dark-theme .arrivals-card {
+    background: linear-gradient(135deg, #3a2316, #5f3720);
+    border-left-color: #ffb36b;
 }
 
 /* Recently Viewed */
@@ -261,6 +279,11 @@
     border-left: 8px solid #6ab7a8;
 }
 
+body.dark-theme .recent-card {
+    background: linear-gradient(135deg, #12362d, #215845);
+    border-left-color: #7fd9c7;
+}
+
 /* Recommended */
 .recommended-card {
     background: linear-gradient(
@@ -269,6 +292,11 @@
         #ebe5ff
     );
     border-left: 8px solid #9b8cff;
+}
+
+body.dark-theme .recommended-card {
+    background: linear-gradient(135deg, #22163f, #3a2a69);
+    border-left-color: #c7b7ff;
 }
 
 /* Mobile */


### PR DESCRIPTION
## Related Issue

Closes #1156

---

## Description

This PR improves the visibility of homepage section headers and descriptions in Dark Mode.

### Changes Made

- Improved text contrast for homepage section cards in Dark Mode.
- Updated styling for section titles such as:
  - New Arrivals
  - Recently Viewed
  - Recommended For You
- Ensured text remains clearly readable while preserving the existing UI design.
- No changes were made to Light Mode styling.

---

## Testing

- Enabled Dark Mode and verified improved readability.
- Confirmed Light Mode appearance remains unchanged.
- Checked multiple homepage section cards for consistent styling.

---

## Screenshots

### Before

<img width="645" height="293" alt="image" src="https://github.com/user-attachments/assets/dae875c3-c854-413c-b40a-19bb84c5f815" />


### After

<img width="959" height="437" alt="image" src="https://github.com/user-attachments/assets/1d6e1671-1810-4f0b-8cd2-4c3d7a89ad95" />


---

## Checklist

- [x] Code follows the project's coding style.
- [x] Tested the changes locally.
- [x] No existing functionality was affected.
- [x] Linked the related issue.