### PR TITLE
fix: restore default system cursor by disabling custom cursor (#1303)

### DIFF
--- a/frontend/scripts/components.js
+++ b/frontend/scripts/components.js
@@ -123,27 +123,8 @@ const loadStylesheet = (
     );
 };
 
-const initializeCustomCursor = async () => {
-    await loadStylesheet(
-        "styles/custom-cursor.css"
-    );
-
-    await loadScript(
-        "scripts/custom-cursor.js"
-    );
-};
-
 // initialize components
 async function initializeComponents() {
-    try {
-        await initializeCustomCursor();
-    } catch (error) {
-        console.error(
-            "Failed to load custom cursor:",
-            error
-        );
-    }
-
     const loadTasks = [
         loadComponent(
             "navbar",

--- a/frontend/styles/custom-cursor.css
+++ b/frontend/styles/custom-cursor.css
@@ -7,7 +7,7 @@
     body.cursor-enhanced .pro,
     body.cursor-enhanced .fe-box,
     body.cursor-enhanced .banner-link {
-        cursor: none;
+        cursor: auto;
     }
 
     body.cursor-enhanced input,


### PR DESCRIPTION
## Summary

Restored the default system cursor by disabling the custom cursor initialization.

### Changes
- Removed custom cursor initialization from `frontend/scripts/components.js`
- Stopped loading `custom-cursor.js` and `custom-cursor.css`
- Restored the default browser cursor by replacing `cursor: none` with `cursor: auto`

### Testing
- Verified the default system cursor is displayed.
- Confirmed no custom cursor is initialized.
- Existing page interactions remain unaffected.

Fixes #1303