### PR TITLE
fix: remove stray closing brace in shop.css causing CSS syntax error …

### DIFF
--- a/frontend/styles/shop.css
+++ b/frontend/styles/shop.css
@@ -881,7 +881,7 @@ body.dark-theme .filter-close {
     #new-arrivals-container{
         justify-content: center;
     }
-}
+
 
 /* ========================================
    CLEAR FILTERS BUTTON (Issue #1124)


### PR DESCRIPTION
Fixes #1210

## Problem
`frontend/styles/shop.css` had an orphaned closing brace on line 884 with no matching opening brace/rule, causing a CSS syntax error ("at-rule or selector expected"). Likely leftover from an earlier edit where a rule was moved out of a media query.

## Fix
Removed the stray `}` on line 884.

## Testing
- Verified CSS parses cleanly (no linter error)
- Checked `/shop.html` layout for featured products, new arrivals, and clear-filters button — no visual regressions