### PR TITLE
fix(auth): restore session renewal and centralise the token contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,10 @@ DB_HOST=localhost
 DB_USER=root
 DB_PASSWORD=yourpassword
 DB_NAME=ecommerce
-JWT_SECRET="jwtsecretkey"
+# Both signing secrets are required, must be at least 32 characters, and must
+# differ from each other. The server refuses to start otherwise.
+JWT_SECRET="replace-with-a-long-random-access-token-secret"
+JWT_REFRESH_SECRET="replace-with-a-different-long-random-refresh-secret"
 CLAUDE_WEBHOOK_SECRET=your_super_secure_claude_webhook_secret_here
 ENABLE_SIGNATURE_VERIFICATION=true
 ENABLE_BEHAVIORAL_CAPTCHA=true

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,9 +35,14 @@ DB_POOL_IDLE=10000
 # JWT & AUTHENTICATION
 # ============================================
 
-# JWT Secret (use a long random string - minimum 32 characters)
+# Signing secrets (use long random strings - minimum 32 characters each).
+# Both are required and they MUST be different values: the server refuses to
+# start if either is missing or if the two are the same.
 JWT_SECRET=your-super-secret-jwt-key-min-32-chars
 JWT_REFRESH_SECRET=your-super-secret-refresh-key-min-32-chars
+
+# How long an access token stays valid. Keep this short - renewal is what keeps
+# a signed-in shopper signed in.
 JWT_EXPIRY=15m
 JWT_REFRESH_EXPIRY=7d
 

--- a/backend/config/cookieConfig.js
+++ b/backend/config/cookieConfig.js
@@ -1,5 +1,7 @@
 // backend/config/cookieConfig.js
 
+const { COOKIE_NAMES, REFRESH_COOKIE_PATH } = require('../utils/tokens');
+
 /**
  * ============================================
  * COOKIE CONFIGURATION
@@ -216,10 +218,11 @@ validateSecureConfig(cookieConfig.secure, cookieConfig.sameSite);
 const cookieNames = {
     // Session cookies
     session: process.env.COOKIE_SESSION_NAME || 'session',
-    refreshToken: process.env.COOKIE_REFRESH_NAME || 'refresh_token',
-    
-    // Auth cookies
-    accessToken: process.env.COOKIE_ACCESS_NAME || 'access_token',
+
+    // Auth cookie names come from the token contract so that the side writing
+    // them and the side reading them cannot disagree.
+    refreshToken: COOKIE_NAMES.refreshToken,
+    accessToken: COOKIE_NAMES.accessToken,
     auth: process.env.COOKIE_AUTH_NAME || 'auth_token',
     
     // User preferences
@@ -291,7 +294,7 @@ function getRefreshTokenOptions(customOptions = {}) {
         secure: isProduction,
         sameSite: 'strict',
         maxAge: TIME.ONE_MONTH,
-        path: '/api/auth/refresh',
+        path: REFRESH_COOKIE_PATH,
         ...customOptions,
     };
 }

--- a/backend/config/envValidator.js
+++ b/backend/config/envValidator.js
@@ -8,6 +8,7 @@ const ENV_CONFIG = {
         { name: 'DB_PASSWORD', type: 'string', message: 'Database password is required' },
         { name: 'DB_NAME', type: 'string', message: 'Database name is required' },
         { name: 'JWT_SECRET', type: 'string', minLength: 32, message: 'JWT secret must be at least 32 characters' },
+        { name: 'JWT_REFRESH_SECRET', type: 'string', minLength: 32, message: 'JWT refresh secret must be at least 32 characters and must differ from JWT_SECRET' },
         { name: 'PORT', type: 'number', message: 'Server port is required' },
         { name: 'FRONTEND_URL', type: 'url', message: 'Frontend URL is required' },
         { name: 'NODE_ENV', type: 'string', message: 'Node environment is required' }

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -4,11 +4,18 @@
  */
 
 const bcrypt = require("bcryptjs");
