### PR TITLE
feat: admin review + inventory restock for returns (part 2/3, #1193)

### DIFF
--- a/backend/controllers/refundController.js
+++ b/backend/controllers/refundController.js
@@ -1,0 +1,190 @@
+const db = require("../config/db");
+const RefundRequest = require("../models/RefundRequest");
+const {
+    safeArray,
+    safeInteger,
+    safeUUID,
+    sanitizeString
+} = require("../utils/helpers");
+
+// Returns are only offered once an order has actually reached the customer.
+const ELIGIBLE_ORDER_STATUS = "delivered";
+const RETURN_WINDOW_DAYS = 30;
+const MIN_REASON_LENGTH = 5;
+const MAX_REASON_LENGTH = 1000;
+
+// The window runs from delivery when we have it, otherwise from order
+// creation so orders delivered before delivered_at was tracked still resolve.
+function isReturnWindowExpired(order) {
+    const reference = order.delivered_at || order.created_at;
+
+    if (!reference) {
+        return false;
+    }
+
+    const referenceTime = new Date(reference).getTime();
+
+    if (Number.isNaN(referenceTime)) {
+        return false;
+    }
+
+    const ageInDays = (Date.now() - referenceTime) / (1000 * 60 * 60 * 24);
+
+    return ageInDays > RETURN_WINDOW_DAYS;
+}
+
+const createRequest = async (req, res) => {
+    const userId = safeUUID(req.user?.id);
+    const orderId = safeUUID(req.body.orderId);
+    const orderItemId = safeInteger(req.body.orderItemId);
+    const reason = sanitizeString(req.body.reason);
+    const requestedQty =
+        req.body.quantity === undefined || req.body.quantity === null
+            ? null
+            : safeInteger(req.body.quantity);
+
+    if (!userId) {
+        return res.status(401).json({
+            success: false,
+            message: "Authentication required"
+        });
+    }
+
+    if (!orderId) {
+        return res.status(400).json({
+            success: false,
+            message: "Invalid order ID"
+        });
+    }
+
+    if (orderItemId < 1) {
+        return res.status(400).json({
+            success: false,
+            message: "Invalid order item"
+        });
+    }
+
+    if (reason.length < MIN_REASON_LENGTH || reason.length > MAX_REASON_LENGTH) {
+        return res.status(400).json({
+            success: false,
+            message: `Reason must be between ${MIN_REASON_LENGTH} and ${MAX_REASON_LENGTH} characters`
+        });
+    }
+
+    try {
+        const [orders] = await db.query(
+            "SELECT user_id, status, delivered_at, created_at FROM orders WHERE id = ? LIMIT 1",
+            [orderId]
+        );
+
+        const order = safeArray(orders)[0];
+
+        if (!order || order.user_id !== userId) {
+            return res.status(404).json({
+                success: false,
+                message: "Order not found"
+            });
+        }
+
+        if (order.status !== ELIGIBLE_ORDER_STATUS) {
+            return res.status(400).json({
+                success: false,
+                message: "Only delivered orders are eligible for a return"
+            });
+        }
+
+        if (isReturnWindowExpired(order)) {
+            return res.status(400).json({
+                success: false,
+                message: `The ${RETURN_WINDOW_DAYS}-day return window for this order has closed`
+            });
+        }
+
+        const [items] = await db.query(
+            "SELECT id, product_id, qty FROM order_items WHERE id = ? AND order_id = ? LIMIT 1",
+            [orderItemId, orderId]
+        );
+
+        const item = safeArray(items)[0];
+
+        if (!item) {
+            return res.status(400).json({
+                success: false,
+                message: "The selected item is not part of this order"
+            });
+        }
+
+        const quantity = requestedQty === null ? item.qty : requestedQty;
+
+        if (quantity < 1 || quantity > item.qty) {
+            return res.status(400).json({
+                success: false,
+                message: `Return quantity must be between 1 and ${item.qty}`
+            });
+        }
+
+        if (await RefundRequest.hasOpenRequestForItem(orderItemId)) {
+            return res.status(409).json({
+                success: false,
+                message: "An open return request already exists for this item"
+            });
+        }
+
+        const requestId = await RefundRequest.create({
+            userId,
+            orderId,
+            orderItemId,
+            productId: item.product_id,
+            reason,
+            quantity
+        });
+
+        const created = await RefundRequest.findById(requestId);
+
+        return res.status(201).json({
+            success: true,
+            message: "Return request submitted",
+            data: created ? created.toJSON() : { id: requestId }
+        });
+    } catch (error) {
+        console.error("CREATE REFUND REQUEST ERROR:", error);
+
+        return res.status(500).json({
+            success: false,
+            message: "Failed to submit return request"
+        });
+    }
+};
+
+const listMyRequests = async (req, res) => {
+    const userId = safeUUID(req.user?.id);
+
+    if (!userId) {
+        return res.status(401).json({
+            success: false,
+            message: "Authentication required"
+        });
+    }
+
+    try {
+        const requests = await RefundRequest.findByUser(userId);
+
+        return res.status(200).json({
+            success: true,
+            message: "Return requests fetched",
+            data: requests.map((request) => request.toJSON())
+        });
+    } catch (error) {
+        console.error("LIST MY REFUND REQUESTS ERROR:", error);
+
+        return res.status(500).json({
+            success: false,
+            message: "Failed to fetch return requests"
+        });
+    }
+};
+
+module.exports = {
+    createRequest,
+    listMyRequests
+};

--- a/backend/controllers/refundController.js
+++ b/backend/controllers/refundController.js
@@ -12,6 +12,8 @@ const ELIGIBLE_ORDER_STATUS = "delivered";
 const RETURN_WINDOW_DAYS = 30;
 const MIN_REASON_LENGTH = 5;
 const MAX_REASON_LENGTH = 1000;
+const MAX_ADMIN_NOTE_LENGTH = 1000;
+const REFUND_STATUSES = ["pending", "approved", "rejected", "refunded"];
 
 // The window runs from delivery when we have it, otherwise from order
 // creation so orders delivered before delivered_at was tracked still resolve.
@@ -184,7 +186,239 @@ const listMyRequests = async (req, res) => {
     }
 };
 
