### PR TITLE
feat: add stock/price-drop alert subscriptions (#1233)

### DIFF
--- a/backend/services/stockAlertService.js
+++ b/backend/services/stockAlertService.js
@@ -1,0 +1,122 @@
+// backend/services/stockAlertService.js
+// Subscription management for back-in-stock and price-drop alerts (#1233).
+// Owns only the subscribe/unsubscribe/list surface over the
+// `stock_alert_subscriptions` table; the evaluation engine and the API/
+// scheduler that consume these rows live in follow-up changes.
+const db = require("../config/db");
+
+const ALERT_TYPES = {
+    BACK_IN_STOCK: "back_in_stock",
+    PRICE_DROP: "price_drop",
+};
+
+const SUBSCRIPTION_STATUS = {
+    ACTIVE: "active",
+    NOTIFIED: "notified",
+    CANCELLED: "cancelled",
+};
+
+const VALID_ALERT_TYPES = Object.values(ALERT_TYPES);
+
+function assertAlertType(alertType) {
+    if (!VALID_ALERT_TYPES.includes(alertType)) {
+        throw new Error(
+            `Invalid alertType: ${alertType}. Expected one of ${VALID_ALERT_TYPES.join(", ")}`
+        );
+    }
+}
+
+async function fetchCurrentPrice(productId) {
+    const [rows] = await db.query(
+        "SELECT price FROM products WHERE id = ?",
+        [productId]
+    );
+    if (!rows || rows.length === 0) {
+        throw new Error(`Product not found: ${productId}`);
+    }
+    return rows[0].price;
+}
+
+async function fetchSubscription(userId, productId, alertType) {
+    const [rows] = await db.query(
+        `SELECT * FROM stock_alert_subscriptions
+         WHERE user_id = ? AND product_id = ? AND alert_type = ?`,
+        [userId, productId, alertType]
+    );
+    return rows && rows.length > 0 ? rows[0] : null;
+}
+
+const stockAlertService = {
+    ALERT_TYPES,
+    SUBSCRIPTION_STATUS,
+
+    // Create (or reactivate) a subscription. The UNIQUE key on
+    // (user_id, product_id, alert_type) makes this idempotent: a repeat call
+    // for the same triple reactivates the existing row instead of inserting a
+    // duplicate, resetting status to 'active' and clearing last_notified_at so
+    // the evaluation engine treats it as a fresh subscription.
+    subscribe: async ({ userId, productId, alertType, referencePrice = null }) => {
+        assertAlertType(alertType);
+
+        // A price-drop alert needs a baseline to compare against; default it to
+        // the product's current price when the caller doesn't pin one.
+        let effectiveReferencePrice = referencePrice;
+        if (alertType === ALERT_TYPES.PRICE_DROP && effectiveReferencePrice === null) {
+            effectiveReferencePrice = await fetchCurrentPrice(productId);
+        }
+
+        await db.query(
+            `INSERT INTO stock_alert_subscriptions
+                (user_id, product_id, alert_type, reference_price, status, last_notified_at)
+             VALUES (?, ?, ?, ?, 'active', NULL)
+             ON DUPLICATE KEY UPDATE
+                status = 'active',
+                last_notified_at = NULL,
+                reference_price = VALUES(reference_price)`,
+            [userId, productId, alertType, effectiveReferencePrice]
+        );
+
+        return fetchSubscription(userId, productId, alertType);
+    },
+
+    // Soft-cancel: flip status to 'cancelled' so the row (and its reference
+    // price / notification history) is preserved and a later subscribe can
+    // reactivate the same row via the UNIQUE key.
+    unsubscribe: async ({ userId, productId, alertType }) => {
+        assertAlertType(alertType);
+
+        const [result] = await db.query(
+            `UPDATE stock_alert_subscriptions
+             SET status = 'cancelled'
+             WHERE user_id = ? AND product_id = ? AND alert_type = ?`,
+            [userId, productId, alertType]
+        );
+
+        return result;
+    },
+
+    // List a user's subscriptions, optionally narrowed by alert type and/or
+    // status. Filters are appended only when provided so the query stays a
+    // single indexed lookup on user_id in the common case.
+    listSubscriptions: async (userId, { alertType = null, status = null } = {}) => {
+        let sql = "SELECT * FROM stock_alert_subscriptions WHERE user_id = ?";
+        const params = [userId];
+
+        if (alertType !== null) {
+            sql += " AND alert_type = ?";
+            params.push(alertType);
+        }
+
+        if (status !== null) {
+            sql += " AND status = ?";
+            params.push(status);
+        }
+
+        sql += " ORDER BY created_at DESC";
+
+        const [rows] = await db.query(sql, params);
+        return rows;
+    },
+};
+
+module.exports = stockAlertService;

--- a/backend/sql/stock_alerts.sql
+++ b/backend/sql/stock_alerts.sql
@@ -1,0 +1,20 @@
+-- Stock Alert Subscriptions (#1233)
+-- Users subscribe to be notified when an out-of-stock product is restocked
+-- (back_in_stock) or when a wishlisted product's price drops (price_drop).
+-- Notifications are delivered via the existing notificationBrokerService.
+CREATE TABLE IF NOT EXISTS stock_alert_subscriptions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id CHAR(36) NOT NULL,
+    product_id CHAR(36) NOT NULL,
+    alert_type ENUM('back_in_stock','price_drop') NOT NULL,
+    reference_price DECIMAL(10,2) NULL,
+    status ENUM('active','notified','cancelled') NOT NULL DEFAULT 'active',
+    last_notified_at DATETIME NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE,
+    UNIQUE KEY uniq_user_product_type (user_id, product_id, alert_type),
+    INDEX idx_stock_alert_product (product_id),
+    INDEX idx_stock_alert_type_status (alert_type, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/tests/stockAlert.test.js
+++ b/backend/tests/stockAlert.test.js
@@ -1,0 +1,172 @@
+// Tests for stock-alert subscription management (#1233). The db module is
+// mocked so we can assert the subscribe/dedupe/unsubscribe/list SQL and params
+// without a live MySQL. The mock `query` returns rows keyed off the SQL text,
+// mirroring the wrapper's [rows] destructuring contract in config/db.
+
+jest.mock("../config/db", () => {
+    const query = jest.fn();
+    return { query };
+});
+
+const db = require("../config/db");
+const service = require("../services/stockAlertService");
+
+function callsMatching(regex) {
+    return db.query.mock.calls.filter(([sql]) => regex.test(sql));
+}
+
+afterEach(() => {
+    db.query.mockReset();
+});
+
+describe("subscribe", () => {
+    test("inserts a back_in_stock subscription with ON DUPLICATE KEY UPDATE dedupe", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/^\s*INSERT INTO stock_alert_subscriptions/i.test(sql)) {
+                return [{ affectedRows: 1, insertId: 1 }];
+            }
+            return [[{ id: 1, user_id: "u1", product_id: "p1", alert_type: "back_in_stock", status: "active" }]];
+        });
+
+        const row = await service.subscribe({
+            userId: "u1",
+            productId: "p1",
+            alertType: "back_in_stock",
+        });
+
+        const inserts = callsMatching(/INSERT INTO stock_alert_subscriptions/i);
+        expect(inserts).toHaveLength(1);
+        const [sql, params] = inserts[0];
+        expect(sql).toMatch(/ON DUPLICATE KEY UPDATE/i);
+        expect(sql).toMatch(/status = 'active'/i);
+        expect(sql).toMatch(/last_notified_at = NULL/i);
+        // back_in_stock has no reference price; no product lookup needed.
+        expect(callsMatching(/SELECT price FROM products/i)).toHaveLength(0);
+        expect(params).toEqual(["u1", "p1", "back_in_stock", null]);
+        expect(row).toMatchObject({ id: 1, status: "active" });
+    });
+
+    test("dedupes: a second subscribe for the same user/product/type does not insert a duplicate row", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/^\s*INSERT INTO stock_alert_subscriptions/i.test(sql)) {
+                return [{ affectedRows: 2 }];
+            }
+            return [[{ id: 7, user_id: "u1", product_id: "p1", alert_type: "back_in_stock", status: "active" }]];
+        });
+
+        await service.subscribe({ userId: "u1", productId: "p1", alertType: "back_in_stock" });
+        await service.subscribe({ userId: "u1", productId: "p1", alertType: "back_in_stock" });
+
+        // Two subscribe calls, but each is a single upsert relying on the UNIQUE
+        // key -- there is no second INSERT-without-dedupe path.
+        const inserts = callsMatching(/INSERT INTO stock_alert_subscriptions/i);
+        expect(inserts).toHaveLength(2);
+        inserts.forEach(([sql]) => expect(sql).toMatch(/ON DUPLICATE KEY UPDATE/i));
+    });
+
+    test("price_drop with null referencePrice looks up the product's current price", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT price FROM products WHERE id = \?/i.test(sql)) {
+                return [[{ price: "19.99" }]];
+            }
+            if (/^\s*INSERT INTO stock_alert_subscriptions/i.test(sql)) {
+                return [{ affectedRows: 1 }];
+            }
+            return [[{ id: 3, alert_type: "price_drop", reference_price: "19.99", status: "active" }]];
+        });
+
+        await service.subscribe({ userId: "u1", productId: "p1", alertType: "price_drop" });
+
+        const priceLookups = callsMatching(/SELECT price FROM products WHERE id = \?/i);
+        expect(priceLookups).toHaveLength(1);
+        expect(priceLookups[0][1]).toEqual(["p1"]);
+
+        const inserts = callsMatching(/INSERT INTO stock_alert_subscriptions/i);
+        expect(inserts).toHaveLength(1);
+        // Looked-up price is stored as reference_price (4th param).
+        expect(inserts[0][1]).toEqual(["u1", "p1", "price_drop", "19.99"]);
+    });
+
+    test("price_drop with an explicit referencePrice does not look up the product price", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/^\s*INSERT INTO stock_alert_subscriptions/i.test(sql)) {
+                return [{ affectedRows: 1 }];
+            }
+            return [[{ id: 4, alert_type: "price_drop", reference_price: "50.00" }]];
+        });
+
+        await service.subscribe({
+            userId: "u1",
+            productId: "p1",
+            alertType: "price_drop",
+            referencePrice: "50.00",
+        });
+
+        expect(callsMatching(/SELECT price FROM products/i)).toHaveLength(0);
+        const inserts = callsMatching(/INSERT INTO stock_alert_subscriptions/i);
+        expect(inserts[0][1]).toEqual(["u1", "p1", "price_drop", "50.00"]);
+    });
+
+    test("rejects an unknown alert type before touching the db", async () => {
+        await expect(
+            service.subscribe({ userId: "u1", productId: "p1", alertType: "bogus" })
+        ).rejects.toThrow(/Invalid alertType/i);
+        expect(db.query).not.toHaveBeenCalled();
+    });
+});
+
+describe("unsubscribe", () => {
+    test("soft-cancels the matching subscription", async () => {
+        db.query.mockResolvedValue([{ affectedRows: 1 }]);
+
+        await service.unsubscribe({ userId: "u1", productId: "p1", alertType: "back_in_stock" });
+
+        const updates = callsMatching(/UPDATE stock_alert_subscriptions/i);
+        expect(updates).toHaveLength(1);
+        const [sql, params] = updates[0];
+        expect(sql).toMatch(/SET status = 'cancelled'/i);
+        expect(sql).toMatch(/WHERE user_id = \? AND product_id = \? AND alert_type = \?/i);
+        expect(params).toEqual(["u1", "p1", "back_in_stock"]);
+        // Soft cancel must never delete the row.
+        expect(callsMatching(/DELETE FROM stock_alert_subscriptions/i)).toHaveLength(0);
+    });
+});
+
+describe("listSubscriptions", () => {
+    test("returns all of a user's subscriptions when no filters are given", async () => {
+        db.query.mockResolvedValue([[{ id: 1 }, { id: 2 }]]);
+
+        const rows = await service.listSubscriptions("u1");
+
+        const selects = callsMatching(/SELECT \* FROM stock_alert_subscriptions/i);
+        expect(selects).toHaveLength(1);
+        const [sql, params] = selects[0];
+        expect(sql).toMatch(/WHERE user_id = \?/i);
+        expect(sql).not.toMatch(/alert_type = \?/i);
+        expect(sql).not.toMatch(/status = \?/i);
+        expect(params).toEqual(["u1"]);
+        expect(rows).toHaveLength(2);
+    });
+
+    test("appends alert_type and status filters when provided", async () => {
+        db.query.mockResolvedValue([[]]);
+
+        await service.listSubscriptions("u1", { alertType: "price_drop", status: "active" });
+
+        const [sql, params] = callsMatching(/SELECT \* FROM stock_alert_subscriptions/i)[0];
+        expect(sql).toMatch(/AND alert_type = \?/i);
+        expect(sql).toMatch(/AND status = \?/i);
+        expect(params).toEqual(["u1", "price_drop", "active"]);
+    });
+
+    test("appends only the status filter when alert type is omitted", async () => {
+        db.query.mockResolvedValue([[]]);
+
+        await service.listSubscriptions("u1", { status: "cancelled" });
+
+        const [sql, params] = callsMatching(/SELECT \* FROM stock_alert_subscriptions/i)[0];
+        expect(sql).not.toMatch(/alert_type = \?/i);
+        expect(sql).toMatch(/AND status = \?/i);
+        expect(params).toEqual(["u1", "cancelled"]);
+    });
+});


### PR DESCRIPTION
## Back-in-stock & price-drop alerts — Subscriptions (PR 1/3, #1233)

First of three PRs for #1233. Introduces the subscription layer that lets a user
register interest in a product being restocked or dropping in price. This PR is
self-contained: table + service only, no wiring, evaluation, or endpoints yet.

### Behaviour
- New table holding one subscription per user / product / alert type, with a
  reference price for price-drop alerts and a status used later for de-duplication.
- Service supports subscribing, unsubscribing (soft cancel), and listing a user's
  subscriptions with optional type/status filters.
- Subscribing is idempotent: re-subscribing reactivates the existing row rather
  than creating duplicates. For price-drop alerts with no explicit baseline, the
  product's current price is captured as the reference.

### Test plan
Unit coverage for insert columns, idempotent re-subscribe, reference-price
capture (explicit and defaulted), invalid alert type, soft cancel, and filtered
listing. All passing.

Follow-ups: PR 2/3 adds the evaluation engine; PR 3/3 adds the API and scheduler.