-const jwt = require("jsonwebtoken");
 const crypto = require("crypto");
 const db = require("../config/db");
 const { sanitizeString, safeArray } = require("../utils/helpers");
 const { getClearCookieOptions } = require("../config/cookieConfig");
+const {
+    COOKIE_NAMES,
+    REFRESH_COOKIE_PATH,
+    issueAccessToken,
+    issueRefreshToken,
+    issueTwoFactorToken,
+    verifyRefreshToken
+} = require("../utils/tokens");
 
 // Appwrite SDK
 const { Client, Account, ID, Databases } = require('node-appwrite');
@@ -57,11 +64,6 @@ setInterval(() => {
     }
 }, CLEANUP_INTERVAL);
 
-// ==================== JWT SECRET VALIDATION ====================
-if (!process.env.JWT_SECRET) {
-    throw new Error("JWT_SECRET environment variable is not set");
-}
-
 // ==================== APPWRITE CLIENT ====================
 const appwriteClient = new Client()
     .setEndpoint(process.env.VITE_APPWRITE_ENDPOINT || 'https://fra.cloud.appwrite.io/v1')
@@ -70,18 +72,6 @@ const appwriteClient = new Client()
 const appwriteAccount = new Account(appwriteClient);
 
 // ==================== HELPER FUNCTIONS ====================
