### PR TITLE
fix: add missing cart_items and recently_viewed tables to schema.sql

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1104,3 +1104,35 @@ CREATE TABLE IF NOT EXISTS inventory_locks (
     INDEX idx_inventory_locks_product (product_id),
     INDEX idx_inventory_locks_expires (expires_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================
+-- CART ITEMS (New)
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS cart_items (
+    user_id CHAR(36) NOT NULL,
+    product_id CHAR(36) NOT NULL,
+    quantity INT NOT NULL DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, product_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE,
+    INDEX idx_cart_items_user (user_id),
+    INDEX idx_cart_items_product (product_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================
+-- RECENTLY VIEWED (New)
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS recently_viewed (
+    user_id CHAR(36) NOT NULL,
+    product_id CHAR(36) NOT NULL,
+    viewed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, product_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE,
+    INDEX idx_recently_viewed_user (user_id),
+    INDEX idx_recently_viewed_product (product_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Bug Description

The backend uses the `cart_items` table for shopping cart synchronization (`cartController.js`) and the `recently_viewed` table for tracking recently viewed products (`recentlyViewedService.js`). However, both table definitions are missing from `backend/schema.sql`.

As a result, applications initialized using the provided schema fail whenever these features are accessed.

## Steps to Reproduce

1. Initialize the database using `backend/schema.sql`.
2. Start the backend server.
3. Add a product to the shopping cart or access the recently viewed products feature.
4. Observe the database error indicating that the required tables do not exist.

## Expected Behavior

The database schema should include both `cart_items` and `recently_viewed` tables so that cart synchronization and recently viewed functionality work without errors.

## Actual Behavior

Requests relying on these tables fail with MySQL errors similar to:

```text
Table 'ecommerce.cart_items' doesn't exist
```

or

```text
Table 'ecommerce.recently_viewed' doesn't exist
```

resulting in **500 Internal Server Error** responses.

## Severity

Critical

## Screenshots / Screen Recording

No response.

## Browser

Chrome

## Operating System

Windows 11

## Additional Context

### Suggested Fix

Add the missing table definitions to `backend/schema.sql`:

- Create the `cart_items` table with:
  - Composite primary key (`user_id`, `product_id`)
  - Foreign keys referencing `users(id)` and `products(id)`
  - `ON DELETE CASCADE`
  - Quantity and timestamp fields

- Create the `recently_viewed` table with:
  - Composite primary key (`user_id`, `product_id`)
  - Foreign keys referencing `users(id)` and `products(id)`
  - `ON DELETE CASCADE`
  - Timestamp for the latest viewed time

This ensures database integrity while enabling automatic cleanup when users or products are removed.

### Files to Modify

- `backend/schema.sql`

---

**Suggested Labels:**  `ecsoc26` `bug` `backend` `database` `mysql` `schema` `high priority`