### PR TITLE
fix(frontend): share one renewal between concurrent requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,10 @@ DB_HOST=localhost
 DB_USER=root
 DB_PASSWORD=yourpassword
 DB_NAME=ecommerce
-JWT_SECRET="jwtsecretkey"
+# Both signing secrets are required, must be at least 32 characters, and must
+# differ from each other. The server refuses to start otherwise.
+JWT_SECRET="replace-with-a-long-random-access-token-secret"
+JWT_REFRESH_SECRET="replace-with-a-different-long-random-refresh-secret"
 CLAUDE_WEBHOOK_SECRET=your_super_secure_claude_webhook_secret_here
 ENABLE_SIGNATURE_VERIFICATION=true
 ENABLE_BEHAVIORAL_CAPTCHA=true

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,9 +35,14 @@ DB_POOL_IDLE=10000
 # JWT & AUTHENTICATION
 # ============================================
 
-# JWT Secret (use a long random string - minimum 32 characters)
+# Signing secrets (use long random strings - minimum 32 characters each).
+# Both are required and they MUST be different values: the server refuses to
+# start if either is missing or if the two are the same.
 JWT_SECRET=your-super-secret-jwt-key-min-32-chars
 JWT_REFRESH_SECRET=your-super-secret-refresh-key-min-32-chars
+
+# How long an access token stays valid. Keep this short - renewal is what keeps
+# a signed-in shopper signed in.
 JWT_EXPIRY=15m
 JWT_REFRESH_EXPIRY=7d
 

--- a/backend/config/cookieConfig.js
+++ b/backend/config/cookieConfig.js
@@ -1,5 +1,7 @@
 // backend/config/cookieConfig.js
 
+const { COOKIE_NAMES, REFRESH_COOKIE_PATH } = require('../utils/tokens');
+
 /**
  * ============================================
  * COOKIE CONFIGURATION
@@ -216,10 +218,11 @@ validateSecureConfig(cookieConfig.secure, cookieConfig.sameSite);
 const cookieNames = {
     // Session cookies
     session: process.env.COOKIE_SESSION_NAME || 'session',
-    refreshToken: process.env.COOKIE_REFRESH_NAME || 'refresh_token',
-    
-    // Auth cookies
-    accessToken: process.env.COOKIE_ACCESS_NAME || 'access_token',
+
+    // Auth cookie names come from the token contract so that the side writing
+    // them and the side reading them cannot disagree.
+    refreshToken: COOKIE_NAMES.refreshToken,
+    accessToken: COOKIE_NAMES.accessToken,
     auth: process.env.COOKIE_AUTH_NAME || 'auth_token',
     
     // User preferences
@@ -291,7 +294,7 @@ function getRefreshTokenOptions(customOptions = {}) {
         secure: isProduction,
         sameSite: 'strict',
         maxAge: TIME.ONE_MONTH,
-        path: '/api/auth/refresh',
+        path: REFRESH_COOKIE_PATH,
         ...customOptions,
     };
 }

--- a/backend/config/envValidator.js
+++ b/backend/config/envValidator.js
@@ -8,6 +8,7 @@ const ENV_CONFIG = {
         { name: 'DB_PASSWORD', type: 'string', message: 'Database password is required' },
         { name: 'DB_NAME', type: 'string', message: 'Database name is required' },
         { name: 'JWT_SECRET', type: 'string', minLength: 32, message: 'JWT secret must be at least 32 characters' },
+        { name: 'JWT_REFRESH_SECRET', type: 'string', minLength: 32, message: 'JWT refresh secret must be at least 32 characters and must differ from JWT_SECRET' },
         { name: 'PORT', type: 'number', message: 'Server port is required' },
         { name: 'FRONTEND_URL', type: 'url', message: 'Frontend URL is required' },
         { name: 'NODE_ENV', type: 'string', message: 'Node environment is required' }

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -4,11 +4,28 @@
  */
 
 const bcrypt = require("bcryptjs");
-const jwt = require("jsonwebtoken");
 const crypto = require("crypto");
 const db = require("../config/db");
 const { sanitizeString, safeArray } = require("../utils/helpers");
 const { getClearCookieOptions } = require("../config/cookieConfig");
+const {
+    COOKIE_NAMES,
+    REFRESH_COOKIE_PATH,
+    SESSION_CLAIM,
+    issueAccessToken,
+    issueRefreshToken,
+    issueTwoFactorToken,
+    verifyRefreshToken
+} = require("../utils/tokens");
+const {
+    REVOKE_REASON,
+    SESSION_OUTCOME,
+    createSession,
+    revokeSessionById,
+    revokeSessionByToken,
+    revokeUserSessions,
+    rotateSession
+} = require("../services/authSessionService");
 
 // Appwrite SDK
 const { Client, Account, ID, Databases } = require('node-appwrite');
@@ -57,11 +74,6 @@ setInterval(() => {
     }
 }, CLEANUP_INTERVAL);
 
-// ==================== JWT SECRET VALIDATION ====================
-if (!process.env.JWT_SECRET) {
-    throw new Error("JWT_SECRET environment variable is not set");
-}
-
 // ==================== APPWRITE CLIENT ====================
 const appwriteClient = new Client()
     .setEndpoint(process.env.VITE_APPWRITE_ENDPOINT || 'https://fra.cloud.appwrite.io/v1')
@@ -71,16 +83,15 @@ const appwriteAccount = new Account(appwriteClient);
 
 // ==================== HELPER FUNCTIONS ====================
 
