### PR TITLE
fix: the chat widget renders user-supplied message c... in...

### DIFF
--- a/frontend/scripts/chat-widget.js
+++ b/frontend/scripts/chat-widget.js
@@ -297,7 +297,7 @@ function renderMessage(msg) {
                 <i class="fas fa-user"></i>
             </div>
             <div class="message-info">
-                <span class="message-sender">${msg.sender_name || 'User'}</span>
+                <span class="message-sender">${AppUtils.escapeHTML(msg.sender_name || 'User')}</span>
                 ${content}
             </div>
         `;
@@ -312,14 +312,14 @@ function renderFileContent(file) {
     if (!file) return '';
     
     if (file.type && file.type.startsWith('image/')) {
-        return `<img src="${file.url || file.data}" alt="${file.name}" class="message-image" />`;
+        return `<img src="${AppUtils.escapeHTML(file.url || file.data)}" alt="${AppUtils.escapeHTML(file.name)}" class="message-image" />`;
     } else {
         return `
             <div class="file-attachment">
                 <i class="fas fa-file"></i>
-                <span class="file-name">${file.name}</span>
+                <span class="file-name">${AppUtils.escapeHTML(file.name)}</span>
                 <span class="file-size">${formatFileSize(file.size)}</span>
-                <a href="${file.url || file.data}" download="${file.name}" class="download-link">
+                <a href="${AppUtils.escapeHTML(file.url || file.data)}" download="${AppUtils.escapeHTML(file.name)}" class="download-link">
                     <i class="fas fa-download"></i>
                 </a>
             </div>
@@ -451,7 +451,7 @@ function markMessagesAsRead() {
 }
 
 function updateMessageReadStatus(data) {
-    const messageEl = document.querySelector(`[data-message-id="${data.messageId}"]`);
+    const messageEl = document.querySelector(`[data-message-id="${CSS.escape(String(data.messageId))}"]`);
     if (messageEl) {
         const status = messageEl.querySelector('.message-status');
         if (status) {


### PR DESCRIPTION
## Summary
Fix high severity security issue in `frontend/scripts/chat-widget.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `frontend/scripts/chat-widget.js:280` |
| **Assessment** | Likely exploitable |

**Description**: The chat widget renders user-supplied message content directly into the DOM using innerHTML without proper encoding. While msg.message is encoded via AppUtils.escapeHTML(), the msg.sender_name field is interpolated directly into the template string without encoding at line 323. Additionally, msg.file content is rendered via renderFileContent() which may not properly sanitize file names. An attacker can inject malicious JavaScript by crafting a message with a specially crafted sender_name or file object.

## Evidence

**Exploitation scenario**: An attacker sends a chat message with a crafted sender_name containing JavaScript payload: {"sender_name": "<img src=x onerror='alert(document.cookie)'>", "message": "test"}.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `frontend/scripts/chat-widget.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project builds successfully with this change applied.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