+const listAll = async (req, res) => {
+    const status = req.query.status
+        ? sanitizeString(req.query.status).toLowerCase()
+        : null;
+
+    if (status && !REFUND_STATUSES.includes(status)) {
+        return res.status(400).json({
+            success: false,
+            message: `Status must be one of: ${REFUND_STATUSES.join(", ")}`
+        });
+    }
+
+    try {
+        const requests = await RefundRequest.list({ status });
+
+        return res.status(200).json({
+            success: true,
+            message: "Return requests fetched",
+            data: requests.map((request) => request.toJSON())
+        });
+    } catch (error) {
+        console.error("LIST REFUND REQUESTS ERROR:", error);
+
+        return res.status(500).json({
+            success: false,
+            message: "Failed to fetch return requests"
+        });
+    }
+};
+
+const approveRequest = async (req, res) => {
+    const adminId = safeUUID(req.user?.id);
+    const requestId = safeInteger(req.params.id);
+    const adminNote = normalizeAdminNote(req.body.note);
+
+    if (requestId < 1) {
+        return res.status(400).json({
+            success: false,
+            message: "Invalid request ID"
+        });
+    }
+
+    if (adminNote && adminNote.length > MAX_ADMIN_NOTE_LENGTH) {
+        return res.status(400).json({
+            success: false,
+            message: `Admin note cannot exceed ${MAX_ADMIN_NOTE_LENGTH} characters`
+        });
+    }
+
+    let connection;
+
+    try {
+        connection = await db.getConnection();
+        await connection.beginTransaction();
+
+        const request = await RefundRequest.findById(requestId, {
+            connection,
+            forUpdate: true
+        });
+
+        if (!request) {
+            await connection.rollback();
+
+            return res.status(404).json({
+                success: false,
+                message: "Return request not found"
+            });
+        }
+
+        if (request.status !== "pending") {
+            await connection.rollback();
+
+            return res.status(400).json({
+                success: false,
+                message: "Only pending requests can be approved"
+            });
+        }
+
+        // The order item may reference a variant; restock both the base
+        // product and the specific variant so inventory stays consistent.
+        let variantId = null;
+
+        if (request.orderItemId) {
+            const [items] = await connection.query(
+                "SELECT variant_id FROM order_items WHERE id = ? LIMIT 1",
+                [request.orderItemId]
+            );
+
+            variantId = safeArray(items)[0]?.variant_id ?? null;
+        }
+
+        if (request.productId) {
+            await connection.query(
+                "UPDATE products SET stock = stock + ? WHERE id = ?",
+                [request.quantity, request.productId]
+            );
+        }
+
+        if (variantId) {
+            await connection.query(
+                "UPDATE product_variants SET stock = stock + ? WHERE id = ?",
+                [request.quantity, variantId]
+            );
+        }
+
+        await RefundRequest.updateStatus(
+            requestId,
+            { status: "approved", adminNote, reviewedBy: adminId },
+            connection
+        );
+
+        await connection.commit();
+
+        const updated = await RefundRequest.findById(requestId);
+
+        return res.status(200).json({
+            success: true,
+            message: "Return request approved and inventory restocked",
+            data: updated ? updated.toJSON() : null
+        });
+    } catch (error) {
+        if (connection) {
+            await connection.rollback();
+        }
+
+        console.error("APPROVE REFUND REQUEST ERROR:", error);
+
+        return res.status(500).json({
+            success: false,
+            message: "Failed to approve return request"
+        });
+    } finally {
+        if (connection) {
+            connection.release();
+        }
+    }
+};
+
+const rejectRequest = async (req, res) => {
+    const adminId = safeUUID(req.user?.id);
+    const requestId = safeInteger(req.params.id);
+    const adminNote = normalizeAdminNote(req.body.note);
+
+    if (requestId < 1) {
+        return res.status(400).json({
+            success: false,
+            message: "Invalid request ID"
+        });
+    }
+
+    if (adminNote && adminNote.length > MAX_ADMIN_NOTE_LENGTH) {
+        return res.status(400).json({
+            success: false,
+            message: `Admin note cannot exceed ${MAX_ADMIN_NOTE_LENGTH} characters`
+        });
+    }
+
+    let connection;
+
+    try {
+        connection = await db.getConnection();
+        await connection.beginTransaction();
+
+        const request = await RefundRequest.findById(requestId, {
+            connection,
+            forUpdate: true
+        });
+
+        if (!request) {
+            await connection.rollback();
+
+            return res.status(404).json({
+                success: false,
+                message: "Return request not found"
+            });
+        }
+
+        if (request.status !== "pending") {
+            await connection.rollback();
+
+            return res.status(400).json({
+                success: false,
+                message: "Only pending requests can be rejected"
+            });
+        }
+
+        await RefundRequest.updateStatus(
+            requestId,
+            { status: "rejected", adminNote, reviewedBy: adminId },
+            connection
+        );
+
+        await connection.commit();
+
+        const updated = await RefundRequest.findById(requestId);
+
+        return res.status(200).json({
+            success: true,
+            message: "Return request rejected",
+            data: updated ? updated.toJSON() : null
+        });
+    } catch (error) {
+        if (connection) {
+            await connection.rollback();
+        }
+
+        console.error("REJECT REFUND REQUEST ERROR:", error);
+
+        return res.status(500).json({
+            success: false,
+            message: "Failed to reject return request"
+        });
+    } finally {
+        if (connection) {
+            connection.release();
+        }
+    }
+};
+
+function normalizeAdminNote(value) {
+    if (value === undefined || value === null) {
+        return null;
+    }
+
+    const note = sanitizeString(value);
+
+    return note.length ? note : null;
+}
+
 module.exports = {
     createRequest,
-    listMyRequests
+    listMyRequests,
+    listAll,
+    approveRequest,
+    rejectRequest
 };

