### PR TITLE
fix: correct script reference so order status stepper updates dynamic…

### DIFF
--- a/frontend/order.html
+++ b/frontend/order.html
@@ -238,11 +238,9 @@
     ></script>
 
     <!-- Order Script -->
-    <script
-        defer
-        src="scripts/order-tracking.js"
-    ></script>
-    <script defer src="scripts/ui.js"></script>
+    <!-- Order Script -->
+<script defer src="scripts/order.js"></script>
+<script defer src="scripts/ui.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Fixes #811

## Problem
The order status stepper UI (Placed → Processing → Shipped → Delivered) was already built in `order.html` and `order.css`, and the logic to populate it existed in `scripts/order.js` — but `order.html` was loading a non-existent file `scripts/order-tracking.js` instead. So the stepper never received real data and stayed static.

## Fix
Changed the script reference in `order.html` from `scripts/order-tracking.js` to `scripts/order.js`, which contains the working fetch + stepper-highlight logic.

## Testing
- Placed a test order and visited `/order.html?id=<id>`
- Confirmed the stepper now correctly highlights the current stage based on order status
- Confirmed no console errors (previously a 404 for the missing script)
