### PR TITLE
Improve empty cart continue shopping CTA

### DIFF
--- a/frontend/scripts/cart.js
+++ b/frontend/scripts/cart.js
@@ -614,7 +614,9 @@ function renderEmptyCart() {
                 <i class="fas fa-shopping-cart fa-3x"></i>
                 <h2>Your cart is empty</h2>
                 <p>Start shopping to add items to your cart</p>
-                <a href="/shop" class="shop-now-btn">Shop Now</a>
+                <a href="shop.html" class="continue-shopping-btn empty-cart-cta">
+                    Continue Shopping
+                </a>
             </div>
         `;
     }

--- a/frontend/styles/cart.css
+++ b/frontend/styles/cart.css
@@ -297,6 +297,22 @@ body.dark-theme #continue-shopping-btn:hover {
     opacity: 0.9;
     transform: translateY(-2px);
 }
+
+.empty-cart-cta{
+    margin-top: 24px;
+    min-width: 220px;
+    padding: 16px 28px;
+    border-radius: 8px;
+    font-size: 16px;
+    font-weight: 700;
+    box-shadow: 0 12px 24px rgba(8, 129, 120, 0.2);
+}
+
+.empty-cart-cta:hover{
+    opacity: 1;
+    background: #066d66;
+    box-shadow: 0 16px 30px rgba(8, 129, 120, 0.26);
+}
 body.dark-theme .cart-container,
 body.dark-theme .cart-items,
 body.dark-theme .order-summary {


### PR DESCRIPTION
## Summary

Improves the empty cart experience by replacing the small "Shop Now" link with a more prominent **Continue Shopping** call-to-action button. This makes it easier for users to return to the shop when their cart is empty.

Closes #780 

## Changes

- Replaced the small empty cart link with a prominent **Continue Shopping** button
- Updated the button to navigate to `shop.html`
- Added dedicated `.empty-cart-cta` styling for better visibility and accessibility
- Kept the change scoped to the empty cart state without affecting existing cart functionality

## Testing

- [x] Verified the empty cart state displays the new CTA correctly
- [x] Confirmed the button redirects users to `shop.html`
- [x] Verified existing cart functionality remains unchanged
- [x] Tested locally

## Checklist

- [x] UI enhancement
- [x] No breaking changes
- [x] Tested locally