### PR TITLE
refactor: route frontend API calls through the shared apiRequest client (PR 1/2)

### DIFF
--- a/frontend/copywriter-demo.html
+++ b/frontend/copywriter-demo.html
@@ -185,6 +185,8 @@
         <div id="versionsContainer"></div>
     </div>
 
+    <script src="scripts/config.js"></script>
+    <script src="scripts/utils.js"></script>
     <script src="scripts/ai-copywriter.js"></script>
 </body>
 </html>

--- a/frontend/scripts/ai-copywriter.js
+++ b/frontend/scripts/ai-copywriter.js
@@ -54,13 +54,8 @@ class AICopywriter {
         this.showLoading(true);
 
         try {
-            const token = localStorage.getItem('jwt');
-            const response = await fetch('/api/copywriter/generate', {
+            const data = await AppUtils.apiRequest('/copywriter/generate', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${token}`
-                },
                 body: JSON.stringify({
                     keywords: keywords.split(',').map(k => k.trim()),
                     category,
@@ -69,8 +64,6 @@ class AICopywriter {
                 })
             });
 
-            const data = await response.json();
-            
             if (data.success) {
                 this.currentCopy = data.data;
                 this.copyHistory.push(data.data);
@@ -115,13 +108,8 @@ class AICopywriter {
         this.showLoading(true);
 
         try {
-            const token = localStorage.getItem('jwt');
-            const response = await fetch('/api/copywriter/multiple', {
+            const data = await AppUtils.apiRequest('/copywriter/multiple', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${token}`
-                },
                 body: JSON.stringify({
                     keywords: keywords.split(',').map(k => k.trim()),
                     category,
@@ -129,8 +117,6 @@ class AICopywriter {
                 })
             });
 
-            const data = await response.json();
-            
             if (data.success) {
                 this.displayVersions(data.data.versions);
                 this.showToast('✅ Generated 3 versions!', 'success');
@@ -234,13 +220,8 @@ class AICopywriter {
      */
     async logCopyUsage() {
         try {
-            const token = localStorage.getItem('jwt');
-            await fetch('/api/copywriter/use', {
+            await AppUtils.apiRequest('/copywriter/use', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${token}`
-                },
                 body: JSON.stringify({
                     copyId: this.currentCopy.id || null,
                     productId: document.getElementById('productId')?.value || null

--- a/frontend/scripts/order.js
+++ b/frontend/scripts/order.js
@@ -60,15 +60,9 @@ async function fetchOrderStatus() {
             return;
         }
 
-        const response = await fetch(`/api/orders/${orderId}/status`, {
-            headers: {
-                'Authorization': `Bearer ${token}`
-            }
-        });
+        const data = await AppUtils.apiRequest(`/orders/${orderId}/status`);
 
-        const data = await response.json();
-
-        if (!response.ok || !data.success) {
+        if (!data.success) {
             throw new Error(data.message || 'Failed to fetch order');
         }
 

--- a/frontend/scripts/pincode.js
+++ b/frontend/scripts/pincode.js
@@ -18,10 +18,9 @@ document.addEventListener("DOMContentLoaded", () => {
         resultEl.className = "pincode-loading";
 
         try {
-            const response = await fetch(
-                `${window.CONFIG.API_BASE}/pincode/check/${pincode}`
+            const data = await AppUtils.apiRequest(
+                `/pincode/check/${pincode}`
             );
-            const data = await response.json();
 
             resultEl.textContent = data.message;
             resultEl.className = data.deliverable

--- a/frontend/scripts/preservation.js
+++ b/frontend/scripts/preservation.js
@@ -2,7 +2,9 @@
 
 class PreservationUI {
   constructor(options = {}) {
-    this.apiBase = options.apiBase || '/api/preservation';
+    // Path only; AppUtils.apiRequest prepends CONFIG.API_BASE (which already
+    // ends in /api), so this must not carry its own /api prefix.
+    this.apiBase = options.apiBase || '/preservation';
     this.container = options.container || '#preservation-container';
     this.currentItem = null;
     this.insights = null;
@@ -62,8 +64,7 @@ class PreservationUI {
 
   async loadItems() {
     try {
-      const response = await fetch(`${this.apiBase}/items`);
-      const data = await response.json();
+      const data = await AppUtils.apiRequest(`${this.apiBase}/items`);
 
       if (data.success) {
         this.renderItems(data.items);
@@ -156,8 +157,7 @@ class PreservationUI {
 
   async loadStats() {
     try {
-      const response = await fetch(`${this.apiBase}/stats`);
-      const data = await response.json();
+      const data = await AppUtils.apiRequest(`${this.apiBase}/stats`);
 
       if (data.success) {
         this.renderStats(data.stats);

--- a/frontend/scripts/product.js
+++ b/frontend/scripts/product.js
@@ -544,15 +544,10 @@ function addProductToCart(
 
     async function recordShareInteraction(productId, method) {
         try {
-            const token = localStorage.getItem('jwt');
-            if (!token) return;
+            if (!AppUtils.isAuthenticated()) return;
 
-            await fetch('/api/interactions', {
+            await AppUtils.apiRequest('/interactions', {
                 method: 'POST',
-                headers: {
-                    'Authorization': `Bearer ${token}`,
-                    'Content-Type': 'application/json'
-                },
                 body: JSON.stringify({
                     productId: productId,
                     type: 'share',


### PR DESCRIPTION
closes #1217 
## Summary
Part 1 of #1217. Routes the remaining application API calls through the shared
`AppUtils.apiRequest` client so every request shares one path for base URL,
`Authorization` header, token refresh, timeout, and error handling. Eight calls
across `product.js`, `order.js`, `pincode.js`, `preservation.js`, and
`ai-copywriter.js` were converted, dropping per-call URL building, manual auth
headers, and `response.json()`.

Static-asset fetches (HTML component partials, bundled blog JSON) intentionally
stay on raw `fetch`. `copywriter-demo.html` previously shipped without the shared
client and now loads `config.js`/`utils.js`. Several converted calls had also been
reading a non-existent `jwt` storage key; going through the shared client makes
them use the real `token`, fixing latent auth breakage.

This PR is independent of PR 2/2 and touches a disjoint set of files.

## Test plan
- Product share, order-status polling, pincode check, and AI copywriter actions
  still hit the same endpoints with the same payloads while authenticated.
- No app-API `fetch(` remains in `frontend/scripts` outside `utils.js`.

Refs #1217