### PR TITLE
fix: restore missing addEventListener binding in setupSearch()

### DIFF
--- a/frontend/scripts/shop.js
+++ b/frontend/scripts/shop.js
@@ -686,6 +686,9 @@ function setupSearch() {
     filters.megaCategory = category;
     filters.megaSubcategory = subcategory;
 
+    elements.searchInput.addEventListener(
+        "input",
+        () => {
             clearTimeout(searchTimeout);
 
             searchTimeout = setTimeout(() => {


### PR DESCRIPTION
### Fixes: #1243 

### Description
`setupSearch()` was missing the `elements.searchInput.addEventListener("input", () => {...})`
opening line. The debounce logic (clearTimeout/setTimeout block) was sitting
outside any event listener, which unbalanced the file's braces/parens.

This caused TypeScript to report syntax errors in two places:
- Lines 706 & 710 — right after the broken function
- Line 1235 — end of file (the `})()` there is actually correct; it closes
  the file's top-level IIFE wrapper, but the earlier imbalance made the
  parser misread it as an extra/unmatched token)

### Fix
Restored the missing `addEventListener` opening so the search input's
input event is properly bound, and the debounce logic runs as intended.

### Testing
- Ran `node --check frontend/scripts/shop.js` — no syntax errors
- Verified search bar triggers debounced product fetch on typing

Fixes #<issue-1-number>
Related to #<issue-2-number> (same root cause — see comment on that issue,
no separate code change was needed there)