### PR TITLE
feat(pricing): add a self-contained pricing engine with the ordering pinned by tests

### DIFF
--- a/backend/config/pricingConfig.js
+++ b/backend/config/pricingConfig.js
@@ -1,0 +1,51 @@
+// Declarative source of truth for order pricing: the tax rule, the shipping
+// rule, how money is rounded, and — critically — the order in which discount,
+// tax and shipping are applied.
+//
+// The ordering is a named value rather than an implicit consequence of the
+// order of statements in the engine, because the three pricing paths that
+// existed before this config disagreed on it (the storefront taxed the
+// discounted subtotal, the checkout route subtracted the discount after tax).
+// Making it data means a change of policy is a change of this file, and the
+// tests that pin the ordering fail loudly if the engine stops honouring it.
+
+const APPLICATION_ORDER = Object.freeze(["discount", "tax", "shipping"]);
+
+const DISCOUNT_TYPES = Object.freeze({
+    PERCENTAGE: "percentage",
+    FIXED: "fixed",
+    FREE_SHIPPING: "free_shipping",
+});
+
+const ROUNDING = Object.freeze({
+    DECIMAL_PLACES: 2,
+    // Half-up (away from zero on the .5 boundary) is what shoppers see on
+    // every other retail surface, and it is what the pre-existing toFixed(2)
+    // calls approximated.
+    MODE: "half-up",
+});
+
+const CURRENCY = Object.freeze({
+    code: "INR",
+    symbol: "₹",
+});
+
+const PRICING_CONFIG = Object.freeze({
+    CURRENCY,
+    APPLICATION_ORDER,
+    DISCOUNT_TYPES,
+    ROUNDING,
+
+    TAX_RATE: 0.18,
+    SHIPPING_FLAT_RATE: 49,
+    // At or above this post-discount subtotal shipping is free.
+    FREE_SHIPPING_THRESHOLD: 999,
+
+    // Both the tax and the shipping rule read the subtotal *after* the
+    // discount has come off. Named so the engine cannot silently switch base
+    // without this file changing too.
+    TAXABLE_BASE: "post_discount_subtotal",
+    SHIPPING_BASE: "post_discount_subtotal",
+});
+
+module.exports = PRICING_CONFIG;

