### PR TITLE
fix: lock account after MAX_LOGIN_ATTEMPTS, not a single failure

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -25,6 +25,9 @@ const OTP_RATE_LIMIT_MAX = 3; // Max 3 OTP requests per window
 const CLEANUP_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const MAX_LOGIN_ATTEMPTS = 5;
 const LOGIN_LOCKOUT_DURATION = 15 * 60 * 1000; // 15 minutes
+// Window in which the failed attempts must accumulate to trip the lockout.
+// Failures older than this roll off so isolated mistakes never reach the threshold.
+const LOGIN_ATTEMPT_WINDOW = 15 * 60 * 1000; // 15 minutes
 
 // ==================== VALIDATION PATTERNS ====================
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -121,25 +124,41 @@ function isOTPRateLimited(email) {
 function isLoginLocked(email) {
     const now = Date.now();
     const record = loginAttempts.get(email);
-    
+
     if (!record) return false;
-    if (now > record.lockoutUntil) {
-        loginAttempts.delete(email);
-        return false;
+
+    // Only an active lockout blocks login. Counting failures within the
+    // window is not itself a lock — that is what let a single mistyped
+    // password lock the account before.
+    if (record.lockoutUntil && now < record.lockoutUntil) {
+        return true;
     }
-    return true;
+
+    // No active lockout: drop the record once the lockout has expired or the
+    // rolling attempt window has elapsed, so the counter restarts cleanly.
+    if ((record.lockoutUntil && now >= record.lockoutUntil) || now > record.windowExpires) {
+        loginAttempts.delete(email);
+    }
+    return false;
 }
 
 function recordLoginFailure(email) {
     const now = Date.now();
     const record = loginAttempts.get(email);
-    
-    if (!record) {
-        loginAttempts.set(email, { attempts: 1, lockoutUntil: now + LOGIN_LOCKOUT_DURATION });
+
+    // Start a fresh window on the first failure or after the previous window
+    // rolled off without reaching the threshold.
+    if (!record || now > record.windowExpires) {
+        loginAttempts.set(email, {
+            attempts: 1,
+            windowExpires: now + LOGIN_ATTEMPT_WINDOW,
+            lockoutUntil: null
+        });
         return;
     }
-    
+
     record.attempts++;
+    // The lockout only starts once the threshold is reached within the window.
     if (record.attempts >= MAX_LOGIN_ATTEMPTS) {
         record.lockoutUntil = now + LOGIN_LOCKOUT_DURATION;
     }
@@ -147,6 +166,11 @@ function recordLoginFailure(email) {
 
 function resetLoginAttempts(email) {
     loginAttempts.delete(email);
+}
+
+// Test-only: drop all tracked attempts so cases start from a clean slate.
+function clearLoginAttempts() {
+    loginAttempts.clear();
 }
 
 // ==================== 1. SIGNUP (Send OTP) ====================
@@ -749,4 +773,16 @@ module.exports = {
     getSecurityAudit, 
     getFraudStatus,
     getMe
+};
+
+// Internal login-guard helpers exposed for unit testing only. Not part of the
+// HTTP surface; runtime behavior is unchanged.
+module.exports._loginGuard = {
+    isLoginLocked,
+    recordLoginFailure,
+    resetLoginAttempts,
+    clearLoginAttempts,
+    MAX_LOGIN_ATTEMPTS,
+    LOGIN_LOCKOUT_DURATION,
+    LOGIN_ATTEMPT_WINDOW
 };

--- a/backend/tests/loginLockout.test.js
+++ b/backend/tests/loginLockout.test.js
@@ -1,0 +1,126 @@
+// backend/tests/loginLockout.test.js
+
+// Requiring the controller pulls in modules that read env at import time
+// (it throws if JWT_SECRET is unset) and constructs an Appwrite client / a
+// MySQL pool. Set env and mock the heavy deps BEFORE requiring so the module
+// loads offline without network or DB.
+process.env.JWT_SECRET = 'test';
+process.env.NODE_ENV = 'test';
+
+jest.mock('node-appwrite', () => {
+    class Client {
+        setEndpoint() { return this; }
+        setProject() { return this; }
+        setSession() { return this; }
+    }
+    return {
+        Client,
+        Account: class { },
+        Databases: class { },
+        ID: { unique: () => 'test-id' }
+    };
+});
+
+jest.mock('../config/db', () => ({
+    query: jest.fn()
+}));
+
+const { _loginGuard } = require('../controllers/authController');
+const {
+    isLoginLocked,
+    recordLoginFailure,
+    resetLoginAttempts,
+    clearLoginAttempts,
+    MAX_LOGIN_ATTEMPTS,
+    LOGIN_LOCKOUT_DURATION,
+    LOGIN_ATTEMPT_WINDOW
+} = _loginGuard;
+
+describe('Login lockout state machine', () => {
+    const email = 'user@example.com';
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+        clearLoginAttempts();
+    });
+
+    afterEach(() => {
+        clearLoginAttempts();
+        jest.useRealTimers();
+    });
+
+    test('exposes the guard helpers without touching the HTTP exports', () => {
+        expect(typeof isLoginLocked).toBe('function');
+        expect(typeof recordLoginFailure).toBe('function');
+        expect(typeof resetLoginAttempts).toBe('function');
+        expect(MAX_LOGIN_ATTEMPTS).toBe(5);
+    });
+
+    test('MAX_LOGIN_ATTEMPTS - 1 failures do NOT lock the account', () => {
+        for (let i = 0; i < MAX_LOGIN_ATTEMPTS - 1; i++) {
+            recordLoginFailure(email);
+            expect(isLoginLocked(email)).toBe(false);
+        }
+    });
+
+    test('the MAX_LOGIN_ATTEMPTS-th failure locks the account', () => {
+        for (let i = 0; i < MAX_LOGIN_ATTEMPTS - 1; i++) {
+            recordLoginFailure(email);
+        }
+        expect(isLoginLocked(email)).toBe(false);
+
+        recordLoginFailure(email);
+        expect(isLoginLocked(email)).toBe(true);
+    });
+
+    test('a successful login before the threshold clears the counter', () => {
+        for (let i = 0; i < MAX_LOGIN_ATTEMPTS - 1; i++) {
+            recordLoginFailure(email);
+        }
+        expect(isLoginLocked(email)).toBe(false);
+
+        // Success resets the counter, so it takes a full MAX run again to lock.
+        resetLoginAttempts(email);
+
+        for (let i = 0; i < MAX_LOGIN_ATTEMPTS - 1; i++) {
+            recordLoginFailure(email);
+            expect(isLoginLocked(email)).toBe(false);
+        }
+        recordLoginFailure(email);
+        expect(isLoginLocked(email)).toBe(true);
+    });
+
+    test('after the lockout window elapses, isLoginLocked returns false again', () => {
+        for (let i = 0; i < MAX_LOGIN_ATTEMPTS; i++) {
+            recordLoginFailure(email);
+        }
+        expect(isLoginLocked(email)).toBe(true);
+
+        // Still locked one tick before expiry.
+        jest.advanceTimersByTime(LOGIN_LOCKOUT_DURATION - 1);
+        expect(isLoginLocked(email)).toBe(true);
+
+        // Lockout has now elapsed: login is allowed and the record is cleared.
+        jest.advanceTimersByTime(2);
+        expect(isLoginLocked(email)).toBe(false);
+
+        // A subsequent single failure must not re-lock.
+        recordLoginFailure(email);
+        expect(isLoginLocked(email)).toBe(false);
+    });
+
+    test('failures spread beyond the rolling window do not accumulate to a lock', () => {
+        // Four failures, then let the window roll off before the fifth.
+        for (let i = 0; i < MAX_LOGIN_ATTEMPTS - 1; i++) {
+            recordLoginFailure(email);
+        }
+        expect(isLoginLocked(email)).toBe(false);
+
+        jest.advanceTimersByTime(LOGIN_ATTEMPT_WINDOW + 1);
+
+        // This failure starts a brand-new window rather than tripping the lock.
+        recordLoginFailure(email);
+        expect(isLoginLocked(email)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
The brute-force guard conflated counting failures with enforcing a lockout:
`lockoutUntil` was set on the very first failure, so the account locked after a
single wrong password and the 5-attempt threshold was never applied.

The failure counter and the lockout are now separate. Failures accumulate within
a rolling window; the lockout only starts once attempts reach
`MAX_LOGIN_ATTEMPTS`, and `isLoginLocked` returns true only while a lockout is
active (expired windows/lockouts reset the counter). A successful login still
clears the counter. The `login` handler and its 429 response are unchanged.

## Test plan
- New unit test: `MAX_LOGIN_ATTEMPTS - 1` failures stay allowed; the Nth locks;
  a success mid-window clears the counter; the account unlocks after the window.
- `cd backend && npm test`.

Closes #1216