--- a/backend/models/RefundRequest.js
+++ b/backend/models/RefundRequest.js
@@ -1,0 +1,153 @@
+const db = require("../config/db");
+
+const REFUND_REQUEST_COLUMNS = `
+    id,
+    user_id,
+    order_id,
+    order_item_id,
+    product_id,
+    reason,
+    quantity,
+    status,
+    admin_note,
+    reviewed_by,
+    reviewed_at,
+    created_at,
+    updated_at
+`;
+
+// A request is "open" while it is still awaiting an outcome or has been
+// approved but not yet closed out, so a second request for the same line
+// should be blocked in either state.
+const OPEN_STATUSES = ["pending", "approved"];
+
+class RefundRequest {
+    constructor(row) {
+        this.id = row.id;
+        this.userId = row.user_id ?? row.userId ?? null;
+        this.orderId = row.order_id ?? row.orderId ?? null;
+        this.orderItemId = row.order_item_id ?? row.orderItemId ?? null;
+        this.productId = row.product_id ?? row.productId ?? null;
+        this.reason = row.reason || "";
+        this.quantity = row.quantity ?? 1;
+        this.status = row.status || "pending";
+        this.adminNote = row.admin_note ?? row.adminNote ?? null;
+        this.reviewedBy = row.reviewed_by ?? row.reviewedBy ?? null;
+        this.reviewedAt = row.reviewed_at ?? row.reviewedAt ?? null;
+        this.createdAt = row.created_at ?? row.createdAt ?? null;
+        this.updatedAt = row.updated_at ?? row.updatedAt ?? null;
+    }
+
+    toJSON() {
+        return {
+            id: this.id,
+            user_id: this.userId,
+            order_id: this.orderId,
+            order_item_id: this.orderItemId,
+            product_id: this.productId,
+            reason: this.reason,
+            quantity: this.quantity,
+            status: this.status,
+            admin_note: this.adminNote,
+            reviewed_by: this.reviewedBy,
+            reviewed_at: this.reviewedAt,
+            created_at: this.createdAt,
+            updated_at: this.updatedAt
+        };
+    }
+
+    static async create(
+        { userId, orderId, orderItemId, productId, reason, quantity },
+        connection = db
+    ) {
+        const [result] = await connection.query(
+            `
+                INSERT INTO refund_requests
+                    (user_id, order_id, order_item_id, product_id, reason, quantity)
+                VALUES (?, ?, ?, ?, ?, ?)
+            `,
+            [userId, orderId, orderItemId, productId, reason, quantity]
+        );
+
+        return result.insertId;
+    }
+
+    static async findById(id, { connection = db, forUpdate = false } = {}) {
+        const [rows] = await connection.query(
+            `
+                SELECT ${REFUND_REQUEST_COLUMNS}
+                FROM refund_requests
+                WHERE id = ?
+                LIMIT 1
+                ${forUpdate ? "FOR UPDATE" : ""}
+            `,
+            [id]
+        );
+
+        return rows.length ? new RefundRequest(rows[0]) : null;
+    }
+
+    static async findByUser(userId) {
+        const [rows] = await db.query(
+            `
+                SELECT ${REFUND_REQUEST_COLUMNS}
+                FROM refund_requests
+                WHERE user_id = ?
+                ORDER BY created_at DESC, id DESC
+            `,
+            [userId]
+        );
+
+        return rows.map((row) => new RefundRequest(row));
+    }
+
+    static async list({ status } = {}) {
+        let query = `SELECT ${REFUND_REQUEST_COLUMNS} FROM refund_requests`;
+        const params = [];
+
+        if (status) {
+            query += " WHERE status = ?";
+            params.push(status);
+        }
+
+        query += " ORDER BY created_at DESC, id DESC";
+
+        const [rows] = await db.query(query, params);
+
+        return rows.map((row) => new RefundRequest(row));
+    }
+
+    static async hasOpenRequestForItem(orderItemId, connection = db) {
+        const [rows] = await connection.query(
+            `
+                SELECT id
+                FROM refund_requests
+                WHERE order_item_id = ?
+                  AND status IN (?, ?)
+                LIMIT 1
+            `,
+            [orderItemId, OPEN_STATUSES[0], OPEN_STATUSES[1]]
+        );
+
+        return rows.length > 0;
+    }
+
+    static async updateStatus(
+        id,
+        { status, adminNote = null, reviewedBy = null },
+        connection = db
+    ) {
+        const [result] = await connection.query(
+            `
+                UPDATE refund_requests
+                SET status = ?, admin_note = ?, reviewed_by = ?, reviewed_at = NOW()
+                WHERE id = ?
+            `,
+            [status, adminNote, reviewedBy, id]
+        );
+
+        return result.affectedRows > 0;
+    }
+}
+
+module.exports = RefundRequest;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -13,6 +13,7 @@ const cartRoutes = require("./cartRoutes");
 const pincodeRoutes = require("./pincodeRoutes");
 const subscriptionRoutes = require("./subscriptionRoutes");
 const courierWebhookRoutes = require("./courierWebhookRoutes");
