### PR TITLE
Fix product price range API filter

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -103,6 +103,40 @@ const getProducts = async (req, res) => {
             ? toBooleanModeQuery(rawSearch)
             : "";
 
+        const rawMinPrice =
+            req.query.minPrice ?? req.query.min;
+        const rawMaxPrice =
+            req.query.maxPrice ?? req.query.max;
+        const minPrice =
+            rawMinPrice !== undefined && rawMinPrice !== ""
+                ? safeNumber(rawMinPrice, null)
+                : null;
+        const maxPrice =
+            rawMaxPrice !== undefined && rawMaxPrice !== ""
+                ? safeNumber(rawMaxPrice, null)
+                : null;
+
+        if (minPrice !== null && (minPrice < 0 || !Number.isFinite(minPrice))) {
+            return res.status(400).json({
+                success: false,
+                message: "Invalid minimum price"
+            });
+        }
+
+        if (maxPrice !== null && (maxPrice < 0 || !Number.isFinite(maxPrice))) {
+            return res.status(400).json({
+                success: false,
+                message: "Invalid maximum price"
+            });
+        }
+
+        if (minPrice !== null && maxPrice !== null && minPrice > maxPrice) {
+            return res.status(400).json({
+                success: false,
+                message: "Minimum price cannot be greater than maximum price"
+            });
+        }
+
         // Resolve sort against the whitelist; unknown/empty falls back to newest.
         const orderByClause =
             SORT_CLAUSES[sanitizeString(req.query.sort)] || DEFAULT_SORT_CLAUSE;
@@ -166,6 +200,16 @@ const getProducts = async (req, res) => {
                     conditions.push("name LIKE ?");
                     params.push(likeSearch);
                 }
+            }
+
+            if (minPrice !== null) {
+                conditions.push("price >= ?");
+                params.push(minPrice);
+            }
+
+            if (maxPrice !== null) {
+                conditions.push("price <= ?");
+                params.push(maxPrice);
             }
 
             const whereClause = conditions.length

--- a/frontend/scripts/shop.js
+++ b/frontend/scripts/shop.js
@@ -230,6 +230,14 @@ function buildProductsQuery(page) {
         params.set("sort", filters.sort);
     }
 
+    if (priceTouched && Number.isFinite(Number(filters.minPrice))) {
+        params.set("minPrice", String(filters.minPrice));
+    }
+
+    if (priceTouched && Number.isFinite(Number(filters.maxPrice))) {
+        params.set("maxPrice", String(filters.maxPrice));
+    }
+
     return `/products?${params.toString()}`;
 }
 


### PR DESCRIPTION
Closes #781 
## Summary

Adds price range filtering to the product listing closes #781 , allowing users to browse products within a specified budget while working seamlessly with the existing search and category filters.

## Changes

- Added support for minimum and maximum price filtering
- Updated the product filtering logic to include price range
- Added support for `minPrice` and `maxPrice` query parameters in the products API
- Updated the frontend to send price range values with product requests
- Preserved compatibility with existing search and category filters

## Testing

- Verified products are filtered correctly within the selected price range
- Confirmed filtering works together with search and category filters
- Verified API accepts and processes `minPrice` and `maxPrice` query parameters
- Tested locally for expected behavior

## Checklist

- [x] Feature implementation
- [x] No breaking changes
- [x] Tested locally