-
-function generateAccessToken(user) {
-    return jwt.sign(
-        { id: user.id, email: user.email, role: user.role },
-        process.env.JWT_SECRET,
-        { expiresIn: process.env.JWT_EXPIRES_IN || "15m" }
-    );
-}
-
-function generateRefreshToken() {
-    return crypto.randomBytes(40).toString("hex");
-}
 
 function sendAuthResponse(res, { message, accessToken, refreshToken, user }) {
     return res.status(200).json({
@@ -352,11 +342,7 @@ const login = async (req, res) => {
 
         // Check if 2FA is enabled
         if (user.is_2fa_enabled === 1) {
-            const tempToken = jwt.sign(
-                { id: user.id, email: user.email, role: user.role, is2FA: true },
-                process.env.JWT_SECRET,
-                { expiresIn: "5m" }
-            );
+            const tempToken = issueTwoFactorToken(user);
             return res.status(200).json({
                 success: true,
                 requires2FA: true,
@@ -365,8 +351,8 @@ const login = async (req, res) => {
             });
         }
 
-        const accessToken = generateAccessToken(user);
-        const refreshToken = generateRefreshToken();
+        const accessToken = issueAccessToken(user);
+        const refreshToken = issueRefreshToken();
 
         // Update refresh token and last login time
         await db.query(
@@ -399,8 +385,8 @@ const logout = async (req, res) => {
         }
 
         // Clear cookies using shared cookie options
-        res.clearCookie('accessToken', getClearCookieOptions());
-        res.clearCookie('refreshToken', getClearCookieOptions('/api/auth/refresh'));
+        res.clearCookie(COOKIE_NAMES.accessToken, getClearCookieOptions());
+        res.clearCookie(COOKIE_NAMES.refreshToken, getClearCookieOptions(REFRESH_COOKIE_PATH));
 
         console.log(`🔓 User ${userId} logged out successfully`);
 
@@ -587,6 +573,12 @@ const refreshAccessToken = async (req, res) => {
             return res.status(401).json({ success: false, message: "Refresh token required" });
         }
 
+        // A token without our tag was never issued here, so there is no point
+        // asking the database about it.
+        if (!verifyRefreshToken(cleanRefreshToken)) {
+            return res.status(401).json({ success: false, message: "Invalid refresh token" });
+        }
+
         const [users] = await db.query(
             `SELECT id, name, email, role, is_active FROM users WHERE refresh_token = ? LIMIT 1`,
             [cleanRefreshToken]
@@ -601,8 +593,8 @@ const refreshAccessToken = async (req, res) => {
             return res.status(403).json({ success: false, message: "Account has been deactivated" });
         }
 
-        const newAccessToken = generateAccessToken(user);
-        const newRefreshToken = generateRefreshToken();
+        const newAccessToken = issueAccessToken(user);
+        const newRefreshToken = issueRefreshToken();
 
         await db.query(`UPDATE users SET refresh_token = ? WHERE id = ?`, [newRefreshToken, user.id]);
 

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,6 +2,8 @@
 module.exports = {
     testEnvironment: 'node',
 
+    setupFiles: ['<rootDir>/tests/setupEnv.js'],
+
     // Transpile the ESM-only packages that Jest's CommonJS runtime cannot load.
     //
     // controllers/authController.js requires `otplib` for 2FA (#1026). otplib

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -1,28 +1,28 @@
 // backend/middleware/authMiddleware.js
-const jwt = require('jsonwebtoken');
 
-// JWT_SECRET must be set in environment - throw error if missing
-const JWT_SECRET = process.env.JWT_SECRET;
-if (!JWT_SECRET) {
-    throw new Error('FATAL: JWT_SECRET environment variable is required but not set. Application cannot start without a secure JWT secret.');
-}
+// Importing the token contract validates the token configuration, so a missing
+// or reused secret stops the process at startup instead of surfacing as a
+// mysterious 401 on the first protected request.
+const {
+    COOKIE_NAMES,
+    assertAccessTokenSecret,
+    hasSubjectClaim,
+    verifyAccessToken
+} = require('../utils/tokens');
 
 /**
  * Verify JWT token from Authorization header or cookies fallback
  */
 function authMiddleware(req, res, next) {
-    const secret = process.env.JWT_SECRET;
-    if (!secret) {
-        throw new Error('JWT_SECRET environment variable is required');
-    }
+    assertAccessTokenSecret();
 
     let token = null;
     const authHeader = req.headers.authorization;
 
     if (authHeader && authHeader.startsWith('Bearer ')) {
         token = authHeader.slice(7);
-    } else if (req.cookies && req.cookies.accessToken) {
-        token = req.cookies.accessToken;
+    } else if (req.cookies && req.cookies[COOKIE_NAMES.accessToken]) {
+        token = req.cookies[COOKIE_NAMES.accessToken];
     }
 
     if (!token || token.trim().length === 0) {
@@ -57,9 +57,9 @@ function authMiddleware(req, res, next) {
     }
 
     try {
-        const decoded = jwt.verify(token, secret);
-        
-        if (!decoded || (decoded.userId === undefined && decoded.id === undefined)) {
+        const decoded = verifyAccessToken(token);
+
+        if (!hasSubjectClaim(decoded)) {
             return res.status(401).json({
                 success: false,
                 message: 'Authorization header required'
@@ -80,18 +80,15 @@ function authMiddleware(req, res, next) {
  * Optional auth - doesn't fail if no token
  */
 function optionalAuth(req, res, next) {
-    const secret = process.env.JWT_SECRET;
-    if (!secret) {
-        throw new Error('JWT_SECRET environment variable is required');
-    }
+    assertAccessTokenSecret();
 
     let token = null;
     const authHeader = req.headers.authorization;
 
     if (authHeader && authHeader.startsWith('Bearer ')) {
         token = authHeader.slice(7);
-    } else if (req.cookies && req.cookies.accessToken) {
-        token = req.cookies.accessToken;
+    } else if (req.cookies && req.cookies[COOKIE_NAMES.accessToken]) {
+        token = req.cookies[COOKIE_NAMES.accessToken];
     }
 
     if (!token || token.trim().length === 0) {
@@ -103,8 +100,7 @@ function optionalAuth(req, res, next) {
     }
 
     try {
-        const decoded = jwt.verify(token, secret);
-        req.user = decoded;
+        req.user = verifyAccessToken(token);
     } catch (error) {
         // Ignore invalid tokens for optional auth
     }

--- a/backend/middleware/authValidation.js
+++ b/backend/middleware/authValidation.js
@@ -1,5 +1,6 @@
 const { sanitizeString } = require("../utils/helpers");
 const { isValidEmail, isValidOTP, validatePassword } = require("../utils/validators");
+const { isRefreshTokenWellFormed } = require("../utils/tokens");
 
 /**
  * Helper to check for missing required fields.
@@ -120,7 +121,10 @@ const validateRefreshToken = (req, res, next) => {
     return res.status(400).json({ success: false, message: `Refresh token is required` });
   }
 
-  if (typeof refreshToken !== 'string' || refreshToken.split('.').length !== 3) {
+  // The shape is asserted by the module that issues these tokens. Spelling the
+  // expected format out here is what let this check drift into rejecting every
+  // token the service produced.
+  if (!isRefreshTokenWellFormed(sanitizeString(refreshToken))) {
     return res.status(400).json({ success: false, message: "Invalid refresh token format" });
   }
 

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -46,9 +46,9 @@ const {
 const db = require("../config/db").promise;
 
 // ======================== ENVIRONMENT VALIDATION ========================
-if (!process.env.JWT_SECRET) {
-    throw new Error("JWT_SECRET environment variable is not set");
-}
+// The token contract checks its own configuration when imported, so a missing
+// or shared secret refuses to start rather than breaking sign-in at runtime.
+require("../utils/tokens");
 
 // ======================== HELPER FUNCTIONS ========================
 

--- a/backend/tests/setupEnv.js
+++ b/backend/tests/setupEnv.js
@@ -1,0 +1,13 @@
+// backend/tests/setupEnv.js
+
+// Loaded by Jest before every suite. Auth modules validate their configuration
+// when imported, so without these each suite would have to declare the same
+// secrets before its first `require` -- which is how several suites ended up
+// setting JWT_SECRET to a different placeholder each.
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
+process.env.JWT_SECRET =
+    process.env.JWT_SECRET || 'test_jwt_secret_at_least_32_characters_long';
+
+process.env.JWT_REFRESH_SECRET =
+    process.env.JWT_REFRESH_SECRET || 'test_jwt_refresh_secret_at_least_32_characters_long';

--- a/backend/utils/tokens.js
+++ b/backend/utils/tokens.js
@@ -1,0 +1,212 @@
+/**
+ * Token contract shared by the issuing and the verifying halves of auth.
+ *
+ * Secrets, lifetimes, claim names, cookie names and the refresh-token shape are
+ * defined here and nowhere else. Both sides import from this module, so a change
+ * to one of them cannot silently invalidate tokens the service just handed out.
+ *
+ * @module utils/tokens
+ */
+
+const crypto = require("crypto");
+const jwt = require("jsonwebtoken");
+
+// ==================== SECRETS ====================
+
+const ACCESS_TOKEN_SECRET_VAR = "JWT_SECRET";
+const REFRESH_TOKEN_SECRET_VAR = "JWT_REFRESH_SECRET";
+
+// ==================== LIFETIMES ====================
+
+// Access tokens stay deliberately short: renewal, not a long expiry, is what
+// keeps a shopper signed in. JWT_EXPIRES_IN is the older spelling and is still
+// honoured so existing deployments do not change behaviour on upgrade.
+const ACCESS_TOKEN_TTL = process.env.JWT_EXPIRY || process.env.JWT_EXPIRES_IN || "15m";
+
+// A password holder who still owes a second factor gets just enough time to
+// supply it.
+const TWO_FACTOR_TOKEN_TTL = "5m";
+
+// ==================== CLAIMS ====================
+
+const SUBJECT_CLAIM = "id";
+
+// Tokens minted before the subject claim was pinned down carry `userId`. They
+// are still accepted when verifying so an upgrade does not sign everybody out
+// mid-session; nothing issues them any more.
+const LEGACY_SUBJECT_CLAIM = "userId";
+
+// ==================== COOKIES ====================
+
+const COOKIE_NAMES = Object.freeze({
+    accessToken: "accessToken",
+    refreshToken: "refreshToken"
+});
+
+// Must match the path the refresh endpoint is actually mounted at. A cookie
+// scoped to any other path is never sent to the endpoint that needs it, and is
+// not removed by the clear on logout either.
+const REFRESH_COOKIE_PATH = "/api/auth/refresh-token";
+
+// ==================== REFRESH TOKEN SHAPE ====================
+
+// Refresh tokens are opaque handles rather than JWTs: nothing about a session
+// is readable from the token, and the server resolves it by lookup. The
+// trailing tag is an HMAC over the handle, so a token this service never issued
+// is rejected without touching the database.
+const REFRESH_TOKEN_HANDLE_BYTES = 40;
+const REFRESH_TOKEN_TAG_HEX_LENGTH = 32;
+const REFRESH_TOKEN_PATTERN = new RegExp(
+    `^[0-9a-f]{${REFRESH_TOKEN_HANDLE_BYTES * 2}}\\.[0-9a-f]{${REFRESH_TOKEN_TAG_HEX_LENGTH}}$`
+);
+
+// ==================== CONFIGURATION ====================
+
+/**
+ * Read a secret at the moment it is used rather than caching it at import.
+ * The auth middleware is expected to react to a secret that changes after the
+ * process has started, and callers rely on a missing secret raising rather than
+ * silently signing with `undefined`.
+ */
+function readSecret(name) {
+    const value = process.env[name];
+    if (!value) {
+        throw new Error(
+            `FATAL: ${name} environment variable is required but not set. ` +
+            `Authentication cannot issue or verify tokens without it.`
+        );
+    }
+    return value;
+}
+
+/**
+ * Fail at startup rather than on the first sign-in or the first renewal.
+ */
+function assertTokenConfiguration() {
+    const accessSecret = readSecret(ACCESS_TOKEN_SECRET_VAR);
+    const refreshSecret = readSecret(REFRESH_TOKEN_SECRET_VAR);
+
+    if (accessSecret === refreshSecret) {
+        throw new Error(
+            `FATAL: ${ACCESS_TOKEN_SECRET_VAR} and ${REFRESH_TOKEN_SECRET_VAR} must be ` +
+            `different values. Sharing one secret lets an access token be presented ` +
+            `as refresh material and vice versa.`
+        );
+    }
+}
+
+function assertAccessTokenSecret() {
+    readSecret(ACCESS_TOKEN_SECRET_VAR);
+}
+
+assertTokenConfiguration();
+
+// ==================== ACCESS TOKENS ====================
+
+/**
+ * @param {Object} user - Row with `id`, `email` and `role`.
+ * @param {Object} [extraClaims] - Additional claims to merge into the payload.
+ * @returns {string} Signed access token.
+ */
+function issueAccessToken(user, extraClaims = {}) {
+    return jwt.sign(
+        {
+            [SUBJECT_CLAIM]: user.id,
+            email: user.email,
+            role: user.role,
+            ...extraClaims
+        },
+        readSecret(ACCESS_TOKEN_SECRET_VAR),
+        { expiresIn: ACCESS_TOKEN_TTL }
+    );
+}
+
+/**
+ * Short-lived token that stands in for a session until a second factor is
+ * supplied.
+ */
+function issueTwoFactorToken(user) {
+    return jwt.sign(
+        {
+            [SUBJECT_CLAIM]: user.id,
+            email: user.email,
+            role: user.role,
+            is2FA: true
+        },
+        readSecret(ACCESS_TOKEN_SECRET_VAR),
+        { expiresIn: TWO_FACTOR_TOKEN_TTL }
+    );
+}
+
+/**
+ * @throws {Error} When the token is malformed, expired or signed with another key.
+ */
+function verifyAccessToken(token) {
+    return jwt.verify(token, readSecret(ACCESS_TOKEN_SECRET_VAR));
+}
+
+/**
+ * Whether a verified payload identifies a user under either accepted claim.
+ */
+function hasSubjectClaim(decoded) {
+    if (!decoded) return false;
+    return decoded[SUBJECT_CLAIM] !== undefined || decoded[LEGACY_SUBJECT_CLAIM] !== undefined;
+}
+
+// ==================== REFRESH TOKENS ====================
+
+function refreshTokenTag(handle) {
+    return crypto
+        .createHmac("sha256", readSecret(REFRESH_TOKEN_SECRET_VAR))
+        .update(handle)
+        .digest("hex")
+        .slice(0, REFRESH_TOKEN_TAG_HEX_LENGTH);
+}
+
+/**
+ * @returns {string} A fresh refresh token, tagged so it can be recognised as ours.
+ */
+function issueRefreshToken() {
+    const handle = crypto.randomBytes(REFRESH_TOKEN_HANDLE_BYTES).toString("hex");
+    return `${handle}.${refreshTokenTag(handle)}`;
+}
+
+/**
+ * Shape-only check, for request validation that runs before authentication.
+ */
+function isRefreshTokenWellFormed(value) {
+    return typeof value === "string" && REFRESH_TOKEN_PATTERN.test(value);
+}
+
+/**
+ * @returns {boolean} True when the token carries a tag this service produced.
+ */
+function verifyRefreshToken(value) {
+    if (!isRefreshTokenWellFormed(value)) {
+        return false;
+    }
+
+    const [handle, tag] = value.split(".");
+    return crypto.timingSafeEqual(
+        Buffer.from(tag, "hex"),
+        Buffer.from(refreshTokenTag(handle), "hex")
+    );
+}
+
+// ==================== EXPORTS ====================
+
+module.exports = {
+    ACCESS_TOKEN_TTL,
+    COOKIE_NAMES,
+    REFRESH_COOKIE_PATH,
+    SUBJECT_CLAIM,
+    assertAccessTokenSecret,
+    assertTokenConfiguration,
+    hasSubjectClaim,
+    isRefreshTokenWellFormed,
+    issueAccessToken,
+    issueRefreshToken,
+    issueTwoFactorToken,
+    verifyAccessToken,
+    verifyRefreshToken
+};


### PR DESCRIPTION
Renewal could never succeed. Request validation on the renewal endpoint required
a refresh token in JWT form, while the service issues an opaque handle, so every
renewal was rejected before it reached the handler. Clients read a rejected
renewal as a dead session, which is why a signed-in shopper was returned to the
login screen a few minutes after arriving.

Fixing that alone would leave the same trap open, so the agreement between the
two halves of authentication now lives in one place: the secrets, the lifetimes,
the claim names, the cookie names and the shape of a refresh token are defined
once and imported by both the side that issues tokens and the side that verifies
them. Two further disagreements surfaced and are fixed by the same move — the
refresh cookie was scoped to a path the renewal endpoint is not mounted at, and
the shared cookie-name table disagreed with the names actually written and read.

Refresh tokens stay opaque, but now carry a keyed tag, so a token this service
never issued is rejected without a database lookup.

## What changes for users
A signed-in shopper stays signed in past the access-token expiry. Nothing else
about sign-in, sign-out or password handling changes.

## Operational note
Two signing secrets are now required and they must differ from each other. The
server refuses to start otherwise, rather than failing later on the first
renewal. Both example environment files are updated.

## Verification
- Renewal accepts a token the service just issued and rejects one with a
  tampered or absent tag.
- Startup fails with a clear message when either secret is missing and when the
  two are identical.
- Existing coverage for the auth middleware still passes: tokens carrying either
  accepted subject claim are honoured, tokens with neither are rejected, and a
  secret removed after startup still raises.

Part 1/4 of #1257