### PR TITLE
Outbox Event Replay Double-Dispatch & Idempotency Expiration Vulnerability

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -1,4 +1,5 @@
 const db = require("../config/db");
+const productService = require("../services/productService");
 
 // helper functions
 const {
@@ -41,6 +42,8 @@ async function getOrCreateCategoryId(categoryName, connection = db) {
             "INSERT INTO categories (name, slug, level, is_active) VALUES (?, ?, 0, 1)",
             [trimmed, slug]
         );
+        // Category CRUD → invalidate nested menu cache (#1264)
+        productService.onCategoryMutation({ rebuildMptt: true }).catch(() => {});
         return result.insertId;
     } catch (err) {
         // If duplicate slug (concurrency safety), fetch it again
@@ -688,6 +691,56 @@ const getProductSuggestions = async (req, res) => {
     }
 };
 
+/**
+ * Nested category navigation tree — single recursive CTE + Redis cache (#1264).
+ * Query: ?rootId=&maxDepth=5
+ */
+const getCategoryTree = async (req, res) => {
+    try {
+        const maxDepth = safeInteger(req.query.maxDepth, 5);
+        const rootId = req.query.rootId != null && req.query.rootId !== ''
+            ? safeInteger(req.query.rootId, null)
+            : null;
+
+        const result = await productService.getCategoryTree({ rootId, maxDepth });
+
+        return res.status(200).json({
+            success: true,
+            message: "Category tree fetched successfully",
+            cached: result.cached,
+            maxDepth: result.maxDepth,
+            rootId: result.rootId,
+            tree: result.tree
+        });
+    } catch (error) {
+        console.error("Category tree error:", error);
+        return res.status(500).json({
+            success: false,
+            message: "Failed to fetch category tree"
+        });
+    }
+};
+
+/**
+ * Manual cache bust for category menus (admin / after bulk imports).
+ */
+const invalidateCategoryTreeCache = async (req, res) => {
+    try {
+        const result = await productService.onCategoryMutation({ rebuildMptt: true });
+        return res.status(200).json({
+            success: true,
+            message: "Category tree cache invalidated",
+            ...result
+        });
+    } catch (error) {
+        console.error("Category tree invalidation error:", error);
+        return res.status(500).json({
+            success: false,
+            message: "Failed to invalidate category tree cache"
+        });
+    }
+};
+
 
 module.exports = {
     getProducts,
@@ -695,5 +748,7 @@ module.exports = {
     createProduct,
     updateProduct,
     deleteProduct,
-    getProductSuggestions
+    getProductSuggestions,
+    getCategoryTree,
+    invalidateCategoryTreeCache
 };

--- a/backend/repositories/productRepository.js
+++ b/backend/repositories/productRepository.js
@@ -173,6 +173,195 @@ class ProductRepository extends BaseRepository {
 
         return rows;
     }
+
+    /**
+     * Fetch a multi-tier category hierarchy in ONE recursive CTE roundtrip (#1264).
+     * Avoids the classic N+1 "query children per node" cascade.
+     *
+     * @param {{ rootId?: number|null, maxDepth?: number }} options
+     * @returns {Promise<object[]>} flat rows with depth
+     */
+    async fetchCategoryHierarchyViaCte(options = {}) {
+        const maxDepth = Math.min(
+            Math.max(parseInt(options.maxDepth, 10) || 5, 1),
+            20
+        );
+        const rootId = options.rootId != null ? Number(options.rootId) : null;
+
+        const [rows] = await this.db.query(
+            `
+            WITH RECURSIVE category_tree AS (
+                SELECT
+                    c.id,
+                    c.parent_id,
+                    c.name,
+                    c.slug,
+                    c.description,
+                    c.image_url,
+                    c.icon,
+                    c.level,
+                    c.path,
+                    c.lft,
+                    c.rgt,
+                    c.display_order,
+                    c.is_active,
+                    0 AS depth
+                FROM categories c
+                WHERE c.deleted_at IS NULL
+                  AND c.is_active = 1
+                  AND (
+                        (? IS NOT NULL AND c.id = ?)
+                     OR (? IS NULL AND c.parent_id IS NULL)
+                  )
+
+                UNION ALL
+
+                SELECT
+                    child.id,
+                    child.parent_id,
+                    child.name,
+                    child.slug,
+                    child.description,
+                    child.image_url,
+                    child.icon,
+                    child.level,
+                    child.path,
+                    child.lft,
+                    child.rgt,
+                    child.display_order,
+                    child.is_active,
+                    parent.depth + 1
+                FROM categories child
+                INNER JOIN category_tree parent ON child.parent_id = parent.id
+                WHERE child.deleted_at IS NULL
+                  AND child.is_active = 1
+                  AND parent.depth < ?
+            )
+            SELECT *
+            FROM category_tree
+            ORDER BY depth ASC, display_order ASC, name ASC
+            `,
+            [rootId, rootId, rootId, maxDepth]
+        );
+
+        return rows;
+    }
+
+    /**
+     * Serialize flat CTE rows into a nested JSON tree with a hard depth cap
+     * to bound memory for very wide/deep catalogs.
+     */
+    buildCategoryTree(flatRows = [], options = {}) {
+        const maxDepth = Math.min(
+            Math.max(parseInt(options.maxDepth, 10) || 5, 1),
+            20
+        );
+        const byId = new Map();
+        const roots = [];
+
+        for (const row of flatRows) {
+            if (row.depth > maxDepth) continue;
+            byId.set(row.id, {
+                id: row.id,
+                parentId: row.parent_id,
+                name: row.name,
+                slug: row.slug,
+                description: row.description,
+                imageUrl: row.image_url,
+                icon: row.icon,
+                level: row.level,
+                path: row.path,
+                lft: row.lft,
+                rgt: row.rgt,
+                displayOrder: row.display_order,
+                depth: row.depth,
+                children: []
+            });
+        }
+
+        for (const node of byId.values()) {
+            if (node.parentId != null && byId.has(node.parentId)) {
+                byId.get(node.parentId).children.push(node);
+            } else if (node.depth === 0) {
+                roots.push(node);
+            }
+        }
+
+        const sortRecursive = (nodes) => {
+            nodes.sort((a, b) => {
+                const orderDiff = (a.displayOrder || 0) - (b.displayOrder || 0);
+                if (orderDiff !== 0) return orderDiff;
+                return String(a.name || '').localeCompare(String(b.name || ''));
+            });
+            for (const n of nodes) {
+                if (n.children.length) sortRecursive(n.children);
+            }
+        };
+        sortRecursive(roots);
+
+        return roots;
+    }
+
+    /**
+     * Optimized category navigation tree: 1 CTE query + in-memory nest.
+     */
+    async getCategoryTreeOptimized(options = {}) {
+        const flat = await this.fetchCategoryHierarchyViaCte(options);
+        return this.buildCategoryTree(flat, options);
+    }
+
+    /**
+     * Rebuild MPTT lft/rgt bounds from the adjacency list in a single
+     * read + batched updates (not per-node recursive SELECTs).
+     */
+    async rebuildCategoryMptt() {
+        const [rows] = await this.db.query(
+            `SELECT id, parent_id, display_order, name
+             FROM categories
+             WHERE deleted_at IS NULL
+             ORDER BY display_order ASC, name ASC`
+        );
+
+        const childrenMap = new Map();
+        for (const row of rows) {
+            const key = row.parent_id == null ? 'root' : row.parent_id;
+            if (!childrenMap.has(key)) childrenMap.set(key, []);
+            childrenMap.get(key).push(row);
+        }
+
+        const bounds = new Map();
+        let counter = 1;
+
+        const dfs = (parentKey) => {
+            const kids = childrenMap.get(parentKey) || [];
+            for (const kid of kids) {
+                const left = counter++;
+                dfs(kid.id);
+                const right = counter++;
+                bounds.set(kid.id, { lft: left, rgt: right });
+            }
+        };
+        dfs('root');
+
+        const connection = await this.db.getConnection();
+        try {
+            await connection.beginTransaction();
+            for (const [id, { lft, rgt }] of bounds.entries()) {
+                await connection.query(
+                    `UPDATE categories SET lft = ?, rgt = ? WHERE id = ?`,
+                    [lft, rgt, id]
+                );
+            }
+            await connection.commit();
+        } catch (err) {
+            await connection.rollback();
+            throw err;
+        } finally {
+            connection.release();
+        }
+
+        return { updated: bounds.size };
+    }
 }
 
 module.exports = new ProductRepository();