+const refundRoutes = require("./refundRoutes");
 
 router.use("/products", productRoutes);
 router.use("/auth", authRoutes);
@@ -26,5 +27,6 @@ router.use("/cart", cartRoutes);
 router.use("/pincode", pincodeRoutes);
 router.use("/subscriptions", subscriptionRoutes);
 router.use("/courier-webhooks", courierWebhookRoutes);
+router.use("/refunds", refundRoutes);
 
 module.exports = router;

--- a/backend/routes/refundRoutes.js
+++ b/backend/routes/refundRoutes.js
@@ -1,144 +1,15 @@
 // backend/routes/refundRoutes.js
-const express = require('express');
+const express = require("express");
 const router = express.Router();
-const authMiddleware = require('../middleware/authMiddleware');
-const {
-    detectAIGeneratedEvidence,
-    validateVideoEvidence,
-    generateTamperEvidence,
-    verifyTamperEvidence,
-    upload
-} = require('../middleware/refundFraudMiddleware');
-const db = require('../config/db').promise;
+const authMiddleware = require("../middleware/authMiddleware");
+const refundController = require("../controllers/refundController");
 
-/**
- * POST /api/refund/request
- * Request refund with evidence
- */
-router.post(
-    '/request',
-    authMiddleware,
-    upload,
-    detectAIGeneratedEvidence,
-    validateVideoEvidence,
-    generateTamperEvidence,
-    async (req, res) => {
-        try {
-            const { orderId, productId, reason } = req.body;
+// ==================== CUSTOMER ROUTES ====================
 
-            // Create refund request
-            const [result] = await db.query(
-                `INSERT INTO refund_requests 
-                 (user_id, order_id, product_id, reason, evidence_files, 
-                  detection_results, qr_data, status, created_at)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', NOW())`,
-                [
-                    req.user.id,
-                    orderId,
-                    productId,
-                    reason,
-                    JSON.stringify(req.files.map(f => f.filename)),
-                    JSON.stringify(req.detectionResults),
-                    JSON.stringify(req.qrData)
-                ]
-            );
+// Submit a return/refund request for a delivered order item
+router.post("/request", authMiddleware, refundController.createRequest);
 
-            res.json({
-                success: true,
-                message: 'Refund request submitted',
-                requestId: result.insertId,
-                qrData: req.qrData
-            });
-        } catch (error) {
-            console.error('Refund request error:', error);
-            res.status(500).json({
-                success: false,
-                error: 'Failed to submit refund request'
-            });
-        }
-    }
-);
-
-/**
- * POST /api/refund/verify-tamper
- * Verify tamper-evident QR code
- */
-router.post('/verify-tamper', authMiddleware, verifyTamperEvidence, (req, res) => {
-    res.json({
-        success: true,
-        message: 'Tamper evidence verified',
-        verification: req.qrVerification
-    });
-});
-
-/**
- * GET /api/refund/alerts
- * Get fraud alerts (admin only)
- */
-router.get('/alerts', authMiddleware, async (req, res) => {
-    try {
-        if (req.user.role !== 'admin') {
-            return res.status(403).json({
-                success: false,
-                error: 'Admin access required'
-            });
-        }
-
-        const [alerts] = await db.query(
-            `SELECT * FROM refund_fraud_alerts 
-             WHERE resolved = FALSE 
-             ORDER BY confidence DESC 
-             LIMIT 50`
-        );
-
-        res.json({
-            success: true,
-            data: alerts,
-            count: alerts.length
-        });
-    } catch (error) {
-        console.error('Alerts error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get alerts'
-        });
-    }
-});
-
-/**
- * POST /api/refund/alerts/:id/resolve
- * Resolve fraud alert (admin only)
- */
-router.post('/alerts/:id/resolve', authMiddleware, async (req, res) => {
-    try {
-        if (req.user.role !== 'admin') {
-            return res.status(403).json({
-                success: false,
-                error: 'Admin access required'
-            });
-        }
-
-        const { id } = req.params;
-        const { notes } = req.body;
-
-        await db.query(
-            `UPDATE refund_fraud_alerts 
-             SET resolved = TRUE, resolved_by = ?, resolution_notes = ? 
-             WHERE id = ?`,
-            [req.user.id, notes || 'Resolved', id]
-        );
-
-        res.json({
-            success: true,
-            message: 'Alert resolved successfully'
-        });
-    } catch (error) {
-        console.error('Resolve error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to resolve alert'
-        });
-    }
-});
+// List the authenticated user's own return requests
+router.get("/mine", authMiddleware, refundController.listMyRequests);
 
 module.exports = router;

