### PR TITLE
Outbox Event Replay Double-Dispatch & Idempotency Expiration Vulnerability

### DIFF
--- a/backend/routes/outboxRoutes.js
+++ b/backend/routes/outboxRoutes.js
@@ -1,8 +1,26 @@
 // backend/routes/outboxRoutes.js
+// Issue #1263: Outbox admin routes + idempotency / stale-lock controls
 const express = require('express');
 const router = express.Router();
 const authMiddleware = require('../middleware/authMiddleware');
-const { outboxService } = require('../services/outboxService');
+const {
+    outboxService,
+    OUTBOX_CONFIG
+} = require('../services/outboxService');
+const {
+    consumerIdempotencyMiddleware
+} = require('../services/domainEventService');
+
+function requireAdmin(req, res) {
+    if (req.user?.role !== 'admin') {
+        res.status(403).json({
+            success: false,
+            error: 'Admin access required'
+        });
+        return false;
+    }
+    return true;
+}
 
 /**
  * GET /api/outbox/stats
@@ -10,12 +28,7 @@ const { outboxService } = require('../services/outboxService');
  */
 router.get('/stats', authMiddleware, async (req, res) => {
     try {
-        if (req.user.role !== 'admin') {
-            return res.status(403).json({
-                success: false,
-                error: 'Admin access required'
-            });
-        }
+        if (!requireAdmin(req, res)) return;
 
         const stats = await outboxService.getStatistics();
 
@@ -38,12 +51,7 @@ router.get('/stats', authMiddleware, async (req, res) => {
  */
 router.post('/retry', authMiddleware, async (req, res) => {
     try {
-        if (req.user.role !== 'admin') {
-            return res.status(403).json({
-                success: false,
-                error: 'Admin access required'
-            });
-        }
+        if (!requireAdmin(req, res)) return;
 
         await outboxService.retryFailedEvents();
 
@@ -80,5 +88,105 @@ router.get('/pending', authMiddleware, async (req, res) => {
         });
     }
 });
+
+/**
+ * POST /api/outbox/reset-stale-locks
+ * Manually reset PROCESSING rows older than 30 seconds (admin only)
+ */
+router.post('/reset-stale-locks', authMiddleware, async (req, res) => {
+    try {
+        if (!requireAdmin(req, res)) return;
+
+        const resetCount = await outboxService.resetStaleProcessingLocks();
+
+        res.json({
+            success: true,
+            message: 'Stale processing locks reset',
+            data: {
+                resetCount,
+                staleProcessingMs: OUTBOX_CONFIG.staleProcessingMs
+            }
+        });
+    } catch (error) {
+        console.error('Reset stale locks error:', error);
+        res.status(500).json({
+            success: false,
+            error: 'Failed to reset stale processing locks'
+        });
+    }
+});
+
+/**
+ * GET /api/outbox/idempotency/:key
+ * Inspect a consumer idempotency record (admin only)
+ */
+router.get('/idempotency/:key', authMiddleware, async (req, res) => {
+    try {
+        if (!requireAdmin(req, res)) return;
+
+        const record = await outboxService.getIdempotencyRecord(req.params.key);
+
+        if (!record) {
+            return res.status(404).json({
+                success: false,
+                message: 'Idempotency key not found'
+            });
+        }
+
+        res.json({
+            success: true,
+            data: record
+        });
+    } catch (error) {
+        console.error('Idempotency lookup error:', error);
+        res.status(500).json({
+            success: false,
+            error: 'Failed to lookup idempotency key'
+        });
+    }
+});
+
+/**
+ * POST /api/outbox/process
+ * Trigger one pending-event batch (admin only) — useful after lock resets
+ */
+router.post('/process', authMiddleware, async (req, res) => {
+    try {
+        if (!requireAdmin(req, res)) return;
+
+        await outboxService.processPendingEvents();
+
+        res.json({
+            success: true,
+            message: 'Outbox batch processing triggered'
+        });
+    } catch (error) {
+        console.error('Process trigger error:', error);
+        res.status(500).json({
+            success: false,
+            error: 'Failed to process pending events'
+        });
+    }
+});
+
+/**
+ * Example protected write path demonstrating consumer idempotency middleware.
+ * Clients should send Idempotency-Key header to prevent double side-effects.
+ */
+router.post(
+    '/demo/idempotent-action',
+    authMiddleware,
+    consumerIdempotencyMiddleware({
+        consumerName: 'outbox-demo',
+        requireKey: true
+    }),
+    async (req, res) => {
+        res.json({
+            success: true,
+            message: 'Idempotent action accepted',
+            idempotencyKey: req.idempotencyKey
+        });
+    }
+);
 
 module.exports = router;

--- a/backend/services/domainEventService.js
+++ b/backend/services/domainEventService.js
@@ -1,56 +1,81 @@
 // backend/services/domainEventService.js
+// Issue #1263: Attach UUID v5 idempotency keys + consumer-side verification
 const EventEmitter = require('events');
 const db = require('../config/db').promise;
+const { v5: uuidv5 } = require('uuid');
+const {
+    withIdempotency,
+    outboxService
+} = require('./outboxService');
 
 // ============================================
 // DOMAIN EVENTS CONFIGURATION
 // ============================================
 
 const DOMAIN_EVENTS = {
-    // Order events
     ORDER_CREATED: 'order.created',
     ORDER_UPDATED: 'order.updated',
     ORDER_CANCELLED: 'order.cancelled',
     ORDER_COMPLETED: 'order.completed',
     ORDER_PAYMENT_SUCCESS: 'order.payment.success',
     ORDER_PAYMENT_FAILED: 'order.payment.failed',
-    
-    // Product events
+
     PRODUCT_VIEWED: 'product.viewed',
     PRODUCT_ADDED: 'product.added',
     PRODUCT_UPDATED: 'product.updated',
     PRODUCT_REMOVED: 'product.removed',
     PRODUCT_REVIEWED: 'product.reviewed',
-    
-    // Wishlist events
+
     WISHLIST_ITEM_ADDED: 'wishlist.item.added',
     WISHLIST_ITEM_REMOVED: 'wishlist.item.removed',
-    
-    // Cart events
+
     CART_ITEM_ADDED: 'cart.item.added',
     CART_ITEM_REMOVED: 'cart.item.removed',
     CART_CLEARED: 'cart.cleared',
-    
-    // User events
+
     USER_REGISTERED: 'user.registered',
     USER_LOGGED_IN: 'user.logged.in',
     USER_LOGGED_OUT: 'user.logged.out',
     USER_UPDATED: 'user.updated',
-    
-    // Payment events
+
     PAYMENT_INITIATED: 'payment.initiated',
     PAYMENT_COMPLETED: 'payment.completed',
     PAYMENT_REFUNDED: 'payment.refunded',
-    
-    // Promo events
+
     COUPON_APPLIED: 'coupon.applied',
     COUPON_CREATED: 'coupon.created',
     COUPON_EXPIRED: 'coupon.expired',
-    
-    // Analytics events
+
     ANALYTICS_TRACK: 'analytics.track',
     ANALYTICS_PAGE_VIEW: 'analytics.page.view'
 };
+
+const DOMAIN_IDEMPOTENCY_NAMESPACE = uuidv5('ecommerce.domain.events', uuidv5.DNS);
+
+function isKnownEvent(eventName) {
+    return Object.values(DOMAIN_EVENTS).includes(eventName);
+}
+
+function extractEntityId(data = {}) {
+    return (
+        data.orderId ||
+        data.paymentId ||
+        data.productId ||
+        data.userId ||
+        data.entityId ||
+        data.id ||
+        null
+    );
+}
+
+/**
+ * UUID v5 idempotency key: Event Type + Entity ID + Timestamp
+ */
+function buildDomainIdempotencyKey(eventName, data, timestamp) {
+    const entityId = extractEntityId(data);
+    const ts = timestamp instanceof Date ? timestamp.toISOString() : String(timestamp || '');
+    return uuidv5(`${eventName}|${entityId || 'none'}|${ts}`, DOMAIN_IDEMPOTENCY_NAMESPACE);
+}
 
 // ============================================
 // DOMAIN EVENT SERVICE
@@ -68,10 +93,11 @@ class DomainEventService {
     }
 
     /**
-     * Register a subscriber for a domain event
+     * Register a subscriber. Pass context.idempotent=true (default for async)
+     * to wrap the handler with consumer-side idempotency checks.
      */
     subscribe(eventName, handler, context = {}) {
-        if (!DOMAIN_EVENTS[Object.keys(DOMAIN_EVENTS).find(key => DOMAIN_EVENTS[key] === eventName)]) {
+        if (!isKnownEvent(eventName)) {
             throw new Error(`Unknown event: ${eventName}`);
         }
 
@@ -79,74 +105,119 @@ class DomainEventService {
             this.subscribers.set(eventName, []);
         }
 
+        const consumerName = context.consumerName || `domain:${eventName}`;
+        const useIdempotency = context.idempotent !== false;
+
+        const guardedHandler = useIdempotency
+            ? withIdempotency(consumerName, async (normalized) => {
+                return handler(normalized.data, {
+                    ...context,
+                    event: normalized,
+                    idempotencyKey: normalized.idempotencyKey
+                });
+            })
+            : async (eventPayload) => handler(eventPayload.data || eventPayload, context);
+
         const subscription = {
             id: this.generateSubscriptionId(),
-            handler,
-            context,
+            handler: guardedHandler,
+            rawHandler: handler,
+            context: { ...context, consumerName, idempotent: useIdempotency },
             subscribedAt: new Date().toISOString()
         };
 
         this.subscribers.get(eventName).push(subscription);
-        
-        this.emitter.on(eventName, async (data) => {
+
+        this.emitter.on(eventName, async (envelope) => {
             try {
-                await handler(data, context);
+                await guardedHandler(envelope);
             } catch (error) {
                 console.error(`Error in subscriber for ${eventName}:`, error);
-                await this.logError(eventName, data, error);
+                await this.logError(eventName, envelope?.data || envelope, error);
             }
         });
 
-        console.log(`✅ Subscriber registered for: ${eventName}`);
+        console.log(`✅ Subscriber registered for: ${eventName} (idempotent=${useIdempotency})`);
         return subscription;
     }
 
     /**
-     * Emit a domain event
+     * Emit a domain event with an attached UUID v5 idempotency key.
+     * Optionally mirrors the event into the transactional outbox.
      */
     async emit(eventName, data, metadata = {}) {
-        if (!DOMAIN_EVENTS[Object.keys(DOMAIN_EVENTS).find(key => DOMAIN_EVENTS[key] === eventName)]) {
+        if (!isKnownEvent(eventName)) {
             throw new Error(`Unknown event: ${eventName}`);
         }
+
+        const timestamp = metadata.timestamp || new Date().toISOString();
+        const entityId = extractEntityId(data);
+        const idempotencyKey =
+            metadata.idempotencyKey ||
+            buildDomainIdempotencyKey(eventName, data, timestamp);
 
         const event = {
             id: this.generateEventId(),
             name: eventName,
+            type: eventName,
             data,
+            entityId,
+            idempotencyKey,
             metadata: {
                 ...metadata,
-                timestamp: new Date().toISOString(),
+                timestamp,
+                entityId,
+                idempotencyKey,
                 source: metadata.source || 'application'
             },
+            createdAt: timestamp,
             status: 'pending'
         };
 
-        // Log event
         await this.logEvent(event);
-
-        // Store in memory
         this.eventHistory.push(event);
 
-        // Emit synchronously (for immediate effects)
-        this.emitter.emit(eventName, data);
+        // Persist to outbox when explicitly requested (durable dispatch path)
+        if (metadata.useOutbox === true) {
+            try {
+                await outboxService.storeEvent(eventName, data, {
+                    ...event.metadata,
+                    eventTimestamp: timestamp,
+                    domainEventId: event.id
+                });
+            } catch (error) {
+                console.error('Outbox mirror failed:', error.message);
+            }
+        }
 
-        // Process async subscribers
-        this.processAsyncSubscribers(event);
+        // Emit envelope (not raw data) so consumers receive idempotencyKey
+        const envelope = {
+            id: event.id,
+            name: eventName,
+            type: eventName,
+            data,
+            entityId,
+            idempotencyKey,
+            metadata: event.metadata,
+            createdAt: timestamp
+        };
 
-        console.log(`📡 Event emitted: ${eventName}`);
+        this.emitter.emit(eventName, envelope);
+        this.processAsyncSubscribers(envelope);
+
+        console.log(`📡 Event emitted: ${eventName} key=${idempotencyKey}`);
         return event;
     }
 
-    /**
-     * Process async subscribers
-     */
     async processAsyncSubscribers(event) {
         const subscribers = this.subscribers.get(event.name) || [];
-        const asyncSubscribers = subscribers.filter(s => s.context.async !== false);
+        // Emitter already invoked handlers; this path covers explicit async fan-out
+        // for subscribers registered with context.asyncFanout=true only.
+        const asyncSubscribers = subscribers.filter((s) => s.context.asyncFanout === true);
 
         for (const subscriber of asyncSubscribers) {
             try {
-                await subscriber.handler(event.data, subscriber.context);
+                await subscriber.handler(event);
             } catch (error) {
                 console.error(`Async subscriber error for ${event.name}:`, error);
                 await this.logError(event.name, event.data, error);
@@ -154,37 +225,29 @@ class DomainEventService {
         }
     }
 
-    /**
-     * Get all events
-     */
     getEvents(filter = {}) {
         let events = this.eventHistory;
 
         if (filter.eventName) {
-            events = events.filter(e => e.name === filter.eventName);
+            events = events.filter((e) => e.name === filter.eventName);
         }
-
         if (filter.fromDate) {
-            events = events.filter(e => e.metadata.timestamp >= filter.fromDate);
+            events = events.filter((e) => e.metadata.timestamp >= filter.fromDate);
         }
-
         if (filter.toDate) {
-            events = events.filter(e => e.metadata.timestamp <= filter.toDate);
+            events = events.filter((e) => e.metadata.timestamp <= filter.toDate);
+        }
+        if (filter.idempotencyKey) {
+            events = events.filter((e) => e.idempotencyKey === filter.idempotencyKey);
         }
 
         return events.slice(-100);
     }
 
-    /**
-     * Get subscribers
-     */
     getSubscribers(eventName) {
         return this.subscribers.get(eventName) || [];
     }
 
-    /**
-     * Get event statistics
-     */
     getStatistics() {
         const stats = {
             totalEvents: this.eventHistory.length,
@@ -193,12 +256,10 @@ class DomainEventService {
             eventQueueSize: this.eventQueue.length
         };
 
-        // Count events by type
         for (const event of this.eventHistory) {
             stats.eventsByType[event.name] = (stats.eventsByType[event.name] || 0) + 1;
         }
 
-        // Count subscribers by type
         for (const [eventName, subscribers] of this.subscribers) {
             stats.subscribersByType[eventName] = subscribers.length;
         }
@@ -206,22 +267,18 @@ class DomainEventService {
         return stats;
     }
 
-    /**
-     * Get status
-     */
     getStatus() {
         return {
             totalEvents: this.eventHistory.length,
-            totalSubscribers: Array.from(this.subscribers.values()).reduce((sum, s) => sum + s.length, 0),
+            totalSubscribers: Array.from(this.subscribers.values()).reduce(
+                (sum, s) => sum + s.length,
+                0
+            ),
             eventTypes: Object.keys(DOMAIN_EVENTS),
             isProcessing: this.isProcessing,
             queueSize: this.eventQueue.length
         };
     }
-
-    // ============================================
-    // HELPER FUNCTIONS
-    // ============================================
 
     generateEventId() {
         return `EVT_${Date.now()}_${Math.random().toString(36).substr(2, 6)}`;
@@ -234,7 +291,7 @@ class DomainEventService {
     async logEvent(event) {
         try {
             await db.query(
-                `INSERT INTO domain_events_log 
+                `INSERT INTO domain_events_log
                  (event_id, event_name, event_data, metadata, status, created_at)
                  VALUES (?, ?, ?, ?, ?, NOW())`,
                 [
@@ -253,7 +310,7 @@ class DomainEventService {
     async logError(eventName, data, error) {
         try {
             await db.query(
-                `INSERT INTO domain_event_errors 
+                `INSERT INTO domain_event_errors
                  (event_name, event_data, error_message, error_stack, created_at)
                  VALUES (?, ?, ?, ?, NOW())`,
                 [
@@ -268,13 +325,10 @@ class DomainEventService {
         }
     }
 
-    /**
-     * Clear old events
-     */
     async clearOldEvents(days = 30) {
         try {
             await db.query(
-                `DELETE FROM domain_events_log 
+                `DELETE FROM domain_events_log
                  WHERE created_at < DATE_SUB(NOW(), INTERVAL ? DAY)`,
                 [days]
             );
@@ -285,17 +339,92 @@ class DomainEventService {
     }
 }
 
-// ============================================
-// DOMAIN EVENT SUBSCRIBERS
-// ============================================
+/**
+ * Express middleware: require / attach Idempotency-Key for mutating APIs
+ * that publish domain events. Rejects replayed keys that are still active.
+ */
+function consumerIdempotencyMiddleware(options = {}) {
+    const {
+        headerName = 'idempotency-key',
+        consumerName = 'http-api',
+        requireKey = false
+    } = options;
+
+    return async (req, res, next) => {
+        try {
+            const headerKey =
+                req.headers[headerName] ||
+                req.headers['x-idempotency-key'] ||
+                req.body?.idempotencyKey;
+
+            if (!headerKey && requireKey) {
+                return res.status(400).json({
+                    success: false,
+                    message: 'Idempotency-Key header is required'
+                });
+            }
+
+            if (!headerKey) {
+                return next();
+            }
+
+            const syntheticEvent = {
+                id: `HTTP_${headerKey}`,
+                type: `${req.method}:${req.path}`,
+                data: req.body || {},
+                idempotencyKey: String(headerKey)
+            };
+
+            const claim = await outboxService.claimConsumerIdempotency(
+                String(headerKey),
+                syntheticEvent,
+                consumerName
+            );
+
+            if (!claim.proceed) {
+                return res.status(409).json({
+                    success: false,
+                    message: 'Duplicate request rejected by idempotency guard',
+                    reason: claim.reason,
+                    idempotencyKey: headerKey
+                });
+            }
+
+            req.idempotencyKey = String(headerKey);
+            req.idempotencyConsumer = consumerName;
+
+            const originalJson = res.json.bind(res);
+            res.json = async function idempotentJson(payload) {
+                try {
+                    if (res.statusCode >= 200 && res.statusCode < 300) {
+                        await outboxService.completeConsumerIdempotency(
+                            String(headerKey),
+                            consumerName
+                        );
+                    }
+                } catch (err) {
+                    console.error('Idempotency completion error:', err.message);
+                }
+                return originalJson(payload);
+            };
+
+            return next();
+        } catch (error) {
+            console.error('Idempotency middleware error:', error);
+            return res.status(500).json({
+                success: false,
+                message: 'Idempotency check failed'
+            });
+        }
+    };
+}
 
 const domainEventService = new DomainEventService();
 
-// ============================================
-// EXPORT
-// ============================================
-
 module.exports = {
     domainEventService,
-    DOMAIN_EVENTS
+    DOMAIN_EVENTS,
+    buildDomainIdempotencyKey,
+    consumerIdempotencyMiddleware,
+    withIdempotency
 };

--- a/backend/services/outboxService.js
+++ b/backend/services/outboxService.js
@@ -1,25 +1,32 @@
 // backend/services/outboxService.js
+// Issue #1263: Outbox double-dispatch & idempotency expiration guards
 const db = require('../config/db');
 const crypto = require('crypto');
+const { v5: uuidv5 } = require('uuid');
 
 // ============================================
 // OUTBOX CONFIGURATION
 // ============================================
 
 const OUTBOX_CONFIG = {
-    // Polling configuration
-    pollInterval: 5000, // 5 seconds
+    pollInterval: 5000,
     batchSize: 100,
     maxRetries: 5,
-    retryDelay: 30000, // 30 seconds
-    
-    // Event retention
+    retryDelay: 30000,
+
     retentionDays: 7,
-    cleanupInterval: 3600000, // 1 hour
-    
-    // Processing
-    processingTimeout: 60000, // 1 minute
-    concurrentProcessors: 3
+    cleanupInterval: 3600000,
+
+    processingTimeout: 60000,
+    // Stale PROCESSING locks are released after 30s (issue #1263)
+    staleProcessingMs: 30000,
+    staleResetInterval: 10000,
+    concurrentProcessors: 3,
+
+    // Completed idempotency keys must outlive outbox retention to avoid
+    // the "idempotency expiration → re-dispatch" vulnerability.
+    idempotencyTtlDays: 14,
+    idempotencyProcessingTtlMs: 30000
 };
 
 const OUTBOX_STATUS = {
@@ -28,6 +35,12 @@ const OUTBOX_STATUS = {
     COMPLETED: 'completed',
     FAILED: 'failed',
     RETRY: 'retry'
+};
+
+const IDEMPOTENCY_STATUS = {
+    PROCESSING: 'processing',
+    COMPLETED: 'completed',
+    EXPIRED: 'expired'
 };
 
 const EVENT_TYPES = {
@@ -47,6 +60,9 @@ const EVENT_TYPES = {
     RECOMMENDATION_UPDATED: 'recommendation.updated'
 };
 
+// Stable namespace for UUID v5 idempotency keys
+const IDEMPOTENCY_NAMESPACE = uuidv5('ecommerce.outbox.idempotency', uuidv5.DNS);
+
 // ============================================
 // OUTBOX SERVICE
 // ============================================
@@ -61,35 +77,29 @@ class OutboxService {
             processed: 0,
             failed: 0,
             retried: 0,
-            total: 0
+            total: 0,
+            skippedDuplicate: 0,
+            optimisticLockConflicts: 0,
+            staleLocksReset: 0
         };
         this.pollInterval = null;
         this.cleanupInterval = null;
+        this.staleResetInterval = null;
     }
 
-    /**
-     * Initialize outbox service
-     */
     async initialize() {
         if (this.isRunning) return;
 
-        // Register default event handlers
         this.registerDefaultHandlers();
-
-        // Start polling
         this.startPolling();
-
-        // Start cleanup
         this.startCleanup();
+        this.startStaleLockReset();
 
         this.isRunning = true;
-        console.log('✅ Outbox Service initialized');
+        console.log('✅ Outbox Service initialized (idempotent dispatch enabled)');
         return this;
     }
 
-    /**
-     * Register an event handler
-     */
     registerHandler(eventType, handler) {
         if (!this.eventHandlers.has(eventType)) {
             this.eventHandlers.set(eventType, []);
@@ -98,11 +108,7 @@ class OutboxService {
         console.log(`✅ Handler registered for: ${eventType}`);
     }
 
-    /**
-     * Register default event handlers
-     */
     registerDefaultHandlers() {
-        // Order event handlers
         this.registerHandler(EVENT_TYPES.ORDER_CREATED, async (event) => {
             console.log(`📦 Order created: ${event.data.orderId}`);
             await this.processOrderCreated(event.data);
@@ -118,52 +124,101 @@ class OutboxService {
             await this.processPaymentCompleted(event.data);
         });
 
-        // Notification handlers
         this.registerHandler(EVENT_TYPES.NOTIFICATION_SENT, async (event) => {
             console.log(`📧 Notification sent: ${event.data.notificationId}`);
         });
 
-        // Analytics handlers
         this.registerHandler(EVENT_TYPES.ANALYTICS_TRACKED, async (event) => {
             console.log(`📊 Analytics tracked: ${event.data.eventType}`);
         });
 
-        // Recommendation handlers
         this.registerHandler(EVENT_TYPES.RECOMMENDATION_UPDATED, async (event) => {
             console.log(`🎯 Recommendations updated for user: ${event.data.userId}`);
         });
     }
 
     /**
-     * Store event in outbox
+     * Deterministic UUID v5 from Event Type + Entity ID + Timestamp.
      */
+    generateIdempotencyKey(eventType, entityId, timestamp) {
+        const ts = timestamp instanceof Date ? timestamp.toISOString() : String(timestamp || '');
+        const name = `${eventType}|${entityId || 'none'}|${ts}`;
+        return uuidv5(name, IDEMPOTENCY_NAMESPACE);
+    }
+
+    extractEntityId(data = {}) {
+        return (
+            data.orderId ||
+            data.paymentId ||
+            data.productId ||
+            data.userId ||
+            data.notificationId ||
+            data.entityId ||
+            data.id ||
+            null
+        );
+    }
+
     async storeEvent(eventType, data, metadata = {}) {
+        const createdAt = new Date();
+        const entityId = this.extractEntityId(data);
+        const idempotencyKey = this.generateIdempotencyKey(
+            eventType,
+            entityId,
+            metadata.eventTimestamp || createdAt.toISOString()
+        );
+
         const event = {
             id: this.generateEventId(),
             type: eventType,
+            entityId,
+            idempotencyKey,
             data,
-            metadata,
+            metadata: {
+                ...metadata,
+                idempotencyKey,
+                entityId
+            },
             status: OUTBOX_STATUS.PENDING,
+            version: 0,
             attempts: 0,
             maxAttempts: OUTBOX_CONFIG.maxRetries,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
+            createdAt: createdAt.toISOString(),
+            updatedAt: createdAt.toISOString(),
             processedAt: null,
             error: null
         };
 
         try {
+            const [existing] = await db.query(
+                `SELECT event_id, status FROM outbox_events WHERE idempotency_key = ? LIMIT 1`,
+                [idempotencyKey]
+            );
+            if (existing.length > 0) {
+                console.log(`♻️ Duplicate outbox store skipped: ${idempotencyKey}`);
+                this.stats.skippedDuplicate++;
+                return {
+                    ...event,
+                    id: existing[0].event_id,
+                    status: existing[0].status,
+                    duplicate: true
+                };
+            }
+
             await db.query(
-                `INSERT INTO outbox_events 
-                 (event_id, event_type, data, metadata, status, attempts, 
-                  max_attempts, created_at, updated_at)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                `INSERT INTO outbox_events
+                 (event_id, event_type, entity_id, idempotency_key, data, metadata,
+                  status, version, attempts, max_attempts, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
                 [
                     event.id,
                     event.type,
+                    event.entityId,
+                    event.idempotencyKey,
                     JSON.stringify(event.data),
                     JSON.stringify(event.metadata),
                     event.status,
+                    event.version,
                     event.attempts,
                     event.maxAttempts,
                     event.createdAt,
@@ -172,83 +227,258 @@ class OutboxService {
             );
 
             this.stats.total++;
-            console.log(`📝 Event stored: ${event.type} (${event.id})`);
-
+            console.log(`📝 Event stored: ${event.type} (${event.id}) key=${event.idempotencyKey}`);
             return event;
         } catch (error) {
+            if (error.code === 'ER_DUP_ENTRY') {
+                this.stats.skippedDuplicate++;
+                console.log(`♻️ Duplicate outbox insert ignored for key ${idempotencyKey}`);
+                return { ...event, duplicate: true };
+            }
             console.error('Store event error:', error);
             throw error;
         }
     }
 
-    /**
-     * Start polling for pending events
-     */
     startPolling() {
         if (this.pollInterval) return;
-
         this.pollInterval = setInterval(() => {
             this.processPendingEvents();
         }, OUTBOX_CONFIG.pollInterval);
-
-        // Initial processing
         setTimeout(() => this.processPendingEvents(), 1000);
     }
 
-    /**
-     * Start cleanup
-     */
     startCleanup() {
         if (this.cleanupInterval) return;
-
         this.cleanupInterval = setInterval(() => {
             this.cleanupOldEvents();
         }, OUTBOX_CONFIG.cleanupInterval);
     }
 
-    /**
-     * Process pending events
-     */
-    async processPendingEvents() {
-        const connection = await db.getConnection();
-        try {
-            await connection.query('START TRANSACTION');
+    startStaleLockReset() {
+        if (this.staleResetInterval) return;
+        this.staleResetInterval = setInterval(() => {
+            this.resetStaleProcessingLocks().catch((err) => {
+                console.error('Stale lock reset error:', err);
+            });
+        }, OUTBOX_CONFIG.staleResetInterval);
+        setTimeout(() => this.resetStaleProcessingLocks(), 2000);
+    }
 
-            // Get pending events using SKIP LOCKED to prevent race conditions
+    async resetStaleProcessingLocks() {
+        const staleSeconds = Math.floor(OUTBOX_CONFIG.staleProcessingMs / 1000);
+
+        const [result] = await db.query(
+            `UPDATE outbox_events
+             SET status = ?,
+                 processing_started_at = NULL,
+                 version = version + 1,
+                 updated_at = NOW(),
+                 error = COALESCE(error, 'Stale processing lock reset')
+             WHERE status = ?
+               AND processing_started_at IS NOT NULL
+               AND processing_started_at < DATE_SUB(NOW(), INTERVAL ? SECOND)`,
+            [OUTBOX_STATUS.RETRY, OUTBOX_STATUS.PROCESSING, staleSeconds]
+        );
+
+        if (result.affectedRows > 0) {
+            this.stats.staleLocksReset += result.affectedRows;
+            console.log(`🔓 Reset ${result.affectedRows} stale outbox processing lock(s)`);
+        }
+
+        await db.query(
+            `UPDATE outbox_idempotency_keys
+             SET status = ?
+             WHERE status = ?
+               AND expires_at < NOW()`,
+            [IDEMPOTENCY_STATUS.EXPIRED, IDEMPOTENCY_STATUS.PROCESSING]
+        );
+
+        return result.affectedRows || 0;
+    }
+
+    async claimEventWithOptimisticLock(eventId, expectedVersion) {
+        const [result] = await db.query(
+            `UPDATE outbox_events
+             SET status = ?,
+                 version = version + 1,
+                 processing_started_at = NOW(),
+                 updated_at = NOW()
+             WHERE event_id = ?
+               AND version = ?
+               AND status IN (?, ?)`,
+            [
+                OUTBOX_STATUS.PROCESSING,
+                eventId,
+                expectedVersion,
+                OUTBOX_STATUS.PENDING,
+                OUTBOX_STATUS.RETRY
+            ]
+        );
+
+        if (result.affectedRows === 0) {
+            this.stats.optimisticLockConflicts++;
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Consumer-side idempotency claim.
+     * Also guards against expired-key replay by checking outbox COMPLETED status.
+     */
+    async claimConsumerIdempotency(idempotencyKey, event, consumerName = 'default') {
+        if (!idempotencyKey) {
+            return { proceed: true, reason: 'missing_key' };
+        }
+
+        const [outboxRows] = await db.query(
+            `SELECT status FROM outbox_events WHERE event_id = ? LIMIT 1`,
+            [event.id]
+        );
+        if (outboxRows[0]?.status === OUTBOX_STATUS.COMPLETED) {
+            return { proceed: false, reason: 'outbox_already_completed' };
+        }
+
+        const [existing] = await db.query(
+            `SELECT status, expires_at, consumer_name
+             FROM outbox_idempotency_keys
+             WHERE idempotency_key = ? AND consumer_name = ?
+             LIMIT 1`,
+            [idempotencyKey, consumerName]
+        );
+
+        if (existing.length > 0) {
+            const row = existing[0];
+            const expired = new Date(row.expires_at).getTime() < Date.now();
+
+            if (row.status === IDEMPOTENCY_STATUS.COMPLETED) {
+                return { proceed: false, reason: 'idempotency_completed' };
+            }
+
+            if (row.status === IDEMPOTENCY_STATUS.PROCESSING && !expired) {
+                return { proceed: false, reason: 'idempotency_in_flight' };
+            }
+
+            await db.query(
+                `UPDATE outbox_idempotency_keys
+                 SET status = ?,
+                     event_id = ?,
+                     event_type = ?,
+                     expires_at = DATE_ADD(NOW(), INTERVAL ? SECOND),
+                     completed_at = NULL
+                 WHERE idempotency_key = ?
+                   AND consumer_name = ?
+                   AND status IN (?, ?)`,
+                [
+                    IDEMPOTENCY_STATUS.PROCESSING,
+                    event.id,
+                    event.type,
+                    Math.floor(OUTBOX_CONFIG.idempotencyProcessingTtlMs / 1000),
+                    idempotencyKey,
+                    consumerName,
+                    IDEMPOTENCY_STATUS.PROCESSING,
+                    IDEMPOTENCY_STATUS.EXPIRED
+                ]
+            );
+            return { proceed: true, reason: 'reclaimed_expired' };
+        }
+
+        try {
+            await db.query(
+                `INSERT INTO outbox_idempotency_keys
+                 (idempotency_key, event_id, event_type, consumer_name, status, expires_at)
+                 VALUES (?, ?, ?, ?, ?, DATE_ADD(NOW(), INTERVAL ? SECOND))`,
+                [
+                    idempotencyKey,
+                    event.id,
+                    event.type,
+                    consumerName,
+                    IDEMPOTENCY_STATUS.PROCESSING,
+                    Math.floor(OUTBOX_CONFIG.idempotencyProcessingTtlMs / 1000)
+                ]
+            );
+            return { proceed: true, reason: 'claimed' };
+        } catch (error) {
+            if (error.code === 'ER_DUP_ENTRY') {
+                return { proceed: false, reason: 'idempotency_race' };
+            }
+            throw error;
+        }
+    }
+
+    async completeConsumerIdempotency(idempotencyKey, consumerName = 'default') {
+        if (!idempotencyKey) return;
+
+        await db.query(
+            `UPDATE outbox_idempotency_keys
+             SET status = ?,
+                 completed_at = NOW(),
+                 expires_at = DATE_ADD(NOW(), INTERVAL ? DAY)
+             WHERE idempotency_key = ?
+               AND consumer_name = ?`,
+            [
+                IDEMPOTENCY_STATUS.COMPLETED,
+                OUTBOX_CONFIG.idempotencyTtlDays,
+                idempotencyKey,
+                consumerName
+            ]
+        );
+    }
+
+    async processPendingEvents() {
+        let connection;
+        try {
+            await this.resetStaleProcessingLocks();
+
+            connection = await db.getConnection();
+            await connection.beginTransaction();
+
             const [events] = await connection.query(
-                `SELECT * FROM outbox_events 
+                `SELECT * FROM outbox_events
                  WHERE status IN (?, ?)
-                 AND attempts < max_attempts
+                   AND attempts < max_attempts
                  ORDER BY created_at ASC
                  LIMIT ?
                  FOR UPDATE SKIP LOCKED`,
                 [OUTBOX_STATUS.PENDING, OUTBOX_STATUS.RETRY, OUTBOX_CONFIG.batchSize]
             );
 
-            if (events.length === 0) {
-                await connection.query('COMMIT');
-                connection.release();
-                return;
-            }
-
-            // Mark events as processing atomically
-            const eventIds = events.map(e => e.event_id);
-            await connection.query(
-                `UPDATE outbox_events SET status = ? WHERE event_id IN (?)`,
-                [OUTBOX_STATUS.PROCESSING, eventIds]
-            );
-
-            await connection.query('COMMIT');
+            await connection.commit();
             connection.release();
+            connection = null;
 
-            // Process each event
+            if (events.length === 0) return;
+
             for (const eventRow of events) {
+                const claimed = await this.claimEventWithOptimisticLock(
+                    eventRow.event_id,
+                    eventRow.version
+                );
+                if (!claimed) {
+                    console.log(`⏭️ Skipped event ${eventRow.event_id} (optimistic lock miss)`);
+                    continue;
+                }
+
                 const event = {
                     id: eventRow.event_id,
                     type: eventRow.event_type,
-                    data: JSON.parse(eventRow.data),
-                    metadata: JSON.parse(eventRow.metadata || '{}'),
+                    entityId: eventRow.entity_id,
+                    idempotencyKey:
+                        eventRow.idempotency_key ||
+                        this.generateIdempotencyKey(
+                            eventRow.event_type,
+                            eventRow.entity_id,
+                            eventRow.created_at
+                        ),
+                    data: typeof eventRow.data === 'string'
+                        ? JSON.parse(eventRow.data)
+                        : eventRow.data,
+                    metadata: typeof eventRow.metadata === 'string'
+                        ? JSON.parse(eventRow.metadata || '{}')
+                        : (eventRow.metadata || {}),
                     status: OUTBOX_STATUS.PROCESSING,
+                    version: (eventRow.version || 0) + 1,
                     attempts: eventRow.attempts,
                     maxAttempts: eventRow.max_attempts,
                     createdAt: eventRow.created_at,
@@ -260,69 +490,112 @@ class OutboxService {
             }
         } catch (error) {
             if (connection) {
-                await connection.query('ROLLBACK');
+                try {
+                    await connection.rollback();
+                } catch (_) {
+                    /* ignore */
+                }
                 connection.release();
             }
             console.error('Process pending events error:', error);
         }
     }
 
-    /**
-     * Process a single event
-     */
     async processEvent(event) {
-        // Update status to processing
-        await this.updateEventStatus(event.id, OUTBOX_STATUS.PROCESSING);
+        const consumerName = 'outbox-dispatcher';
+        const claim = await this.claimConsumerIdempotency(
+            event.idempotencyKey,
+            event,
+            consumerName
+        );
+
+        if (!claim.proceed) {
+            this.stats.skippedDuplicate++;
+            console.log(`♻️ Skipping duplicate dispatch ${event.id} (${claim.reason})`);
+            if (
+                claim.reason === 'idempotency_completed' ||
+                claim.reason === 'outbox_already_completed'
+            ) {
+                await this.updateEventStatus(event.id, OUTBOX_STATUS.COMPLETED, {
+                    versionGuard: event.version
+                });
+            }
+            return { skipped: true, reason: claim.reason };
+        }
 
         try {
-            // Get handlers for this event type
             const handlers = this.eventHandlers.get(event.type) || [];
 
             if (handlers.length === 0) {
                 console.warn(`No handlers for event type: ${event.type}`);
-                await this.updateEventStatus(event.id, OUTBOX_STATUS.COMPLETED);
-                return;
+                await this.updateEventStatus(event.id, OUTBOX_STATUS.COMPLETED, {
+                    versionGuard: event.version
+                });
+                await this.completeConsumerIdempotency(event.idempotencyKey, consumerName);
+                return { skipped: false, handlers: 0 };
             }
 
-            // Execute all handlers
             for (const handler of handlers) {
                 await handler(event);
             }
 
-            // Update status to completed
-            await this.updateEventStatus(event.id, OUTBOX_STATUS.COMPLETED);
+            const completed = await this.updateEventStatus(
+                event.id,
+                OUTBOX_STATUS.COMPLETED,
+                { versionGuard: event.version }
+            );
+
+            if (!completed) {
+                console.warn(`⚠️ Completion lock lost for ${event.id}`);
+                return { skipped: false, lockLost: true };
+            }
+
+            await this.completeConsumerIdempotency(event.idempotencyKey, consumerName);
             this.stats.processed++;
-
             console.log(`✅ Event processed: ${event.type} (${event.id})`);
-
+            return { skipped: false, processed: true };
         } catch (error) {
             console.error(`Error processing event ${event.id}:`, error);
 
-            // Increment attempts
             const newAttempts = event.attempts + 1;
-            const newStatus = newAttempts >= event.maxAttempts 
-                ? OUTBOX_STATUS.FAILED 
-                : OUTBOX_STATUS.RETRY;
+            const newStatus =
+                newAttempts >= event.maxAttempts
+                    ? OUTBOX_STATUS.FAILED
+                    : OUTBOX_STATUS.RETRY;
 
             await this.updateEventStatus(event.id, newStatus, {
                 attempts: newAttempts,
                 error: error.message,
-                updatedAt: new Date().toISOString()
+                versionGuard: event.version,
+                clearProcessingLock: true
             });
+
+            await db.query(
+                `UPDATE outbox_idempotency_keys
+                 SET status = ?, expires_at = NOW()
+                 WHERE idempotency_key = ? AND consumer_name = ? AND status = ?`,
+                [
+                    IDEMPOTENCY_STATUS.EXPIRED,
+                    event.idempotencyKey,
+                    consumerName,
+                    IDEMPOTENCY_STATUS.PROCESSING
+                ]
+            );
 
             if (newStatus === OUTBOX_STATUS.FAILED) {
                 this.stats.failed++;
                 console.error(`💀 Event permanently failed: ${event.type} (${event.id})`);
             } else {
                 this.stats.retried++;
-                console.log(`🔄 Event retrying: ${event.type} (${event.id}) attempt ${newAttempts}`);
+                console.log(
+                    `🔄 Event retrying: ${event.type} (${event.id}) attempt ${newAttempts}`
+                );
             }
+
+            return { skipped: false, failed: true, error: error.message };
         }
     }
 
-    /**
-     * Update event status
-     */
     async updateEventStatus(eventId, status, additional = {}) {
         const updates = {
             status,
@@ -334,38 +607,64 @@ class OutboxService {
             updates.processedAt = new Date().toISOString();
         }
 
-        await db.query(
-            `UPDATE outbox_events 
-             SET status = ?, 
-                 attempts = COALESCE(?, attempts),
-                 error = COALESCE(?, error),
-                 processed_at = COALESCE(?, processed_at),
-                 updated_at = ?
-             WHERE event_id = ?`,
-            [
-                status,
-                additional.attempts || null,
-                additional.error || null,
-                updates.processedAt || null,
-                updates.updatedAt,
-                eventId
-            ]
-        );
+        const params = [
+            status,
+            additional.attempts != null ? additional.attempts : null,
+            additional.error != null ? additional.error : null,
+            updates.processedAt || null,
+            updates.updatedAt
+        ];
+
+        let sql = `UPDATE outbox_events
+                   SET status = ?,
+                       attempts = COALESCE(?, attempts),
+                       error = COALESCE(?, error),
+                       processed_at = COALESCE(?, processed_at),
+                       updated_at = ?,
+                       version = version + 1`;
+
+        if (
+            status === OUTBOX_STATUS.COMPLETED ||
+            status === OUTBOX_STATUS.FAILED ||
+            status === OUTBOX_STATUS.RETRY ||
+            additional.clearProcessingLock
+        ) {
+            sql += `, processing_started_at = NULL`;
+        }
+
+        sql += ` WHERE event_id = ?`;
+        params.push(eventId);
+
+        if (additional.versionGuard != null) {
+            sql += ` AND version = ?`;
+            params.push(additional.versionGuard);
+        }
+
+        const [result] = await db.query(sql, params);
+        if (result.affectedRows === 0 && additional.versionGuard != null) {
+            this.stats.optimisticLockConflicts++;
+            return false;
+        }
+        return true;
     }
 
-    /**
-     * Clean up old events
-     */
     async cleanupOldEvents() {
         try {
             const cutoff = new Date();
             cutoff.setDate(cutoff.getDate() - OUTBOX_CONFIG.retentionDays);
 
             const [result] = await db.query(
-                `DELETE FROM outbox_events 
+                `DELETE FROM outbox_events
                  WHERE status IN (?, ?)
-                 AND updated_at < ?`,
+                   AND updated_at < ?`,
                 [OUTBOX_STATUS.COMPLETED, OUTBOX_STATUS.FAILED, cutoff.toISOString()]
+            );
+
+            await db.query(
+                `DELETE FROM outbox_idempotency_keys
+                 WHERE status = ?
+                   AND expires_at < NOW()`,
+                [IDEMPOTENCY_STATUS.COMPLETED]
             );
 
             if (result.affectedRows > 0) {
@@ -376,13 +675,10 @@ class OutboxService {
         }
     }
 
-    /**
-     * Get event statistics
-     */
     async getStatistics() {
         try {
             const [stats] = await db.query(
-                `SELECT 
+                `SELECT
                     COUNT(*) as total,
                     SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) as pending,
                     SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) as processing,
@@ -393,9 +689,20 @@ class OutboxService {
                  FROM outbox_events`
             );
 
+            const [idem] = await db.query(
+                `SELECT
+                    SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as idempotency_completed,
+                    SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) as idempotency_processing,
+                    SUM(CASE WHEN status = 'expired' THEN 1 ELSE 0 END) as idempotency_expired
+                 FROM outbox_idempotency_keys`
+            );
+
             return {
                 ...stats[0],
+                ...(idem[0] || {}),
                 ...this.stats,
+                staleProcessingMs: OUTBOX_CONFIG.staleProcessingMs,
+                idempotencyTtlDays: OUTBOX_CONFIG.idempotencyTtlDays,
                 timestamp: new Date().toISOString()
             };
         } catch (error) {
@@ -404,25 +711,20 @@ class OutboxService {
         }
     }
 
-    /**
-     * Retry failed events
-     */
     async retryFailedEvents() {
         await db.query(
-            `UPDATE outbox_events 
-             SET status = ?, 
+            `UPDATE outbox_events
+             SET status = ?,
+                 version = version + 1,
+                 processing_started_at = NULL,
                  updated_at = NOW()
-             WHERE status = ? 
-             AND attempts < max_attempts`,
+             WHERE status = ?
+               AND attempts < max_attempts`,
             [OUTBOX_STATUS.RETRY, OUTBOX_STATUS.FAILED]
         );
-
         console.log('🔄 Retried failed events');
     }
 
-    /**
-     * Get pending events count
-     */
     async getPendingCount() {
         const [result] = await db.query(
             'SELECT COUNT(*) as count FROM outbox_events WHERE status = ?',
@@ -431,15 +733,15 @@ class OutboxService {
         return result[0]?.count || 0;
     }
 
-    // ============================================
-    // EVENT HANDLERS
-    // ============================================
+    async getIdempotencyRecord(idempotencyKey) {
+        const [rows] = await db.query(
+            `SELECT * FROM outbox_idempotency_keys WHERE idempotency_key = ?`,
+            [idempotencyKey]
+        );
+        return rows[0] || null;
+    }
 
-    /**
-     * Process order created event
-     */
     async processOrderCreated(data) {
-        // Send notification
         await this.sendNotification({
             userId: data.userId,
             type: 'order_confirmation',
@@ -450,8 +752,6 @@ class OutboxService {
                 items: data.items
             }
         });
-
-        // Update analytics
         await this.updateAnalytics({
             event: 'order_created',
             userId: data.userId,
@@ -459,8 +759,6 @@ class OutboxService {
             total: data.total,
             timestamp: new Date().toISOString()
         });
-
-        // Update recommendations
         await this.updateRecommendations({
             userId: data.userId,
             orderId: data.orderId,
@@ -468,11 +766,7 @@ class OutboxService {
         });
     }
 
-    /**
-     * Process order completed event
-     */
     async processOrderCompleted(data) {
-        // Send delivery notification
         await this.sendNotification({
             userId: data.userId,
             type: 'order_completed',
@@ -482,8 +776,6 @@ class OutboxService {
                 deliveryDate: data.deliveryDate
             }
         });
-
-        // Update analytics
         await this.updateAnalytics({
             event: 'order_completed',
             userId: data.userId,
@@ -492,11 +784,7 @@ class OutboxService {
         });
     }
 
-    /**
-     * Process payment completed event
-     */
     async processPaymentCompleted(data) {
-        // Send payment confirmation
         await this.sendNotification({
             userId: data.userId,
             type: 'payment_confirmation',
@@ -507,8 +795,6 @@ class OutboxService {
                 amount: data.amount
             }
         });
-
-        // Update analytics
         await this.updateAnalytics({
             event: 'payment_completed',
             userId: data.userId,
@@ -518,70 +804,110 @@ class OutboxService {
         });
     }
 
-    // ============================================
-    // HELPER FUNCTIONS
-    // ============================================
-
-    /**
-     * Send notification (simplified)
-     */
     async sendNotification(data) {
-        // In production, send actual notification
         console.log(`📧 Notification: ${data.type} for user ${data.userId}`);
         return { sent: true };
     }
 
-    /**
-     * Update analytics (simplified)
-     */
     async updateAnalytics(data) {
-        // In production, update analytics
         console.log(`📊 Analytics: ${data.event}`);
         return { updated: true };
     }
 
-    /**
-     * Update recommendations (simplified)
-     */
     async updateRecommendations(data) {
-        // In production, update recommendations
         console.log(`🎯 Recommendations updated for user ${data.userId}`);
         return { updated: true };
     }
 
-    /**
-     * Generate event ID
-     */
     generateEventId() {
         return `EVT_${Date.now()}_${crypto.randomBytes(6).toString('hex')}`;
     }
 
-    /**
-     * Stop the outbox service
-     */
     async shutdown() {
         if (this.pollInterval) {
             clearInterval(this.pollInterval);
             this.pollInterval = null;
         }
-
         if (this.cleanupInterval) {
             clearInterval(this.cleanupInterval);
             this.cleanupInterval = null;
         }
-
+        if (this.staleResetInterval) {
+            clearInterval(this.staleResetInterval);
+            this.staleResetInterval = null;
+        }
         this.isRunning = false;
         console.log('⏹️ Outbox Service stopped');
     }
 }
 
-// ============================================
-// EXPORT
-// ============================================
+/**
+ * Wrap an async event consumer so side-effects run at most once per
+ * idempotency key (UUID v5 of type + entity + timestamp).
+ */
+function withIdempotency(consumerName, handler, outbox = null) {
+    const service = outbox || module.exports.outboxService;
+
+    return async (event) => {
+        const idempotencyKey =
+            event.idempotencyKey ||
+            event.metadata?.idempotencyKey ||
+            service.generateIdempotencyKey(
+                event.type || event.name,
+                service.extractEntityId(event.data || event),
+                event.createdAt || event.metadata?.timestamp || event.metadata?.eventTimestamp
+            );
+
+        const normalized = {
+            id: event.id || event.eventId || idempotencyKey,
+            type: event.type || event.name,
+            data: event.data || event,
+            idempotencyKey,
+            metadata: event.metadata || {}
+        };
+
+        const claim = await service.claimConsumerIdempotency(
+            idempotencyKey,
+            normalized,
+            consumerName
+        );
+
+        if (!claim.proceed) {
+            console.log(
+                `♻️ Consumer "${consumerName}" skipped duplicate ${idempotencyKey} (${claim.reason})`
+            );
+            return { skipped: true, reason: claim.reason };
+        }
+
+        try {
+            const result = await handler(normalized);
+            await service.completeConsumerIdempotency(idempotencyKey, consumerName);
+            return result;
+        } catch (error) {
+            await db.query(
+                `UPDATE outbox_idempotency_keys
+                 SET status = ?, expires_at = NOW()
+                 WHERE idempotency_key = ? AND consumer_name = ? AND status = ?`,
+                [
+                    IDEMPOTENCY_STATUS.EXPIRED,
+                    idempotencyKey,
+                    consumerName,
+                    IDEMPOTENCY_STATUS.PROCESSING
+                ]
+            );
+            throw error;
+        }
+    };
+}
+
+const outboxService = new OutboxService();
 
 module.exports = {
     OutboxService,
     OUTBOX_STATUS,
+    IDEMPOTENCY_STATUS,
     EVENT_TYPES,
-    outboxService: new OutboxService()
+    OUTBOX_CONFIG,
+    withIdempotency,
+    outboxService
 };

--- a/backend/sql/outbox_pattern.sql
+++ b/backend/sql/outbox_pattern.sql
@@ -1,31 +1,57 @@
--- Outbox Events Table
+-- Outbox Events Table (Issue #1263: optimistic locks + idempotency)
 CREATE TABLE IF NOT EXISTS outbox_events (
     id INT PRIMARY KEY AUTO_INCREMENT,
     event_id VARCHAR(100) UNIQUE NOT NULL,
     event_type VARCHAR(100) NOT NULL,
+    entity_id VARCHAR(100) DEFAULT NULL,
+    idempotency_key CHAR(36) DEFAULT NULL,
     data JSON NOT NULL,
     metadata JSON,
     status ENUM('pending', 'processing', 'completed', 'failed', 'retry') DEFAULT 'pending',
+    version INT NOT NULL DEFAULT 0,
     attempts INT DEFAULT 0,
     max_attempts INT DEFAULT 5,
     error TEXT,
+    processing_started_at DATETIME DEFAULT NULL,
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL,
     processed_at DATETIME,
     INDEX idx_status (status),
     INDEX idx_type (event_type),
     INDEX idx_created (created_at),
-    INDEX idx_updated (updated_at)
+    INDEX idx_updated (updated_at),
+    INDEX idx_status_attempts (status, attempts),
+    INDEX idx_processing_started (status, processing_started_at),
+    UNIQUE INDEX idx_idempotency_key (idempotency_key),
+    INDEX idx_entity_id (entity_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Consumer-side idempotency ledger (prevents double side-effects on replay)
+CREATE TABLE IF NOT EXISTS outbox_idempotency_keys (
+    idempotency_key CHAR(36) NOT NULL,
+    event_id VARCHAR(100) NOT NULL,
+    event_type VARCHAR(100) NOT NULL,
+    consumer_name VARCHAR(100) NOT NULL DEFAULT 'default',
+    status ENUM('processing', 'completed', 'expired') NOT NULL DEFAULT 'processing',
+    result_hash VARCHAR(64) DEFAULT NULL,
+    expires_at DATETIME NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at DATETIME DEFAULT NULL,
+    PRIMARY KEY (idempotency_key, consumer_name),
+    INDEX idx_idempotency_event (event_id),
+    INDEX idx_idempotency_status_expires (status, expires_at),
+    INDEX idx_idempotency_consumer (consumer_name, status)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Outbox Dashboard View
-CREATE VIEW outbox_dashboard AS
+CREATE OR REPLACE VIEW outbox_dashboard AS
 SELECT 
     DATE(created_at) as date,
     COUNT(*) as total_events,
     SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
     SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
     SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) as pending,
+    SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) as processing,
     AVG(attempts) as avg_attempts
 FROM outbox_events
 WHERE created_at > DATE_SUB(NOW(), INTERVAL 30 DAY)

--- a/migrations/add_outbox_idempotency.sql
+++ b/migrations/add_outbox_idempotency.sql
@@ -1,0 +1,39 @@
+-- Issue #1263: Outbox optimistic lock + idempotency columns
+-- Run once on existing DBs. Ignore duplicate-column / duplicate-index errors if already applied.
+
+ALTER TABLE outbox_events
+    ADD COLUMN entity_id VARCHAR(100) DEFAULT NULL AFTER event_type;
+
+ALTER TABLE outbox_events
+    ADD COLUMN idempotency_key CHAR(36) DEFAULT NULL AFTER entity_id;
+
+ALTER TABLE outbox_events
+    ADD COLUMN version INT NOT NULL DEFAULT 0 AFTER status;
+
+ALTER TABLE outbox_events
+    ADD COLUMN processing_started_at DATETIME DEFAULT NULL AFTER error;
+
+ALTER TABLE outbox_events
+    ADD UNIQUE INDEX idx_idempotency_key (idempotency_key);
+
+ALTER TABLE outbox_events
+    ADD INDEX idx_processing_started (status, processing_started_at);
+
+ALTER TABLE outbox_events
+    ADD INDEX idx_entity_id (entity_id);
+
+CREATE TABLE IF NOT EXISTS outbox_idempotency_keys (
+    idempotency_key CHAR(36) NOT NULL,
+    event_id VARCHAR(100) NOT NULL,
+    event_type VARCHAR(100) NOT NULL,
+    consumer_name VARCHAR(100) NOT NULL DEFAULT 'default',
+    status ENUM('processing', 'completed', 'expired') NOT NULL DEFAULT 'processing',
+    result_hash VARCHAR(64) DEFAULT NULL,
+    expires_at DATETIME NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at DATETIME DEFAULT NULL,
+    PRIMARY KEY (idempotency_key, consumer_name),
+    INDEX idx_idempotency_event (event_id),
+    INDEX idx_idempotency_status_expires (status, expires_at),
+    INDEX idx_idempotency_consumer (consumer_name, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
# #1263 issue resolved
## Description

This PR fixes outbox double-dispatch caused by retries/timeouts by adding optimistic lock status transitions and consumer-side idempotency checks.

## Features

- Transactional status flow: PENDING → PROCESSING → COMPLETED/FAILED with version locks
- UUID v5 idempotency keys from Event Type + Entity ID + Timestamp
- Consumer-side idempotency verification before side-effects
- Automatic stale PROCESSING lock reset after 30 seconds
- Guards against idempotency-key expiration replay

## Files Changed

- `backend/services/outboxService.js`
- `backend/services/domainEventService.js`
- `backend/routes/outboxRoutes.js`
- `backend/sql/outbox_pattern.sql`
- `migrations/add_outbox_idempotency.sql`