### PR TITLE
feat: add loyalty points ledger and service

### DIFF
--- a/backend/services/loyaltyService.js
+++ b/backend/services/loyaltyService.js
@@ -1,0 +1,224 @@
+// backend/services/loyaltyService.js
+//
+// Loyalty & Reward Points — ledger core (issue #1232, PR 1/3).
+//
+// LEDGER IS THE SOURCE OF TRUTH.
+// `loyalty_transactions` is an append-only ledger; every points change is one
+// immutable row with a signed `points` value and a `balance_after` snapshot.
+// `loyalty_accounts.points_balance` is only a cache of that ledger (the sum of
+// a user's `points`), kept so reads don't have to aggregate the whole history.
+//
+// The danger with a cached balance is drift: if the ledger row is written but
+// the cache update fails (or two concurrent earns/redeems interleave), the
+// cache silently disagrees with the ledger. To make drift impossible, every
+// write path here does BOTH the ledger append and the cache update inside a
+// single DB transaction, with the account row locked FOR UPDATE so concurrent
+// mutations serialize instead of racing on a stale read. A failure anywhere
+// rolls the whole thing back, so the cache can never move without a matching
+// ledger row and vice versa.
+
+const db = require("../config/db");
+
+// EARN_RATE: points granted per whole currency unit spent (1 unit -> 1 point).
+// REDEEM_RATE: currency value of a single point when redeemed (100 pts -> 1.00).
+const EARN_RATE = 1;
+const REDEEM_RATE = 0.01;
+
+// Ascending lifetime-points thresholds; the highest one a member clears is
+// their tier. Kept here (not the DB) because it's program config, not data.
+const TIER_THRESHOLDS = [
+    ["Bronze", 0],
+    ["Silver", 1000],
+    ["Gold", 5000],
+    ["Platinum", 20000],
+];
+
+const ENSURE_ACCOUNT_SQL =
+    "INSERT INTO loyalty_accounts (user_id) VALUES (?) ON DUPLICATE KEY UPDATE user_id = user_id";
+
+const INSERT_LEDGER_SQL =
+    `INSERT INTO loyalty_transactions
+        (user_id, order_id, type, points, balance_after, reason, metadata, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, NOW())`;
+
+class LoyaltyService {
+    constructor() {
+        this.isInitialized = false;
+        this.tablePresent = false;
+    }
+
+    // Idempotent. Probes for the migration so callers can boot the service
+    // before `loyalty_points.sql` has been applied without crashing.
+    async initialize() {
+        if (this.isInitialized) return this;
+        try {
+            await db.query("SELECT 1 FROM loyalty_accounts LIMIT 1");
+            this.tablePresent = true;
+            console.log("✅ Loyalty service initialized");
+        } catch (error) {
+            this.tablePresent = false;
+            console.warn(`Loyalty tables not present yet, service is a no-op: ${error.message}`);
+        }
+        this.isInitialized = true;
+        return this;
+    }
+
+    async getOrCreateAccount(userId) {
+        await db.query(ENSURE_ACCOUNT_SQL, [userId]);
+        const [rows] = await db.query(
+            `SELECT user_id, points_balance, lifetime_points, tier, created_at, updated_at
+             FROM loyalty_accounts WHERE user_id = ?`,
+            [userId]
+        );
+        return rows[0];
+    }
+
+    // Grant points for a purchase. Ledger append + balance/lifetime bump happen
+    // atomically; returns the new cached balance.
+    async award(userId, { orderId = null, amount, reason = null } = {}) {
+        const points = _earnedPoints(amount);
+
+        const conn = await db.getConnection();
+        try {
+            await db.beginTransaction(conn);
+
+            await conn.query(ENSURE_ACCOUNT_SQL, [userId]);
+            const [rows] = await conn.query(
+                "SELECT points_balance, lifetime_points FROM loyalty_accounts WHERE user_id = ? FOR UPDATE",
+                [userId]
+            );
+            const { points_balance: balance, lifetime_points: lifetime } = rows[0];
+
+            const newBalance = balance + points;
+            const newLifetime = lifetime + points;
+            const tier = _tierForLifetime(newLifetime);
+
+            await conn.query(
+                "UPDATE loyalty_accounts SET points_balance = ?, lifetime_points = ?, tier = ? WHERE user_id = ?",
+                [newBalance, newLifetime, tier, userId]
+            );
+            await conn.query(INSERT_LEDGER_SQL, [
+                userId,
+                orderId,
+                "earn",
+                points,
+                newBalance,
+                reason,
+                JSON.stringify({ amount, earnRate: EARN_RATE }),
+            ]);
+
+            await db.commitTransaction(conn);
+            return newBalance;
+        } catch (error) {
+            await db.rollbackTransaction(conn);
+            throw error;
+        } finally {
+            conn.release();
+        }
+    }
+
+    // Spend points. Rejects (before any write) if the balance can't cover the
+    // request, naming the exact shortfall. Ledger row is signed-negative.
+    async redeem(userId, { points, reason = null } = {}) {
+        if (!Number.isInteger(points) || points <= 0) {
+            throw new Error(`redeem requires a positive integer points amount, got: ${points}`);
+        }
+
+        const conn = await db.getConnection();
+        try {
+            await db.beginTransaction(conn);
+
+            await conn.query(ENSURE_ACCOUNT_SQL, [userId]);
+            const [rows] = await conn.query(
+                "SELECT points_balance FROM loyalty_accounts WHERE user_id = ? FOR UPDATE",
+                [userId]
+            );
+            const balance = rows[0].points_balance;
+
+            if (balance < points) {
+                throw new Error(
+                    `Insufficient loyalty points for user ${userId}: requested ${points}, ` +
+                        `available ${balance}, short by ${points - balance}`
+                );
+            }
+
+            const newBalance = balance - points;
+            await conn.query(
+                "UPDATE loyalty_accounts SET points_balance = ? WHERE user_id = ?",
+                [newBalance, userId]
+            );
+            await conn.query(INSERT_LEDGER_SQL, [
+                userId,
+                null,
+                "redeem",
+                -points,
+                newBalance,
+                reason,
+                JSON.stringify({ redeemRate: REDEEM_RATE }),
+            ]);
+
+            await db.commitTransaction(conn);
+            return {
+                pointsRedeemed: points,
+                discountValue: points * REDEEM_RATE,
+                balance: newBalance,
+            };
+        } catch (error) {
+            await db.rollbackTransaction(conn);
+            throw error;
+        } finally {
+            conn.release();
+        }
+    }
+
+    async getBalance(userId) {
+        const [rows] = await db.query(
+            "SELECT points_balance FROM loyalty_accounts WHERE user_id = ?",
+            [userId]
+        );
+        return rows.length > 0 ? rows[0].points_balance : 0;
+    }
+
+    async getHistory(userId, { limit = 50, offset = 0 } = {}) {
+        const safeLimit = Math.max(1, Math.min(Number(limit) || 50, 500));
+        const safeOffset = Math.max(0, Number(offset) || 0);
+        const [rows] = await db.query(
+            `SELECT id, user_id, order_id, type, points, balance_after, reason, metadata, created_at
+             FROM loyalty_transactions
+             WHERE user_id = ?
+             ORDER BY id DESC
+             LIMIT ? OFFSET ?`,
+            [userId, safeLimit, safeOffset]
+        );
+        return {
+            userId,
+            limit: safeLimit,
+            offset: safeOffset,
+            count: rows.length,
+            transactions: rows,
+        };
+    }
+}
+
+function _earnedPoints(amount) {
+    if (typeof amount !== "number" || !Number.isFinite(amount) || amount < 0) {
+        throw new Error(`award requires a non-negative numeric amount, got: ${amount}`);
+    }
+    // Whole points only: fractional spend never rounds up into a free point.
+    return Math.floor(amount * EARN_RATE);
+}
+
+function _tierForLifetime(lifetimePoints) {
+    let tier = TIER_THRESHOLDS[0][0];
+    for (const [name, minPoints] of TIER_THRESHOLDS) {
+        if (lifetimePoints >= minPoints) tier = name;
+    }
+    return tier;
+}
+
+module.exports = {
+    loyaltyService: new LoyaltyService(),
+    LoyaltyService,
+    EARN_RATE,
+    REDEEM_RATE,
+};

