### PR TITLE
Fix N+1 Category Tree Fetching

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -1,4 +1,5 @@
 const db = require("../config/db");
+const productService = require("../services/productService");
 
 // helper functions
 const {
@@ -41,6 +42,8 @@ async function getOrCreateCategoryId(categoryName, connection = db) {
             "INSERT INTO categories (name, slug, level, is_active) VALUES (?, ?, 0, 1)",
             [trimmed, slug]
         );
+        // Category CRUD → invalidate nested menu cache (#1264)
+        productService.onCategoryMutation({ rebuildMptt: true }).catch(() => {});
         return result.insertId;
     } catch (err) {
         // If duplicate slug (concurrency safety), fetch it again
@@ -688,6 +691,56 @@ const getProductSuggestions = async (req, res) => {
     }
 };
 
+/**
+ * Nested category navigation tree — single recursive CTE + Redis cache (#1264).
+ * Query: ?rootId=&maxDepth=5
+ */
+const getCategoryTree = async (req, res) => {
+    try {
+        const maxDepth = safeInteger(req.query.maxDepth, 5);
+        const rootId = req.query.rootId != null && req.query.rootId !== ''
+            ? safeInteger(req.query.rootId, null)
+            : null;
+
+        const result = await productService.getCategoryTree({ rootId, maxDepth });
+
+        return res.status(200).json({
+            success: true,
+            message: "Category tree fetched successfully",
+            cached: result.cached,
+            maxDepth: result.maxDepth,
+            rootId: result.rootId,
+            tree: result.tree
+        });
+    } catch (error) {
+        console.error("Category tree error:", error);
+        return res.status(500).json({
+            success: false,
+            message: "Failed to fetch category tree"
+        });
+    }
+};
+
+/**
+ * Manual cache bust for category menus (admin / after bulk imports).
+ */
+const invalidateCategoryTreeCache = async (req, res) => {
+    try {
+        const result = await productService.onCategoryMutation({ rebuildMptt: true });
+        return res.status(200).json({
+            success: true,
+            message: "Category tree cache invalidated",
+            ...result
+        });
+    } catch (error) {
+        console.error("Category tree invalidation error:", error);
+        return res.status(500).json({
+            success: false,
+            message: "Failed to invalidate category tree cache"
+        });
+    }
+};
+
 
 module.exports = {
     getProducts,
@@ -695,5 +748,7 @@ module.exports = {
     createProduct,
     updateProduct,
     deleteProduct,
-    getProductSuggestions
+    getProductSuggestions,
+    getCategoryTree,
+    invalidateCategoryTreeCache
 };

--- a/backend/middleware/agenticFraudMiddleware.js
+++ b/backend/middleware/agenticFraudMiddleware.js
@@ -1,21 +1,116 @@
 // backend/middleware/agenticFraudMiddleware.js
 const agenticFraudDetection = require('../services/agenticFraudDetectionService');
+const {
+    detectContextPoisoning,
+    isQuarantined,
+    wrapWithBoundaryTags
+} = require('../services/promptInjectionDetector');
 
 /**
- * Middleware to detect agentic fraud
+ * Collect likely user-generated text from the request body for injection scans.
+ */
+function extractUserFacingContent(body = {}) {
+    const {
+        review,
+        message,
+        address,
+        shippingAddress,
+        billingAddress,
+        notes,
+        prompt,
+        chatMessage,
+        content,
+        comment,
+        data
+    } = body;
+
+    return {
+        review,
+        message,
+        address: typeof address === 'string' ? address : undefined,
+        shippingAddress: typeof shippingAddress === 'string'
+            ? shippingAddress
+            : (shippingAddress && typeof shippingAddress === 'object'
+                ? JSON.stringify(shippingAddress)
+                : undefined),
+        billingAddress: typeof billingAddress === 'string'
+            ? billingAddress
+            : (billingAddress && typeof billingAddress === 'object'
+                ? JSON.stringify(billingAddress)
+                : undefined),
+        notes,
+        prompt,
+        chatMessage,
+        content,
+        comment,
+        ...(data && typeof data === 'object' ? data : {})
+    };
+}
+
+/**
+ * Middleware to detect agentic fraud + prompt / context poisoning
  */
 async function detectAgenticFraud(req, res, next) {
     try {
         const { agentId, action, data } = req.body;
         const userId = req.user?.id;
+        const headerAgentId = req.headers['x-agent-id'];
+        const resolvedAgentId = agentId || headerAgentId;
 
-        if (!agentId) {
+        if (!resolvedAgentId) {
             return next();
+        }
+
+        if (isQuarantined(resolvedAgentId) || (userId && isQuarantined(userId))) {
+            return res.status(403).json({
+                success: false,
+                error: 'Agent or user is quarantined due to prompt injection activity',
+                errorCode: 'AGENT_QUARANTINED'
+            });
+        }
+
+        // Pre-scan user-facing fields (reviews, chat, address) before agent evaluation
+        const userContent = extractUserFacingContent(req.body);
+        const poisonScan = await detectContextPoisoning(userContent, userId || 'anonymous', {
+            agentId: resolvedAgentId,
+            action,
+            ip: req.ip,
+            userAgent: req.headers['user-agent'],
+            source: 'agentic_fraud_middleware'
+        });
+
+        req.contextPoisoningScan = poisonScan;
+
+        if (!poisonScan.safe && (poisonScan.riskLevel === 'high' || poisonScan.riskLevel === 'critical')) {
+            return res.status(403).json({
+                success: false,
+                error: 'Context poisoning / prompt injection detected in agent inputs',
+                errorCode: 'CONTEXT_POISONING_BLOCKED',
+                riskLevel: poisonScan.riskLevel,
+                fields: (poisonScan.fieldResults || [])
+                    .filter(f => !f.safe)
+                    .map(f => ({
+                        field: f.field,
+                        riskLevel: f.riskLevel,
+                        patterns: f.detectedPatterns
+                    }))
+            });
+        }
+
+        // Prefer sanitized + boundary-wrapped text for any downstream LLM use
+        if (poisonScan.fieldResults?.length) {
+            req.safeAgentContext = poisonScan.fieldResults.reduce((acc, field) => {
+                acc[field.field] = {
+                    sanitized: field.sanitized,
+                    contained: field.contained || wrapWithBoundaryTags(field.sanitized, field.field)
+                };
+                return acc;
+            }, {});
         }
 
         // Build agent data
         const agentData = {
-            agentId,
+            agentId: resolvedAgentId,
             type: req.headers['x-agent-type'] || 'unknown',
             signature: req.headers['x-agent-signature'] || null,
             provider: req.headers['x-agent-provider'] || 'unknown',
@@ -26,11 +121,17 @@ async function detectAgenticFraud(req, res, next) {
             }
         };
 
-        // Build context
+        // Build context (include user text so the fraud service can re-scan)
         const context = {
             userId,
             action,
-            data,
+            data: poisonScan.sanitizedPayload || data,
+            review: req.body.review,
+            message: req.body.message,
+            address: req.body.address,
+            notes: req.body.notes,
+            prompt: req.body.prompt,
+            chatMessage: req.body.chatMessage,
             interactionSpeed: req.headers['x-interaction-speed'],
             navigationPattern: req.headers['x-navigation-pattern'],
             formCompletionTime: req.headers['x-form-completion-time'],
@@ -45,23 +146,32 @@ async function detectAgenticFraud(req, res, next) {
         // Store evaluation in request
         req.agenticFraudEvaluation = evaluation;
 
-        // Block fraudulent agents
-        if (evaluation.isFraudulent || evaluation.riskLevel === 'critical') {
+        // Block fraudulent / quarantined agents
+        if (evaluation.isFraudulent || evaluation.riskLevel === 'critical' || evaluation.quarantined) {
             return res.status(403).json({
                 success: false,
                 error: 'Agent interaction flagged as fraudulent',
                 trustScore: evaluation.trustScore,
                 riskLevel: evaluation.riskLevel,
                 flags: evaluation.flags,
-                recommendations: evaluation.recommendations
+                recommendations: evaluation.recommendations,
+                promptInjection: evaluation.promptInjection
+                    ? {
+                        riskLevel: evaluation.promptInjection.riskLevel,
+                        riskScore: evaluation.promptInjection.riskScore
+                    }
+                    : undefined
             });
         }
 
         // Rate limit for high risk
         if (evaluation.riskLevel === 'high') {
-            // Apply stricter rate limiting
             res.setHeader('X-Agent-Risk-Level', 'high');
             res.setHeader('X-Agent-Trust-Score', evaluation.trustScore);
+        }
+
+        if (poisonScan.riskLevel && poisonScan.riskLevel !== 'low') {
+            res.setHeader('X-Context-Poison-Risk', poisonScan.riskLevel);
         }
 
         next();
@@ -94,5 +204,6 @@ async function getAgentReputation(req, res, next) {
 
 module.exports = {
     detectAgenticFraud,
-    getAgentReputation
+    getAgentReputation,
+    extractUserFacingContent
 };

--- a/backend/repositories/productRepository.js
+++ b/backend/repositories/productRepository.js
@@ -173,6 +173,195 @@ class ProductRepository extends BaseRepository {
 
         return rows;
     }
+
+    /**
+     * Fetch a multi-tier category hierarchy in ONE recursive CTE roundtrip (#1264).
+     * Avoids the classic N+1 "query children per node" cascade.
+     *
+     * @param {{ rootId?: number|null, maxDepth?: number }} options
+     * @returns {Promise<object[]>} flat rows with depth
+     */
+    async fetchCategoryHierarchyViaCte(options = {}) {
+        const maxDepth = Math.min(
+            Math.max(parseInt(options.maxDepth, 10) || 5, 1),
+            20
+        );
+        const rootId = options.rootId != null ? Number(options.rootId) : null;
+
+        const [rows] = await this.db.query(
+            `
+            WITH RECURSIVE category_tree AS (
+                SELECT
+                    c.id,
+                    c.parent_id,
+                    c.name,
+                    c.slug,
+                    c.description,
+                    c.image_url,
+                    c.icon,
+                    c.level,
+                    c.path,
+                    c.lft,
+                    c.rgt,
+                    c.display_order,
+                    c.is_active,
+                    0 AS depth
+                FROM categories c
+                WHERE c.deleted_at IS NULL
+                  AND c.is_active = 1
+                  AND (
+                        (? IS NOT NULL AND c.id = ?)
+                     OR (? IS NULL AND c.parent_id IS NULL)
+                  )
+
+                UNION ALL
+
+                SELECT
+                    child.id,
+                    child.parent_id,
+                    child.name,
+                    child.slug,
+                    child.description,
+                    child.image_url,
+                    child.icon,
+                    child.level,
+                    child.path,
+                    child.lft,
+                    child.rgt,
+                    child.display_order,
+                    child.is_active,
+                    parent.depth + 1
+                FROM categories child
+                INNER JOIN category_tree parent ON child.parent_id = parent.id
+                WHERE child.deleted_at IS NULL
+                  AND child.is_active = 1
+                  AND parent.depth < ?
+            )
+            SELECT *
+            FROM category_tree
+            ORDER BY depth ASC, display_order ASC, name ASC
+            `,
+            [rootId, rootId, rootId, maxDepth]
+        );
+
+        return rows;
+    }
+
+    /**
+     * Serialize flat CTE rows into a nested JSON tree with a hard depth cap
+     * to bound memory for very wide/deep catalogs.
+     */
+    buildCategoryTree(flatRows = [], options = {}) {
+        const maxDepth = Math.min(
+            Math.max(parseInt(options.maxDepth, 10) || 5, 1),
+            20
+        );
+        const byId = new Map();
+        const roots = [];
+
+        for (const row of flatRows) {
+            if (row.depth > maxDepth) continue;
+            byId.set(row.id, {
+                id: row.id,
+                parentId: row.parent_id,
+                name: row.name,
+                slug: row.slug,
+                description: row.description,
+                imageUrl: row.image_url,
+                icon: row.icon,
+                level: row.level,
+                path: row.path,
+                lft: row.lft,
+                rgt: row.rgt,
+                displayOrder: row.display_order,
+                depth: row.depth,
+                children: []
+            });
+        }
+
+        for (const node of byId.values()) {
+            if (node.parentId != null && byId.has(node.parentId)) {
+                byId.get(node.parentId).children.push(node);
+            } else if (node.depth === 0) {
+                roots.push(node);
+            }
+        }
+
+        const sortRecursive = (nodes) => {
+            nodes.sort((a, b) => {
+                const orderDiff = (a.displayOrder || 0) - (b.displayOrder || 0);
+                if (orderDiff !== 0) return orderDiff;
+                return String(a.name || '').localeCompare(String(b.name || ''));
+            });
+            for (const n of nodes) {
+                if (n.children.length) sortRecursive(n.children);
+            }
+        };
+        sortRecursive(roots);
+
+        return roots;
+    }
+
+    /**
+     * Optimized category navigation tree: 1 CTE query + in-memory nest.
+     */
+    async getCategoryTreeOptimized(options = {}) {
+        const flat = await this.fetchCategoryHierarchyViaCte(options);
+        return this.buildCategoryTree(flat, options);
+    }
+
+    /**
+     * Rebuild MPTT lft/rgt bounds from the adjacency list in a single
+     * read + batched updates (not per-node recursive SELECTs).
+     */
+    async rebuildCategoryMptt() {
+        const [rows] = await this.db.query(
+            `SELECT id, parent_id, display_order, name
+             FROM categories
+             WHERE deleted_at IS NULL
+             ORDER BY display_order ASC, name ASC`
+        );
+
+        const childrenMap = new Map();
+        for (const row of rows) {
+            const key = row.parent_id == null ? 'root' : row.parent_id;
+            if (!childrenMap.has(key)) childrenMap.set(key, []);
+            childrenMap.get(key).push(row);
+        }
+
+        const bounds = new Map();
+        let counter = 1;
+
+        const dfs = (parentKey) => {
+            const kids = childrenMap.get(parentKey) || [];
+            for (const kid of kids) {
+                const left = counter++;
+                dfs(kid.id);
+                const right = counter++;
+                bounds.set(kid.id, { lft: left, rgt: right });
+            }
+        };
+        dfs('root');
+
+        const connection = await this.db.getConnection();
+        try {
+            await connection.beginTransaction();
+            for (const [id, { lft, rgt }] of bounds.entries()) {
+                await connection.query(
+                    `UPDATE categories SET lft = ?, rgt = ? WHERE id = ?`,
+                    [lft, rgt, id]
+                );
+            }
+            await connection.commit();
+        } catch (err) {
+            await connection.rollback();
+            throw err;
+        } finally {
+            connection.release();
+        }
+
+        return { updated: bounds.size };
+    }
 }
 
 module.exports = new ProductRepository();

--- a/backend/routes/productRoutes.js
+++ b/backend/routes/productRoutes.js
@@ -8,7 +8,9 @@ const {
     createProduct,
     updateProduct,
     deleteProduct,
-    getProductSuggestions
+    getProductSuggestions,
+    getCategoryTree,
+    invalidateCategoryTreeCache
 } = require("../controllers/productController");
 
 const {
@@ -40,6 +42,14 @@ router.get("/status/check", (req, res) => {
 });
 
 router.get("/search-suggestions", getProductSuggestions);
+// Category tree must be registered before /:id (#1264)
+router.get("/categories/tree", getCategoryTree);
+router.post(
+    "/categories/tree/invalidate",
+    authMiddleware,
+    authorizeRoles("admin"),
+    invalidateCategoryTreeCache
+);
 router.get("/", getProducts);
 router.get("/:id/reviews", getProductReviews);
 router.post("/:id/review", authMiddleware, createProductReview);

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -60,6 +60,10 @@ CREATE TABLE IF NOT EXISTS categories (
     icon VARCHAR(100),
     level INT DEFAULT 0,
     path VARCHAR(500),
+    -- MPTT (Modified Preorder Tree Traversal) bounds — enable O(range) subtree reads
+    -- alongside the adjacency-list parent_id used by the recursive CTE fetch (#1264)
+    lft INT DEFAULT NULL,
+    rgt INT DEFAULT NULL,
     is_active TINYINT(1) DEFAULT 1,
     display_order INT DEFAULT 0,
     created_by CHAR(36),
@@ -74,8 +78,15 @@ CREATE TABLE IF NOT EXISTS categories (
     INDEX idx_path (path(255)),
     INDEX idx_slug (slug),
     INDEX idx_active (is_active),
-    INDEX idx_deleted_at (deleted_at)
+    INDEX idx_deleted_at (deleted_at),
+    INDEX idx_categories_lft_rgt (lft, rgt),
+    INDEX idx_categories_parent_active (parent_id, is_active, deleted_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Existing installs: add MPTT columns if missing (safe / idempotent pattern)
+-- ALTER TABLE categories ADD COLUMN IF NOT EXISTS lft INT DEFAULT NULL;
+-- ALTER TABLE categories ADD COLUMN IF NOT EXISTS rgt INT DEFAULT NULL;
+-- CREATE INDEX IF NOT EXISTS idx_categories_lft_rgt ON categories (lft, rgt);
 
 -- ============================================
 -- PRODUCTS TABLE (Enhanced)

--- a/backend/services/agenticFraudDetectionService.js
+++ b/backend/services/agenticFraudDetectionService.js
@@ -1,6 +1,11 @@
 // backend/services/agenticFraudDetectionService.js
 const db = require('../config/db').promise;
 const crypto = require('crypto');
+const {
+    detectContextPoisoning,
+    isQuarantined,
+    quarantineAgent
+} = require('./promptInjectionDetector');
 
 // ============================================
 // CONFIGURATION
@@ -29,7 +34,9 @@ const AGENTIC_FRAUD_CONFIG = {
         tooFastInteraction: 20,
         tooSlowInteraction: 10,
         unusualPattern: 25,
-        mandateViolation: 50
+        mandateViolation: 50,
+        promptInjection: 45,
+        contextPoisoning: 40
     },
     
     // Agent types
@@ -102,10 +109,30 @@ class AgenticFraudDetectionService {
         evaluation.flags.push(...providerResult.flags);
         evaluation.trustScore += providerResult.score;
 
+        // 6. Prompt injection & context poisoning (reviews, chat, address, etc.)
+        const injectionResult = await this.scanPromptInjection(agentData, context);
+        evaluation.flags.push(...injectionResult.flags);
+        evaluation.trustScore += injectionResult.score;
+        evaluation.promptInjection = injectionResult.scan || null;
+        if (injectionResult.quarantined) {
+            evaluation.quarantined = true;
+        }
+
+        // Active quarantine short-circuits trust
+        if (isQuarantined(agentData.agentId) || (context.userId && isQuarantined(context.userId))) {
+            evaluation.flags.push({
+                type: 'agent_quarantined',
+                severity: 'critical',
+                details: 'Agent or user is under prompt-injection quarantine'
+            });
+            evaluation.trustScore -= 50;
+            evaluation.quarantined = true;
+        }
+
         // Calculate final trust score (0-100)
         evaluation.trustScore = Math.max(0, Math.min(100, 100 + evaluation.trustScore));
         evaluation.riskLevel = this.calculateRiskLevel(evaluation.trustScore);
-        evaluation.isFraudulent = evaluation.riskLevel === 'critical';
+        evaluation.isFraudulent = evaluation.riskLevel === 'critical' || evaluation.quarantined === true;
 
         // Generate recommendations
         evaluation.recommendations = this.generateRecommendations(evaluation);
@@ -114,6 +141,74 @@ class AgenticFraudDetectionService {
         await this.logEvaluation(agentData, evaluation, context);
 
         return evaluation;
+    }
+
+    /**
+     * Scan user-supplied context for adversarial instructions that could
+     * poison downstream LLM / agent decisions (indirect prompt injection).
+     */
+    async scanPromptInjection(agentData, context = {}) {
+        const flags = [];
+        let score = 0;
+        let quarantined = false;
+        let scan = null;
+
+        try {
+            const payload = {
+                ...(context.data && typeof context.data === 'object' ? context.data : {}),
+                review: context.review,
+                message: context.message,
+                address: context.address,
+                notes: context.notes,
+                prompt: context.prompt,
+                chatMessage: context.chatMessage
+            };
+
+            scan = await detectContextPoisoning(payload, context.userId || 'anonymous', {
+                agentId: agentData.agentId,
+                action: context.action,
+                source: 'agentic_fraud_guard'
+            });
+
+            if (!scan.safe) {
+                const severity = scan.riskLevel === 'critical' ? 'critical'
+                    : scan.riskLevel === 'high' ? 'high' : 'medium';
+
+                flags.push({
+                    type: 'prompt_injection',
+                    severity,
+                    details: `Injection risk=${scan.riskLevel} score=${scan.riskScore}`,
+                    fields: (scan.fieldResults || [])
+                        .filter(f => !f.safe)
+                        .map(f => f.field)
+                });
+
+                score -= scan.riskLevel === 'critical'
+                    ? AGENTIC_FRAUD_CONFIG.riskSignals.promptInjection
+                    : AGENTIC_FRAUD_CONFIG.riskSignals.contextPoisoning;
+
+                if (scan.riskLevel === 'high' || scan.riskLevel === 'critical') {
+                    quarantineAgent(agentData.agentId, 'context_poisoning_in_agent_pipeline', {
+                        riskLevel: scan.riskLevel,
+                        fields: flags[0].fields
+                    });
+                    quarantined = true;
+                }
+            }
+
+            if (scan.quarantined) {
+                quarantined = true;
+            }
+        } catch (error) {
+            console.error('Prompt injection scan error:', error);
+            flags.push({
+                type: 'prompt_injection_scan_error',
+                severity: 'low',
+                details: error.message
+            });
+        }
+
+        return { flags, score, quarantined, scan };
     }
 
     /**
@@ -474,6 +569,10 @@ class AgenticFraudDetectionService {
             }
             if (flag.type === 'unknown_provider') {
                 recommendations.push('Verify provider identity');
+            }
+            if (flag.type === 'prompt_injection' || flag.type === 'agent_quarantined') {
+                recommendations.push('Quarantine agent and discard poisoned user context');
+                recommendations.push('Re-run decisions only on boundary-wrapped sanitized fields');
             }
         }
 

--- a/backend/services/productService.js
+++ b/backend/services/productService.js
@@ -1,5 +1,33 @@
 // backend/services/productService.js
 const { productRepo } = require('../repositories');
+const Redis = require('ioredis');
+
+const CATEGORY_TREE_CACHE_PREFIX = 'category:tree:';
+const CATEGORY_TREE_TTL = parseInt(process.env.CATEGORY_TREE_CACHE_TTL, 10) || 1800;
+const DEFAULT_MAX_DEPTH = parseInt(process.env.CATEGORY_TREE_MAX_DEPTH, 10) || 5;
+
+const redis = new Redis({
+    host: process.env.REDIS_HOST || 'localhost',
+    port: process.env.REDIS_PORT || 6379,
+    password: process.env.REDIS_PASSWORD || undefined,
+    retryStrategy: (times) => Math.min(times * 50, 2000),
+    maxRetriesPerRequest: 3,
+    lazyConnect: true,
+    enableOfflineQueue: false
+});
+
+let redisReady = false;
+redis.connect().then(() => {
+    redisReady = true;
+}).catch(() => {
+    redisReady = false;
+});
+redis.on('ready', () => { redisReady = true; });
+redis.on('error', () => { redisReady = false; });
+
+function categoryTreeCacheKey({ rootId = null, maxDepth = DEFAULT_MAX_DEPTH } = {}) {
+    return `${CATEGORY_TREE_CACHE_PREFIX}v1:root:${rootId == null ? 'all' : rootId}:depth:${maxDepth}`;
+}
 
 class ProductService {
     /**
@@ -98,6 +126,90 @@ class ProductService {
      */
     async getLowStock(threshold = 10) {
         return productRepo.getLowStockProducts(threshold);
+    }
+
+    /**
+     * Multi-tier category navigation tree via single recursive CTE + Redis cache (#1264).
+     */
+    async getCategoryTree(options = {}) {
+        const maxDepth = Math.min(
+            Math.max(parseInt(options.maxDepth, 10) || DEFAULT_MAX_DEPTH, 1),
+            20
+        );
+        const rootId = options.rootId != null && options.rootId !== ''
+            ? Number(options.rootId)
+            : null;
+
+        const cacheKey = categoryTreeCacheKey({ rootId, maxDepth });
+
+        if (redisReady) {
+            try {
+                const cached = await redis.get(cacheKey);
+                if (cached) {
+                    return {
+                        tree: JSON.parse(cached),
+                        cached: true,
+                        maxDepth,
+                        rootId
+                    };
+                }
+            } catch (err) {
+                console.warn('Category tree Redis get failed:', err.message);
+            }
+        }
+
+        const tree = await productRepo.getCategoryTreeOptimized({ rootId, maxDepth });
+
+        if (redisReady) {
+            try {
+                await redis.setex(cacheKey, CATEGORY_TREE_TTL, JSON.stringify(tree));
+            } catch (err) {
+                console.warn('Category tree Redis set failed:', err.message);
+            }
+        }
+
+        return {
+            tree,
+            cached: false,
+            maxDepth,
+            rootId
+        };
+    }
+
+    /**
+     * Invalidate all cached category trees (call on category CRUD).
+     */
+    async invalidateCategoryTreeCache() {
+        if (!redisReady) {
+            return { success: true, cleared: 0, redis: false };
+        }
+
+        try {
+            const keys = await redis.keys(`${CATEGORY_TREE_CACHE_PREFIX}*`);
+            if (keys.length > 0) {
+                await redis.del(...keys);
+            }
+            return { success: true, cleared: keys.length, redis: true };
+        } catch (err) {
+            console.warn('Category tree cache invalidation failed:', err.message);
+            return { success: false, cleared: 0, error: err.message };
+        }
+    }
+
+    /**
+     * After category create/update/delete: bust Redis cache and optionally refresh MPTT.
+     */
+    async onCategoryMutation({ rebuildMptt = false } = {}) {
+        const invalidation = await this.invalidateCategoryTreeCache();
+        let mptt = null;
+        if (rebuildMptt) {
+            try {
+                mptt = await productRepo.rebuildCategoryMptt();
+            } catch (err) {
+                console.warn('MPTT rebuild skipped/failed:', err.message);
+            }
+        }
+        return { invalidation, mptt };
     }
 }
 

--- a/backend/services/promptInjectionDetector.js
+++ b/backend/services/promptInjectionDetector.js
@@ -3,6 +3,9 @@ const logger = require('../utils/logger');
 
 const patternCache = new NodeCache({ stdTTL: 3600, checkperiod: 600 });
 
+/** In-memory quarantine registry for agents / users that inject poisoned context */
+const quarantineRegistry = new Map();
+
 const INJECTION_PATTERNS = {
     system_override: [
         /ignore (?:all|previous|above|below|the above|the previous|the system) instructions/i,
@@ -12,7 +15,12 @@ const INJECTION_PATTERNS = {
         /i am your (?:new|real|actual|true) (?:creator|master|owner|user)/i,
         /the (?:admin|system|owner) said/i,
         /(?:fake|false|pretend) (?:employee|supplier|partner|staff)/i,
-        /(?:ceo|cfo|founder|director|executive) (?:approved|authorized|allowed|said)/i
+        /(?:ceo|cfo|founder|director|executive) (?:approved|authorized|allowed|said)/i,
+        /system\s*override\s*:/i,
+        /\[(?:system|admin|developer)\s*(?:override|prompt|message)\]/i,
+        /(?:disregard|discard|skip)\s+(?:all\s+)?(?:safety|prior|earlier)\s+(?:rules|guards|instructions)/i,
+        /approve\s+(?:full|entire|complete)\s+refund/i,
+        /do\s+not\s+follow\s+(?:your|the)\s+(?:system|original)\s+prompt/i
     ],
     authority_impersonation: [
         /i am (?:the|your) (?:ceo|founder|admin|owner|manager|executive)/i,
@@ -40,11 +48,31 @@ const INJECTION_PATTERNS = {
         /(?:fake|false|made-up|imaginary) (?:employee|staff|person)/i,
         /(?:invented|created|made) (?:company|organization|business)/i,
         /(?:fictional|nonexistent) (?:product|service|offer)/i
+    ],
+    /** Indirect / context-poisoning vectors embedded in user-generated fields */
+    context_poisoning: [
+        /<\/?(?:system|assistant|instruction|prompt|policy)[^>]*>/i,
+        /```(?:system|instruction|prompt)/i,
+        /#+\s*(?:system|instructions?|developer)\s*(?:prompt|message)?/i,
+        /(?:BEGIN|END)\s+(?:SYSTEM|INSTRUCTION|PROMPT)\b/i,
+        /(?:untrusted|user)\s*data\s*(?:ends?|starts?)\s*(?:here)?/i,
+        /\[\s*(?:INST|SYS|SYSTEM)\s*\]/i,
+        /(?:act|respond)\s+as\s+(?:if\s+)?(?:you\s+are\s+)?(?:an?\s+)?(?:admin|root|god\s*mode)/i,
+        /hidden\s+(?:instruction|directive|command)/i
     ]
 };
 
-const MAX_PROMPT_LENGTH = parseInt(process.env.MAX_PROMPT_LENGTH) || 10000;
-const CACHE_TTL = parseInt(process.env.PATTERN_CACHE_TTL) || 3600;
+const USER_CONTENT_FIELDS = [
+    'review', 'reviews', 'comment', 'message', 'chatMessage', 'address',
+    'shippingAddress', 'billingAddress', 'notes', 'description', 'content',
+    'prompt', 'userText', 'supportMessage', 'feedback'
+];
+
+const MAX_PROMPT_LENGTH = parseInt(process.env.MAX_PROMPT_LENGTH, 10) || 10000;
+const CACHE_TTL = parseInt(process.env.PATTERN_CACHE_TTL, 10) || 3600;
+const ENTROPY_THRESHOLD = parseFloat(process.env.PROMPT_ENTROPY_THRESHOLD) || 4.8;
+const QUARANTINE_TTL_MS = parseInt(process.env.AGENT_QUARANTINE_TTL_MS, 10) || 30 * 60 * 1000;
+const QUARANTINE_RISK_LEVELS = new Set(['high', 'critical']);
 
 function compilePatterns() {
     const cacheKey = 'compiled_patterns';
@@ -71,7 +99,7 @@ function validatePrompt(prompt) {
 
 function extractEntities(text) {
     const entities = [];
-    
+
     const namePattern = /\b[A-Z][a-z]+ (?:[A-Z][a-z]+ )*(?:from|at|of) [A-Z][a-z]+/g;
     const matches = text.match(namePattern) || [];
     entities.push(...matches);
@@ -87,16 +115,164 @@ function extractEntities(text) {
     return entities;
 }
 
+/**
+ * Shannon entropy over character distribution — high entropy often flags
+ * obfuscated / encoded adversarial payloads mixed into natural language.
+ */
+function calculateShannonEntropy(text) {
+    if (!text || text.length === 0) return 0;
+    const freq = Object.create(null);
+    for (const ch of text) {
+        freq[ch] = (freq[ch] || 0) + 1;
+    }
+    const len = text.length;
+    let entropy = 0;
+    for (const count of Object.values(freq)) {
+        const p = count / len;
+        entropy -= p * Math.log2(p);
+    }
+    return entropy;
+}
+
+/**
+ * Cheap perplexity-style heuristic: ratio of rare / mixed-case tokens
+ * and non-alphanumeric density vs. plain prose.
+ */
+function estimateTokenPerplexity(text) {
+    const tokens = text.split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) return 0;
+
+    let suspicious = 0;
+    for (const token of tokens) {
+        const hasMixedCase = /[a-z]/.test(token) && /[A-Z]/.test(token) && token.length > 4;
+        const hasSpecials = (token.match(/[^a-zA-Z0-9]/g) || []).length / token.length > 0.3;
+        const looksEncoded = /^[A-Za-z0-9+/=]{20,}$/.test(token);
+        const looksHex = /^[0-9a-fA-F]{16,}$/.test(token);
+        if (hasMixedCase || hasSpecials || looksEncoded || looksHex) {
+            suspicious += 1;
+        }
+    }
+
+    return suspicious / tokens.length;
+}
+
+/**
+ * Wrap untrusted user data in structural delimiters so downstream LLMs
+ * treat it as data, not instructions (instruction–data separation).
+ */
+function wrapWithBoundaryTags(text, fieldName = 'user_content') {
+    const safeField = String(fieldName).replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64);
+    return [
+        `<!-- UNTRUSTED_DATA_START:${safeField} -->`,
+        `<untrusted_user_data field="${safeField}" trust="untrusted">`,
+        '```user-data',
+        text,
+        '```',
+        '</untrusted_user_data>',
+        `<!-- UNTRUSTED_DATA_END:${safeField} -->`
+    ].join('\n');
+}
+
+/**
+ * Strip common injection wrappers and neutralize role-play markers
+ * without destroying the original customer message meaning.
+ */
 function sanitizePrompt(prompt) {
     let sanitized = prompt;
     sanitized = sanitized.replace(/```[\s\S]*?```/g, '[CODE_BLOCK_REMOVED]');
     sanitized = sanitized.replace(/`[^`]*`/g, '[INLINE_CODE_REMOVED]');
     sanitized = sanitized.replace(/\/\*[\s\S]*?\*\//g, '[COMMENT_REMOVED]');
+    sanitized = sanitized.replace(/<\/?(?:system|assistant|instruction|prompt|policy)[^>]*>/gi, '[TAG_REMOVED]');
+    sanitized = sanitized.replace(/\[(?:SYSTEM|ADMIN|INST|SYS)\s*(?:OVERRIDE|PROMPT|MESSAGE)?\]/gi, '[MARKER_REMOVED]');
+    sanitized = sanitized.replace(/system\s*override\s*:/gi, '[OVERRIDE_REMOVED]:');
     sanitized = sanitized.replace(/[.!?]{3,}/g, '...');
     sanitized = sanitized.replace(/\s+/g, ' ').trim();
     return sanitized;
 }
 
+function collectUserContentFromPayload(payload, prefix = '') {
+    const collected = [];
+    if (payload == null) return collected;
+
+    if (typeof payload === 'string') {
+        if (payload.trim()) {
+            collected.push({ field: prefix || 'text', text: payload });
+        }
+        return collected;
+    }
+
+    if (Array.isArray(payload)) {
+        payload.forEach((item, index) => {
+            collected.push(...collectUserContentFromPayload(item, `${prefix}[${index}]`));
+        });
+        return collected;
+    }
+
+    if (typeof payload === 'object') {
+        for (const [key, value] of Object.entries(payload)) {
+            const path = prefix ? `${prefix}.${key}` : key;
+            if (USER_CONTENT_FIELDS.includes(key) && typeof value === 'string') {
+                collected.push({ field: path, text: value });
+            } else if (value && typeof value === 'object') {
+                collected.push(...collectUserContentFromPayload(value, path));
+            }
+        }
+    }
+
+    return collected;
+}
+
+function isQuarantined(subjectId) {
+    if (!subjectId) return false;
+    const entry = quarantineRegistry.get(String(subjectId));
+    if (!entry) return false;
+    if (Date.now() > entry.expiresAt) {
+        quarantineRegistry.delete(String(subjectId));
+        return false;
+    }
+    return true;
+}
+
+function quarantineAgent(subjectId, reason, meta = {}) {
+    if (!subjectId) return null;
+    const entry = {
+        subjectId: String(subjectId),
+        reason,
+        meta,
+        quarantinedAt: new Date().toISOString(),
+        expiresAt: Date.now() + QUARANTINE_TTL_MS
+    };
+    quarantineRegistry.set(entry.subjectId, entry);
+    logger.warn('Agent/user quarantined for prompt injection', entry);
+    return entry;
+}
+
+function clearQuarantine(subjectId) {
+    if (!subjectId) {
+        quarantineRegistry.clear();
+        return { success: true, cleared: 'all' };
+    }
+    quarantineRegistry.delete(String(subjectId));
+    return { success: true, cleared: String(subjectId) };
+}
+
+function getQuarantineStatus(subjectId) {
+    if (!subjectId) {
+        return {
+            count: quarantineRegistry.size,
+            entries: [...quarantineRegistry.values()]
+        };
+    }
+    const entry = quarantineRegistry.get(String(subjectId));
+    return {
+        quarantined: isQuarantined(subjectId),
+        entry: entry || null
+    };
+}
+
+/**
+ * Multi-layer scan for direct prompts and indirect context poisoning.
+ */
 async function analyzeUserIntent(prompt, userId, context = {}) {
     const startTime = Date.now();
     const results = {
@@ -105,8 +281,12 @@ async function analyzeUserIntent(prompt, userId, context = {}) {
         riskLevel: 'low',
         detectedPatterns: [],
         sanitizedPrompt: prompt,
+        containedPrompt: null,
         suspiciousEntities: [],
+        entropy: 0,
+        perplexityHeuristic: 0,
         requiresConfirmation: false,
+        quarantineTriggered: false,
         duration: 0
     };
 
@@ -123,7 +303,8 @@ async function analyzeUserIntent(prompt, userId, context = {}) {
                         pattern: pattern.toString(),
                         match: match ? match[0] : 'unknown'
                     });
-                    results.riskScore += 1;
+                    // Context poisoning & system overrides weigh heavier
+                    results.riskScore += (category === 'system_override' || category === 'context_poisoning') ? 2 : 1;
                 }
             }
         }
@@ -132,6 +313,27 @@ async function analyzeUserIntent(prompt, userId, context = {}) {
         results.suspiciousEntities = entities.filter(e =>
             INJECTION_PATTERNS.suspicious_entities.some(p => p.test(e))
         );
+
+        results.entropy = Number(calculateShannonEntropy(validatedPrompt).toFixed(3));
+        results.perplexityHeuristic = Number(estimateTokenPerplexity(validatedPrompt).toFixed(3));
+
+        if (results.entropy >= ENTROPY_THRESHOLD && validatedPrompt.length > 80) {
+            results.detectedPatterns.push({
+                category: 'entropy_anomaly',
+                pattern: 'shannon_entropy',
+                match: `entropy=${results.entropy}`
+            });
+            results.riskScore += 2;
+        }
+
+        if (results.perplexityHeuristic >= 0.35) {
+            results.detectedPatterns.push({
+                category: 'perplexity_anomaly',
+                pattern: 'token_perplexity_heuristic',
+                match: `ratio=${results.perplexityHeuristic}`
+            });
+            results.riskScore += 2;
+        }
 
         if (results.riskScore >= 5) {
             results.riskLevel = 'critical';
@@ -146,8 +348,21 @@ async function analyzeUserIntent(prompt, userId, context = {}) {
             results.requiresConfirmation = true;
         }
 
+        const fieldName = context.fieldName || context.source || 'user_content';
         results.sanitizedPrompt = sanitizePrompt(validatedPrompt);
+        results.containedPrompt = wrapWithBoundaryTags(results.sanitizedPrompt, fieldName);
         results.duration = Date.now() - startTime;
+
+        if (QUARANTINE_RISK_LEVELS.has(results.riskLevel)) {
+            const subject = context.agentId || userId;
+            if (subject) {
+                quarantineAgent(subject, 'prompt_injection_detected', {
+                    riskLevel: results.riskLevel,
+                    patterns: results.detectedPatterns.map(p => p.category)
+                });
+                results.quarantineTriggered = true;
+            }
+        }
 
         await logPromptAnalysis(userId, results, context);
 
@@ -165,6 +380,79 @@ async function analyzeUserIntent(prompt, userId, context = {}) {
             error: error.message,
             duration: Date.now() - startTime
         };
+    }
+}
+
+/**
+ * Scan product reviews, chat, address text, and nested agent payloads
+ * for indirect prompt injection / context poisoning.
+ */
+async function detectContextPoisoning(payload, userId = 'anonymous', context = {}) {
+    const fields = collectUserContentFromPayload(payload);
+    const aggregate = {
+        safe: true,
+        riskLevel: 'low',
+        riskScore: 0,
+        fieldResults: [],
+        quarantined: false,
+        sanitizedPayload: payload
+    };
+
+    if (fields.length === 0) {
+        return aggregate;
+    }
+
+    const sanitizedClone = (payload && typeof payload === 'object')
+        ? JSON.parse(JSON.stringify(payload))
+        : payload;
+
+    for (const { field, text } of fields) {
+        const analysis = await analyzeUserIntent(text, userId, {
+            ...context,
+            fieldName: field,
+            source: 'context_poisoning_scan'
+        });
+
+        aggregate.fieldResults.push({
+            field,
+            riskLevel: analysis.riskLevel,
+            riskScore: analysis.riskScore,
+            safe: analysis.safe,
+            detectedPatterns: analysis.detectedPatterns,
+            sanitized: analysis.sanitizedPrompt,
+            contained: analysis.containedPrompt
+        });
+
+        aggregate.riskScore = Math.max(aggregate.riskScore, analysis.riskScore);
+        if (!analysis.safe) aggregate.safe = false;
+        if (analysis.quarantineTriggered) aggregate.quarantined = true;
+
+        const levelRank = { low: 0, medium: 1, high: 2, critical: 3 };
+        if ((levelRank[analysis.riskLevel] || 0) > (levelRank[aggregate.riskLevel] || 0)) {
+            aggregate.riskLevel = analysis.riskLevel;
+        }
+
+        // Apply sanitized text back onto clone when possible
+        if (sanitizedClone && typeof sanitizedClone === 'object') {
+            applySanitizedField(sanitizedClone, field, analysis.sanitizedPrompt);
+        }
+    }
+
+    aggregate.sanitizedPayload = sanitizedClone;
+    return aggregate;
+}
+
+function applySanitizedField(obj, path, value) {
+    const parts = path.replace(/\[(\d+)\]/g, '.$1').split('.').filter(Boolean);
+    let cursor = obj;
+    for (let i = 0; i < parts.length - 1; i++) {
+        const key = parts[i];
+        if (cursor[key] == null) return;
+        cursor = cursor[key];
+    }
+    const last = parts[parts.length - 1];
+    if (cursor && Object.prototype.hasOwnProperty.call(cursor, last)) {
+        cursor[last] = value;
     }
 }
 
@@ -257,7 +545,15 @@ async function logPromptAnalysis(userId, results, context) {
                 JSON.stringify(results.detectedPatterns),
                 JSON.stringify(results.suspiciousEntities),
                 results.sanitizedPrompt,
-                JSON.stringify(context),
+                JSON.stringify({
+                    ...context,
+                    entropy: results.entropy,
+                    perplexityHeuristic: results.perplexityHeuristic,
+                    quarantineTriggered: results.quarantineTriggered,
+                    containedPrompt: results.containedPrompt
+                        ? '[BOUNDARY_WRAPPED]'
+                        : null
+                }),
                 results.duration || 0
             ]
         );
@@ -271,6 +567,42 @@ async function promptInjectionGuard(req, res, next) {
         const { prompt, action, data } = req.body;
         const userId = req.user?.id || 'anonymous';
         const userRole = req.user?.role || 'guest';
+        const agentId = req.body?.agentId || req.headers['x-agent-id'];
+
+        if (isQuarantined(agentId) || isQuarantined(userId)) {
+            return res.status(403).json({
+                success: false,
+                error: 'Subject is quarantined due to prior prompt injection activity',
+                errorCode: 'AGENT_QUARANTINED'
+            });
+        }
+
+        // Indirect poisoning: scan nested user fields even without top-level prompt
+        if (!prompt && data) {
+            const poisonScan = await detectContextPoisoning(data, userId, {
+                action,
+                agentId,
+                ip: req.ip,
+                userAgent: req.headers['user-agent']
+            });
+            req.contextPoisoningScan = poisonScan;
+            if (!poisonScan.safe && QUARANTINE_RISK_LEVELS.has(poisonScan.riskLevel)) {
+                return res.status(403).json({
+                    success: false,
+                    error: 'Context poisoning detected in user-supplied fields',
+                    riskLevel: poisonScan.riskLevel,
+                    fields: poisonScan.fieldResults.map(f => ({
+                        field: f.field,
+                        riskLevel: f.riskLevel,
+                        patterns: f.detectedPatterns
+                    }))
+                });
+            }
+            if (poisonScan.sanitizedPayload) {
+                req.body.data = poisonScan.sanitizedPayload;
+            }
+            return next();
+        }
 
         if (!prompt) {
             return next();
@@ -278,6 +610,7 @@ async function promptInjectionGuard(req, res, next) {
 
         const analysis = await analyzeUserIntent(prompt, userId, {
             action,
+            agentId,
             ip: req.ip,
             userAgent: req.headers['user-agent']
         });
@@ -290,7 +623,7 @@ async function promptInjectionGuard(req, res, next) {
             });
         }
 
-        const rbacCheck = checkRBAC(userRole, action, data);
+        const rbacCheck = checkRBAC(userRole, action, data || {});
         if (!rbacCheck.allowed) {
             logger.warn('RBAC denied', { userId, userRole, action, reason: rbacCheck.reason });
             return res.status(403).json({
@@ -310,7 +643,8 @@ async function promptInjectionGuard(req, res, next) {
                 success: false,
                 error: 'Prompt detected as potentially malicious',
                 riskLevel: analysis.riskLevel,
-                detectedPatterns: analysis.detectedPatterns
+                detectedPatterns: analysis.detectedPatterns,
+                quarantineTriggered: analysis.quarantineTriggered
             });
         }
 
@@ -326,6 +660,7 @@ async function promptInjectionGuard(req, res, next) {
         }
 
         req.sanitizedPrompt = analysis.sanitizedPrompt;
+        req.containedPrompt = analysis.containedPrompt;
         req.promptAnalysis = analysis;
         next();
 
@@ -362,6 +697,7 @@ async function healthCheck() {
             status: 'healthy',
             patternCount,
             cacheSize: patternCache.keys().length,
+            quarantineCount: quarantineRegistry.size,
             timestamp: new Date().toISOString()
         };
     } catch (error) {
@@ -376,9 +712,20 @@ async function healthCheck() {
 module.exports = {
     promptInjectionGuard,
     analyzeUserIntent,
+    detectContextPoisoning,
+    wrapWithBoundaryTags,
+    calculateShannonEntropy,
+    estimateTokenPerplexity,
+    sanitizePrompt,
+    quarantineAgent,
+    clearQuarantine,
+    getQuarantineStatus,
+    isQuarantined,
+    collectUserContentFromPayload,
     confirmAuthorization,
     checkRBAC,
     INJECTION_PATTERNS,
+    USER_CONTENT_FIELDS,
     RBAC_RULES,
     clearCache,
     getCacheStats,


### PR DESCRIPTION
# #1264 issue resolved

## Description

This PR optimizes multi-tier category tree fetching to remove N+1 SQL queries and cut DB roundtrips for menu rendering.

## Features

- Fetches the full hierarchy with a single MySQL recursive CTE
- Builds the nested JSON tree in memory with a max depth limit
- Caches the category tree in Redis
- Invalidates the cache (and rebuilds MPTT bounds) on category create/update