### PR TITLE
fix: reserve inventory on cart sync and update paths to prevent overselling

### DIFF
--- a/backend/controllers/cartController.js
+++ b/backend/controllers/cartController.js
@@ -71,6 +71,10 @@ const cartController = {
 
             await connection.beginTransaction();
 
+            // /cart/sync is replace-all: drop the user's current reservations
+            // up front so the ones created below match the synced quantities.
+            await inventoryReservationService.releaseUserLocks(userId, null, connection);
+
             let placeholders = [];
             let values = [];
 
@@ -92,9 +96,9 @@ const cartController = {
                 for (const [productId, qty] of quantities) {
                     if (!productMap.has(productId)) continue;
 
-                    const availableStock = productMap.get(productId);
+                    const reserved = await inventoryReservationService.reserveStock(userId, productId, qty, connection);
 
-                    if (qty > availableStock) {
+                    if (!reserved) {
                         await connection.rollback();
 
                         return res.status(400).json({
@@ -199,12 +203,18 @@ const cartController = {
 
             await connection.beginTransaction();
 
-            const [products] = await connection.query("SELECT id, stock FROM products WHERE id = ?", [productId]);
+            const [products] = await connection.query("SELECT id FROM products WHERE id = ?", [productId]);
             if (products.length === 0) {
                 await connection.rollback();
                 return res.status(404).json({ success: false, message: "Product not found" });
             }
-            if (quantity > products[0].stock) {
+
+            // Move the user's reservation for this product to the new quantity
+            // (release then re-reserve) so held stock tracks the cart.
+            await inventoryReservationService.releaseUserLocks(userId, productId, connection);
+
+            const reserved = await inventoryReservationService.reserveStock(userId, productId, quantity, connection);
+            if (!reserved) {
                 await connection.rollback();
                 return res.status(400).json({ success: false, message: "Requested quantity exceeds available stock" });
             }

--- a/backend/services/inventoryReservationService.js
+++ b/backend/services/inventoryReservationService.js
@@ -37,6 +37,21 @@ const inventoryReservationService = {
         return true;
     },
 
+    // Release a user's reservation(s); pass a productId to target a single
+    // product, omit it to clear the user's entire reservation set.
+    releaseUserLocks: async (userId, productId = null, connection = null) => {
+        const pool = connection || promisePool;
+
+        if (productId === null) {
+            await pool.query("DELETE FROM inventory_locks WHERE user_id = ?", [userId]);
+        } else {
+            await pool.query(
+                "DELETE FROM inventory_locks WHERE user_id = ? AND product_id = ?",
+                [userId, productId]
+            );
+        }
+    },
+
     // Validate if the user holds locks for their entire cart
     validateCartLocks: async (userId, cartItems, connection = null) => {
         const pool = connection || promisePool;


### PR DESCRIPTION
## Summary
`/cart/sync` and `/cart/update` wrote cart quantities directly, bypassing
`inventoryReservationService` so items added through those paths were never
reserved, defeating the reservation system `/cart/add` relies on and allowing
two shoppers to hold the same last unit. Both paths now reconcile reservations
inside their existing transactions: `syncCart` clears the user's reservations
and re-reserves each final quantity (replace-all semantics), and
`updateCartItem` releases and re-reserves the affected product at its new
quantity. On any reservation failure they roll back and return the same 400
responses as before.

Fixes #1195.

## Changes
- `backend/services/inventoryReservationService.js`: add transaction-aware
  `releaseUserLocks(userId, productId?, connection?)`.
- `backend/controllers/cartController.js`: reserve via the service in `syncCart`
  and `updateCartItem`; release-before-reserve so a user's own prior locks don't
  count against their new availability.

## Test plan
- Sync a cart at quantity = current stock, then attempt to reserve the same unit
  from another user -> blocked.
- Update a cart item up/down -> held reservation tracks the new quantity.
- Reservation failure rolls back the transaction and returns the existing 400.
