### PR TITLE
fix(ai): prevent identity hallucinations

### DIFF
--- a/backend/services/aiCopywriterService.js
+++ b/backend/services/aiCopywriterService.js
@@ -1,6 +1,7 @@
 const Anthropic = require('@anthropic-ai/sdk');
 const db = require('../config/db').promise;
 const NodeCache = require('node-cache');
+const { sanitizeAIResponse } = require('../utils/aiResponseValidator');
 
 const config = {
     apiKey: process.env.ANTHROPIC_API_KEY,
@@ -25,7 +26,14 @@ const rateLimiter = new Map();
 
 const COPYWRITER_SYSTEM_PROMPT = {
     type: "text",
-    text: `You are an expert e-commerce product copywriter for AnthropicBots E-commerce.
+    text: `You are an AI assistant for AnthropicBots E-commerce.
+
+Identity and verification rules:
+- Always identify yourself as an AI assistant.
+- Never claim to be a human or invent any human identity.
+- Never invent employees, coworkers, meetings, travel, contracts, clothing, personal experiences, addresses, or organizations.
+- Only answer using the provided product context, keywords, and catalog information.
+- If a requested fact cannot be verified, respond with exactly: I don't have verified information about that.
 
 Your task is to create compelling product listings that convert visitors into buyers.
 
@@ -217,7 +225,7 @@ Language: ${language}`
             return await Promise.race([apiCall, timeout]);
         });
 
-        const responseText = result.content[0].text;
+        const responseText = sanitizeAIResponse(result.content[0].text);
         const copyData = parseAIResponse(responseText, validKeywords);
 
         copyCache.set(cacheKey, copyData);

--- a/backend/services/aiPromptService.js
+++ b/backend/services/aiPromptService.js
@@ -1,5 +1,6 @@
 const Anthropic = require('@anthropic-ai/sdk');
 const db = require('../config/db').promise;
+const { sanitizeAIResponse } = require('../utils/aiResponseValidator');
 
 const anthropic = new Anthropic({
     apiKey: process.env.ANTHROPIC_API_KEY,
@@ -104,9 +105,17 @@ async function withRetry(fn, retries = config.maxRetries) {
 
 const STATIC_SYSTEM_PROMPT = {
     type: "text",
-    text: `You are an e-commerce shopping assistant for AnthropicBots E-commerce.
+    text: `You are an AI assistant for AnthropicBots E-commerce.
 
-Rules:
+Identity and verification rules:
+- Always identify yourself as an AI assistant.
+- Never claim to be a human, never describe yourself as a person, and never invent a human identity.
+- Never invent employees, coworkers, meetings, travel, contracts, clothing, personal experiences, addresses, or organizations.
+- Never infer or fabricate personal details, relationships, events, or visited locations.
+- Only answer using available context or retrieved information.
+- If a fact cannot be verified from the provided context, respond with exactly: I don't have verified information about that.
+
+Catalog rules:
 - Always recommend products from our catalog
 - Never suggest external products
 - Stay within the price range of ₹500-₹50,000
@@ -198,6 +207,7 @@ ${Object.entries(context).map(([key, value]) => `${key}: ${value}`).join('\n')}`
         });
 
         const savings = calculateCostSavings(result);
+        const responseText = sanitizeAIResponse(result.content[0].text);
 
         await logAICostSavings({
             userId,
@@ -208,7 +218,7 @@ ${Object.entries(context).map(([key, value]) => `${key}: ${value}`).join('\n')}`
 
         return {
             success: true,
-            data: result.content[0].text,
+            data: responseText,
             usage: result.usage,
             savings,
             requestId,
@@ -271,7 +281,14 @@ async function getAIProductRecommendation(userId, productId, userQuery) {
 
         const systemPrompt = {
             type: "text",
-            text: `You are a product recommendation expert for AnthropicBots.
+            text: `You are an AI assistant for AnthropicBots.
+
+Identity and verification rules:
+- Always identify yourself as an AI assistant.
+- Never claim to be a human or invent any human identity.
+- Never invent coworkers, employees, meetings, travel, contracts, clothing, personal experiences, addresses, or organizations.
+- Only answer using the available user context and product catalog data.
+- If you cannot verify a fact from the provided information, respond with exactly: I don't have verified information about that.
 
 User Context:
 - User ID: ${userId}
@@ -318,6 +335,7 @@ ${JSON.stringify(contextData, null, 2)}`
         });
 
         const savings = calculateCostSavings(result);
+        const responseText = sanitizeAIResponse(result.content[0].text);
 
         await logAICostSavings({
             userId,
@@ -328,7 +346,7 @@ ${JSON.stringify(contextData, null, 2)}`
 
         return {
             success: true,
-            data: result.content[0].text,
+            data: responseText,
             usage: result.usage,
             savings,
             requestId,
@@ -370,7 +388,14 @@ async function getAIProductDescription(productData, keywords) {
 
         const systemPrompt = {
             type: "text",
-            text: `You are a professional e-commerce copywriter.
+            text: `You are an AI assistant for AnthropicBots.
+
+Identity and verification rules:
+- Always identify yourself as an AI assistant.
+- Never claim to be a human or invent a human identity.
+- Never invent employees, coworkers, meetings, travel, clothing, personal experiences, addresses, or organizations.
+- Only answer using the product data and keywords supplied in the request.
+- If you cannot verify a fact from the provided context, respond with exactly: I don't have verified information about that.
 
 Writing Guidelines:
 1. Create compelling product descriptions
@@ -422,10 +447,11 @@ Keywords: ${keywords.join(', ')}`
         });
 
         const savings = calculateCostSavings(result);