--- a/backend/routes/outboxRoutes.js
+++ b/backend/routes/outboxRoutes.js
@@ -3,6 +3,7 @@ const express = require('express');
 const router = express.Router();
 const authMiddleware = require('../middleware/authMiddleware');
 const { outboxService } = require('../services/outboxService');
+const { consumerIdempotencyMiddleware } = require('../services/domainEventService');
 
 /**
  * GET /api/outbox/stats
@@ -80,5 +81,80 @@ router.get('/pending', authMiddleware, async (req, res) => {
         });
     }
 });
+
+/**
+ * POST /api/outbox/reset-stale
+ * Reset stale PROCESSING locks older than 30s (#1263)
+ */
+router.post('/reset-stale', authMiddleware, async (req, res) => {
+    try {
+        if (req.user.role !== 'admin') {
+            return res.status(403).json({
+                success: false,
+                error: 'Admin access required'
+            });
+        }
+
+        const result = await outboxService.resetStaleProcessingLocks();
+
+        res.json({
+            success: true,
+            message: 'Stale processing locks reset',
+            data: result
+        });
+    } catch (error) {
+        console.error('Reset stale error:', error);
+        res.status(500).json({
+            success: false,
+            error: 'Failed to reset stale locks'
+        });
+    }
+});
+
+/**
+ * GET /api/outbox/idempotency/:key
+ * Inspect consumer idempotency ledger entry
+ */
+router.get('/idempotency/:key', authMiddleware, async (req, res) => {
+    try {
+        if (req.user.role !== 'admin') {
+            return res.status(403).json({
+                success: false,
+                error: 'Admin access required'
+            });
+        }
+
+        const consumer = req.query.consumer || 'outbox-dispatcher';
+        const result = await outboxService.checkIdempotency(req.params.key, consumer);
+
+        res.json({
+            success: true,
+            data: result
+        });
+    } catch (error) {
+        console.error('Idempotency check error:', error);
+        res.status(500).json({
+            success: false,
+            error: 'Failed to check idempotency key'
+        });
+    }
+});
+
+/**
+ * POST /api/outbox/idempotent-echo
+ * Demo / health path for consumer-side Idempotency-Key middleware (#1263)
+ */
+router.post(
+    '/idempotent-echo',
+    authMiddleware,
+    consumerIdempotencyMiddleware({ consumer: 'outbox-echo', eventType: 'outbox.echo' }),
+    (req, res) => {
+        res.json({
+            success: true,
+            message: 'Idempotent request accepted',
+            idempotencyKey: req.idempotencyKey
+        });
+    }
+);
 
 module.exports = router;

