### PR TITLE
fix: resolve wishlist status check type mismatch in wishlistController.js (fixes #1191)

### DIFF
--- a/backend/controllers/wishlistController.js
+++ b/backend/controllers/wishlistController.js
@@ -153,14 +153,15 @@ const wishlistController = {
     checkWishlistStatus: async (req, res) => {
         try {
             const userId = req.user.id;
-            const productId = safeNumber(req.params.productId);
+            const productId = safeUUID(req.params.productId);
 
-            if (!productId || productId < 1) {
+            if (!productId) {
                 return res.status(400).json({
                     success: false,
                     message: "Valid product ID is required"
                 });
             }
+
 
             const [rows] = await promisePool.query(
                 "SELECT id FROM wishlist_items WHERE user_id = ? AND product_id = ?",


### PR DESCRIPTION
## Description

This Pull Request fixes the wishlist status check API in `backend/controllers/wishlistController.js` by correcting the validation logic for product IDs. The endpoint now properly accepts UUID-based product IDs instead of incorrectly treating them as numeric values.

## Related Issue

**Closes #1191**

## Changes Made

###  Corrected Product ID Parsing
- Replaced the incorrect numeric parsing:
  ```javascript
  safeNumber(req.params.productId)
  ```
  with:
  ```javascript
  safeUUID(req.params.productId)
  ```
- Ensured the endpoint correctly handles UUID product identifiers.

###  Updated Validation Logic
- Removed the numeric validation check (`productId < 1`).
- Updated the validation to verify that a valid UUID is present:
  ```javascript
  if (!productId) {
      // Return 400 Bad Request
  }
  ```
- Prevents valid UUIDs from being rejected with a `400 Bad Request`.

## Verification

### Syntax Check
```bash
node -c backend/controllers/wishlistController.js
```

**Result:**  Exit code `0` (Success)

### Runtime Verification
- Verified the controller loads successfully without syntax errors.
- Confirmed the wishlist status endpoint accepts valid UUID product IDs.
- Tested that valid requests return the correct wishlist status instead of a `400 Bad Request`.

## Labels

> **Suggested labels for maintainers:**
- `bug`
- `backend`
- `high priority`
- `good first issue`
- `ECSoC '26`