--- a/backend/routes/refundRoutes.js
+++ b/backend/routes/refundRoutes.js
@@ -2,6 +2,7 @@
 const express = require("express");
 const router = express.Router();
 const authMiddleware = require("../middleware/authMiddleware");
+const { authorizeRoles } = require("../middleware/rbacMiddleware");
 const refundController = require("../controllers/refundController");
 
 // ==================== CUSTOMER ROUTES ====================
@@ -11,5 +12,26 @@ router.post("/request", authMiddleware, refundController.createRequest);
 
 // List the authenticated user's own return requests
 router.get("/mine", authMiddleware, refundController.listMyRequests);
+
+// ==================== ADMIN ROUTES ====================
+
+// List all return requests (optionally filtered by ?status=)
+router.get("/", authMiddleware, authorizeRoles("admin"), refundController.listAll);
+
+// Approve a request and restock inventory
+router.post(
+    "/:id/approve",
+    authMiddleware,
+    authorizeRoles("admin"),
+    refundController.approveRequest
+);
+
+// Reject a request
+router.post(
+    "/:id/reject",
+    authMiddleware,
+    authorizeRoles("admin"),
+    refundController.rejectRequest
+);
 
 module.exports = router;

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -565,6 +565,40 @@ CREATE TABLE IF NOT EXISTS refunds (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================
+-- CUSTOMER RETURNS / REFUND REQUESTS (RMA)
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS refund_requests (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id CHAR(36) NOT NULL,
+    order_id CHAR(36) NOT NULL,
+    order_item_id INT,
+    product_id CHAR(36),
+    reason TEXT NOT NULL,
+    quantity INT NOT NULL DEFAULT 1,
+    status ENUM('pending', 'approved', 'rejected', 'refunded') DEFAULT 'pending',
+    admin_note TEXT,
+    reviewed_by CHAR(36),
+    reviewed_at DATETIME,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    CONSTRAINT chk_refund_requests_quantity CHECK (quantity > 0),
+
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE,
+    FOREIGN KEY (order_item_id) REFERENCES order_items(id) ON DELETE SET NULL,
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE SET NULL,
+    FOREIGN KEY (reviewed_by) REFERENCES users(id) ON DELETE SET NULL,
+
+    INDEX idx_refund_requests_user (user_id),
+    INDEX idx_refund_requests_order (order_id),
+    INDEX idx_refund_requests_status (status),
+    INDEX idx_refund_requests_order_item (order_item_id),
+    INDEX idx_refund_requests_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================
 -- SECURITY TABLES (New)
 -- ============================================
 


### PR DESCRIPTION
closes #1193 
## Summary
Second of three stacked PRs. Adds admin endpoints to list return requests and
approve/reject them (`GET /api/refunds`, `POST /api/refunds/:id/approve`,
`POST /api/refunds/:id/reject`). Approval restocks the product and, when the
order item references one, the variant, inside a transaction before transitioning
status; only pending requests can be actioned.

Part of #1193. Stacked on part 1/3 (#1200).

## Test plan
- Approve a pending request -> status flips and product/variant stock increments
  in one transaction; reject -> status flips, no restock.
- Actioning a non-pending request -> 400.
