### PR TITLE
fix: make stock reservation atomic and consume locks by units

### DIFF
--- a/backend/services/inventoryReservationService.js
+++ b/backend/services/inventoryReservationService.js
@@ -1,40 +1,72 @@
 const promisePool = require("../config/db");
 
+const LOCK_TTL_MS = 15 * 60000;
+
+// Availability check + lock insert. This MUST run inside a transaction on
+// `conn`: the `FOR UPDATE` row lock only serializes concurrent reservations
+// while the surrounding transaction is open, which is what closes the
+// check-then-insert oversell race.
+async function reserveStockInTransaction(conn, userId, productId, quantity, now) {
+    // Remove expired locks
+    await conn.query("DELETE FROM inventory_locks WHERE expires_at <= ?", [now]);
+
+    // Lock the product row so competing reservations queue behind us instead
+    // of all reading the same pre-insert availability.
+    const [products] = await conn.query(
+        "SELECT stock FROM products WHERE id = ? FOR UPDATE",
+        [productId]
+    );
+    if (products.length === 0) return false;
+
+    const totalStock = products[0].stock;
+
+    const [locks] = await conn.query(
+        "SELECT SUM(quantity) as locked_qty FROM inventory_locks WHERE product_id = ? AND expires_at > ?",
+        [productId, now]
+    );
+
+    const lockedStock = locks[0].locked_qty || 0;
+    const availableStock = totalStock - lockedStock;
+
+    if (quantity > availableStock) {
+        return false;
+    }
+
+    // Create lock for 15 minutes
+    const expiresAt = new Date(now.getTime() + LOCK_TTL_MS);
+    await conn.query(
+        "INSERT INTO inventory_locks (user_id, product_id, quantity, expires_at) VALUES (?, ?, ?, ?)",
+        [userId, productId, quantity, expiresAt]
+    );
+
+    return true;
+}
+
 const inventoryReservationService = {
     // Acquire a lock for a product
     reserveStock: async (userId, productId, quantity, connection = null) => {
-        const pool = connection || promisePool;
-        
-        // Remove expired locks
         const now = new Date();
-        await pool.query("DELETE FROM inventory_locks WHERE expires_at <= ?", [now]);
 
-        // Calculate available stock
-        const [products] = await pool.query("SELECT stock FROM products WHERE id = ?", [productId]);
-        if (products.length === 0) return false;
-        
-        const totalStock = products[0].stock;
-        
-        const [locks] = await pool.query(
-            "SELECT SUM(quantity) as locked_qty FROM inventory_locks WHERE product_id = ? AND expires_at > ?", 
-            [productId, now]
-        );
-        
-        const lockedStock = locks[0].locked_qty || 0;
-        const availableStock = totalStock - lockedStock;
-        
-        if (quantity > availableStock) {
-            return false;
+        // Caller owns the transaction (e.g. cartController.addToCart), so the
+        // FOR UPDATE row lock is already effective — just run the check+insert.
+        if (connection) {
+            return reserveStockInTransaction(connection, userId, productId, quantity, now);
         }
 
-        // Create lock for 15 minutes
-        const expiresAt = new Date(now.getTime() + 15 * 60000);
-        await pool.query(
-            "INSERT INTO inventory_locks (user_id, product_id, quantity, expires_at) VALUES (?, ?, ?, ?)",
-            [userId, productId, quantity, expiresAt]
-        );
-        
-        return true;
+        // Standalone caller: own the transaction ourselves so FOR UPDATE
+        // actually locks the row. Signature is unchanged for these callers.
+        const conn = await promisePool.getConnection();
+        try {
+            await conn.beginTransaction();
+            const reserved = await reserveStockInTransaction(conn, userId, productId, quantity, now);
+            await conn.commit();
+            return reserved;
+        } catch (error) {
+            await conn.rollback();
+            throw error;
+        } finally {
+            conn.release();
+        }
     },
 
     // Validate if the user holds locks for their entire cart
@@ -65,12 +97,35 @@ const inventoryReservationService = {
     // Consume locks after purchase
     consumeLocks: async (userId, cartItems, connection = null) => {
         const pool = connection || promisePool;
-        // Simply delete the user's locks for these products
+        const now = new Date();
+
+        // Consume exactly item.quantity UNITS per product. A single lock row can
+        // hold quantity > 1, so we walk rows (oldest-expiring first for
+        // determinism) fully deleting those we can consume whole and decrementing
+        // the final partially-consumed row.
         for (const item of cartItems) {
-            await pool.query(
-                "DELETE FROM inventory_locks WHERE user_id = ? AND product_id = ? LIMIT ?",
-                [userId, item.productId, item.quantity]
+            let remaining = item.quantity;
+            if (remaining <= 0) continue;
+
+            const [locks] = await pool.query(
+                "SELECT id, quantity FROM inventory_locks WHERE user_id = ? AND product_id = ? AND expires_at > ? ORDER BY expires_at ASC",
+                [userId, item.productId, now]
             );
+
+            for (const lock of locks) {
+                if (remaining <= 0) break;
+
+                if (lock.quantity <= remaining) {
+                    await pool.query("DELETE FROM inventory_locks WHERE id = ?", [lock.id]);
+                    remaining -= lock.quantity;
+                } else {
+                    await pool.query(
+                        "UPDATE inventory_locks SET quantity = quantity - ? WHERE id = ?",
+                        [remaining, lock.id]
+                    );
+                    remaining = 0;
+                }
+            }
         }
     }
 };

--- a/backend/tests/inventoryReservation.test.js
+++ b/backend/tests/inventoryReservation.test.js
@@ -1,0 +1,156 @@
+// Tests for inventory reservation (#1215). The db module is mocked so we can
+// assert the FOR UPDATE-guarded oversell check and the units-vs-rows lock
+// consumption without a live MySQL. A fake connection/pool records every SQL
+// string and returns canned rows keyed off the query text.
+
+jest.mock("../config/db", () => {
+    const query = jest.fn();
+    const pool = { query, getConnection: jest.fn() };
+    return pool;
+});
+
+const db = require("../config/db");
+const service = require("../services/inventoryReservationService");
+
+// Builds a fake connection whose `.query()` returns canned rows based on the
+// SQL text, and records every call so tests can assert on the SQL/params.
+function makeConnection(responder) {
+    const calls = [];
+    const query = jest.fn(async (sql, params = []) => {
+        calls.push({ sql, params });
+        return responder(sql, params);
+    });
+    return { query, calls };
+}
+
+function sqlsMatching(calls, regex) {
+    return calls.filter(({ sql }) => regex.test(sql));
+}
+
+afterEach(() => {
+    db.query.mockReset();
+    db.getConnection.mockReset();
+});
+
+describe("consumeLocks", () => {
+    test("consumes exact units across rows, decrements the final partial row, orders by expires_at", async () => {
+        // 5 units to consume across rows holding 2, 2 and 3 units.
+        const { query, calls } = makeConnection((sql) => {
+            if (/^\s*SELECT id, quantity FROM inventory_locks/i.test(sql)) {
+                return [[
+                    { id: 10, quantity: 2 },
+                    { id: 11, quantity: 2 },
+                    { id: 12, quantity: 3 }
+                ]];
+            }
+            return [{ affectedRows: 1 }];
+        });
+
+        await service.consumeLocks("user-1", [{ productId: 7, quantity: 5 }], { query });
+
+        const selects = sqlsMatching(calls, /SELECT id, quantity FROM inventory_locks/i);
+        expect(selects).toHaveLength(1);
+        expect(selects[0].sql).toMatch(/ORDER BY expires_at ASC/i);
+
+        // Rows 10 and 11 (2 + 2 = 4) are fully deleted; row 12 keeps 3 - 1 = 2.
+        const deletes = sqlsMatching(calls, /^\s*DELETE FROM inventory_locks WHERE id = \?/i);
+        expect(deletes.map((c) => c.params[0])).toEqual([10, 11]);
+
+        const updates = sqlsMatching(calls, /UPDATE inventory_locks SET quantity = quantity - \?/i);
+        expect(updates).toHaveLength(1);
+        expect(updates[0].params).toEqual([1, 12]);
+    });
+
+    test("stops once the requested units are satisfied by whole rows", async () => {
+        const { query, calls } = makeConnection((sql) => {
+            if (/^\s*SELECT id, quantity FROM inventory_locks/i.test(sql)) {
+                return [[
+                    { id: 20, quantity: 2 },
+                    { id: 21, quantity: 5 }
+                ]];
+            }
+            return [{ affectedRows: 1 }];
+        });
+
+        await service.consumeLocks("user-1", [{ productId: 9, quantity: 2 }], { query });
+
+        const deletes = sqlsMatching(calls, /^\s*DELETE FROM inventory_locks WHERE id = \?/i);
+        expect(deletes.map((c) => c.params[0])).toEqual([20]);
+        expect(sqlsMatching(calls, /UPDATE inventory_locks/i)).toHaveLength(0);
+    });
+});
+
+describe("reserveStock", () => {
+    test("rejects when requested quantity exceeds available and locks the product row FOR UPDATE", async () => {
+        // stock 10, already 8 locked -> only 2 available, request 5 -> reject.
+        const { query, calls } = makeConnection((sql) => {
+            if (/SELECT stock FROM products WHERE id = \?/i.test(sql)) {
+                return [[{ stock: 10 }]];
+            }
+            if (/SELECT SUM\(quantity\) as locked_qty/i.test(sql)) {
+                return [[{ locked_qty: 8 }]];
+            }
+            return [{ affectedRows: 1 }];
+        });
+
+        const reserved = await service.reserveStock("user-1", 7, 5, { query });
+
+        expect(reserved).toBe(false);
+
+        const stockSelect = sqlsMatching(calls, /SELECT stock FROM products WHERE id = \?/i);
+        expect(stockSelect).toHaveLength(1);
+        expect(stockSelect[0].sql).toMatch(/FOR UPDATE/i);
+
+        // Rejection must not insert a lock.
+        expect(sqlsMatching(calls, /INSERT INTO inventory_locks/i)).toHaveLength(0);
+    });
+
+    test("inserts a lock when capacity is available", async () => {
+        const { query, calls } = makeConnection((sql) => {
+            if (/SELECT stock FROM products WHERE id = \?/i.test(sql)) {
+                return [[{ stock: 10 }]];
+            }
+            if (/SELECT SUM\(quantity\) as locked_qty/i.test(sql)) {
+                return [[{ locked_qty: 2 }]];
+            }
+            return [{ affectedRows: 1, insertId: 1 }];
+        });
+
+        const reserved = await service.reserveStock("user-1", 7, 3, { query });
+
+        expect(reserved).toBe(true);
+        const inserts = sqlsMatching(calls, /INSERT INTO inventory_locks/i);
+        expect(inserts).toHaveLength(1);
+        expect(inserts[0].params.slice(0, 3)).toEqual(["user-1", 7, 3]);
+    });
+
+    test("without a connection, opens its own transaction around the FOR UPDATE and commits", async () => {
+        const conn = makeConnection((sql) => {
+            if (/SELECT stock FROM products WHERE id = \?/i.test(sql)) {
+                return [[{ stock: 10 }]];
+            }
+            if (/SELECT SUM\(quantity\) as locked_qty/i.test(sql)) {
+                return [[{ locked_qty: 0 }]];
+            }
+            return [{ affectedRows: 1, insertId: 1 }];
+        });
+        const connection = {
+            query: conn.query,
+            beginTransaction: jest.fn(async () => {}),
+            commit: jest.fn(async () => {}),
+            rollback: jest.fn(async () => {}),
+            release: jest.fn()
+        };
+        db.getConnection.mockResolvedValue(connection);
+
+        const reserved = await service.reserveStock("user-1", 7, 3);
+
+        expect(reserved).toBe(true);
+        expect(db.getConnection).toHaveBeenCalledTimes(1);
+        expect(connection.beginTransaction).toHaveBeenCalledTimes(1);
+        expect(connection.commit).toHaveBeenCalledTimes(1);
+        expect(connection.rollback).not.toHaveBeenCalled();
+        expect(connection.release).toHaveBeenCalledTimes(1);
+        expect(sqlsMatching(conn.calls, /SELECT stock FROM products WHERE id = \? FOR UPDATE/i)).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
## Summary
`inventoryReservationService` had two defects in the 15-minute stock-hold logic:

- **Oversell race:** `reserveStock` did a check-then-insert with no row lock, so
  two concurrent reservations for the last unit both passed. The availability
  check and lock insert now run under `SELECT stock ... FOR UPDATE`, forcing
  concurrent reservations to serialize on the product row. The lock is only
  effective inside a transaction, so `reserveStock` uses the caller's connection
  when given one (as add-to-cart does) and otherwise opens/commits its own.
- **Wrong release amount:** `consumeLocks` used `DELETE ... LIMIT quantity`,
  which limits *rows* rather than *units* and had no ordering — buying 2 units
  could delete a row that reserved 10. It now consumes exactly the requested
  units, oldest-expiring first, decrementing the final partial row.

Public signatures, the TTL, and expired-lock cleanup are unchanged.

## Test plan
- New unit test (mocked pool, no live DB) covers: exact-unit consumption across
  multiple lock rows incl. a partial decrement; rejection when the request
  exceeds availability; and that reservation issues a `FOR UPDATE` lock.
- `cd backend && npm test`.

Closes #1215