### PR TITLE
fix: wire up existing "Recently Searched" suggestions feature on Shop search bar

### DIFF
--- a/frontend/scripts/shop.js
+++ b/frontend/scripts/shop.js
@@ -93,6 +93,12 @@ let hasAppliedUrlFilters = false;
 // SHOP PAGE ELEMENTS
 const elements = {};
 
+const cacheShopElements = () => {
+    elements.searchInput = document.getElementById("search-input");
+    elements.suggestions = document.getElementById("search-suggestions");
+    elements.searchForm = document.querySelector(".search-box");
+};
+
 const getFilterUtils = () =>
     globalThis.ShopFilterUtils;
 
@@ -1133,6 +1139,7 @@ function setupFilterDrawer() {
 
 // INITIALIZATION (Updated)
 document.addEventListener("DOMContentLoaded", () => {
+    cacheShopElements();
     fetchProducts();
     setupSearch();
     setupCategoryFilters();

--- a/frontend/shop.html
+++ b/frontend/shop.html
@@ -121,6 +121,7 @@
     <div class="search-box">
         <input type="text" id="search-input" placeholder="Search products...">
         <i class="fas fa-search"></i>
+        <div id="search-suggestions" class="search-suggestions" hidden></div>
     </div>
 
     <!-- Category Filters -->


### PR DESCRIPTION
Fixes #812

## Problem
`frontend/shop.html` and `frontend/scripts/shop.js` already contained a fully-built "Recently Searched" suggestions feature — `saveSearchHistory`, `showSearchSuggestions`, `renderSuggestionList`, and a `SEARCH_HISTORY_KEY` localStorage entry — but it never actually ran.

Root cause: the `elements` object used throughout `shop.js` was declared as `const elements = {}` and never populated via `getElementById`/`querySelector` anywhere in the file. So `elements.searchInput` and `elements.suggestions` were always `undefined`, and `setupSearch()` bailed out immediately on:

```js
if (!elements.searchInput) return;
```

There was also no suggestions container element in the HTML for the dropdown to render into, despite matching CSS classes already existing in `shop.css`.

## Fix
- Added `<div id="search-suggestions" class="search-suggestions" hidden></div>` inside `.search-box` in `frontend/shop.html`, matching the existing `shop.css` classes
- Added a `cacheShopElements()` function in `frontend/scripts/shop.js` that populates `elements.searchInput`, `elements.suggestions`, and `elements.searchForm`
- Called `cacheShopElements()` as the first line inside the existing `DOMContentLoaded` listener, before `fetchProducts()`

## Testing
- Searched a term (e.g. "hoodie"), cleared the input, clicked back into the search bar, and confirmed the "Recent searches" dropdown now appears
- Clicked a suggestion and confirmed it re-triggers that search correctly
- Verified existing filter/category/sort behavior on the Shop page is unaffected

**Before/after screenshots:**
[attach: search bar with no dropdown vs. search bar showing "Recent searches" dropdown]