-function generateAccessToken(user) {
-    return jwt.sign(
-        { id: user.id, email: user.email, role: user.role },
-        process.env.JWT_SECRET,
-        { expiresIn: process.env.JWT_EXPIRES_IN || "15m" }
-    );
-}
-
-function generateRefreshToken() {
-    return crypto.randomBytes(40).toString("hex");
+/**
+ * Where the request appears to come from, used to label a session so an account
+ * holder can recognise it later.
+ */
+function describeRequestOrigin(req) {
+    return {
+        ip: req.ip,
+        userAgent: req.headers ? req.headers["user-agent"] : undefined
+    };
 }
 
 function sendAuthResponse(res, { message, accessToken, refreshToken, user }) {
@@ -352,11 +363,7 @@ const login = async (req, res) => {
 
         // Check if 2FA is enabled
         if (user.is_2fa_enabled === 1) {
-            const tempToken = jwt.sign(
-                { id: user.id, email: user.email, role: user.role, is2FA: true },
-                process.env.JWT_SECRET,
-                { expiresIn: "5m" }
-            );
+            const tempToken = issueTwoFactorToken(user);
             return res.status(200).json({
                 success: true,
                 requires2FA: true,
@@ -365,14 +372,18 @@ const login = async (req, res) => {
             });
         }
 
-        const accessToken = generateAccessToken(user);
-        const refreshToken = generateRefreshToken();
+        // A session per device: signing in here leaves any session on another
+        // device untouched.
+        const refreshToken = issueRefreshToken();
+        const { sessionId } = await createSession({
+            userId: user.id,
+            refreshToken,
+            ...describeRequestOrigin(req)
+        });
 
-        // Update refresh token and last login time
-        await db.query(
-            `UPDATE users SET refresh_token = ?, last_login = NOW() WHERE id = ?`, 
-            [refreshToken, user.id]
-        );
+        const accessToken = issueAccessToken(user, { [SESSION_CLAIM]: sessionId });
+
+        await db.query(`UPDATE users SET last_login = NOW() WHERE id = ?`, [user.id]);
 
         return sendAuthResponse(res, { 
             message: "Login successful", 
@@ -390,17 +401,27 @@ const login = async (req, res) => {
 const logout = async (req, res) => {
     try {
         const userId = req.user?.id;
+
+        // End only the session this request belongs to. The session id on the
+        // access token identifies it without the client having to hand back its
+        // refresh token; the body is a fallback for callers that still do.
+        const sessionId = req.user?.[SESSION_CLAIM];
+        if (sessionId) {
+            await revokeSessionById(sessionId, REVOKE_REASON.LOGOUT);
+        } else {
+            const presentedToken = sanitizeString(req.body?.refreshToken);
+            if (presentedToken) {
+                await revokeSessionByToken(presentedToken, REVOKE_REASON.LOGOUT);
+            }
+        }
+
         if (userId) {
-            // Clear refresh token AND update last logout time
-            await db.query(
-                `UPDATE users SET refresh_token = NULL, last_logout = NOW() WHERE id = ?`,
-                [userId]
-            );
+            await db.query(`UPDATE users SET last_logout = NOW() WHERE id = ?`, [userId]);
         }
 
         // Clear cookies using shared cookie options
-        res.clearCookie('accessToken', getClearCookieOptions());
-        res.clearCookie('refreshToken', getClearCookieOptions('/api/auth/refresh'));
+        res.clearCookie(COOKIE_NAMES.accessToken, getClearCookieOptions());
+        res.clearCookie(COOKIE_NAMES.refreshToken, getClearCookieOptions(REFRESH_COOKIE_PATH));
 
         console.log(`🔓 User ${userId} logged out successfully`);
 
@@ -512,6 +533,20 @@ const resetPassword = async (req, res) => {
         const hashedPassword = await bcrypt.hash(newPassword, 10);
         await db.query(`UPDATE users SET password = ? WHERE email = ?`, [hashedPassword, appwriteUser.email]);
 
+        // A reset is the path someone takes when they may have lost control of
+        // the account, so every existing session goes -- there is no session to
+        // keep here, because the reset is not made from a signed-in device.
+        const [resetUsers] = await db.query(
+            `SELECT id FROM users WHERE email = ? LIMIT 1`,
+            [appwriteUser.email]
+        );
+        if (safeArray(resetUsers).length) {
+            await revokeUserSessions({
+                userId: resetUsers[0].id,
+                reason: REVOKE_REASON.PASSWORD_CHANGED
+            });
+        }
+
         // Cleanup Appwrite session
         try {
             await userAccount.deleteSession('current');
@@ -567,9 +602,20 @@ const changePassword = async (req, res) => {
         const hashedPassword = await bcrypt.hash(newPassword, 10);
         await db.query(`UPDATE users SET password = ? WHERE id = ?`, [hashedPassword, userId]);
 
+        // Anyone signed in with the old password loses their session. The device
+        // making the change keeps its own, so changing a password does not sign
+        // you out of the page you are on.
+        const currentSessionId = req.user?.[SESSION_CLAIM];
+        const revokedCount = await revokeUserSessions({
+            userId,
+            exceptSessionId: currentSessionId,
+            reason: REVOKE_REASON.PASSWORD_CHANGED
+        });
+
         return res.status(200).json({ 
             success: true, 
-            message: "Password changed successfully" 
+            message: "Password changed successfully",
+            revokedSessionCount: revokedCount
         });
     } catch (error) {
         console.error("CHANGE PASSWORD ERROR:", error);
@@ -587,24 +633,65 @@ const refreshAccessToken = async (req, res) => {
             return res.status(401).json({ success: false, message: "Refresh token required" });
         }
 
+        // A token without our tag was never issued here, so there is no point
+        // asking the database about it.
+        if (!verifyRefreshToken(cleanRefreshToken)) {
+            return res.status(401).json({ success: false, message: "Invalid refresh token" });
+        }
+
+        const newRefreshToken = issueRefreshToken();
+        const rotation = await rotateSession({
+            refreshToken: cleanRefreshToken,
+            newRefreshToken,
+            ...describeRequestOrigin(req)
+        });
+
+        // A superseded token coming back means it is in two places at once. That
+        // is worth acting on, so every session descended from the same sign-in
+        // has already been ended by this point.
+        if (rotation.outcome === SESSION_OUTCOME.REPLAY) {
+            console.warn(
+                `🚨 Refresh token replay detected for user ${rotation.userId}. ` +
+                `Session family ${rotation.familyId} revoked.`
+            );
+            return res.status(401).json({
+                success: false,
+                code: "SESSION_REPLAY_DETECTED",
+                message: "This session was ended for security reasons. Please sign in again."
+            });
+        }
+
+        if (rotation.outcome !== SESSION_OUTCOME.ROTATED) {
+            return res.status(401).json({
+                success: false,
+                code: "SESSION_EXPIRED",
+                message: "Session has expired. Please sign in again."
+            });
+        }
+
         const [users] = await db.query(
-            `SELECT id, name, email, role, is_active FROM users WHERE refresh_token = ? LIMIT 1`,
-            [cleanRefreshToken]
+            `SELECT id, name, email, role, is_active FROM users WHERE id = ? LIMIT 1`,
+            [rotation.userId]
         );
 
         if (!safeArray(users).length) {
+            await revokeUserSessions({
+                userId: rotation.userId,
+                reason: REVOKE_REASON.ACCOUNT_DISABLED
+            });
             return res.status(401).json({ success: false, message: "Invalid refresh token" });
         }
 
         const user = users[0];
         if (user.is_active === 0) {
+            await revokeUserSessions({
+                userId: user.id,
+                reason: REVOKE_REASON.ACCOUNT_DISABLED
+            });
             return res.status(403).json({ success: false, message: "Account has been deactivated" });
         }
 
-        const newAccessToken = generateAccessToken(user);
-        const newRefreshToken = generateRefreshToken();
-
-        await db.query(`UPDATE users SET refresh_token = ? WHERE id = ?`, [newRefreshToken, user.id]);
+        const newAccessToken = issueAccessToken(user, { [SESSION_CLAIM]: rotation.sessionId });
 
         return sendAuthResponse(res, { 
             message: "Token refreshed", 

--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -1,0 +1,115 @@
+/**
+ * Lets an account holder see where their account is signed in and end those
+ * sessions.
+ *
+ * @module controllers/sessionController
+ */
+
+const { sanitizeString } = require("../utils/helpers");
+const { SESSION_CLAIM } = require("../utils/tokens");
+const {
+    REVOKE_REASON,
+    listActiveSessions,
+    revokeSessionForUser,
+    revokeUserSessions
+} = require("../services/authSessionService");
+
+// ==================== 1. LIST SESSIONS ====================
+const getSessions = async (req, res) => {
+    try {
+        const userId = req.user?.id;
+        if (!userId) {
+            return res.status(401).json({ success: false, message: "Unauthorized" });
+        }
+
+        const currentSessionId = req.user?.[SESSION_CLAIM] || null;
+        const sessions = await listActiveSessions(userId);
+
+        return res.status(200).json({
+            success: true,
+            count: sessions.length,
+            sessions: sessions.map((session) => ({
+                id: session.id,
+                device: session.device_label,
+                ipAddress: session.ip_address,
+                createdAt: session.issued_at,
+                lastUsedAt: session.last_used_at,
+                expiresAt: session.expires_at,
+                isCurrent: session.id === currentSessionId
+            }))
+        });
+    } catch (error) {
+        console.error("❌ LIST SESSIONS ERROR:", error);
+        return res.status(500).json({ success: false, message: "Failed to fetch sessions" });
+    }
+};
+
+// ==================== 2. REVOKE ONE SESSION ====================
+const deleteSession = async (req, res) => {
+    try {
+        const userId = req.user?.id;
+        if (!userId) {
+            return res.status(401).json({ success: false, message: "Unauthorized" });
+        }
+
+        const sessionId = sanitizeString(req.params.sessionId);
+        if (!sessionId) {
+            return res.status(400).json({ success: false, message: "Session id is required" });
+        }
+
+        const wasRevoked = await revokeSessionForUser({
+            userId,
+            sessionId,
+            reason: REVOKE_REASON.USER_REVOKED
+        });
+
+        if (!wasRevoked) {
+            return res.status(404).json({ success: false, message: "Session not found" });
+        }
+
+        const isCurrentSession = sessionId === req.user?.[SESSION_CLAIM];
+
+        return res.status(200).json({
+            success: true,
+            message: "Session ended",
+            // The caller has just ended the session it is using, so it needs to
+            // stop using the tokens it holds rather than wait for a 401.
+            endedCurrentSession: isCurrentSession
+        });
+    } catch (error) {
+        console.error("❌ REVOKE SESSION ERROR:", error);
+        return res.status(500).json({ success: false, message: "Failed to end session" });
+    }
+};
+
+// ==================== 3. REVOKE EVERY OTHER SESSION ====================
+const deleteOtherSessions = async (req, res) => {
+    try {
+        const userId = req.user?.id;
+        if (!userId) {
+            return res.status(401).json({ success: false, message: "Unauthorized" });
+        }
+
+        const revokedCount = await revokeUserSessions({
+            userId,
+            exceptSessionId: req.user?.[SESSION_CLAIM],
+            reason: REVOKE_REASON.USER_REVOKED
+        });
+
+        return res.status(200).json({
+            success: true,
+            message: "Other sessions ended",
+            revokedCount
+        });
+    } catch (error) {
+        console.error("❌ REVOKE OTHER SESSIONS ERROR:", error);
+        return res.status(500).json({ success: false, message: "Failed to end other sessions" });
+    }
+};
+
+// ==================== EXPORTS ====================
+module.exports = {
+    getSessions,
+    deleteSession,
+    deleteOtherSessions
+};

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,6 +2,8 @@
 module.exports = {
     testEnvironment: 'node',
 
+    setupFiles: ['<rootDir>/tests/setupEnv.js'],
+
     // Transpile the ESM-only packages that Jest's CommonJS runtime cannot load.
     //
     // controllers/authController.js requires `otplib` for 2FA (#1026). otplib

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -1,28 +1,28 @@
 // backend/middleware/authMiddleware.js
-const jwt = require('jsonwebtoken');
 
-// JWT_SECRET must be set in environment - throw error if missing
-const JWT_SECRET = process.env.JWT_SECRET;
-if (!JWT_SECRET) {
-    throw new Error('FATAL: JWT_SECRET environment variable is required but not set. Application cannot start without a secure JWT secret.');
-}
+// Importing the token contract validates the token configuration, so a missing
+// or reused secret stops the process at startup instead of surfacing as a
+// mysterious 401 on the first protected request.
+const {
+    COOKIE_NAMES,
+    assertAccessTokenSecret,
+    hasSubjectClaim,
+    verifyAccessToken
+} = require('../utils/tokens');
 
 /**
  * Verify JWT token from Authorization header or cookies fallback
  */
 function authMiddleware(req, res, next) {
-    const secret = process.env.JWT_SECRET;
-    if (!secret) {
-        throw new Error('JWT_SECRET environment variable is required');
-    }
+    assertAccessTokenSecret();
 
     let token = null;
     const authHeader = req.headers.authorization;
 
     if (authHeader && authHeader.startsWith('Bearer ')) {
         token = authHeader.slice(7);
-    } else if (req.cookies && req.cookies.accessToken) {
-        token = req.cookies.accessToken;
+    } else if (req.cookies && req.cookies[COOKIE_NAMES.accessToken]) {
+        token = req.cookies[COOKIE_NAMES.accessToken];
     }
 
     if (!token || token.trim().length === 0) {
@@ -57,9 +57,9 @@ function authMiddleware(req, res, next) {
     }
 
     try {
-        const decoded = jwt.verify(token, secret);
-        
-        if (!decoded || (decoded.userId === undefined && decoded.id === undefined)) {
+        const decoded = verifyAccessToken(token);
+
+        if (!hasSubjectClaim(decoded)) {
             return res.status(401).json({
                 success: false,
                 message: 'Authorization header required'
@@ -80,18 +80,15 @@ function authMiddleware(req, res, next) {
  * Optional auth - doesn't fail if no token
  */
 function optionalAuth(req, res, next) {
-    const secret = process.env.JWT_SECRET;
-    if (!secret) {
-        throw new Error('JWT_SECRET environment variable is required');
-    }
+    assertAccessTokenSecret();
 
     let token = null;
     const authHeader = req.headers.authorization;
 
     if (authHeader && authHeader.startsWith('Bearer ')) {
         token = authHeader.slice(7);
-    } else if (req.cookies && req.cookies.accessToken) {
-        token = req.cookies.accessToken;
+    } else if (req.cookies && req.cookies[COOKIE_NAMES.accessToken]) {
+        token = req.cookies[COOKIE_NAMES.accessToken];
     }
 
     if (!token || token.trim().length === 0) {
@@ -103,8 +100,7 @@ function optionalAuth(req, res, next) {
     }
 
     try {
-        const decoded = jwt.verify(token, secret);
-        req.user = decoded;
+        req.user = verifyAccessToken(token);
     } catch (error) {
         // Ignore invalid tokens for optional auth
     }

--- a/backend/middleware/authValidation.js
+++ b/backend/middleware/authValidation.js
@@ -1,5 +1,6 @@
 const { sanitizeString } = require("../utils/helpers");
 const { isValidEmail, isValidOTP, validatePassword } = require("../utils/validators");
+const { isRefreshTokenWellFormed } = require("../utils/tokens");
 
 /**
  * Helper to check for missing required fields.
@@ -120,7 +121,10 @@ const validateRefreshToken = (req, res, next) => {
     return res.status(400).json({ success: false, message: `Refresh token is required` });
   }
 
-  if (typeof refreshToken !== 'string' || refreshToken.split('.').length !== 3) {
+  // The shape is asserted by the module that issues these tokens. Spelling the
+  // expected format out here is what let this check drift into rejecting every
+  // token the service produced.
+  if (!isRefreshTokenWellFormed(sanitizeString(refreshToken))) {
     return res.status(400).json({ success: false, message: "Invalid refresh token format" });
   }
 

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -218,26 +218,6 @@ class User {
         return this;
     }
 
-    // ==================== TOKEN METHODS ====================
-
-    /**
-     * Generate refresh token for user
-     * @param {string} refreshToken - Refresh token
-     * @param {string} ip - IP address
-     * @param {string} userAgent - User agent
-     * @returns {Object} Token data
-     */
-    generateRefreshToken(refreshToken, ip, userAgent) {
-        return {
-            userId: this.id,
-            token: refreshToken,
-            expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
-            ipAddress: ip,
-            userAgent: userAgent,
-            isRevoked: false
-        };
-    }
-
     // ==================== PASSWORD HISTORY ====================
 
     /**

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -20,6 +20,11 @@ const {
     //enable2FA,
     //disable2FA
 } = require("../controllers/authController");
+const {
+    getSessions,
+    deleteSession,
+    deleteOtherSessions
+} = require("../controllers/sessionController");
 // ======================== MIDDLEWARE ========================
 const authMiddleware = require("../middleware/authMiddleware");
 const {
@@ -46,9 +51,9 @@ const {
 const db = require("../config/db").promise;
 
 // ======================== ENVIRONMENT VALIDATION ========================
-if (!process.env.JWT_SECRET) {
-    throw new Error("JWT_SECRET environment variable is not set");
-}
+// The token contract checks its own configuration when imported, so a missing
+// or shared secret refuses to start rather than breaking sign-in at runtime.
+require("../utils/tokens");
 
 // ======================== HELPER FUNCTIONS ========================
 
@@ -177,65 +182,39 @@ router.post(
     authMiddleware,
     applyCaptchaCheck,
     validateChangePassword,
-    async (req, res) => {
-        try {
-            const { currentPassword, newPassword } = req.body;
+    changePassword
+);
 
-            // ❌ Inline validations removed (handled in middleware)
+// ======================== SESSION ROUTES ========================
 
-            // Get user with password
-            const [users] = await db.query(
-                `SELECT id, password 
-                 FROM users 
-                 WHERE id = ?`,
-                [req.user.id]
-            );
+/**
+ * GET /api/auth/sessions
+ * List the account's active sessions
+ */
+router.get(
+    "/sessions",
+    authMiddleware,
+    getSessions
+);
 
-            if (users.length === 0) {
-                return res.status(404).json({
-                    success: false,
-                    message: "User not found"
-                });
-            }
+/**
+ * DELETE /api/auth/sessions
+ * End every session on the account except the one making the request
+ */
+router.delete(
+    "/sessions",
+    authMiddleware,
+    deleteOtherSessions
+);
 
-            // Verify current password
-            const bcrypt = require('bcryptjs');
-            const isValidPassword = await bcrypt.compare(currentPassword, users[0].password);
-
-            if (!isValidPassword) {
-                return res.status(401).json({
-                    success: false,
-                    message: "Current password is incorrect"
-                });
-            }
-
-            // Hash new password
-            const hashedPassword = await bcrypt.hash(newPassword, 10);
-
-            // Update password
-            await db.query(
-                `UPDATE users 
-                 SET password = ?, 
-                     updated_at = NOW() 
-                 WHERE id = ?`,
-                [hashedPassword, req.user.id]
-            );
-
-            console.log(`🔐 User ${req.user.id} changed password successfully`);
-
-            return res.status(200).json({
-                success: true,
-                message: "Password changed successfully"
-            });
-
-        } catch (error) {
-            console.error("❌ CHANGE PASSWORD ERROR:", error);
-            return res.status(500).json({
-                success: false,
-                message: "Failed to change password"
-            });
-        }
-    }
+/**
+ * DELETE /api/auth/sessions/:sessionId
+ * End one session on the account
+ */
+router.delete(
+    "/sessions/:sessionId",
+    authMiddleware,
+    deleteSession
 );
 
 /**

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -15,7 +15,6 @@ CREATE TABLE IF NOT EXISTS users (
     email VARCHAR(255) NOT NULL UNIQUE,
     password VARCHAR(255) NOT NULL,
     `role` ENUM('customer', 'support', 'admin', 'seller') DEFAULT 'customer',
-    refresh_token VARCHAR(255),
     avatar VARCHAR(500),
     phone VARCHAR(20),
     address TEXT,
@@ -662,6 +661,36 @@ CREATE TABLE IF NOT EXISTS user_sessions (
     INDEX idx_user_sessions_expires (expires_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- One row per signed-in device. Rotation on renewal inserts a successor in the
+-- same family and marks the predecessor superseded, so a superseded row that is
+-- presented again is a replay rather than an ordinary expiry.
+--
+-- Only the SHA-256 digest of the refresh token is stored: a copy of this table
+-- does not hand over the ability to impersonate anyone.
+CREATE TABLE IF NOT EXISTS auth_sessions (
+    id CHAR(36) PRIMARY KEY,
+    user_id CHAR(36) NOT NULL,
+    family_id CHAR(36) NOT NULL,
+    token_hash CHAR(64) NOT NULL UNIQUE,
+    device_label VARCHAR(120),
+    user_agent TEXT,
+    ip_address VARCHAR(45),
+    issued_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_used_at DATETIME DEFAULT NULL,
+    expires_at DATETIME NOT NULL,
+    revoked_at DATETIME DEFAULT NULL,
+    revoked_reason VARCHAR(40) DEFAULT NULL,
+    replaced_by CHAR(36) DEFAULT NULL,
+
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+
+    INDEX idx_auth_sessions_token (token_hash),
+    INDEX idx_auth_sessions_user (user_id),
+    INDEX idx_auth_sessions_family (family_id),
+    INDEX idx_auth_sessions_expires (expires_at),
+    INDEX idx_auth_sessions_live (user_id, revoked_at, expires_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE IF NOT EXISTS login_attempts (
     id INT AUTO_INCREMENT PRIMARY KEY,
     email VARCHAR(255) NOT NULL,
@@ -946,6 +975,9 @@ BEGIN
     DELETE FROM password_reset_tokens WHERE expires_at < NOW() OR used = 1;
     DELETE FROM email_verification_tokens WHERE expires_at < NOW() OR used = 1;
     DELETE FROM user_sessions WHERE expires_at < NOW() OR is_active = 0;
+    -- Superseded rows are kept until they expire; deleting them earlier would
+    -- throw away the evidence that makes a replay recognisable.
+    DELETE FROM auth_sessions WHERE expires_at < NOW();
     DELETE FROM api_tokens WHERE expires_at < NOW() OR is_active = 0;
     
     -- Delete old user interactions

--- a/backend/services/authSessionService.js
+++ b/backend/services/authSessionService.js
@@ -1,0 +1,352 @@
+/**
+ * Durable per-device sessions.
+ *
+ * A session is a row in `auth_sessions`, not a credential on the user row, so an
+ * account can be signed in on several devices at once. Renewal rotates a session
+ * forward: the presented row is marked superseded and a successor is inserted in
+ * the same family. Presenting a superseded row afterwards is therefore a replay,
+ * which is treated as theft of the whole family rather than as an expiry.
+ *
+ * Only the digest of a refresh token is stored.
+ *
+ * @module services/authSessionService
+ */
+
+const crypto = require("crypto");
+const db = require("../config/db");
+const { safeArray } = require("../utils/helpers");
+const { REFRESH_TOKEN_TTL_MS, hashRefreshToken } = require("../utils/tokens");
+
+// ==================== CONSTANTS ====================
+
+/**
+ * Why a session stopped being usable. `replay` is deliberately distinct from
+ * `expired`: it is a signal about the account, not about the clock.
+ */
+const SESSION_OUTCOME = Object.freeze({
+    ROTATED: "rotated",
+    UNKNOWN: "unknown",
+    EXPIRED: "expired",
+    REVOKED: "revoked",
+    REPLAY: "replay"
+});
+
+const REVOKE_REASON = Object.freeze({
+    ROTATED: "rotated",
+    LOGOUT: "logout",
+    REPLAY_DETECTED: "replay_detected",
+    PASSWORD_CHANGED: "password_changed",
+    USER_REVOKED: "user_revoked",
+    ACCOUNT_DISABLED: "account_disabled"
+});
+
+const DEVICE_LABEL_MAX_LENGTH = 120;
+
+// Enough of a label for someone to recognise their own device in a list, drawn
+// from the only hint an HTTP client reliably gives us.
+const BROWSERS = [
+    [/edg/i, "Edge"],
+    [/opr|opera/i, "Opera"],
+    [/chrome|crios/i, "Chrome"],
+    [/firefox|fxios/i, "Firefox"],
+    [/safari/i, "Safari"]
+];
+
+const PLATFORMS = [
+    [/iphone|ipad|ipod/i, "iOS"],
+    [/android/i, "Android"],
+    [/windows/i, "Windows"],
+    [/mac os|macintosh/i, "macOS"],
+    [/linux/i, "Linux"]
+];
+
+// ==================== PUBLIC SURFACE ====================
+
+/**
+ * Record a new session for a freshly issued refresh token.
+ *
+ * @param {Object} params
+ * @param {string} params.userId
+ * @param {string} params.refreshToken - Raw token; only its digest is stored.
+ * @param {string} [params.ip]
+ * @param {string} [params.userAgent]
+ * @returns {Promise<{sessionId: string, familyId: string, expiresAt: Date}>}
+ */
+async function createSession({ userId, refreshToken, ip, userAgent }) {
+    const sessionId = crypto.randomUUID();
+    const familyId = crypto.randomUUID();
+    const expiresAt = new Date(Date.now() + REFRESH_TOKEN_TTL_MS);
+
+    await db.query(
+        `INSERT INTO auth_sessions
+            (id, user_id, family_id, token_hash, device_label, user_agent, ip_address, issued_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), ?)`,
+        [
+            sessionId,
+            userId,
+            familyId,
+            hashRefreshToken(refreshToken),
+            describeDevice(userAgent),
+            userAgent || null,
+            ip || null,
+            expiresAt
+        ]
+    );
+
+    return { sessionId, familyId, expiresAt };
+}
+
+/**
+ * Move a session forward onto a new refresh token.
+ *
+ * The caller is expected to have already established that `refreshToken` was
+ * issued by this service.
+ *
+ * @param {Object} params
+ * @param {string} params.refreshToken - Token being presented.
+ * @param {string} params.newRefreshToken - Token to hand back on success.
+ * @param {string} [params.ip]
+ * @param {string} [params.userAgent]
+ * @returns {Promise<{outcome: string, userId?: string, sessionId?: string, expiresAt?: Date}>}
+ */
+async function rotateSession({ refreshToken, newRefreshToken, ip, userAgent }) {
+    const [rows] = await db.query(
+        `SELECT id, user_id, family_id, expires_at, revoked_at, replaced_by
+         FROM auth_sessions
+         WHERE token_hash = ?
+         LIMIT 1`,
+        [hashRefreshToken(refreshToken)]
+    );
+
+    const session = safeArray(rows)[0];
+    if (!session) {
+        return { outcome: SESSION_OUTCOME.UNKNOWN };
+    }
+
+    // A token that has already been rotated away should never appear again. If
+    // it does, either it or its successor is in someone else's hands, and there
+    // is no way to tell which -- so the whole family goes.
+    if (session.replaced_by) {
+        await revokeFamily(session.family_id, REVOKE_REASON.REPLAY_DETECTED);
+        return {
+            outcome: SESSION_OUTCOME.REPLAY,
+            userId: session.user_id,
+            familyId: session.family_id
+        };
+    }
+
+    if (session.revoked_at) {
+        return { outcome: SESSION_OUTCOME.REVOKED, userId: session.user_id };
+    }
+
+    if (new Date(session.expires_at).getTime() <= Date.now()) {
+        return { outcome: SESSION_OUTCOME.EXPIRED, userId: session.user_id };
+    }
+
+    const successorId = crypto.randomUUID();
+
+    await db.query(
+        `INSERT INTO auth_sessions
+            (id, user_id, family_id, token_hash, device_label, user_agent, ip_address, issued_at, last_used_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW(), ?)`,
+        [
+            successorId,
+            session.user_id,
+            session.family_id,
+            hashRefreshToken(newRefreshToken),
+            describeDevice(userAgent),
+            userAgent || null,
+            ip || null,
+            session.expires_at
+        ]
+    );
+
+    // Guarded on `replaced_by IS NULL` so two renewals racing on the same token
+    // cannot both claim to have superseded it.
+    const [update] = await db.query(
+        `UPDATE auth_sessions
+         SET replaced_by = ?, revoked_at = NOW(), revoked_reason = ?
+         WHERE id = ? AND replaced_by IS NULL`,
+        [successorId, REVOKE_REASON.ROTATED, session.id]
+    );
+
+    if (!update || update.affectedRows === 0) {
+        await revokeFamily(session.family_id, REVOKE_REASON.REPLAY_DETECTED);
+        return {
+            outcome: SESSION_OUTCOME.REPLAY,
+            userId: session.user_id,
+            familyId: session.family_id
+        };
+    }
+
+    return {
+        outcome: SESSION_OUTCOME.ROTATED,
+        userId: session.user_id,
+        sessionId: successorId,
+        expiresAt: new Date(session.expires_at)
+    };
+}
+
+/**
+ * Sessions on an account that are neither ended nor expired, newest first.
+ *
+ * Rows that have been rotated away are excluded, so one device appears once
+ * however many times it has renewed. Nothing derived from the token is included.
+ *
+ * @param {string} userId
+ * @returns {Promise<Array<Object>>} Rows with id, device_label, ip_address,
+ *   issued_at, last_used_at and expires_at.
+ */
+async function listActiveSessions(userId) {
+    const [rows] = await db.query(
+        `SELECT id, device_label, ip_address, issued_at, last_used_at, expires_at
+         FROM auth_sessions
+         WHERE user_id = ?
+           AND revoked_at IS NULL
+           AND replaced_by IS NULL
+           AND expires_at > NOW()
+         ORDER BY issued_at DESC`,
+        [userId]
+    );
+
+    return safeArray(rows);
+}
+
+/**
+ * End one session, identified by the session id carried on an access token.
+ *
+ * @returns {Promise<boolean>} Whether a live session was ended.
+ */
+async function revokeSessionById(sessionId, reason) {
+    if (!sessionId) return false;
+
+    const [result] = await db.query(
+        `UPDATE auth_sessions
+         SET revoked_at = NOW(), revoked_reason = ?
+         WHERE id = ? AND revoked_at IS NULL`,
+        [reason, sessionId]
+    );
+
+    return Boolean(result && result.affectedRows > 0);
+}
+
+/**
+ * End one session on behalf of its owner.
+ *
+ * Scoped to `userId` so a session id learned elsewhere cannot be used to sign
+ * another account out.
+ *
+ * @returns {Promise<boolean>} Whether a live session belonging to the account
+ *   was ended.
+ */
+async function revokeSessionForUser({ userId, sessionId, reason }) {
+    if (!sessionId) return false;
+
+    const [result] = await db.query(
+        `UPDATE auth_sessions
+         SET revoked_at = NOW(), revoked_reason = ?
+         WHERE id = ? AND user_id = ? AND revoked_at IS NULL`,
+        [reason, sessionId, userId]
+    );
+
+    return Boolean(result && result.affectedRows > 0);
+}
+
+/**
+ * End one session, identified by the refresh token that belongs to it.
+ *
+ * @returns {Promise<boolean>} Whether a live session was ended.
+ */
+async function revokeSessionByToken(refreshToken, reason) {
+    if (!refreshToken) return false;
+
+    const [result] = await db.query(
+        `UPDATE auth_sessions
+         SET revoked_at = NOW(), revoked_reason = ?
+         WHERE token_hash = ? AND revoked_at IS NULL`,
+        [reason, hashRefreshToken(refreshToken)]
+    );
+
+    return Boolean(result && result.affectedRows > 0);
+}
+
+/**
+ * End every session descended from one sign-in, including rows already
+ * superseded, so nothing in the chain can be rotated forward again.
+ *
+ * @returns {Promise<number>} Number of rows ended.
+ */
+async function revokeFamily(familyId, reason) {
+    const [result] = await db.query(
+        `UPDATE auth_sessions
+         SET revoked_at = NOW(), revoked_reason = ?
+         WHERE family_id = ? AND revoked_at IS NULL`,
+        [reason, familyId]
+    );
+
+    return result ? result.affectedRows : 0;
+}
+
+/**
+ * End every session on an account.
+ *
+ * @param {Object} params
+ * @param {string} params.userId
+ * @param {string} [params.exceptSessionId] - Session to leave signed in.
+ * @param {string} params.reason
+ * @returns {Promise<number>} Number of rows ended.
+ */
+async function revokeUserSessions({ userId, exceptSessionId, reason }) {
+    const conditions = ["user_id = ?", "revoked_at IS NULL"];
+    const params = [reason, userId];
+
+    if (exceptSessionId) {
+        conditions.push("id <> ?");
+        params.push(exceptSessionId);
+    }
+
+    const [result] = await db.query(
+        `UPDATE auth_sessions
+         SET revoked_at = NOW(), revoked_reason = ?
+         WHERE ${conditions.join(" AND ")}`,
+        params
+    );
+
+    return result ? result.affectedRows : 0;
+}
+
+// ==================== PRIVATE HELPERS ====================
+
+/**
+ * Turn a user-agent string into something a person can recognise.
+ */
+function describeDevice(userAgent) {
+    if (!userAgent) return "Unknown device";
+
+    const browser = BROWSERS.find(([pattern]) => pattern.test(userAgent));
+    const platform = PLATFORMS.find(([pattern]) => pattern.test(userAgent));
+
+    if (!browser && !platform) {
+        return userAgent.slice(0, DEVICE_LABEL_MAX_LENGTH);
+    }
+    if (!platform) return browser[1];
+    if (!browser) return platform[1];
+
+    return `${browser[1]} on ${platform[1]}`;
+}
+
+// ==================== EXPORTS ====================
+
+module.exports = {
+    REVOKE_REASON,
+    SESSION_OUTCOME,
+    createSession,
+    describeDevice,
+    listActiveSessions,
+    revokeFamily,
+    revokeSessionById,
+    revokeSessionByToken,
+    revokeSessionForUser,
+    revokeUserSessions,
+    rotateSession
+};

--- a/backend/sql/auth_sessions.sql
+++ b/backend/sql/auth_sessions.sql
@@ -1,0 +1,31 @@
+-- Authenticated Sessions Table
+--
+-- One row per signed-in device. Rotation on renewal inserts a successor in the
+-- same family and marks the predecessor superseded, so a superseded row that is
+-- presented again is a replay rather than an ordinary expiry.
+--
+-- Only the SHA-256 digest of the refresh token is stored: a copy of this table
+-- does not hand over the ability to impersonate anyone.
+CREATE TABLE IF NOT EXISTS auth_sessions (
+    id CHAR(36) PRIMARY KEY,
+    user_id CHAR(36) NOT NULL,
+    family_id CHAR(36) NOT NULL,
+    token_hash CHAR(64) NOT NULL UNIQUE,
+    device_label VARCHAR(120),
+    user_agent TEXT,
+    ip_address VARCHAR(45),
+    issued_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_used_at DATETIME DEFAULT NULL,
+    expires_at DATETIME NOT NULL,
+    revoked_at DATETIME DEFAULT NULL,
+    revoked_reason VARCHAR(40) DEFAULT NULL,
+    replaced_by CHAR(36) DEFAULT NULL,
+
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+
+    INDEX idx_auth_sessions_token (token_hash),
+    INDEX idx_auth_sessions_user (user_id),
+    INDEX idx_auth_sessions_family (family_id),
+    INDEX idx_auth_sessions_expires (expires_at),
+    INDEX idx_auth_sessions_live (user_id, revoked_at, expires_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/tests/setupEnv.js
+++ b/backend/tests/setupEnv.js
@@ -1,0 +1,13 @@
+// backend/tests/setupEnv.js
+
+// Loaded by Jest before every suite. Auth modules validate their configuration
+// when imported, so without these each suite would have to declare the same
+// secrets before its first `require` -- which is how several suites ended up
+// setting JWT_SECRET to a different placeholder each.
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
+process.env.JWT_SECRET =
+    process.env.JWT_SECRET || 'test_jwt_secret_at_least_32_characters_long';
+
+process.env.JWT_REFRESH_SECRET =
+    process.env.JWT_REFRESH_SECRET || 'test_jwt_refresh_secret_at_least_32_characters_long';

--- a/backend/utils/tokens.js
+++ b/backend/utils/tokens.js
@@ -1,0 +1,263 @@
+/**
+ * Token contract shared by the issuing and the verifying halves of auth.
+ *
+ * Secrets, lifetimes, claim names, cookie names and the refresh-token shape are
+ * defined here and nowhere else. Both sides import from this module, so a change
+ * to one of them cannot silently invalidate tokens the service just handed out.
+ *
+ * @module utils/tokens
+ */
+
+const crypto = require("crypto");
+const jwt = require("jsonwebtoken");
+
+// ==================== SECRETS ====================
+
+const ACCESS_TOKEN_SECRET_VAR = "JWT_SECRET";
+const REFRESH_TOKEN_SECRET_VAR = "JWT_REFRESH_SECRET";
+
+// ==================== LIFETIMES ====================
+
+// Access tokens stay deliberately short: renewal, not a long expiry, is what
+// keeps a shopper signed in. JWT_EXPIRES_IN is the older spelling and is still
+// honoured so existing deployments do not change behaviour on upgrade.
+const ACCESS_TOKEN_TTL = process.env.JWT_EXPIRY || process.env.JWT_EXPIRES_IN || "15m";
+
+// A password holder who still owes a second factor gets just enough time to
+// supply it.
+const TWO_FACTOR_TOKEN_TTL = "5m";
+
+// Absolute lifetime of a session. Rotation moves a session forward but never
+// past this, so a session cannot be kept alive indefinitely by refreshing.
+const REFRESH_TOKEN_TTL = process.env.JWT_REFRESH_EXPIRY || "7d";
+
+// ==================== CLAIMS ====================
+
+const SUBJECT_CLAIM = "id";
+
+// Ties an access token back to the session that produced it, so a request can
+// tell which of the account's sessions it belongs to.
+const SESSION_CLAIM = "sid";
+
+// Tokens minted before the subject claim was pinned down carry `userId`. They
+// are still accepted when verifying so an upgrade does not sign everybody out
+// mid-session; nothing issues them any more.
+const LEGACY_SUBJECT_CLAIM = "userId";
+
+// ==================== COOKIES ====================
+
+const COOKIE_NAMES = Object.freeze({
+    accessToken: "accessToken",
+    refreshToken: "refreshToken"
+});
+
+// Must match the path the refresh endpoint is actually mounted at. A cookie
+// scoped to any other path is never sent to the endpoint that needs it, and is
+// not removed by the clear on logout either.
+const REFRESH_COOKIE_PATH = "/api/auth/refresh-token";
+
+// ==================== REFRESH TOKEN SHAPE ====================
+
+// Refresh tokens are opaque handles rather than JWTs: nothing about a session
+// is readable from the token, and the server resolves it by lookup. The
+// trailing tag is an HMAC over the handle, so a token this service never issued
+// is rejected without touching the database.
+const REFRESH_TOKEN_HANDLE_BYTES = 40;
+const REFRESH_TOKEN_TAG_HEX_LENGTH = 32;
+const REFRESH_TOKEN_PATTERN = new RegExp(
+    `^[0-9a-f]{${REFRESH_TOKEN_HANDLE_BYTES * 2}}\\.[0-9a-f]{${REFRESH_TOKEN_TAG_HEX_LENGTH}}$`
+);
+
+// ==================== CONFIGURATION ====================
+
+/**
+ * Read a secret at the moment it is used rather than caching it at import.
+ * The auth middleware is expected to react to a secret that changes after the
+ * process has started, and callers rely on a missing secret raising rather than
+ * silently signing with `undefined`.
+ */
+function readSecret(name) {
+    const value = process.env[name];
+    if (!value) {
+        throw new Error(
+            `FATAL: ${name} environment variable is required but not set. ` +
+            `Authentication cannot issue or verify tokens without it.`
+        );
+    }
+    return value;
+}
+
+/**
+ * Fail at startup rather than on the first sign-in or the first renewal.
+ */
+function assertTokenConfiguration() {
+    const accessSecret = readSecret(ACCESS_TOKEN_SECRET_VAR);
+    const refreshSecret = readSecret(REFRESH_TOKEN_SECRET_VAR);
+
+    if (accessSecret === refreshSecret) {
+        throw new Error(
+            `FATAL: ${ACCESS_TOKEN_SECRET_VAR} and ${REFRESH_TOKEN_SECRET_VAR} must be ` +
+            `different values. Sharing one secret lets an access token be presented ` +
+            `as refresh material and vice versa.`
+        );
+    }
+}
+
+function assertAccessTokenSecret() {
+    readSecret(ACCESS_TOKEN_SECRET_VAR);
+}
+
+assertTokenConfiguration();
+
+// ==================== ACCESS TOKENS ====================
+
+/**
+ * @param {Object} user - Row with `id`, `email` and `role`.
+ * @param {Object} [extraClaims] - Additional claims to merge into the payload.
+ * @returns {string} Signed access token.
+ */
+function issueAccessToken(user, extraClaims = {}) {
+    return jwt.sign(
+        {
+            [SUBJECT_CLAIM]: user.id,
+            email: user.email,
+            role: user.role,
+            ...extraClaims
+        },
+        readSecret(ACCESS_TOKEN_SECRET_VAR),
+        { expiresIn: ACCESS_TOKEN_TTL }
+    );
+}
+
+/**
+ * Short-lived token that stands in for a session until a second factor is
+ * supplied.
+ */
+function issueTwoFactorToken(user) {
+    return jwt.sign(
+        {
+            [SUBJECT_CLAIM]: user.id,
+            email: user.email,
+            role: user.role,
+            is2FA: true
+        },
+        readSecret(ACCESS_TOKEN_SECRET_VAR),
+        { expiresIn: TWO_FACTOR_TOKEN_TTL }
+    );
+}
+
+/**
+ * @throws {Error} When the token is malformed, expired or signed with another key.
+ */
+function verifyAccessToken(token) {
+    return jwt.verify(token, readSecret(ACCESS_TOKEN_SECRET_VAR));
+}
+
+/**
+ * Whether a verified payload identifies a user under either accepted claim.
+ */
+function hasSubjectClaim(decoded) {
+    if (!decoded) return false;
+    return decoded[SUBJECT_CLAIM] !== undefined || decoded[LEGACY_SUBJECT_CLAIM] !== undefined;
+}
+
+// ==================== REFRESH TOKENS ====================
+
+function refreshTokenTag(handle) {
+    return crypto
+        .createHmac("sha256", readSecret(REFRESH_TOKEN_SECRET_VAR))
+        .update(handle)
+        .digest("hex")
+        .slice(0, REFRESH_TOKEN_TAG_HEX_LENGTH);
+}
+
+/**
+ * @returns {string} A fresh refresh token, tagged so it can be recognised as ours.
+ */
+function issueRefreshToken() {
+    const handle = crypto.randomBytes(REFRESH_TOKEN_HANDLE_BYTES).toString("hex");
+    return `${handle}.${refreshTokenTag(handle)}`;
+}
+
+/**
+ * Shape-only check, for request validation that runs before authentication.
+ */
+function isRefreshTokenWellFormed(value) {
+    return typeof value === "string" && REFRESH_TOKEN_PATTERN.test(value);
+}
+
+/**
+ * @returns {boolean} True when the token carries a tag this service produced.
+ */
+function verifyRefreshToken(value) {
+    if (!isRefreshTokenWellFormed(value)) {
+        return false;
+    }
+
+    const [handle, tag] = value.split(".");
+    return crypto.timingSafeEqual(
+        Buffer.from(tag, "hex"),
+        Buffer.from(refreshTokenTag(handle), "hex")
+    );
+}
+
+/**
+ * Digest stored in place of the token itself, so a copy of the session table
+ * cannot be replayed as a set of live credentials.
+ *
+ * @returns {string} 64-character hex digest.
+ */
+function hashRefreshToken(value) {
+    return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+// ==================== DURATIONS ====================
+
+const DURATION_UNIT_MS = {
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000
+};
+
+/**
+ * Convert a `jsonwebtoken`-style duration ("15m", "7d", "3600") to milliseconds,
+ * so a lifetime configured once can also be used as a row expiry.
+ */
+function durationToMs(duration) {
+    const match = /^(\d+)([smhd])?$/.exec(String(duration).trim());
+    if (!match) {
+        throw new Error(
+            `Unsupported duration "${duration}". Use a number of seconds or a value ` +
+            `like 30s, 15m, 12h or 7d.`
+        );
+    }
+
+    const [, amount, unit] = match;
+    return Number(amount) * (unit ? DURATION_UNIT_MS[unit] : DURATION_UNIT_MS.s);
+}
+
+const REFRESH_TOKEN_TTL_MS = durationToMs(REFRESH_TOKEN_TTL);
+
+// ==================== EXPORTS ====================
+
+module.exports = {
+    ACCESS_TOKEN_TTL,
+    COOKIE_NAMES,
+    REFRESH_COOKIE_PATH,
+    REFRESH_TOKEN_TTL,
+    REFRESH_TOKEN_TTL_MS,
+    SESSION_CLAIM,
+    SUBJECT_CLAIM,
+    assertAccessTokenSecret,
+    assertTokenConfiguration,
+    durationToMs,
+    hasSubjectClaim,
+    hashRefreshToken,
+    isRefreshTokenWellFormed,
+    issueAccessToken,
+    issueRefreshToken,
+    issueTwoFactorToken,
+    verifyAccessToken,
+    verifyRefreshToken
+};

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -176,6 +176,31 @@
                             Edit Profile
                         </button>
                     </div>
+
+                    <div
+                        id="sessions-card"
+                        class="profile-info-card"
+                    >
+                        <h3>
+                            Signed-In Devices
+                        </h3>
+
+                        <p id="sessions-empty" style="display: none;">
+                            No devices are signed in.
+                        </p>
+
+                        <p id="sessions-error" style="display: none;"></p>
+
+                        <div id="sessions-list"></div>
+
+                        <button
+                            id="revoke-other-sessions-btn"
+                            class="profile-save-btn"
+                        >
+                            <i class="fas fa-sign-out-alt"></i>
+                            Sign Out Other Devices
+                        </button>
+                    </div>
                 </div>
             
                 <!-- Profile Edit -->
@@ -299,6 +324,11 @@
     <script
         defer
         src="scripts/profile.js"
+    ></script>
+
+    <script
+        defer
+        src="scripts/sessions.js"
     ></script>
     <script defer src="scripts/ui.js"></script>
 

--- a/frontend/scripts/sessions.js
+++ b/frontend/scripts/sessions.js
@@ -1,0 +1,141 @@
+// ============================================
+// SIGNED-IN DEVICES
+// Lists where the account is signed in and lets
+// the account holder end those sessions.
+// ============================================
+
+const sessionElements = {
+    card: document.getElementById("sessions-card"),
+    list: document.getElementById("sessions-list"),
+    empty: document.getElementById("sessions-empty"),
+    error: document.getElementById("sessions-error"),
+    revokeOthersBtn: document.getElementById("revoke-other-sessions-btn")
+};
+
+function formatSessionTimestamp(value) {
+    if (!value) return "—";
+
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return "—";
+
+    return parsed.toLocaleString();
+}
+
+function renderSessions(sessions) {
+    if (!sessionElements.list) return;
+
+    sessionElements.list.innerHTML = "";
+
+    if (!sessions.length) {
+        if (sessionElements.empty) sessionElements.empty.style.display = "block";
+        return;
+    }
+
+    if (sessionElements.empty) sessionElements.empty.style.display = "none";
+
+    sessions.forEach((session) => {
+        const row = document.createElement("div");
+        row.className = "profile-info-item";
+
+        const heading = document.createElement("span");
+        heading.textContent = session.isCurrent
+            ? `${session.device || "Unknown device"} (this device)`
+            : session.device || "Unknown device";
+
+        const detail = document.createElement("p");
+        detail.textContent =
+            `${session.ipAddress || "Unknown location"} · ` +
+            `signed in ${formatSessionTimestamp(session.createdAt)} · ` +
+            `last used ${formatSessionTimestamp(session.lastUsedAt || session.createdAt)}`;
+
+        row.appendChild(heading);
+        row.appendChild(detail);
+
+        if (!session.isCurrent) {
+            const endBtn = document.createElement("button");
+            endBtn.type = "button";
+            endBtn.className = "profile-save-btn";
+            endBtn.textContent = "End session";
+            endBtn.addEventListener("click", () => endSession(session.id, endBtn));
+            row.appendChild(endBtn);
+        }
+
+        sessionElements.list.appendChild(row);
+    });
+}
+
+async function loadSessions() {
+    if (!sessionElements.card) return;
+
+    try {
+        const response = await AppUtils.apiRequest("/auth/sessions");
+
+        if (!response.success) {
+            throw new Error(response.message || "Failed to load sessions");
+        }
+
+        if (sessionElements.error) sessionElements.error.style.display = "none";
+        renderSessions(response.sessions || []);
+    } catch (error) {
+        console.error("LOAD SESSIONS ERROR:", error);
+        if (sessionElements.error) {
+            sessionElements.error.style.display = "block";
+            sessionElements.error.textContent = "Could not load your signed-in devices.";
+        }
+    }
+}
+
+async function endSession(sessionId, button) {
+    if (button) button.disabled = true;
+
+    try {
+        const response = await AppUtils.apiRequest(`/auth/sessions/${encodeURIComponent(sessionId)}`, {
+            method: "DELETE"
+        });
+
+        if (!response.success) {
+            throw new Error(response.message || "Failed to end session");
+        }
+
+        AppUtils.notify("Session ended.", "success");
+        await loadSessions();
+    } catch (error) {
+        console.error("END SESSION ERROR:", error);
+        AppUtils.notify("Could not end that session.", "error");
+        if (button) button.disabled = false;
+    }
+}
+
+async function endOtherSessions() {
+    const button = sessionElements.revokeOthersBtn;
+    if (button) button.disabled = true;
+
+    try {
+        const response = await AppUtils.apiRequest("/auth/sessions", { method: "DELETE" });
+
+        if (!response.success) {
+            throw new Error(response.message || "Failed to end sessions");
+        }
+
+        AppUtils.notify(
+            response.revokedCount
+                ? `Ended ${response.revokedCount} other session(s).`
+                : "No other sessions were signed in.",
+            "success"
+        );
+        await loadSessions();
+    } catch (error) {
+        console.error("END OTHER SESSIONS ERROR:", error);
+        AppUtils.notify("Could not end your other sessions.", "error");
+    } finally {
+        if (button) button.disabled = false;
+    }
+}
+
+sessionElements.revokeOthersBtn?.addEventListener("click", endOtherSessions);
+
+document.addEventListener("DOMContentLoaded", () => {
+    if (AppUtils.getUser()) {
+        loadSessions();
+    }
+});

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -217,8 +217,68 @@ const requireAuth = () => {
     return user;
 };
 
+// Endpoints that establish or renew a session themselves. A 401 from one of
+// these is the answer, not a signal that the session needs renewing, so they are
+// never retried behind a refresh.
+const SESSION_ENDPOINTS = [
+    "/auth/login",
+    "/auth/signup",
+    "/auth/verify-signup",
+    "/auth/refresh-token",
+    "/auth/forgot-password",
+    "/auth/reset-password"
+];
+
+const isRenewable = (
+    url
+) => {
+
+    return !SESSION_ENDPOINTS.some(
+        (endpoint) => url.startsWith(endpoint)
+    );
+};
+
+// The renewal currently in flight, if any, and whether the shopper has already
+// been told their session ended.
+let pendingRefresh = null;
+
+let hasSignedOut = false;
+
+// Ends the session once however many requests discovered it was over.
+const signOutOnce = (
+    message
+) => {
+
+    if (
+        hasSignedOut
+    ) {
+
+        return;
+    }
+
+    hasSignedOut = true;
+
+    clearAuthData();
+
+    notify(
+        message
+        || "Session expired. Please login again.",
+        "error"
+    );
+
+    setTimeout(
+        () => {
+
+            window.location.href =
+                "signin.html";
+
+        },
+        1000
+    );
+};
+
 // refresh token
-const refreshAccessToken =
+const performRefresh =
     async () => {
 
         try {
@@ -229,8 +289,6 @@ const refreshAccessToken =
             if (
                 !refreshToken
             ) {
-
-                clearAuthData();
 
                 return null;
             }
@@ -266,8 +324,6 @@ const refreshAccessToken =
                 ||
                 !data.accessToken
             ) {
-
-                clearAuthData();
 
                 return null;
             }
@@ -308,11 +364,30 @@ const refreshAccessToken =
                 error
             );
 
-            clearAuthData();
-
             return null;
         }
     };
+
+// Requests that hit an expired session at the same moment share one renewal and
+// then continue, rather than each starting their own and racing one another into
+// a sign-out.
+const refreshAccessToken = () => {
+
+    if (
+        !pendingRefresh
+    ) {
+
+        pendingRefresh =
+            performRefresh().finally(
+                () => {
+
+                    pendingRefresh = null;
+                }
+            );
+    }
+
+    return pendingRefresh;
+};
 
 // api request
 const apiRequest =
@@ -387,11 +462,15 @@ const apiRequest =
                 response.status === 401
                 &&
                 retry
+                &&
+                isRenewable(url)
             ) {
 
                 const newToken =
                     await refreshAccessToken();
 
+                // Replayed with `retry` off, so a request is only ever tried a
+                // second time -- never a third.
                 if (
                     newToken
                 ) {
@@ -403,22 +482,7 @@ const apiRequest =
                     );
                 }
 
-                clearAuthData();
-
-                notify(
-                    "Session expired. Please login again.",
-                    "error"
-                );
-
-                setTimeout(
-                    () => {
-
-                        window.location.href =
-                            "signin.html";
-
-                    },
-                    1000
-                );
+                signOutOnce();
 
                 return {
 

--- a/migrations/add_auth_sessions.sql
+++ b/migrations/add_auth_sessions.sql
@@ -1,0 +1,49 @@
+-- =====================
+-- MOVE SESSIONS OFF THE USER ROW
+-- =====================
+-- Replaces the single credential stored on users.refresh_token with one durable
+-- record per signed-in device. See backend/sql/auth_sessions.sql for the table
+-- definition kept in step with backend/schema.sql.
+
+CREATE TABLE IF NOT EXISTS auth_sessions (
+    id CHAR(36) PRIMARY KEY,
+    user_id CHAR(36) NOT NULL,
+    family_id CHAR(36) NOT NULL,
+    token_hash CHAR(64) NOT NULL UNIQUE,
+    device_label VARCHAR(120),
+    user_agent TEXT,
+    ip_address VARCHAR(45),
+    issued_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_used_at DATETIME DEFAULT NULL,
+    expires_at DATETIME NOT NULL,
+    revoked_at DATETIME DEFAULT NULL,
+    revoked_reason VARCHAR(40) DEFAULT NULL,
+    replaced_by CHAR(36) DEFAULT NULL,
+
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+
+    INDEX idx_auth_sessions_token (token_hash),
+    INDEX idx_auth_sessions_user (user_id),
+    INDEX idx_auth_sessions_family (family_id),
+    INDEX idx_auth_sessions_expires (expires_at),
+    INDEX idx_auth_sessions_live (user_id, revoked_at, expires_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- =====================
+-- DROP THE SINGLE-CREDENTIAL COLUMN
+-- =====================
+-- Nothing reads or writes it any more. Existing values are not migrated: the
+-- column held the raw token, and the replacement stores only a digest, so every
+-- shopper signs in once more after this runs.
+ALTER TABLE users DROP COLUMN IF EXISTS refresh_token;
+
+-- =====================
+-- VERIFY CHANGES
+-- =====================
+SELECT
+    COLUMN_NAME,
+    DATA_TYPE,
+    IS_NULLABLE
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_NAME = 'auth_sessions'
+ORDER BY ORDINAL_POSITION;


### PR DESCRIPTION
Depends on the session-management change. Please merge that first; this diff
shrinks to just the client behaviour once it lands.

Several requests that discovered an expired session at the same moment each
started a renewal of their own. Because renewal rotates the session, the
attempts invalidated one another, and whichever lost the race signed the shopper
out — so a page that loads its cart, wishlist and profile together could throw
away a session that was perfectly renewable.

Renewal is now co-operative. The first request to find an expired session starts
one renewal; every request that arrives while it is in flight waits on that same
attempt and then continues, retrying itself exactly once. If the renewal
genuinely fails, the shopper is signed out once rather than once per waiting
request. Endpoints that establish or renew a session themselves are excluded: a
refusal from one of those is the answer, not a signal to renew, so a mistyped
password no longer triggers a renewal attempt and a redirect.

## What changes for users
Loading a page after the access token has expired renews quietly and the page
finishes loading. Being signed out produces one message instead of several.

## Verification
- Several authenticated requests hitting an expired session concurrently produce
  one renewal and all complete.
- A failed renewal signs out once, with a single message and a single redirect.
- A request is retried at most once, so a persistently refused call cannot loop.
- A refused sign-in or renewal is returned to the caller without attempting a
  renewal.

Closes #1257