### PR TITLE
fix: route unmatched URLs to custom 404 page (#1165)

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -6,7 +6,9 @@
     { "src": "/womens.html", "dest": "/womens.html" },
     { "src": "/seasonal.html", "dest": "/seasonal.html" },
     { "src": "/early_summer.html", "dest": "/early_summer.html" },
-    { "src": "/tshirt.html", "dest": "/tshirt.html" }
+    { "src": "/tshirt.html", "dest": "/tshirt.html" },
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/404.html" }
   ],
   
   "headers": [


### PR DESCRIPTION
Fixes #1165

## Problem
A branded `frontend/404.html` page already existed in the repo, but `vercel.json` had no rule sending unmatched URLs to it. Since defining a `routes` array in vercel.json disables Vercel's default filesystem-based serving, any URL not explicitly listed (e.g. /xyz.html) fell through to Vercel's raw platform-level 404 page instead of the site's branded one.

## Fix
Added two entries to the end of the `routes` array in `frontend/vercel.json`:
- `{ "handle": "filesystem" }` — restores default serving of real files/pages
- `{ "src": "/(.*)", "dest": "/404.html" }` — catch-all fallback to the branded 404 page

## Testing
- Confirmed `/404.html` still loads correctly and shows navbar/footer/branding
- Verified existing explicit routes (Buy1Get1.html, mens.html, etc.) and general site pages still resolve normally
- [After deploy] Visited an invalid URL on the Vercel preview link and confirmed the branded 404 page now shows instead of the raw Vercel error