--- a/backend/sql/loyalty_points.sql
+++ b/backend/sql/loyalty_points.sql
@@ -1,0 +1,33 @@
+-- Loyalty & Reward Points program (issue #1232, PR 1/3: ledger core).
+-- `loyalty_transactions` is the append-only source of truth for a user's
+-- points; `loyalty_accounts` caches the running balance so reads stay cheap.
+
+-- Per-user loyalty account: cached running totals plus the derived tier. The
+-- balance here is a cache of the ledger and must only ever be mutated in the
+-- same transaction that appends the corresponding ledger row.
+CREATE TABLE IF NOT EXISTS loyalty_accounts (
+    user_id INT PRIMARY KEY,
+    points_balance INT NOT NULL DEFAULT 0,
+    lifetime_points INT NOT NULL DEFAULT 0,
+    tier VARCHAR(20) NOT NULL DEFAULT 'Bronze',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Append-only points ledger: one immutable row per points event. `points` is
+-- signed (positive earn, negative redeem/expire) and `balance_after` snapshots
+-- the account balance at write time so the history is self-describing.
+CREATE TABLE IF NOT EXISTS loyalty_transactions (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    order_id INT DEFAULT NULL,
+    type ENUM('earn', 'redeem', 'expire', 'adjust') NOT NULL,
+    points INT NOT NULL,
+    balance_after INT NOT NULL,
+    reason VARCHAR(255) DEFAULT NULL,
+    metadata JSON DEFAULT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_user (user_id),
+    INDEX idx_type (type),
+    INDEX idx_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/backend/tests/loyalty.test.js
+++ b/backend/tests/loyalty.test.js
@@ -1,0 +1,175 @@
+// Tests for the loyalty ledger core (#1232, PR 1/3). The db module is mocked so
+// we exercise the transactional earn/redeem paths without a live MySQL: a fake
+// connection records every SQL string + params and returns canned rows keyed
+// off the query text, and the transaction helpers are spies so we can assert
+// commit-on-success / rollback-on-failure.
+
+jest.mock("../config/db", () => ({
+    query: jest.fn(),
+    getConnection: jest.fn(),
+    beginTransaction: jest.fn(async () => {}),
+    commitTransaction: jest.fn(async () => {}),
+    rollbackTransaction: jest.fn(async () => {}),
+}));
+
+const db = require("../config/db");
+const { loyaltyService, EARN_RATE, REDEEM_RATE } = require("../services/loyaltyService");
+
+// Fake promise-pool connection: `.query()` returns canned rows based on the SQL
+// text and records each call so tests can assert on the SQL/params.
+function makeConnection(responder) {
+    const calls = [];
+    const query = jest.fn(async (sql, params = []) => {
+        calls.push({ sql, params });
+        return responder(sql, params);
+    });
+    return { query, calls, release: jest.fn() };
+}
+
+function sqlsMatching(calls, regex) {
+    return calls.filter(({ sql }) => regex.test(sql));
+}
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+describe("award", () => {
+    test("computes points from amount via EARN_RATE and records balance_after", async () => {
+        const conn = makeConnection((sql) => {
+            if (/SELECT points_balance, lifetime_points/i.test(sql)) {
+                return [[{ points_balance: 100, lifetime_points: 300 }]];
+            }
+            return [{ affectedRows: 1, insertId: 1 }];
+        });
+        db.getConnection.mockResolvedValue(conn);
+
+        const newBalance = await loyaltyService.award("user-1", {
+            orderId: 55,
+            amount: 250,
+            reason: "order #55",
+        });
+
+        // 250 currency units * EARN_RATE(1) = 250 points on top of the 100 held.
+        expect(newBalance).toBe(100 + 250 * EARN_RATE);
+
+        expect(db.beginTransaction).toHaveBeenCalledTimes(1);
+        expect(db.commitTransaction).toHaveBeenCalledTimes(1);
+        expect(db.rollbackTransaction).not.toHaveBeenCalled();
+        expect(conn.release).toHaveBeenCalledTimes(1);
+
+        const inserts = sqlsMatching(conn.calls, /INSERT INTO loyalty_transactions/i);
+        expect(inserts).toHaveLength(1);
+        const [userId, orderId, type, points, balanceAfter] = inserts[0].params;
+        expect({ userId, orderId, type, points, balanceAfter }).toEqual({
+            userId: "user-1",
+            orderId: 55,
+            type: "earn",
+            points: 250,
+            balanceAfter: 350,
+        });
+    });
+
+    test("floors fractional points and rejects a negative amount", async () => {
+        const conn = makeConnection((sql) => {
+            if (/SELECT points_balance, lifetime_points/i.test(sql)) {
+                return [[{ points_balance: 0, lifetime_points: 0 }]];
+            }
+            return [{ affectedRows: 1 }];
+        });
+        db.getConnection.mockResolvedValue(conn);
+
+        const balance = await loyaltyService.award("user-2", { amount: 10.9 });
+        expect(balance).toBe(10);
+
+        await expect(loyaltyService.award("user-2", { amount: -5 })).rejects.toThrow(
+            /non-negative numeric amount/i
+        );
+    });
+});
+
+describe("redeem", () => {
+    test("succeeds when the balance covers the request and returns the discount value", async () => {
+        const conn = makeConnection((sql) => {
+            if (/SELECT points_balance FROM loyalty_accounts/i.test(sql)) {
+                return [[{ points_balance: 500 }]];
+            }
+            return [{ affectedRows: 1, insertId: 1 }];
+        });
+        db.getConnection.mockResolvedValue(conn);
+
+        const result = await loyaltyService.redeem("user-1", { points: 200, reason: "checkout" });
+
+        expect(result).toEqual({
+            pointsRedeemed: 200,
+            discountValue: 200 * REDEEM_RATE,
+            balance: 300,
+        });
+        expect(db.commitTransaction).toHaveBeenCalledTimes(1);
+        expect(db.rollbackTransaction).not.toHaveBeenCalled();
+        expect(conn.release).toHaveBeenCalledTimes(1);
+
+        // Ledger row is signed-negative with balance_after tracking the new total.
+        const inserts = sqlsMatching(conn.calls, /INSERT INTO loyalty_transactions/i);
+        expect(inserts).toHaveLength(1);
+        const [, , type, points, balanceAfter] = inserts[0].params;
+        expect({ type, points, balanceAfter }).toEqual({
+            type: "redeem",
+            points: -200,
+            balanceAfter: 300,
+        });
+    });
+
+    test("throws naming the shortfall on insufficient balance and rolls back without writing", async () => {
+        const conn = makeConnection((sql) => {
+            if (/SELECT points_balance FROM loyalty_accounts/i.test(sql)) {
+                return [[{ points_balance: 50 }]];
+            }
+            return [{ affectedRows: 1 }];
+        });
+        db.getConnection.mockResolvedValue(conn);
+
+        await expect(
+            loyaltyService.redeem("user-1", { points: 200 })
+        ).rejects.toThrow(/requested 200, available 50, short by 150/i);
+
+        // Never appended a ledger row or updated the balance.
+        expect(sqlsMatching(conn.calls, /INSERT INTO loyalty_transactions/i)).toHaveLength(0);
+        expect(sqlsMatching(conn.calls, /UPDATE loyalty_accounts SET points_balance/i)).toHaveLength(0);
+
+        expect(db.rollbackTransaction).toHaveBeenCalledTimes(1);
+        expect(db.commitTransaction).not.toHaveBeenCalled();
+        expect(conn.release).toHaveBeenCalledTimes(1);
+    });
+
+    test("rejects a non-positive points request before touching the DB", async () => {
+        await expect(loyaltyService.redeem("user-1", { points: 0 })).rejects.toThrow(
+            /positive integer/i
+        );
+        expect(db.getConnection).not.toHaveBeenCalled();
+    });
+});
+
+describe("getHistory", () => {
+    test("returns the pagination envelope and passes limit/offset to SQL", async () => {
+        const rows = [
+            { id: 3, user_id: "user-1", type: "redeem", points: -200, balance_after: 300 },
+            { id: 2, user_id: "user-1", type: "earn", points: 250, balance_after: 500 },
+        ];
+        db.query.mockResolvedValue([rows, null]);
+
+        const history = await loyaltyService.getHistory("user-1", { limit: 10, offset: 20 });
+
+        expect(history).toEqual({
+            userId: "user-1",
+            limit: 10,
+            offset: 20,
+            count: 2,
+            transactions: rows,
+        });
+
+        const [sql, params] = db.query.mock.calls[0];
+        expect(sql).toMatch(/LIMIT \? OFFSET \?/i);
+        expect(params).toEqual(["user-1", 10, 20]);
+    });
+});


### PR DESCRIPTION
## Summary
First of three stacked PRs for the loyalty & reward-points program (#1232).
This one is the self-contained data + service layer — no routes, no `server.js`
wiring, no event hooks, so it changes no existing behaviour.

- `backend/sql/loyalty_points.sql`: `loyalty_accounts` (balance cache) and an
  append-only `loyalty_transactions` ledger (`earn`/`redeem`/`expire`/`adjust`,
  signed points, `balance_after`).
- `backend/services/loyaltyService.js`: `award`, `redeem`, `getBalance`,
  `getHistory`. The ledger is authoritative; every balance mutation appends the
  ledger row and updates the cache in one transaction with the account row
  locked `FOR UPDATE`, so concurrent earns/redeems serialise. Redeeming more
  than the balance is rejected with an error naming the shortfall.

## Test plan
Unit tests (`backend/tests/loyalty.test.js`, DB mocked) cover earn math and
`balance_after` tracking, redeem success with discount value, insufficient-
balance rejection (with rollback and no writes), and history pagination shape.

## Notes
Base for PR 2/3 (REST API) and PR 3/3 (tiers + auto-earn).