### PR TITLE
refactor: make coupon validation and cart pricing server-authoritative (PR 2/2)

### DIFF
--- a/frontend/scripts/cart-drawer.js
+++ b/frontend/scripts/cart-drawer.js
@@ -110,7 +110,7 @@ function closeCartDrawer() {
 }
 
 // render cart drawer
-function renderCartDrawer() {
+async function renderCartDrawer() {
     if (
         !cartDrawerItems
         ||
@@ -231,14 +231,14 @@ function renderCartDrawer() {
             }
         ).join("");
 
-    const total =
-        AppUtils.calculateCartTotals(
+    const { subtotal } =
+        await AppUtils.calculateCartTotals(
             drawerCart
-        ).subtotal;
+        );
 
     cartDrawerTotal.innerHTML =
         AppUtils.formatPrice(
-            total
+            subtotal
         );
 }
 

--- a/frontend/scripts/cart.js
+++ b/frontend/scripts/cart.js
@@ -237,8 +237,8 @@ function updateButtonStates() {
 }
 
 // ==================== UPDATE CART TOTALS ====================
-function updateCartTotals() {
-    const totals = AppUtils.calculateCartTotals(cart, appliedCoupon);
+async function updateCartTotals() {
+    const totals = await AppUtils.calculateCartTotals(cart, appliedCoupon);
     
     AppUtils.setJSON("shippingCost", totals.shipping);
     AppUtils.setJSON("cartTotals", totals);
@@ -759,14 +759,17 @@ document.addEventListener("click", (event) => {
 
 // ==================== COUPON FORM ====================
 if (elements.couponForm) {
-    elements.couponForm.addEventListener("submit", (event) => {
+    elements.couponForm.addEventListener("submit", async (event) => {
         event.preventDefault();
         const code = elements.couponCode ? elements.couponCode.value : "";
-        const result = AppUtils.validateCoupon(code);
+        // Validate against the current subtotal so the server can enforce any
+        // minimum-cart-value rule on the promo.
+        const { subtotal } = await AppUtils.calculateCartTotals(cart);
+        const result = await AppUtils.validateCoupon(code, subtotal);
         if (!result.valid) {
             appliedCoupon = "";
             setCouponMessage(result.message, "error");
-            updateCartTotals();
+            await updateCartTotals();
             return;
         }
         if (appliedCoupon === result.code) {
@@ -779,7 +782,7 @@ if (elements.couponForm) {
         }
         setCouponMessage(result.message, "success");
         AppUtils.setJSON("appliedCoupon", appliedCoupon);
-        updateCartTotals();
+        await updateCartTotals();
     });
 }
 

--- a/frontend/scripts/checkout.js
+++ b/frontend/scripts/checkout.js
@@ -261,7 +261,7 @@ function safeQty(
 }
 
 // CALCULATE TOTALS
-function calculateTotals() {
+async function calculateTotals() {
 
     return AppUtils.calculateCartTotals(
         cart,
@@ -270,7 +270,7 @@ function calculateTotals() {
 }
 
 // RENDER CHECKOUT
-function renderCheckout() {
+async function renderCheckout() {
 
     if (
         !elements.checkoutItems
@@ -347,7 +347,7 @@ function renderCheckout() {
     );
 
     const totals =
-        calculateTotals();
+        await calculateTotals();
 
     if (
         elements.subtotal
@@ -513,7 +513,7 @@ function validateCheckoutForm() {
     return true;
 }
 // CREATE ORDER PAYLOAD
-function createOrderPayload() {
+async function createOrderPayload() {
 
     const selectedPayment =
         document.querySelector(
@@ -521,7 +521,7 @@ function createOrderPayload() {
         );
 
     const totals =
-        calculateTotals();
+        await calculateTotals();
 
     return {
 
@@ -628,7 +628,7 @@ if (
                     "Processing...";
             }
 
-            const order = createOrderPayload();
+            const order = await createOrderPayload();
             const selectedPaymentMethod = order.paymentMethod;
 
             try {

--- a/frontend/scripts/config.js
+++ b/frontend/scripts/config.js
@@ -33,6 +33,13 @@ const CONFIG = {
     CURRENCY:
         "₹",
 
+    // pricing rules (single source of truth for cart math)
+    PRICING: {
+        TAX_RATE: 0.18,
+        SHIPPING_FEE: 49,
+        FREE_SHIPPING_THRESHOLD: 999
+    },
+
     // storage keys
     STORAGE_KEYS: {
         CART:
@@ -62,6 +69,10 @@ Object.freeze(
 
 Object.freeze(
     CONFIG.STORAGE_KEYS
+);
+
+Object.freeze(
+    CONFIG.PRICING
 );
 
 // expose globally

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -1145,130 +1145,119 @@ const getCartCount = (
     );
 };
 
-const validateCoupon = (
-    code
+// Coupon validation is server-authoritative: the browser no longer knows which
+// codes exist or what they're worth. It POSTs the code + current cart total to
+// /promo/validate and maps the response onto the legacy { valid, code, percent,
+// message } shape callers already understand. Any failure (network, timeout,
+// unknown code, rate limit) resolves to a safe invalid result rather than
+// throwing, so a broken promo endpoint never blocks checkout.
+const validateCoupon = async (
+    code,
+    cartTotal = 0
 ) => {
+    const normalizedCode = String(code || "").trim().toUpperCase();
 
-    const normalizedCode =
-        String(
-            code || ""
-        )
-            .trim()
-            .toUpperCase();
-
-    const coupons = {
-        SAVE10: 10,
-        SAVE20: 20
-    };
-
-    if (
-        !normalizedCode
-    ) {
-
+    if (!normalizedCode) {
         return {
             valid: false,
             code: "",
             percent: 0,
-            message:
-                "Enter a coupon code."
+            message: "Enter a coupon code."
         };
     }
 
-    if (
-        !coupons[normalizedCode]
-    ) {
+    const safeCartTotal = safeNumber(cartTotal, 0);
+
+    try {
+        const response = await apiRequest("/promo/validate", {
+            method: "POST",
+            body: JSON.stringify({
+                promoCode: normalizedCode,
+                cartTotal: safeCartTotal
+            })
+        });
+
+        const promo = response && response.success ? response.data : null;
+
+        if (!promo || !promo.valid) {
+            return {
+                valid: false,
+                code: normalizedCode,
+                percent: 0,
+                message:
+                    (response && response.message) || "Invalid coupon code."
+            };
+        }
+
+        // Express the server's discount as a percent of the submitted cart
+        // total so percentage- and fixed-amount promos both flow through the
+        // existing percent-based math. discountType/discountValue are stable
+        // promo attributes (unlike the response's cartTotal-derived `discount`,
+        // which the backend caches by code only), so this stays correct across
+        // cart edits.
+        const percent =
+            promo.discountType === "fixed"
+                ? (safeCartTotal > 0
+                    ? (safeNumber(promo.discountValue, 0) / safeCartTotal) * 100
+                    : 0)
+                : safeNumber(promo.discountValue, 0);
+
+        const resolvedCode = promo.promoCode || normalizedCode;
+
+        return {
+            valid: true,
+            code: resolvedCode,
+            percent,
+            message: `${resolvedCode} applied successfully.`
+        };
+    } catch (error) {
+        console.error("COUPON VALIDATION ERROR:", error);
 
         return {
             valid: false,
-            code:
-                normalizedCode,
+            code: normalizedCode,
             percent: 0,
-            message:
-                "Invalid coupon code."
+            message: "Could not validate coupon. Please try again."
         };
     }
-
-    return {
-        valid: true,
-        code:
-            normalizedCode,
-        percent:
-            coupons[normalizedCode],
-        message:
-            `${normalizedCode} applied successfully.`
-    };
 };
 
-const calculateCartTotals = (
+const calculateCartTotals = async (
     cart = getCart(),
     couponCode = ""
 ) => {
+    const subtotal = safeArray(cart).reduce(
+        (sum, item) =>
+            sum +
+            safeNumber(item.price, 0) *
+                Math.max(1, safeInteger(item.qty, 1)),
+        0
+    );
 
-    const subtotal =
-        safeArray(
-            cart
-        ).reduce(
-            (
-                sum,
-                item
-            ) =>
-                sum +
-                (
-                    safeNumber(
-                        item.price,
-                        0
-                    ) *
-                    Math.max(
-                        1,
-                        safeInteger(
-                            item.qty,
-                            1
-                        )
-                    )
-                ),
-            0
-        );
-
-    const coupon =
-        validateCoupon(
-            couponCode
-        );
+    // Skip the round-trip when there's nothing to validate; an empty code is
+    // never a coupon.
+    const coupon = couponCode
+        ? await validateCoupon(couponCode, subtotal)
+        : null;
 
     const discount =
-        coupon.valid
-            ? subtotal *
-                (
-                    coupon.percent / 100
-                )
-            : 0;
+        coupon && coupon.valid ? subtotal * (coupon.percent / 100) : 0;
 
-    const discountedSubtotal =
-        Math.max(
-            0,
-            subtotal - discount
-        );
+    const discountedSubtotal = Math.max(0, subtotal - discount);
 
-    const tax =
-        discountedSubtotal * 0.18;
+    const tax = discountedSubtotal * CONFIG.PRICING.TAX_RATE;
 
     const shipping =
-        discountedSubtotal > 0
-        &&
-        discountedSubtotal < 999
-            ? 49
+        discountedSubtotal > 0 &&
+        discountedSubtotal < CONFIG.PRICING.FREE_SHIPPING_THRESHOLD
+            ? CONFIG.PRICING.SHIPPING_FEE
             : 0;
 
-    const total =
-        discountedSubtotal +
-        tax +
-        shipping;
+    const total = discountedSubtotal + tax + shipping;
 
     return {
         subtotal,
-        coupon:
-            coupon.valid
-                ? coupon
-                : null,
+        coupon: coupon && coupon.valid ? coupon : null,
         discount,
         tax,
         shipping,


### PR DESCRIPTION
## Summary
Part 2 of #1217. Coupon codes were validated in the browser against a hardcoded
`{ SAVE10, SAVE20 }` table, so any user could grant themselves a discount, and
tax/shipping literals were duplicated across `cart.js`, `checkout.js`, and
`cart-drawer.js`.

- `validateCoupon` now calls `POST /promo/validate` (`{ promoCode, cartTotal }`)
  and maps the server's `{ valid, discountType, discountValue }` onto the existing
  return shape; any failure resolves to a safe invalid result so a promo outage
  never blocks checkout.
- Tax rate, shipping fee, and free-shipping threshold move to a single frozen
  `CONFIG.PRICING`.
- `calculateCartTotals` is now async; its callers in cart, checkout, and the cart
  drawer were updated to `await` through their render/order paths.

This PR is independent of PR 1/2 and touches a disjoint set of files.

## Test plan
- A valid promo discounts against the current subtotal; an unknown/forged code is
  rejected by the server; a promo-endpoint failure degrades to "no discount"
  without throwing.
- Cart page, checkout, and cart drawer render correct totals after the async
  change.
- No `SAVE10`/`SAVE20` literals remain in `frontend/`.

Closes #1217