--- a/backend/services/pricing.service.js
+++ b/backend/services/pricing.service.js
@@ -1,0 +1,207 @@
+// The single owner of order pricing arithmetic.
+//
+// Everything here is pure: no database, no logger, no clock. Promo *validation*
+// (is the code real, active, in date, above its minimum) still belongs to
+// promo.service because it needs the database; this module only takes the
+// already-validated promo descriptor and does the maths. That split is what
+// makes the pricing rules testable on their own.
+//
+// Ordering, which the three previous pricing paths disagreed on, is resolved
+// here as: discount first, then tax on the discounted base, then shipping from
+// the discounted subtotal. That matches the figures the storefront has always
+// shown shoppers, so moving ownership to the server does not silently change
+// anyone's bill. pricingConfig.APPLICATION_ORDER records the decision and the
+// tests pin it.
+//
+// Rounding happens at defined boundaries only — each line total, then each
+// component — so that the per-line figures a customer sees always add up to
+// the total that gets charged and recorded.
+
+const PRICING_CONFIG = require("../config/pricingConfig");
+
+const { DISCOUNT_TYPES, ROUNDING } = PRICING_CONFIG;
+
+const ROUNDING_FACTOR = 10 ** ROUNDING.DECIMAL_PLACES;
+
+// The smallest representable money difference; used by callers that need to
+// compare a claimed total against a computed one.
+const MINOR_UNIT = 1 / ROUNDING_FACTOR;
+
+// helpers.js is not reused here because it pulls in third-party validation and
+// crypto, which would give this module a dependency graph it does not need.
+const toFiniteNumber = (value, fallback = 0) => {
+    const parsed = parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const toQuantity = (value) => {
+    const parsed = parseInt(value, 10);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
+};
+
+/**
+ * Round to the configured precision, half away from zero.
+ *
+ * Scaling by a power of ten lands values such as 1.005 on 100.49999999999999
+ * in binary floating point, which a plain Math.round would send *down* and
+ * break the reconciliation invariant. Nudging by one unit in the last place
+ * before rounding keeps the half-up boundary honest.
+ */
+const roundMoney = (value) => {
+    const amount = toFiniteNumber(value);
+    const scaled = Math.abs(amount) * ROUNDING_FACTOR;
+    const rounded = Math.round(scaled + Number.EPSILON * scaled) / ROUNDING_FACTOR;
+    return amount < 0 ? -rounded : rounded;
+};
+
+/**
+ * Price a set of line items.
+ *
+ * Each line is rounded on its own and the subtotal is the sum of those already
+ * rounded figures, so a receipt printed from `lines` can never disagree with
+ * `subtotal`.
+ *
+ * @param {Array<Object>} items - objects carrying at least a price and a quantity
+ * @returns {{ lines: Array<Object>, subtotal: number }}
+ */
+const priceLineItems = (items) => {
+    const lines = (Array.isArray(items) ? items : []).map((item) => {
+        const source = item || {};
+        // The unit price is multiplied out before it is rounded: rounding it
+        // first would lose sub-minor-unit prices and hand the customer a line
+        // total that does not match quantity times price.
+        const unitPrice = toFiniteNumber(source.price ?? source.unitPrice);
+        const quantity = toQuantity(source.qty ?? source.quantity);
+
+        return {
+            id: source.id ?? null,
+            name: source.name ?? null,
+            unitPrice,
+            quantity,
+            lineTotal: roundMoney(unitPrice * quantity),
+        };
+    });
+
+    const subtotal = roundMoney(
+        lines.reduce((sum, line) => sum + line.lineTotal, 0),
+    );
+
+    return { lines, subtotal };
+};
+
+/**
+ * Apply an already-validated promo to a base amount.
+ *
+ * Percentage and fixed semantics mirror promo.service.calculateDiscount: a
+ * percentage is capped by `maximum_discount` when one is set, and no discount
+ * may exceed the base. `free_shipping`, which that function silently treated
+ * as a fixed discount of its (zero) value, is handled explicitly here as a
+ * shipping waiver.
+ *
+ * @param {Object|null} promo - validated promo descriptor
+ * @param {number} baseAmount
+ * @returns {{ amount: number, isShippingWaived: boolean }}
+ */
+const applyDiscount = (promo, baseAmount) => {
+    const base = Math.max(0, roundMoney(baseAmount));
+
+    if (!promo) {
+        return { amount: 0, isShippingWaived: false };
+    }
+
+    const type = String(promo.discount_type ?? promo.discountType ?? "")
+        .trim()
+        .toLowerCase();
+
+    if (type === DISCOUNT_TYPES.FREE_SHIPPING) {
+        return { amount: 0, isShippingWaived: true };
+    }
+
+    const value = toFiniteNumber(promo.discount_value ?? promo.discountValue);
+    let amount = type === DISCOUNT_TYPES.PERCENTAGE ? base * (value / 100) : value;
+
+    const cap = toFiniteNumber(promo.maximum_discount ?? promo.maximumDiscount);
+    if (type === DISCOUNT_TYPES.PERCENTAGE && cap > 0) {
+        amount = Math.min(amount, cap);
+    }
+
+    amount = Math.min(Math.max(0, amount), base);
+
+    return { amount: roundMoney(amount), isShippingWaived: false };
+};
+
+/**
+ * Tax due on a taxable base.
+ *
+ * @param {number} taxableBase
+ * @returns {number}
+ */
+const calculateTax = (taxableBase) =>
+    roundMoney(Math.max(0, roundMoney(taxableBase)) * PRICING_CONFIG.TAX_RATE);
+
+/**
+ * Shipping due on a post-discount subtotal. An empty basket never attracts a
+ * shipping charge, and a `free_shipping` promo waives it outright.
+ *
+ * @param {number} postDiscountSubtotal
+ * @param {{ isShippingWaived?: boolean }} [options]
+ * @returns {number}
+ */
+const calculateShipping = (postDiscountSubtotal, options = {}) => {
+    const base = Math.max(0, roundMoney(postDiscountSubtotal));
+
+    if (options.isShippingWaived || base <= 0) {
+        return 0;
+    }
+
+    return base >= PRICING_CONFIG.FREE_SHIPPING_THRESHOLD
+        ? 0
+        : roundMoney(PRICING_CONFIG.SHIPPING_FLAT_RATE);
+};
+
+/**
+ * Price a basket end to end and return the complete breakdown.
+ *
+ * The returned figures reconcile exactly: the line totals sum to `subtotal`,
+ * and `subtotal - discount + tax + shipping` equals `total`.
+ *
+ * @param {Object} input
+ * @param {Array<Object>} input.items
+ * @param {Object|null} [input.promo] - validated promo descriptor, if any
+ * @param {string|null} [input.promoCode] - code to echo back on the breakdown
+ * @returns {Object} breakdown
+ */
+const quote = ({ items = [], promo = null, promoCode = null } = {}) => {
+    const { lines, subtotal } = priceLineItems(items);
+
+    const discount = applyDiscount(promo, subtotal);
+    const taxableBase = roundMoney(Math.max(0, subtotal - discount.amount));
+    const tax = calculateTax(taxableBase);
+    const shipping = calculateShipping(taxableBase, {
+        isShippingWaived: discount.isShippingWaived,
+    });
+
+    return {
+        currency: PRICING_CONFIG.CURRENCY,
+        appliedOrder: PRICING_CONFIG.APPLICATION_ORDER,
+        lines,
+        subtotal,
+        discount: discount.amount,
+        isShippingWaived: discount.isShippingWaived,
+        promoCode: promoCode ?? promo?.code ?? null,
+        taxableBase,
+        tax,
+        shipping,
+        total: roundMoney(taxableBase + tax + shipping),
+    };
+};
+
+module.exports = {
+    MINOR_UNIT,
+    roundMoney,
+    priceLineItems,
+    applyDiscount,
+    calculateTax,
+    calculateShipping,
+    quote,
+};

--- a/backend/tests/pricing.service.test.js
+++ b/backend/tests/pricing.service.test.js
@@ -1,0 +1,295 @@
+// Tests for the pricing engine (#1256). These pin the two things the issue
+// cares about and that nothing enforced before: the order in which discount,
+// tax and shipping are applied, and the guarantee that the figures a shopper
+// is shown add up to the total that gets charged.
+//
+// The engine has no database or logger dependency, so nothing is mocked here.
+
+const PRICING_CONFIG = require("../config/pricingConfig");
+const {
+    roundMoney,
+    priceLineItems,
+    applyDiscount,
+    calculateTax,
+    calculateShipping,
+    quote
+} = require("../services/pricing.service");
+
+// Every breakdown must satisfy this, whatever the inputs.
+function expectReconciles(breakdown) {
+    const linesTotal = breakdown.lines.reduce(
+        (sum, line) => sum + line.lineTotal,
+        0
+    );
+
+    expect(roundMoney(linesTotal)).toBe(breakdown.subtotal);
+    expect(
+        roundMoney(
+            breakdown.subtotal -
+                breakdown.discount +
+                breakdown.tax +
+                breakdown.shipping
+        )
+    ).toBe(breakdown.total);
+}
+
+const percentagePromo = (value, maximumDiscount = null) => ({
+    code: "PCT",
+    discount_type: "percentage",
+    discount_value: value,
+    maximum_discount: maximumDiscount
+});
+
+describe("rounding policy", () => {
+    it("rounds half away from zero at two places", () => {
+        expect(roundMoney(1.005)).toBe(1.01);
+        expect(roundMoney(2.675)).toBe(2.68);
+        expect(roundMoney(1.004)).toBe(1);
+        expect(roundMoney(-1.005)).toBe(-1.01);
+    });
+
+    it("coerces unusable input to zero rather than NaN", () => {
+        expect(roundMoney(undefined)).toBe(0);
+        expect(roundMoney("not a price")).toBe(0);
+    });
+});
+
+describe("line pricing", () => {
+    it("keeps the subtotal equal to the sum of the rounded lines", () => {
+        // A third of a cent per unit: rounding each line and summing gives
+        // 3.03, while rounding one naive grand total gives 3.01. The lines are
+        // what the shopper sees, so the lines are what the subtotal follows.
+        const { lines, subtotal } = priceLineItems([
+            { id: "a", price: 0.335, qty: 3 },
+            { id: "b", price: 0.335, qty: 3 },
+            { id: "c", price: 0.335, qty: 3 }
+        ]);
+
+        expect(lines.map((line) => line.lineTotal)).toEqual([1.01, 1.01, 1.01]);
+        expect(subtotal).toBe(3.03);
+        expect(subtotal).not.toBe(3.01);
+    });
+
+    it("treats a missing or invalid quantity as one unit", () => {
+        const { subtotal } = priceLineItems([
+            { price: 10 },
+            { price: 10, qty: 0 },
+            { price: 10, qty: "x" }
+        ]);
+
+        expect(subtotal).toBe(30);
+    });
+});
+
+describe("discount application", () => {
+    it("caps a percentage discount at its maximum", () => {
+        expect(applyDiscount(percentagePromo(50, 100), 1000)).toEqual({
+            amount: 100,
+            isShippingWaived: false
+        });
+    });
+
+    it("applies the full percentage when no cap is set", () => {
+        expect(applyDiscount(percentagePromo(10), 1000).amount).toBe(100);
+    });
+
+    it("clamps a fixed discount to the amount being discounted", () => {
+        const promo = {
+            code: "BIG",
+            discount_type: "fixed",
+            discount_value: 500
+        };
+
+        expect(applyDiscount(promo, 200).amount).toBe(200);
+    });
+
+    it("waives shipping instead of discounting for a free_shipping promo", () => {
+        const promo = {
+            code: "FREESHIP",
+            discount_type: "free_shipping",
+            discount_value: 0
+        };
+
+        expect(applyDiscount(promo, 500)).toEqual({
+            amount: 0,
+            isShippingWaived: true
+        });
+    });
+
+    it("returns no discount when there is no promo", () => {
+        expect(applyDiscount(null, 500).amount).toBe(0);
+    });
+});
+
+describe("tax and shipping rules", () => {
+    it("taxes at the configured rate", () => {
+        expect(calculateTax(900)).toBe(
+            roundMoney(900 * PRICING_CONFIG.TAX_RATE)
+        );
+    });
+
+    it("never taxes a negative base", () => {
+        expect(calculateTax(-50)).toBe(0);
+    });
+
+    it("charges shipping just below the free-shipping threshold", () => {
+        expect(calculateShipping(PRICING_CONFIG.FREE_SHIPPING_THRESHOLD - 0.01))
+            .toBe(PRICING_CONFIG.SHIPPING_FLAT_RATE);
+    });
+
+    it("ships free at the threshold itself", () => {
+        expect(calculateShipping(PRICING_CONFIG.FREE_SHIPPING_THRESHOLD)).toBe(0);
+    });
+
+    it("does not charge shipping on an empty basket", () => {
+        expect(calculateShipping(0)).toBe(0);
+    });
+});
+
+describe("quote", () => {
+    it("applies the discount before tax", () => {
+        const breakdown = quote({
+            items: [{ id: "a", price: 1000, qty: 1 }],
+            promo: percentagePromo(10)
+        });
+
+        // Tax is 18% of 900, not of 1000. Were the discount applied after tax
+        // the tax would be 180 and the total 1080 rather than 1111, so this
+        // assertion flips the moment the ordering regresses.
+        expect(breakdown.discount).toBe(100);
+        expect(breakdown.taxableBase).toBe(900);
+        expect(breakdown.tax).toBe(162);
+        expect(breakdown.shipping).toBe(49);
+        expect(breakdown.total).toBe(1111);
+        expectReconciles(breakdown);
+    });
+
+    it("derives shipping from the post-discount subtotal", () => {
+        // 1200 would ship free on its own; after a 50% discount the basket
+        // falls under the threshold and shipping is due.
+        const breakdown = quote({
+            items: [{ id: "a", price: 1200, qty: 1 }],
+            promo: percentagePromo(50)
+        });
+
+        expect(breakdown.taxableBase).toBe(600);
+        expect(breakdown.shipping).toBe(PRICING_CONFIG.SHIPPING_FLAT_RATE);
+        expectReconciles(breakdown);
+    });
+
+    it("ships free at the threshold and charges a cent below it", () => {
+        const atThreshold = quote({
+            items: [
+                { id: "a", price: PRICING_CONFIG.FREE_SHIPPING_THRESHOLD, qty: 1 }
+            ]
+        });
+        const belowThreshold = quote({
+            items: [
+                {
+                    id: "a",
+                    price: PRICING_CONFIG.FREE_SHIPPING_THRESHOLD - 0.01,
+                    qty: 1
+                }
+            ]
+        });
+
+        expect(atThreshold.shipping).toBe(0);
+        expect(belowThreshold.shipping).toBe(PRICING_CONFIG.SHIPPING_FLAT_RATE);
+        expectReconciles(atThreshold);
+        expectReconciles(belowThreshold);
+    });
+
+    it("honours the maximum on a percentage promo", () => {
+        const breakdown = quote({
+            items: [{ id: "a", price: 500, qty: 2 }],
+            promo: percentagePromo(50, 100)
+        });
+
+        expect(breakdown.subtotal).toBe(1000);
+        expect(breakdown.discount).toBe(100);
+        expect(breakdown.taxableBase).toBe(900);
+        expectReconciles(breakdown);
+    });
+
+    it("cannot be discounted below zero by an oversized fixed promo", () => {
+        const breakdown = quote({
+            items: [{ id: "a", price: 200, qty: 1 }],
+            promo: {
+                code: "BIG",
+                discount_type: "fixed",
+                discount_value: 500
+            }
+        });
+
+        expect(breakdown.discount).toBe(200);
+        expect(breakdown.taxableBase).toBe(0);
+        expect(breakdown.tax).toBe(0);
+        expect(breakdown.shipping).toBe(0);
+        expect(breakdown.total).toBe(0);
+        expectReconciles(breakdown);
+    });
+
+    it("zeroes shipping for a free_shipping promo without touching the base", () => {
+        const breakdown = quote({
+            items: [{ id: "a", price: 500, qty: 1 }],
+            promo: {
+                code: "FREESHIP",
+                discount_type: "free_shipping",
+                discount_value: 0
+            }
+        });
+
+        expect(breakdown.discount).toBe(0);
+        expect(breakdown.taxableBase).toBe(500);
+        expect(breakdown.tax).toBe(90);
+        expect(breakdown.shipping).toBe(0);
+        expect(breakdown.total).toBe(590);
+        expectReconciles(breakdown);
+    });
+
+    it("returns an all-zero breakdown for an empty basket", () => {
+        const breakdown = quote({ items: [] });
+
+        expect(breakdown.lines).toEqual([]);
+        expect(breakdown.subtotal).toBe(0);
+        expect(breakdown.discount).toBe(0);
+        expect(breakdown.tax).toBe(0);
+        expect(breakdown.shipping).toBe(0);
+        expect(breakdown.total).toBe(0);
+        expectReconciles(breakdown);
+    });
+
+    it("reconciles when per-line rounding and whole-basket rounding disagree", () => {
+        const breakdown = quote({
+            items: [
+                { id: "a", price: 0.335, qty: 3 },
+                { id: "b", price: 0.335, qty: 3 },
+                { id: "c", price: 0.335, qty: 3 }
+            ]
+        });
+
+        expect(breakdown.subtotal).toBe(3.03);
+        expectReconciles(breakdown);
+    });
+
+    it("reports the currency and the ordering it applied", () => {
+        const breakdown = quote({ items: [{ id: "a", price: 100, qty: 1 }] });
+
+        expect(breakdown.currency).toBe(PRICING_CONFIG.CURRENCY);
+        expect(breakdown.appliedOrder).toEqual(["discount", "tax", "shipping"]);
+    });
+
+    it("echoes the promo code that was applied", () => {
+        const breakdown = quote({
+            items: [{ id: "a", price: 100, qty: 1 }],
+            promo: percentagePromo(10),
+            promoCode: "PCT"
+        });
+
+        expect(breakdown.promoCode).toBe("PCT");
+    });
+
+    it("tolerates being called with nothing at all", () => {
+        expect(quote().total).toBe(0);
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

Pricing rules currently exist in three places that disagree about what a total is, including the order in which discount, tax and shipping apply. This adds one place that owns those rules, expressed so they can be reasoned about and tested on their own.

The engine is deliberately inert: no existing caller changes, so behaviour is identical after this lands. It takes a basket and an already-validated promo and returns a full breakdown — per-line figures, subtotal, discount, taxable base, tax, shipping and total — along with the currency it was priced in.

Rounding becomes an explicit policy applied at one boundary, so line figures always reconcile exactly with the total instead of drifting by a fraction of a unit.

Where the existing paths disagreed, this follows what shoppers are currently shown: the discount applies before tax, and shipping is a function of the post-discount subtotal. That choice is recorded as configuration rather than being implied by the order of statements, so changing it later is a visible decision rather than an accident.

---

## 🔗 Related Issue

Part 1/4 of #1256

---

## 🛠️ Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Not applicable — nothing calls the engine yet, so there is no visible change.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

The ordering is pinned by a case whose total differs measurably if discount and tax are ever swapped, so a regression fails loudly rather than silently repricing every basket. Also covered: the free-shipping threshold on both sides, a percentage discount meeting its cap, a fixed discount larger than the basket, a promo that removes shipping, an empty basket, and amounts where naive per-line rounding would fail to reconcile with the total.

The engine has no database or logger dependency, so its tests need no fixtures or mocks.