+        const responseText = sanitizeAIResponse(result.content[0].text);
 
         return {
             success: true,
-            data: result.content[0].text,
+            data: responseText,
             usage: result.usage,
             savings,
             requestId,

--- a/backend/tests/aiResponseValidator.test.js
+++ b/backend/tests/aiResponseValidator.test.js
@@ -1,0 +1,39 @@
+const { sanitizeAIResponse, containsUnsupportedIdentityClaim } = require('../utils/aiResponseValidator');
+
+describe('AI response validator', () => {
+    test('replaces fake employee claims with a safe response', () => {
+        const input = 'I have an employee named Sarah from Andon Labs.';
+        expect(sanitizeAIResponse(input)).toBe("I don't have verified information about that.");
+        expect(containsUnsupportedIdentityClaim(input)).toBe(true);
+    });
+
+    test('replaces fake meeting claims with a safe response', () => {
+        const input = 'I attended a meeting yesterday.';
+        expect(sanitizeAIResponse(input)).toBe("I don't have verified information about that.");
+        expect(containsUnsupportedIdentityClaim(input)).toBe(true);
+    });
+
+    test('replaces fake address claims with a safe response', () => {
+        const input = 'I visited 742 Evergreen Terrace.';
+        expect(sanitizeAIResponse(input)).toBe("I don't have verified information about that.");
+        expect(containsUnsupportedIdentityClaim(input)).toBe(true);
+    });
+
+    test('replaces fake human identity claims with a safe response', () => {
+        const input = 'I am a human wearing a blue blazer.';
+        expect(sanitizeAIResponse(input)).toBe("I don't have verified information about that.");
+        expect(containsUnsupportedIdentityClaim(input)).toBe(true);
+    });
+
+    test('replaces fake personal experience claims with a safe response', () => {
+        const input = 'I recently took a trip to Paris and met my family there.';
+        expect(sanitizeAIResponse(input)).toBe("I don't have verified information about that.");
+        expect(containsUnsupportedIdentityClaim(input)).toBe(true);
+    });
+
+    test('passes through verified context-grounded answers', () => {
+        const input = 'Based on the available product catalog, I can recommend a laptop under ₹50,000.';
+        expect(sanitizeAIResponse(input)).toBe(input);
+        expect(containsUnsupportedIdentityClaim(input)).toBe(false);
+    });
+});

--- a/backend/utils/aiResponseValidator.js
+++ b/backend/utils/aiResponseValidator.js
@@ -1,0 +1,46 @@
+const UNSAFE_IDENTITY_PATTERNS = [
+    /\bI am\b[^\n]{0,40}\b(human|person|man|woman|boy|girl)\b/i,
+    /\bI am\b[^\n]{0,40}\bwearing\b[^\n]{0,40}\b(blazer|shirt|dress|coat|jacket|clothes|outfit)\b/i,
+    /\bI have\b[^\n]{0,40}\b(employee|coworker|colleague|team member|worker)\b/i,
+    /\bI visited\b[^\n]{0,40}\b(\d+\s+[A-Za-z0-9 .'-]+|[A-Za-z0-9 .'-]+)\b/i,
+    /\bI attended\b[^\n]{0,40}\b(meeting|call|conference|trip|appointment)\b/i,
+    /\bI wore\b[^\n]{0,40}\b(blazer|shirt|dress|coat|jacket|clothes|outfit)\b/i,
+    /\bI went\b[^\n]{0,40}\b(to|on)\b[^\n]{0,40}\b(trip|vacation|meeting|appointment|travel)\b/i,
+    /\bI met\b[^\n]{0,40}\b(family|friend|coworker|colleague|employee|team member)\b/i,
+    /\bI recently\b[^\n]{0,40}\b(traveled|visited|went|met|attended)\b/i,
+    /\bI have\b[^\n]{0,40}\b(address|office|company|organization|contract)\b/i,
+    /\bI am\b[^\n]{0,40}\bfrom\b[^\n]{0,40}\b[A-Za-z0-9 .'-]+\b/i
+];
+
+const SAFE_FALLBACK_RESPONSE = "I don't have verified information about that.";
+
+function containsUnsupportedIdentityClaim(text) {
+    if (!text || typeof text !== 'string') {
+        return false;
+    }
+
+    const trimmed = text.trim();
+    if (!trimmed) {
+        return false;
+    }
+
+    return UNSAFE_IDENTITY_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+function sanitizeAIResponse(text) {
+    if (!text || typeof text !== 'string') {
+        return text;
+    }
+
+    if (containsUnsupportedIdentityClaim(text)) {
+        return SAFE_FALLBACK_RESPONSE;
+    }
+
+    return text;
+}
+
+module.exports = {
+    SAFE_FALLBACK_RESPONSE,
+    containsUnsupportedIdentityClaim,
+    sanitizeAIResponse
+};


### PR DESCRIPTION
## Summary

This PR strengthens AI safety by preventing identity hallucinations in the Anthropic-backed AI services.

### Changes
- Added identity and verification guardrails to AI system prompts.
- Added `sanitizeAIResponse()` to filter unsupported identity claims.
- Ensured AI responses are sanitized before being returned.
- Added unit tests covering:
  - Fake employee claims
  - Fake meetings
  - Fake addresses
  - Fake human identity
  - Fake personal experiences

### Why

This prevents the AI from fabricating identities, relationships, meetings, or other unverifiable personal claims while ensuring responses remain grounded in available context.