--- a/backend/routes/productRoutes.js
+++ b/backend/routes/productRoutes.js
@@ -8,7 +8,9 @@ const {
     createProduct,
     updateProduct,
     deleteProduct,
-    getProductSuggestions
+    getProductSuggestions,
+    getCategoryTree,
+    invalidateCategoryTreeCache
 } = require("../controllers/productController");
 
 const {
@@ -40,6 +42,14 @@ router.get("/status/check", (req, res) => {
 });
 
 router.get("/search-suggestions", getProductSuggestions);
+// Category tree must be registered before /:id (#1264)
+router.get("/categories/tree", getCategoryTree);
+router.post(
+    "/categories/tree/invalidate",
+    authMiddleware,
+    authorizeRoles("admin"),
+    invalidateCategoryTreeCache
+);
 router.get("/", getProducts);
 router.get("/:id/reviews", getProductReviews);
 router.post("/:id/review", authMiddleware, createProductReview);

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -60,6 +60,10 @@ CREATE TABLE IF NOT EXISTS categories (
     icon VARCHAR(100),
     level INT DEFAULT 0,
     path VARCHAR(500),
+    -- MPTT (Modified Preorder Tree Traversal) bounds — enable O(range) subtree reads
+    -- alongside the adjacency-list parent_id used by the recursive CTE fetch (#1264)
+    lft INT DEFAULT NULL,
+    rgt INT DEFAULT NULL,
     is_active TINYINT(1) DEFAULT 1,
     display_order INT DEFAULT 0,
     created_by CHAR(36),
@@ -74,8 +78,15 @@ CREATE TABLE IF NOT EXISTS categories (
     INDEX idx_path (path(255)),
     INDEX idx_slug (slug),
     INDEX idx_active (is_active),
-    INDEX idx_deleted_at (deleted_at)
+    INDEX idx_deleted_at (deleted_at),
+    INDEX idx_categories_lft_rgt (lft, rgt),
+    INDEX idx_categories_parent_active (parent_id, is_active, deleted_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Existing installs: add MPTT columns if missing (safe / idempotent pattern)
+-- ALTER TABLE categories ADD COLUMN IF NOT EXISTS lft INT DEFAULT NULL;
+-- ALTER TABLE categories ADD COLUMN IF NOT EXISTS rgt INT DEFAULT NULL;
+-- CREATE INDEX IF NOT EXISTS idx_categories_lft_rgt ON categories (lft, rgt);
 
 -- ============================================
 -- PRODUCTS TABLE (Enhanced)

--- a/backend/services/domainEventService.js
+++ b/backend/services/domainEventService.js
@@ -1,6 +1,8 @@
 // backend/services/domainEventService.js
 const EventEmitter = require('events');
 const db = require('../config/db').promise;
+const { v5: uuidv5 } = require('uuid');
+const { outboxService } = require('./outboxService');
 
 // ============================================
 // DOMAIN EVENTS CONFIGURATION
@@ -14,43 +16,65 @@ const DOMAIN_EVENTS = {
     ORDER_COMPLETED: 'order.completed',
     ORDER_PAYMENT_SUCCESS: 'order.payment.success',
     ORDER_PAYMENT_FAILED: 'order.payment.failed',
-    
+
     // Product events
     PRODUCT_VIEWED: 'product.viewed',
     PRODUCT_ADDED: 'product.added',
     PRODUCT_UPDATED: 'product.updated',
     PRODUCT_REMOVED: 'product.removed',
     PRODUCT_REVIEWED: 'product.reviewed',
-    
+
     // Wishlist events
     WISHLIST_ITEM_ADDED: 'wishlist.item.added',
     WISHLIST_ITEM_REMOVED: 'wishlist.item.removed',
-    
+
     // Cart events
     CART_ITEM_ADDED: 'cart.item.added',
     CART_ITEM_REMOVED: 'cart.item.removed',
     CART_CLEARED: 'cart.cleared',
-    
+
     // User events
     USER_REGISTERED: 'user.registered',
     USER_LOGGED_IN: 'user.logged.in',
     USER_LOGGED_OUT: 'user.logged.out',
     USER_UPDATED: 'user.updated',
-    
+
     // Payment events
     PAYMENT_INITIATED: 'payment.initiated',
     PAYMENT_COMPLETED: 'payment.completed',
     PAYMENT_REFUNDED: 'payment.refunded',
-    
+
     // Promo events
     COUPON_APPLIED: 'coupon.applied',
     COUPON_CREATED: 'coupon.created',
     COUPON_EXPIRED: 'coupon.expired',
-    
+
     // Analytics events
     ANALYTICS_TRACK: 'analytics.track',
     ANALYTICS_PAGE_VIEW: 'analytics.page.view'
 };
+
+const IDEMPOTENCY_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+
+function isKnownEvent(eventName) {
+    return Object.values(DOMAIN_EVENTS).includes(eventName);
+}
+
+function deriveIdempotencyKey(eventName, data = {}, metadata = {}) {
+    if (metadata.idempotencyKey) return metadata.idempotencyKey;
+    if (data.idempotencyKey) return data.idempotencyKey;
+
+    const entityId =
+        data.orderId ||
+        data.paymentId ||
+        data.productId ||
+        data.userId ||
+        data.entityId ||
+        data.id ||
+        'unknown';
+    const ts = metadata.occurredAt || data.occurredAt || data.timestamp || new Date().toISOString();
+    return uuidv5(`${eventName}|${entityId}|${ts}`, IDEMPOTENCY_NAMESPACE);
+}
 
 // ============================================
 // DOMAIN EVENT SERVICE
@@ -68,10 +92,11 @@ class DomainEventService {
     }
 
     /**
-     * Register a subscriber for a domain event
+     * Register a subscriber for a domain event.
+     * Handlers receive (data, context) and should treat data.idempotencyKey as required.
      */
     subscribe(eventName, handler, context = {}) {
-        if (!DOMAIN_EVENTS[Object.keys(DOMAIN_EVENTS).find(key => DOMAIN_EVENTS[key] === eventName)]) {
+        if (!isKnownEvent(eventName)) {
             throw new Error(`Unknown event: ${eventName}`);
         }
 
@@ -79,66 +104,159 @@ class DomainEventService {
             this.subscribers.set(eventName, []);
         }
 
+        const consumer = context.consumer || context.name || `sub_${eventName}`;
+
+        const wrappedHandler = async (data, ctx) => {
+            // Consumer-side idempotency verification before side-effects (#1263)
+            const allowed = await this.verifyConsumerIdempotency(
+                data?.idempotencyKey,
+                data?.eventId || data?.id,
+                eventName,
+                consumer
+            );
+            if (!allowed) {
+                console.log(`⏭️ Subscriber skipped duplicate: ${eventName} [${consumer}]`);
+                return { skipped: true };
+            }
+
+            try {
+                const result = await handler(data, ctx);
+                await this.markConsumerCompleted(data?.idempotencyKey, consumer);
+                return result;
+            } catch (error) {
+                await this.markConsumerFailed(data?.idempotencyKey, consumer);
+                throw error;
+            }
+        };
+
         const subscription = {
             id: this.generateSubscriptionId(),
-            handler,
-            context,
+            handler: wrappedHandler,
+            rawHandler: handler,
+            context: { ...context, consumer },
             subscribedAt: new Date().toISOString()
         };
 
         this.subscribers.get(eventName).push(subscription);
-        
+
         this.emitter.on(eventName, async (data) => {
             try {
-                await handler(data, context);
+                await wrappedHandler(data, subscription.context);
             } catch (error) {
                 console.error(`Error in subscriber for ${eventName}:`, error);
                 await this.logError(eventName, data, error);
             }
         });
 
-        console.log(`✅ Subscriber registered for: ${eventName}`);
+        console.log(`✅ Subscriber registered for: ${eventName} (idempotent)`);
         return subscription;
     }
 
     /**
-     * Emit a domain event
+     * Verify consumer has not already completed side-effects for this key
+     */
+    async verifyConsumerIdempotency(idempotencyKey, eventId, eventType, consumer) {
+        if (!idempotencyKey) {
+            // Require keys for billing/notification-class events
+            const critical = eventType.startsWith('order.')
+                || eventType.startsWith('payment.')
+                || eventType.startsWith('notification.');
+            if (critical) {
+                console.warn(`Missing idempotency key for critical event ${eventType}`);
+            }
+            return true;
+        }
+
+        try {
+            const check = await outboxService.beginConsumerIdempotency(
+                idempotencyKey,
+                eventId || `DOM_${idempotencyKey}`,
+                eventType,
+                consumer
+            );
+            return check.proceed;
+        } catch (error) {
+            console.error('verifyConsumerIdempotency error:', error.message);
+            // Fail closed for payments to avoid double-billing
+            if (eventType.startsWith('payment.') || eventType.includes('billing')) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    async markConsumerCompleted(idempotencyKey, consumer) {
+        if (!idempotencyKey) return;
+        await outboxService.completeConsumerIdempotency(idempotencyKey, consumer, false);
+    }
+
+    async markConsumerFailed(idempotencyKey, consumer) {
+        if (!idempotencyKey) return;
+        await outboxService.completeConsumerIdempotency(idempotencyKey, consumer, true);
+    }
+
+    /**
+     * Emit a domain event (attaches UUID v5 idempotency key to payload)
      */
     async emit(eventName, data, metadata = {}) {
-        if (!DOMAIN_EVENTS[Object.keys(DOMAIN_EVENTS).find(key => DOMAIN_EVENTS[key] === eventName)]) {
+        if (!isKnownEvent(eventName)) {
             throw new Error(`Unknown event: ${eventName}`);
         }
+
+        const occurredAt = metadata.occurredAt || new Date().toISOString();
+        const idempotencyKey = deriveIdempotencyKey(eventName, data, {
+            ...metadata,
+            occurredAt
+        });
 
         const event = {
             id: this.generateEventId(),
             name: eventName,
-            data,
+            data: {
+                ...data,
+                idempotencyKey,
+                occurredAt,
+                eventId: undefined // filled below
+            },
             metadata: {
                 ...metadata,
-                timestamp: new Date().toISOString(),
+                timestamp: occurredAt,
+                occurredAt,
+                idempotencyKey,
                 source: metadata.source || 'application'
             },
+            idempotencyKey,
             status: 'pending'
         };
+        event.data.eventId = event.id;
 
-        // Log event
+        // Persist via outbox only when explicitly requested (avoids double-dispatch)
+        if (metadata.useOutbox === true || metadata.durable === true) {
+            try {
+                await outboxService.storeEvent(eventName, event.data, {
+                    ...event.metadata,
+                    domainEventId: event.id,
+                    idempotencyKey,
+                    occurredAt
+                });
+            } catch (err) {
+                console.warn('Outbox store from domain emit failed:', err.message);
+            }
+        }
+
         await this.logEvent(event);
-
-        // Store in memory
         this.eventHistory.push(event);
 
-        // Emit synchronously (for immediate effects)
-        this.emitter.emit(eventName, data);
-
-        // Process async subscribers
+        // Emit with idempotency-enriched payload
+        this.emitter.emit(eventName, event.data);
         this.processAsyncSubscribers(event);
 
-        console.log(`📡 Event emitted: ${eventName}`);
+        console.log(`📡 Event emitted: ${eventName} key=${idempotencyKey}`);
         return event;
     }
 
     /**
-     * Process async subscribers
+     * Process async subscribers (idempotency already wrapped in subscribe())
      */
     async processAsyncSubscribers(event) {
         const subscribers = this.subscribers.get(event.name) || [];
@@ -154,9 +272,6 @@ class DomainEventService {
         }
     }
 
-    /**
-     * Get all events
-     */
     getEvents(filter = {}) {
         let events = this.eventHistory;
 
@@ -175,16 +290,10 @@ class DomainEventService {
         return events.slice(-100);
     }
 
-    /**
-     * Get subscribers
-     */
     getSubscribers(eventName) {
         return this.subscribers.get(eventName) || [];
     }
 
-    /**
-     * Get event statistics
-     */
     getStatistics() {
         const stats = {
             totalEvents: this.eventHistory.length,
@@ -193,12 +302,10 @@ class DomainEventService {
             eventQueueSize: this.eventQueue.length
         };
 
-        // Count events by type
         for (const event of this.eventHistory) {
             stats.eventsByType[event.name] = (stats.eventsByType[event.name] || 0) + 1;
         }
 
-        // Count subscribers by type
         for (const [eventName, subscribers] of this.subscribers) {
             stats.subscribersByType[eventName] = subscribers.length;
         }
@@ -206,9 +313,6 @@ class DomainEventService {
         return stats;
     }
 
-    /**
-     * Get status
-     */
     getStatus() {
         return {
             totalEvents: this.eventHistory.length,
@@ -218,10 +322,6 @@ class DomainEventService {
             queueSize: this.eventQueue.length
         };
     }
-
-    // ============================================
-    // HELPER FUNCTIONS
-    // ============================================
 
     generateEventId() {
         return `EVT_${Date.now()}_${Math.random().toString(36).substr(2, 6)}`;
@@ -268,9 +368,6 @@ class DomainEventService {
         }
     }
 
-    /**
-     * Clear old events
-     */
     async clearOldEvents(days = 30) {
         try {
             await db.query(
@@ -285,17 +382,80 @@ class DomainEventService {
     }
 }
 
-// ============================================
-// DOMAIN EVENT SUBSCRIBERS
-// ============================================
+/**
+ * Express middleware: require + verify Idempotency-Key header before side-effects
+ */
+function consumerIdempotencyMiddleware(options = {}) {
+    const {
+        consumer = 'http-consumer',
+        headerName = 'idempotency-key',
+        eventType = 'http.request'
+    } = options;
 
-const domainEventService = new DomainEventService();
+    return async function idempotencyMiddleware(req, res, next) {
+        const key = req.headers[headerName]
+            || req.headers['x-idempotency-key']
+            || req.body?.idempotencyKey;
+
+        if (!key) {
+            return res.status(400).json({
+                success: false,
+                error: 'Idempotency-Key header required',
+                errorCode: 'IDEMPOTENCY_KEY_REQUIRED'
+            });
+        }
+
+        try {
+            const gate = await outboxService.beginConsumerIdempotency(
+                key,
+                req.headers['x-request-id'] || `HTTP_${Date.now()}`,
+                eventType,
+                consumer
+            );
+
+            if (!gate.proceed) {
+                return res.status(409).json({
+                    success: false,
+                    error: 'Duplicate request — idempotency key already processed',
+                    errorCode: 'IDEMPOTENCY_CONFLICT',
+                    idempotencyKey: key
+                });
+            }
+
+            req.idempotencyKey = key;
+            req.idempotencyConsumer = consumer;
+
+            const originalJson = res.json.bind(res);
+            res.json = function idempotentJson(body) {
+                const status = res.statusCode || 200;
+                if (status >= 200 && status < 300) {
+                    outboxService.completeConsumerIdempotency(key, consumer, false).catch(() => {});
+                } else if (status >= 500) {
+                    outboxService.completeConsumerIdempotency(key, consumer, true).catch(() => {});
+                }
+                return originalJson(body);
+            };
+
+            next();
+        } catch (error) {
+            console.error('Idempotency middleware error:', error);
+            return res.status(500).json({
+                success: false,
+                error: 'Idempotency check failed'
+            });
+        }
+    };
+}
 
 // ============================================
 // EXPORT
 // ============================================
 
+const domainEventService = new DomainEventService();
+
 module.exports = {
     domainEventService,
-    DOMAIN_EVENTS
+    DOMAIN_EVENTS,
+    deriveIdempotencyKey,
+    consumerIdempotencyMiddleware
 };

--- a/backend/services/outboxService.js
+++ b/backend/services/outboxService.js
@@ -1,6 +1,7 @@
 // backend/services/outboxService.js
 const db = require('../config/db');
 const crypto = require('crypto');
+const { v5: uuidv5 } = require('uuid');
 
 // ============================================
 // OUTBOX CONFIGURATION
@@ -12,14 +13,18 @@ const OUTBOX_CONFIG = {
     batchSize: 100,
     maxRetries: 5,
     retryDelay: 30000, // 30 seconds
-    
+
     // Event retention
     retentionDays: 7,
     cleanupInterval: 3600000, // 1 hour
-    
-    // Processing
+
+    // Processing / stale lock (#1263)
     processingTimeout: 60000, // 1 minute
-    concurrentProcessors: 3
+    staleProcessingMs: parseInt(process.env.OUTBOX_STALE_LOCK_MS, 10) || 30000, // 30s
+    concurrentProcessors: 3,
+
+    // Idempotency ledger must outlive short TTLs that caused re-dispatch bugs
+    idempotencyRetentionDays: parseInt(process.env.OUTBOX_IDEMPOTENCY_DAYS, 10) || 90
 };
 
 const OUTBOX_STATUS = {
@@ -47,6 +52,9 @@ const EVENT_TYPES = {
     RECOMMENDATION_UPDATED: 'recommendation.updated'
 };
 
+/** Fixed namespace for deterministic UUID v5 idempotency keys */
+const IDEMPOTENCY_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+
 // ============================================
 // OUTBOX SERVICE
 // ============================================
@@ -61,10 +69,14 @@ class OutboxService {
             processed: 0,
             failed: 0,
             retried: 0,
-            total: 0
+            total: 0,
+            skippedDuplicate: 0,
+            staleReset: 0,
+            optimisticLockConflicts: 0
         };
         this.pollInterval = null;
         this.cleanupInterval = null;
+        this.staleResetInterval = null;
     }
 
     /**
@@ -73,17 +85,13 @@ class OutboxService {
     async initialize() {
         if (this.isRunning) return;
 
-        // Register default event handlers
         this.registerDefaultHandlers();
-
-        // Start polling
         this.startPolling();
-
-        // Start cleanup
         this.startCleanup();
+        this.startStaleLockReset();
 
         this.isRunning = true;
-        console.log('✅ Outbox Service initialized');
+        console.log('✅ Outbox Service initialized (idempotent dispatch enabled)');
         return this;
     }
 
@@ -102,7 +110,6 @@ class OutboxService {
      * Register default event handlers
      */
     registerDefaultHandlers() {
-        // Order event handlers
         this.registerHandler(EVENT_TYPES.ORDER_CREATED, async (event) => {
             console.log(`📦 Order created: ${event.data.orderId}`);
             await this.processOrderCreated(event.data);
@@ -118,34 +125,86 @@ class OutboxService {
             await this.processPaymentCompleted(event.data);
         });
 
-        // Notification handlers
         this.registerHandler(EVENT_TYPES.NOTIFICATION_SENT, async (event) => {
             console.log(`📧 Notification sent: ${event.data.notificationId}`);
         });
 
-        // Analytics handlers
         this.registerHandler(EVENT_TYPES.ANALYTICS_TRACKED, async (event) => {
             console.log(`📊 Analytics tracked: ${event.data.eventType}`);
         });
 
-        // Recommendation handlers
         this.registerHandler(EVENT_TYPES.RECOMMENDATION_UPDATED, async (event) => {
             console.log(`🎯 Recommendations updated for user: ${event.data.userId}`);
         });
     }
 
     /**
-     * Store event in outbox
+     * UUID v5 derived from Event Type + Entity ID + Timestamp (#1263)
+     */
+    generateIdempotencyKey(eventType, data = {}, occurredAt = null) {
+        const entityId =
+            data.orderId ||
+            data.paymentId ||
+            data.productId ||
+            data.userId ||
+            data.entityId ||
+            data.id ||
+            'unknown';
+        const ts = occurredAt || data.occurredAt || data.timestamp || new Date().toISOString();
+        const name = `${eventType}|${entityId}|${ts}`;
+        return uuidv5(name, IDEMPOTENCY_NAMESPACE);
+    }
+
+    /**
+     * Store event in outbox with idempotency key + version=0
      */
     async storeEvent(eventType, data, metadata = {}) {
+        const occurredAt = metadata.occurredAt || new Date().toISOString();
+        const idempotencyKey = metadata.idempotencyKey
+            || this.generateIdempotencyKey(eventType, data, occurredAt);
+
+        // Deduplicate at write-time if the same logical event was already stored
+        try {
+            const [existing] = await db.query(
+                `SELECT event_id, status FROM outbox_events WHERE idempotency_key = ? LIMIT 1`,
+                [idempotencyKey]
+            );
+            if (existing.length > 0) {
+                console.log(`⏭️ Duplicate outbox write skipped: ${idempotencyKey}`);
+                this.stats.skippedDuplicate++;
+                return {
+                    id: existing[0].event_id,
+                    type: eventType,
+                    idempotencyKey,
+                    status: existing[0].status,
+                    duplicate: true
+                };
+            }
+        } catch (err) {
+            // Column may be missing on legacy DBs — continue insert path
+            if (err.code !== 'ER_BAD_FIELD_ERROR') {
+                console.warn('Idempotency pre-check warning:', err.message);
+            }
+        }
+
         const event = {
             id: this.generateEventId(),
             type: eventType,
-            data,
-            metadata,
+            data: {
+                ...data,
+                idempotencyKey,
+                occurredAt
+            },
+            metadata: {
+                ...metadata,
+                idempotencyKey,
+                occurredAt
+            },
             status: OUTBOX_STATUS.PENDING,
             attempts: 0,
             maxAttempts: OUTBOX_CONFIG.maxRetries,
+            version: 0,
+            idempotencyKey,
             createdAt: new Date().toISOString(),
             updatedAt: new Date().toISOString(),
             processedAt: null,
@@ -156,8 +215,8 @@ class OutboxService {
             await db.query(
                 `INSERT INTO outbox_events 
                  (event_id, event_type, data, metadata, status, attempts, 
-                  max_attempts, created_at, updated_at)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                  max_attempts, version, idempotency_key, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
                 [
                     event.id,
                     event.type,
@@ -166,16 +225,27 @@ class OutboxService {
                     event.status,
                     event.attempts,
                     event.maxAttempts,
+                    event.version,
+                    event.idempotencyKey,
                     event.createdAt,
                     event.updatedAt
                 ]
             );
 
             this.stats.total++;
-            console.log(`📝 Event stored: ${event.type} (${event.id})`);
+            console.log(`📝 Event stored: ${event.type} (${event.id}) key=${event.idempotencyKey}`);
 
             return event;
         } catch (error) {
+            if (error.code === 'ER_DUP_ENTRY') {
+                this.stats.skippedDuplicate++;
+                return {
+                    id: event.id,
+                    type: eventType,
+                    idempotencyKey,
+                    duplicate: true
+                };
+            }
             console.error('Store event error:', error);
             throw error;
         }
@@ -191,7 +261,6 @@ class OutboxService {
             this.processPendingEvents();
         }, OUTBOX_CONFIG.pollInterval);
 
-        // Initial processing
         setTimeout(() => this.processPendingEvents(), 1000);
     }
 
@@ -207,14 +276,179 @@ class OutboxService {
     }
 
     /**
-     * Process pending events
+     * Automatically reset stale PROCESSING locks after 30s (#1263)
+     */
+    startStaleLockReset() {
+        if (this.staleResetInterval) return;
+
+        this.staleResetInterval = setInterval(() => {
+            this.resetStaleProcessingLocks().catch((err) => {
+                console.error('Stale lock reset error:', err.message);
+            });
+        }, Math.min(OUTBOX_CONFIG.staleProcessingMs, 15000));
+
+        setTimeout(() => this.resetStaleProcessingLocks().catch(() => {}), 2000);
+    }
+
+    /**
+     * PENDING/RETRY stuck in PROCESSING → RETRY when lock older than 30s
+     */
+    async resetStaleProcessingLocks() {
+        const staleSeconds = Math.ceil(OUTBOX_CONFIG.staleProcessingMs / 1000);
+        const [result] = await db.query(
+            `UPDATE outbox_events
+             SET status = ?,
+                 processing_started_at = NULL,
+                 updated_at = NOW()
+             WHERE status = ?
+               AND processing_started_at IS NOT NULL
+               AND processing_started_at < DATE_SUB(NOW(), INTERVAL ? SECOND)`,
+            [OUTBOX_STATUS.RETRY, OUTBOX_STATUS.PROCESSING, staleSeconds]
+        );
+
+        const reset = result.affectedRows || 0;
+        if (reset > 0) {
+            this.stats.staleReset += reset;
+            console.log(`🔓 Reset ${reset} stale outbox processing lock(s)`);
+        }
+        return { reset };
+    }
+
+    /**
+     * Claim a single event with optimistic lock (version check).
+     * Returns true only if this worker owns the transition PENDING/RETRY → PROCESSING.
+     */
+    async claimEventWithOptimisticLock(eventRow) {
+        const currentVersion = eventRow.version != null ? Number(eventRow.version) : 0;
+        const [result] = await db.query(
+            `UPDATE outbox_events
+             SET status = ?,
+                 version = version + 1,
+                 processing_started_at = NOW(),
+                 updated_at = NOW()
+             WHERE event_id = ?
+               AND version = ?
+               AND status IN (?, ?)`,
+            [
+                OUTBOX_STATUS.PROCESSING,
+                eventRow.event_id,
+                currentVersion,
+                OUTBOX_STATUS.PENDING,
+                OUTBOX_STATUS.RETRY
+            ]
+        );
+
+        if (!result.affectedRows) {
+            this.stats.optimisticLockConflicts++;
+            return false;
+        }
+
+        eventRow.version = currentVersion + 1;
+        return true;
+    }
+
+    /**
+     * Consumer-side idempotency: reserve key before side-effects.
+     * Returns { proceed: false } if already completed for this consumer.
+     */
+    async beginConsumerIdempotency(idempotencyKey, eventId, eventType, consumer = 'outbox-dispatcher') {
+        if (!idempotencyKey) {
+            return { proceed: true, skipped: false };
+        }
+
+        try {
+            const [existing] = await db.query(
+                `SELECT status FROM outbox_idempotency_ledger
+                 WHERE idempotency_key = ? AND consumer = ?
+                 LIMIT 1`,
+                [idempotencyKey, consumer]
+            );
+
+            if (existing.length > 0) {
+                if (existing[0].status === 'completed') {
+                    this.stats.skippedDuplicate++;
+                    return { proceed: false, skipped: true, reason: 'already_completed' };
+                }
+                // Allow retry of failed / abandoned processing rows after stale window
+                if (existing[0].status === 'processing') {
+                    await db.query(
+                        `UPDATE outbox_idempotency_ledger
+                         SET status = 'processing', event_id = ?, event_type = ?
+                         WHERE idempotency_key = ? AND consumer = ? AND status != 'completed'`,
+                        [eventId, eventType, idempotencyKey, consumer]
+                    );
+                    return { proceed: true, skipped: false, resumed: true };
+                }
+            }
+
+            const expiresAt = new Date();
+            expiresAt.setDate(expiresAt.getDate() + OUTBOX_CONFIG.idempotencyRetentionDays);
+
+            await db.query(
+                `INSERT INTO outbox_idempotency_ledger
+                 (idempotency_key, event_id, consumer, event_type, status, created_at, expires_at)
+                 VALUES (?, ?, ?, ?, 'processing', NOW(), ?)
+                 ON DUPLICATE KEY UPDATE
+                   event_id = IF(status = 'completed', event_id, VALUES(event_id)),
+                   status = IF(status = 'completed', status, 'processing')`,
+                [idempotencyKey, eventId, consumer, eventType, expiresAt]
+            );
+
+            // Re-read to honor concurrent completer
+            const [again] = await db.query(
+                `SELECT status FROM outbox_idempotency_ledger
+                 WHERE idempotency_key = ? AND consumer = ? LIMIT 1`,
+                [idempotencyKey, consumer]
+            );
+            if (again[0]?.status === 'completed') {
+                this.stats.skippedDuplicate++;
+                return { proceed: false, skipped: true, reason: 'race_completed' };
+            }
+
+            return { proceed: true, skipped: false };
+        } catch (error) {
+            // Fail closed for billing/notification safety if ledger insert races
+            if (error.code === 'ER_DUP_ENTRY') {
+                this.stats.skippedDuplicate++;
+                return { proceed: false, skipped: true, reason: 'duplicate_key' };
+            }
+            console.error('Consumer idempotency begin error:', error.message);
+            // Fail open only for missing table during migration
+            if (error.code === 'ER_NO_SUCH_TABLE') {
+                return { proceed: true, skipped: false, legacy: true };
+            }
+            throw error;
+        }
+    }
+
+    async completeConsumerIdempotency(idempotencyKey, consumer = 'outbox-dispatcher', failed = false) {
+        if (!idempotencyKey) return;
+        try {
+            await db.query(
+                `UPDATE outbox_idempotency_ledger
+                 SET status = ?, completed_at = NOW()
+                 WHERE idempotency_key = ? AND consumer = ?`,
+                [failed ? 'failed' : 'completed', idempotencyKey, consumer]
+            );
+        } catch (error) {
+            if (error.code !== 'ER_NO_SUCH_TABLE') {
+                console.error('Consumer idempotency complete error:', error.message);
+            }
+        }
+    }
+
+    /**
+     * Process pending events with per-row optimistic claims
      */
     async processPendingEvents() {
-        const connection = await db.getConnection();
+        let connection;
         try {
-            await connection.query('START TRANSACTION');
+            // Unlock stale processors first so retries are eligible
+            await this.resetStaleProcessingLocks();
 
-            // Get pending events using SKIP LOCKED to prevent race conditions
+            connection = await db.getConnection();
+            await connection.beginTransaction();
+
             const [events] = await connection.query(
                 `SELECT * FROM outbox_events 
                  WHERE status IN (?, ?)
@@ -225,32 +459,42 @@ class OutboxService {
                 [OUTBOX_STATUS.PENDING, OUTBOX_STATUS.RETRY, OUTBOX_CONFIG.batchSize]
             );
 
+            await connection.commit();
+            connection.release();
+            connection = null;
+
             if (events.length === 0) {
-                await connection.query('COMMIT');
-                connection.release();
                 return;
             }
 
-            // Mark events as processing atomically
-            const eventIds = events.map(e => e.event_id);
-            await connection.query(
-                `UPDATE outbox_events SET status = ? WHERE event_id IN (?)`,
-                [OUTBOX_STATUS.PROCESSING, eventIds]
-            );
-
-            await connection.query('COMMIT');
-            connection.release();
-
-            // Process each event
             for (const eventRow of events) {
+                const claimed = await this.claimEventWithOptimisticLock(eventRow);
+                if (!claimed) {
+                    continue;
+                }
+
+                let data = eventRow.data;
+                let metadata = eventRow.metadata;
+                try {
+                    data = typeof data === 'string' ? JSON.parse(data) : data;
+                    metadata = typeof metadata === 'string' ? JSON.parse(metadata || '{}') : (metadata || {});
+                } catch {
+                    data = {};
+                    metadata = {};
+                }
+
                 const event = {
                     id: eventRow.event_id,
                     type: eventRow.event_type,
-                    data: JSON.parse(eventRow.data),
-                    metadata: JSON.parse(eventRow.metadata || '{}'),
+                    data,
+                    metadata,
                     status: OUTBOX_STATUS.PROCESSING,
                     attempts: eventRow.attempts,
                     maxAttempts: eventRow.max_attempts,
+                    version: eventRow.version,
+                    idempotencyKey: eventRow.idempotency_key
+                        || data.idempotencyKey
+                        || metadata.idempotencyKey,
                     createdAt: eventRow.created_at,
                     updatedAt: eventRow.updated_at,
                     error: eventRow.error
@@ -260,54 +504,86 @@ class OutboxService {
             }
         } catch (error) {
             if (connection) {
-                await connection.query('ROLLBACK');
-                connection.release();
+                try {
+                    await connection.rollback();
+                } catch (_) { /* ignore */ }
+                try {
+                    connection.release();
+                } catch (_) { /* ignore */ }
             }
             console.error('Process pending events error:', error);
         }
     }
 
     /**
-     * Process a single event
+     * Process a single event with consumer-side idempotency gate
      */
     async processEvent(event) {
-        // Update status to processing
-        await this.updateEventStatus(event.id, OUTBOX_STATUS.PROCESSING);
+        const idempotencyKey = event.idempotencyKey
+            || this.generateIdempotencyKey(event.type, event.data, event.metadata?.occurredAt);
+
+        const gate = await this.beginConsumerIdempotency(
+            idempotencyKey,
+            event.id,
+            event.type,
+            'outbox-dispatcher'
+        );
+
+        if (!gate.proceed) {
+            await this.updateEventStatus(event.id, OUTBOX_STATUS.COMPLETED, {
+                version: event.version
+            });
+            console.log(`⏭️ Skipped duplicate dispatch: ${event.type} (${event.id})`);
+            return;
+        }
 
         try {
-            // Get handlers for this event type
             const handlers = this.eventHandlers.get(event.type) || [];
 
             if (handlers.length === 0) {
                 console.warn(`No handlers for event type: ${event.type}`);
-                await this.updateEventStatus(event.id, OUTBOX_STATUS.COMPLETED);
+                await this.completeConsumerIdempotency(idempotencyKey);
+                await this.updateEventStatus(event.id, OUTBOX_STATUS.COMPLETED, {
+                    version: event.version
+                });
                 return;
             }
 
-            // Execute all handlers
+            const payload = {
+                ...event,
+                data: {
+                    ...event.data,
+                    idempotencyKey
+                },
+                idempotencyKey
+            };
+
             for (const handler of handlers) {
-                await handler(event);
+                await handler(payload);
             }
 
-            // Update status to completed
-            await this.updateEventStatus(event.id, OUTBOX_STATUS.COMPLETED);
+            await this.completeConsumerIdempotency(idempotencyKey);
+            await this.updateEventStatus(event.id, OUTBOX_STATUS.COMPLETED, {
+                version: event.version
+            });
             this.stats.processed++;
 
             console.log(`✅ Event processed: ${event.type} (${event.id})`);
-
         } catch (error) {
             console.error(`Error processing event ${event.id}:`, error);
 
-            // Increment attempts
+            await this.completeConsumerIdempotency(idempotencyKey, 'outbox-dispatcher', true);
+
             const newAttempts = event.attempts + 1;
-            const newStatus = newAttempts >= event.maxAttempts 
-                ? OUTBOX_STATUS.FAILED 
+            const newStatus = newAttempts >= event.maxAttempts
+                ? OUTBOX_STATUS.FAILED
                 : OUTBOX_STATUS.RETRY;
 
             await this.updateEventStatus(event.id, newStatus, {
                 attempts: newAttempts,
                 error: error.message,
-                updatedAt: new Date().toISOString()
+                version: event.version,
+                clearProcessingLock: true
             });
 
             if (newStatus === OUTBOX_STATUS.FAILED) {
@@ -321,17 +597,48 @@ class OutboxService {
     }
 
     /**
-     * Update event status
+     * Update event status (optionally with optimistic version bump)
      */
     async updateEventStatus(eventId, status, additional = {}) {
-        const updates = {
-            status,
-            updatedAt: new Date().toISOString(),
-            ...additional
-        };
+        const updatedAt = new Date().toISOString();
+        const processedAt = status === OUTBOX_STATUS.COMPLETED
+            ? new Date().toISOString()
+            : null;
 
-        if (status === OUTBOX_STATUS.COMPLETED) {
-            updates.processedAt = new Date().toISOString();
+        const clearLock = status === OUTBOX_STATUS.COMPLETED
+            || status === OUTBOX_STATUS.FAILED
+            || status === OUTBOX_STATUS.RETRY
+            || additional.clearProcessingLock;
+
+        if (additional.version != null) {
+            const [result] = await db.query(
+                `UPDATE outbox_events 
+                 SET status = ?, 
+                     attempts = COALESCE(?, attempts),
+                     error = COALESCE(?, error),
+                     processed_at = COALESCE(?, processed_at),
+                     processing_started_at = IF(?, NULL, processing_started_at),
+                     version = version + 1,
+                     updated_at = ?
+                 WHERE event_id = ?
+                   AND version = ?`,
+                [
+                    status,
+                    additional.attempts != null ? additional.attempts : null,
+                    additional.error != null ? additional.error : null,
+                    processedAt,
+                    clearLock ? 1 : 0,
+                    updatedAt,
+                    eventId,
+                    additional.version
+                ]
+            );
+
+            if (!result.affectedRows) {
+                this.stats.optimisticLockConflicts++;
+                console.warn(`Optimistic lock miss on status update for ${eventId}`);
+            }
+            return;
         }
 
         await db.query(
@@ -340,21 +647,23 @@ class OutboxService {
                  attempts = COALESCE(?, attempts),
                  error = COALESCE(?, error),
                  processed_at = COALESCE(?, processed_at),
+                 processing_started_at = IF(?, NULL, processing_started_at),
                  updated_at = ?
              WHERE event_id = ?`,
             [
                 status,
-                additional.attempts || null,
-                additional.error || null,
-                updates.processedAt || null,
-                updates.updatedAt,
+                additional.attempts != null ? additional.attempts : null,
+                additional.error != null ? additional.error : null,
+                processedAt,
+                clearLock ? 1 : 0,
+                updatedAt,
                 eventId
             ]
         );
     }
 
     /**
-     * Clean up old events
+     * Clean up old events (keep idempotency ledger longer)
      */
     async cleanupOldEvents() {
         try {
@@ -371,6 +680,19 @@ class OutboxService {
             if (result.affectedRows > 0) {
                 console.log(`🧹 Cleaned up ${result.affectedRows} old events`);
             }
+
+            // Only purge ledger rows past long retention (avoid early expiration re-dispatch)
+            const ledgerCutoff = new Date();
+            ledgerCutoff.setDate(
+                ledgerCutoff.getDate() - OUTBOX_CONFIG.idempotencyRetentionDays
+            );
+            await db.query(
+                `DELETE FROM outbox_idempotency_ledger
+                 WHERE status = 'completed'
+                   AND (expires_at IS NOT NULL AND expires_at < NOW()
+                        OR completed_at < ?)`,
+                [ledgerCutoff.toISOString()]
+            );
         } catch (error) {
             console.error('Cleanup error:', error);
         }
@@ -393,9 +715,25 @@ class OutboxService {
                  FROM outbox_events`
             );
 
+            let ledger = null;
+            try {
+                const [ledgerRows] = await db.query(
+                    `SELECT
+                        COUNT(*) as ledger_total,
+                        SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as ledger_completed
+                     FROM outbox_idempotency_ledger`
+                );
+                ledger = ledgerRows[0];
+            } catch (_) {
+                ledger = null;
+            }
+
             return {
                 ...stats[0],
                 ...this.stats,
+                ledger,
+                staleProcessingMs: OUTBOX_CONFIG.staleProcessingMs,
+                idempotencyRetentionDays: OUTBOX_CONFIG.idempotencyRetentionDays,
                 timestamp: new Date().toISOString()
             };
         } catch (error) {
@@ -411,6 +749,7 @@ class OutboxService {
         await db.query(
             `UPDATE outbox_events 
              SET status = ?, 
+                 processing_started_at = NULL,
                  updated_at = NOW()
              WHERE status = ? 
              AND attempts < max_attempts`,
@@ -431,19 +770,40 @@ class OutboxService {
         return result[0]?.count || 0;
     }
 
+    /**
+     * Check whether an idempotency key was already consumed
+     */
+    async checkIdempotency(idempotencyKey, consumer = 'outbox-dispatcher') {
+        const [rows] = await db.query(
+            `SELECT status, event_id, completed_at, expires_at
+             FROM outbox_idempotency_ledger
+             WHERE idempotency_key = ? AND consumer = ?
+             LIMIT 1`,
+            [idempotencyKey, consumer]
+        );
+        if (!rows.length) {
+            return { exists: false, completed: false };
+        }
+        return {
+            exists: true,
+            completed: rows[0].status === 'completed',
+            status: rows[0].status,
+            eventId: rows[0].event_id,
+            completedAt: rows[0].completed_at,
+            expiresAt: rows[0].expires_at
+        };
+    }
+
     // ============================================
     // EVENT HANDLERS
     // ============================================
 
-    /**
-     * Process order created event
-     */
     async processOrderCreated(data) {
-        // Send notification
         await this.sendNotification({
             userId: data.userId,
             type: 'order_confirmation',
             template: 'order-confirmation',
+            idempotencyKey: data.idempotencyKey,
             data: {
                 orderId: data.orderId,
                 total: data.total,
@@ -451,56 +811,50 @@ class OutboxService {
             }
         });
 
-        // Update analytics
         await this.updateAnalytics({
             event: 'order_created',
             userId: data.userId,
             orderId: data.orderId,
             total: data.total,
+            idempotencyKey: data.idempotencyKey,
             timestamp: new Date().toISOString()
         });
 
-        // Update recommendations
         await this.updateRecommendations({
             userId: data.userId,
             orderId: data.orderId,
-            items: data.items
+            items: data.items,
+            idempotencyKey: data.idempotencyKey
         });
     }
 
-    /**
-     * Process order completed event
-     */
     async processOrderCompleted(data) {
-        // Send delivery notification
         await this.sendNotification({
             userId: data.userId,
             type: 'order_completed',
             template: 'order-completed',
+            idempotencyKey: data.idempotencyKey,
             data: {
                 orderId: data.orderId,
                 deliveryDate: data.deliveryDate
             }
         });
 
-        // Update analytics
         await this.updateAnalytics({
             event: 'order_completed',
             userId: data.userId,
             orderId: data.orderId,
+            idempotencyKey: data.idempotencyKey,
             timestamp: new Date().toISOString()
         });
     }
 
-    /**
-     * Process payment completed event
-     */
     async processPaymentCompleted(data) {
-        // Send payment confirmation
         await this.sendNotification({
             userId: data.userId,
             type: 'payment_confirmation',
             template: 'payment-confirmation',
+            idempotencyKey: data.idempotencyKey,
             data: {
                 paymentId: data.paymentId,
                 orderId: data.orderId,
@@ -508,12 +862,12 @@ class OutboxService {
             }
         });
 
-        // Update analytics
         await this.updateAnalytics({
             event: 'payment_completed',
             userId: data.userId,
             paymentId: data.paymentId,
             amount: data.amount,
+            idempotencyKey: data.idempotencyKey,
             timestamp: new Date().toISOString()
         });
     }
@@ -522,43 +876,25 @@ class OutboxService {
     // HELPER FUNCTIONS
     // ============================================
 
-    /**
-     * Send notification (simplified)
-     */
     async sendNotification(data) {
-        // In production, send actual notification
-        console.log(`📧 Notification: ${data.type} for user ${data.userId}`);
+        console.log(`📧 Notification: ${data.type} for user ${data.userId} key=${data.idempotencyKey || 'n/a'}`);
         return { sent: true };
     }
 
-    /**
-     * Update analytics (simplified)
-     */
     async updateAnalytics(data) {
-        // In production, update analytics
         console.log(`📊 Analytics: ${data.event}`);
         return { updated: true };
     }
 
-    /**
-     * Update recommendations (simplified)
-     */
     async updateRecommendations(data) {
-        // In production, update recommendations
         console.log(`🎯 Recommendations updated for user ${data.userId}`);
         return { updated: true };
     }
 
-    /**
-     * Generate event ID
-     */
     generateEventId() {
         return `EVT_${Date.now()}_${crypto.randomBytes(6).toString('hex')}`;
     }
 
-    /**
-     * Stop the outbox service
-     */
     async shutdown() {
         if (this.pollInterval) {
             clearInterval(this.pollInterval);
@@ -568,6 +904,11 @@ class OutboxService {
         if (this.cleanupInterval) {
             clearInterval(this.cleanupInterval);
             this.cleanupInterval = null;
+        }
+
+        if (this.staleResetInterval) {
+            clearInterval(this.staleResetInterval);
+            this.staleResetInterval = null;
         }
 
         this.isRunning = false;
@@ -583,5 +924,6 @@ module.exports = {
     OutboxService,
     OUTBOX_STATUS,
     EVENT_TYPES,
+    OUTBOX_CONFIG,
     outboxService: new OutboxService()
 };

--- a/backend/services/productService.js
+++ b/backend/services/productService.js
@@ -1,5 +1,33 @@
 // backend/services/productService.js
 const { productRepo } = require('../repositories');
+const Redis = require('ioredis');
+
+const CATEGORY_TREE_CACHE_PREFIX = 'category:tree:';
+const CATEGORY_TREE_TTL = parseInt(process.env.CATEGORY_TREE_CACHE_TTL, 10) || 1800;
+const DEFAULT_MAX_DEPTH = parseInt(process.env.CATEGORY_TREE_MAX_DEPTH, 10) || 5;
+
+const redis = new Redis({
+    host: process.env.REDIS_HOST || 'localhost',
+    port: process.env.REDIS_PORT || 6379,
+    password: process.env.REDIS_PASSWORD || undefined,
+    retryStrategy: (times) => Math.min(times * 50, 2000),
+    maxRetriesPerRequest: 3,
+    lazyConnect: true,
+    enableOfflineQueue: false
+});
+
+let redisReady = false;
+redis.connect().then(() => {
+    redisReady = true;
+}).catch(() => {
+    redisReady = false;
+});
+redis.on('ready', () => { redisReady = true; });
+redis.on('error', () => { redisReady = false; });
+
+function categoryTreeCacheKey({ rootId = null, maxDepth = DEFAULT_MAX_DEPTH } = {}) {
+    return `${CATEGORY_TREE_CACHE_PREFIX}v1:root:${rootId == null ? 'all' : rootId}:depth:${maxDepth}`;
+}
 
 class ProductService {
     /**
@@ -98,6 +126,90 @@ class ProductService {
      */
     async getLowStock(threshold = 10) {
         return productRepo.getLowStockProducts(threshold);
+    }
+
+    /**
+     * Multi-tier category navigation tree via single recursive CTE + Redis cache (#1264).
+     */
+    async getCategoryTree(options = {}) {
+        const maxDepth = Math.min(
+            Math.max(parseInt(options.maxDepth, 10) || DEFAULT_MAX_DEPTH, 1),
+            20
+        );
+        const rootId = options.rootId != null && options.rootId !== ''
+            ? Number(options.rootId)
+            : null;
+
+        const cacheKey = categoryTreeCacheKey({ rootId, maxDepth });
+
+        if (redisReady) {
+            try {
+                const cached = await redis.get(cacheKey);
+                if (cached) {
+                    return {
+                        tree: JSON.parse(cached),
+                        cached: true,
+                        maxDepth,
+                        rootId
+                    };
+                }
+            } catch (err) {
+                console.warn('Category tree Redis get failed:', err.message);
+            }
+        }
+
+        const tree = await productRepo.getCategoryTreeOptimized({ rootId, maxDepth });
+
+        if (redisReady) {
+            try {
+                await redis.setex(cacheKey, CATEGORY_TREE_TTL, JSON.stringify(tree));
+            } catch (err) {
+                console.warn('Category tree Redis set failed:', err.message);
+            }
+        }
+
+        return {
+            tree,
+            cached: false,
+            maxDepth,
+            rootId
+        };
+    }
+
+    /**
+     * Invalidate all cached category trees (call on category CRUD).
+     */
+    async invalidateCategoryTreeCache() {
+        if (!redisReady) {
+            return { success: true, cleared: 0, redis: false };
+        }
+
+        try {
+            const keys = await redis.keys(`${CATEGORY_TREE_CACHE_PREFIX}*`);
+            if (keys.length > 0) {
+                await redis.del(...keys);
+            }
+            return { success: true, cleared: keys.length, redis: true };
+        } catch (err) {
+            console.warn('Category tree cache invalidation failed:', err.message);
+            return { success: false, cleared: 0, error: err.message };
+        }
+    }
+
+    /**
+     * After category create/update/delete: bust Redis cache and optionally refresh MPTT.
+     */
+    async onCategoryMutation({ rebuildMptt = false } = {}) {
+        const invalidation = await this.invalidateCategoryTreeCache();
+        let mptt = null;
+        if (rebuildMptt) {
+            try {
+                mptt = await productRepo.rebuildCategoryMptt();
+            } catch (err) {
+                console.warn('MPTT rebuild skipped/failed:', err.message);
+            }
+        }
+        return { invalidation, mptt };
     }
 }
 

--- a/backend/sql/outbox_pattern.sql
+++ b/backend/sql/outbox_pattern.sql
@@ -1,4 +1,4 @@
--- Outbox Events Table
+-- Outbox Events Table (#1263: optimistic lock + idempotency)
 CREATE TABLE IF NOT EXISTS outbox_events (
     id INT PRIMARY KEY AUTO_INCREMENT,
     event_id VARCHAR(100) UNIQUE NOT NULL,
@@ -8,24 +8,57 @@ CREATE TABLE IF NOT EXISTS outbox_events (
     status ENUM('pending', 'processing', 'completed', 'failed', 'retry') DEFAULT 'pending',
     attempts INT DEFAULT 0,
     max_attempts INT DEFAULT 5,
+    -- Optimistic lock version — claim only succeeds when version matches
+    version INT NOT NULL DEFAULT 0,
+    -- Deterministic UUID v5 (event_type + entity_id + occurred_at)
+    idempotency_key VARCHAR(64) NOT NULL,
+    processing_started_at DATETIME NULL,
     error TEXT,
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL,
     processed_at DATETIME,
+    UNIQUE KEY uq_outbox_idempotency (idempotency_key),
     INDEX idx_status (status),
     INDEX idx_type (event_type),
     INDEX idx_created (created_at),
-    INDEX idx_updated (updated_at)
+    INDEX idx_updated (updated_at),
+    INDEX idx_status_version (status, version),
+    INDEX idx_processing_started (processing_started_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- Consumer-side idempotency ledger (survives outbox retention; prevents double side-effects)
+CREATE TABLE IF NOT EXISTS outbox_idempotency_ledger (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    idempotency_key VARCHAR(64) NOT NULL,
+    event_id VARCHAR(100) NOT NULL,
+    consumer VARCHAR(100) NOT NULL DEFAULT 'default',
+    event_type VARCHAR(100),
+    status ENUM('processing', 'completed', 'failed') DEFAULT 'processing',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at DATETIME NULL,
+    expires_at DATETIME NULL,
+    UNIQUE KEY uq_idempotency_consumer (idempotency_key, consumer),
+    INDEX idx_ledger_event (event_id),
+    INDEX idx_ledger_expires (expires_at),
+    INDEX idx_ledger_status (status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Existing installs (run manually if table already exists):
+-- ALTER TABLE outbox_events
+--   ADD COLUMN version INT NOT NULL DEFAULT 0,
+--   ADD COLUMN idempotency_key VARCHAR(64) NULL,
+--   ADD COLUMN processing_started_at DATETIME NULL;
+-- CREATE UNIQUE INDEX uq_outbox_idempotency ON outbox_events (idempotency_key);
+
 -- Outbox Dashboard View
-CREATE VIEW outbox_dashboard AS
+CREATE OR REPLACE VIEW outbox_dashboard AS
 SELECT 
     DATE(created_at) as date,
     COUNT(*) as total_events,
     SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
     SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
     SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) as pending,
+    SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) as processing,
     AVG(attempts) as avg_attempts
 FROM outbox_events
 WHERE created_at > DATE_SUB(NOW(), INTERVAL 30 DAY)


### PR DESCRIPTION
# #1263 issue resolved

## Description

This PR fixes outbox event double-dispatch caused by retries/timeouts and strengthens consumer-side idempotency so notifications and billing side-effects are not repeated.

## Features

- Adds PENDING → PROCESSING → COMPLETED/FAILED transitions with optimistic lock versions
- Attaches UUID v5 idempotency keys (event type + entity id + timestamp)
- Enforces consumer-side idempotency checks before side-effects
- Auto-resets stale PROCESSING locks after 30 seconds