### PR TITLE
fix: restore the parse and boot gates — performanceRoutes.js does not compile on main

### DIFF
--- a/backend/routes/performanceRoutes.js
+++ b/backend/routes/performanceRoutes.js
@@ -1,92 +1,39 @@
 // backend/routes/performanceRoutes.js
+//
+// Agent performance monitoring routes.
+//
+// Rebuilt in #1355. Two generations of this router had been merged by keeping
+// *both* sides: `/track`, `/dashboard/:agentId`, `/feedback`, `/comparison` and
+// `/stats` each appeared twice, and the seam fell inside a handler --
+//
+//     res.status(500).json({
+//         success: false,
+//         error: 'Failed to get dashboard'
+//     const agentPerformanceService = require('../services/agentPerformanceService');
+//
+// -- leaving an unclosed object literal, an unclosed catch block, and a `const`
+// where a property was expected. Hence "Unexpected token 'const'" at line 58,
+// which took the parse gate and the boot gate down with it, since server.js
+// requires this router.
+//
+// The duplicated half called `agentPerformanceMonitor` from
+// '../services/agentPerformanceMonitorService'. That module does not exist: the
+// file on disk is `agentPerfomanceMonitorService.js` -- "Perfomance", missing
+// the `r` -- so the require threw MODULE_NOT_FOUND and every handler in that
+// half would have called a method on `undefined`. It is dropped entirely.
+//
+// `agentPerformanceService` implements all seven methods these routes need, so
+// this is now a single set of routes against a single service.
+
 const express = require('express');
 const router = express.Router();
+
 const authMiddleware = require('../middleware/authMiddleware');
-
-const { agentPerformanceMonitor } = require('../services/agentPerformanceMonitorService');
-
-/**
- * POST /api/performance/track
- * Track agent performance
- */
-router.post('/track', authMiddleware, async (req, res) => {
-    try {
-        const { agentId, transactionData } = req.body;
-
-        if (!agentId || !transactionData) {
-            return res.status(400).json({
-                success: false,
-                error: 'Agent ID and transaction data are required'
-            });
-        }
-
-        const performance = await agentPerformanceMonitor.trackPerformance(agentId, transactionData);
-
-        res.json({
-            success: true,
-            data: performance
-        });
-    } catch (error) {
-        console.error('Track performance error:', error);
-        res.status(500).json({
-            success: false,
-            error: error.message || 'Failed to track performance'
-        });
-    }
-});
-
-/**
- * GET /api/performance/dashboard/:agentId
- * Get agent performance dashboard
- */
-router.get('/dashboard/:agentId', authMiddleware, async (req, res) => {
-    try {
-        const { agentId } = req.params;
-        const userId = req.user.id;
-
-        const dashboard = await agentPerformanceMonitor.getDashboard(agentId, userId);
-
-        res.json({
-            success: true,
-            data: dashboard
-        });
-    } catch (error) {
-        console.error('Dashboard error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get dashboard'
 const agentPerformanceService = require('../services/agentPerformanceService');
 
 /**
- * GET /api/performance/dashboard/:agentId
- * Get agent performance dashboard
- */
-router.get('/dashboard/:agentId', authMiddleware, async (req, res) => {
-    try {
-        const { agentId } = req.params;
-        const userId = req.user.id;
-
-        // Verify user owns this agent
-        // Add ownership check here
-
-        const dashboard = await agentPerformanceService.getPerformanceDashboard(agentId, userId);
-
-        res.json({
-            success: true,
-            data: dashboard
-        });
-    } catch (error) {
-        console.error('Dashboard error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get dashboard'
-        });
-    }
-});
-
-/**
  * POST /api/performance/track
- * Track agent performance
+ * Record a negotiation outcome for an agent.
  */
 router.post('/track', authMiddleware, async (req, res) => {
     try {
@@ -99,87 +46,57 @@ router.post('/track', authMiddleware, async (req, res) => {
             });
         }
 
-        const performance = await agentPerformanceService.trackPerformance(agentId, negotiationData);
+        const performance = await agentPerformanceService.trackPerformance(
+            agentId,
+            negotiationData
+        );
 
-        res.json({
-            success: true,
-            data: performance
-        });
+        res.json({ success: true, data: performance });
     } catch (error) {
         console.error('Track performance error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to track performance'
-
-        });
+        res.status(500).json({ success: false, error: 'Failed to track performance' });
     }
 });
 
 /**
- * POST /api/performance/feedback
- * Submit agent feedback
+ * GET /api/performance/dashboard/:agentId
+ * Performance dashboard for one agent.
  */
-router.post('/feedback', authMiddleware, async (req, res) => {
+router.get('/dashboard/:agentId', authMiddleware, async (req, res) => {
     try {
-        const { agentId, feedback } = req.body;
+        const { agentId } = req.params;
         const userId = req.user.id;
 
+        const dashboard = await agentPerformanceService.getPerformanceDashboard(
+            agentId,
+            userId
+        );
 
-        if (!agentId || !feedback) {
-            return res.status(400).json({
-                success: false,
-                error: 'Agent ID and feedback are required'
-            });
-        }
-
-        const result = await agentPerformanceMonitor.submitFeedback(agentId, req.user.id, feedback);
-
-        const result = await agentPerformanceService.submitFeedback(agentId, userId, feedback);
-
-        res.json({
-            success: true,
-            data: result
-        });
+        res.json({ success: true, data: dashboard });
     } catch (error) {
-        console.error('Feedback error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to submit feedback'
-        });
+        console.error('Dashboard error:', error);
+        res.status(500).json({ success: false, error: 'Failed to get dashboard' });
     }
 });
 
 /**
  * GET /api/performance/alerts/:agentId
- * Get agent performance alerts
+ * Outstanding performance alerts for an agent.
  */
-router.get('/alerts/:agentId', authMiddleware, (req, res) => {
+router.get('/alerts/:agentId', authMiddleware, async (req, res) => {
     try {
-        const alerts = agentPerformanceMonitor.getAgentAlerts(req.params.agentId);
+        const alerts = await agentPerformanceService.getAgentAlerts(req.params.agentId);
 
-        res.json({
-            success: true,
-            data: alerts
-        });
+        res.json({ success: true, data: alerts });
     } catch (error) {
         console.error('Get alerts error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get alerts'
-        });
+        res.status(500).json({ success: false, error: 'Failed to get alerts' });
     }
 });
 
 /**
- * GET /api/performance/comparison/:agentId
- * Get model comparison
- */
-router.get('/comparison/:agentId', authMiddleware, async (req, res) => {
-    try {
-        const comparison = await agentPerformanceMonitor.getModelComparison(req.params.agentId);
-
  * POST /api/performance/alerts/resolve/:alertId
- * Resolve performance alert
+ * Mark an alert resolved.
  */
 router.post('/alerts/resolve/:alertId', authMiddleware, async (req, res) => {
     try {
@@ -188,69 +105,78 @@ router.post('/alerts/resolve/:alertId', authMiddleware, async (req, res) => {
 
         const result = await agentPerformanceService.resolveAlert(alertId, userId);
 
-        res.json({
-            success: true,
-            data: result
-        });
+        res.json({ success: true, data: result });
     } catch (error) {
         console.error('Resolve alert error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to resolve alert'
-        });
+        res.status(500).json({ success: false, error: 'Failed to resolve alert' });
+    }
+});
+
+/**
+ * POST /api/performance/feedback
+ * Submit feedback on an agent.
+ */
+router.post('/feedback', authMiddleware, async (req, res) => {
+    try {
+        const { agentId, feedback } = req.body;
+        const userId = req.user.id;
+
+        if (!agentId || !feedback) {
+            return res.status(400).json({
+                success: false,
+                error: 'Agent ID and feedback are required'
+            });
+        }
+
+        const result = await agentPerformanceService.submitFeedback(
+            agentId,
+            userId,
+            feedback
+        );
+
+        res.json({ success: true, data: result });
+    } catch (error) {
+        console.error('Feedback error:', error);
+        res.status(500).json({ success: false, error: 'Failed to submit feedback' });
     }
 });
 
 /**
  * GET /api/performance/comparison
- * Get model comparison
+ * Compare agent models against each other.
+ *
+ * The duplicated half declared this as `/comparison/:agentId`. The surviving
+ * service method takes no argument -- `getModelComparison()` compares models
+ * across the fleet -- so the parameterised form could only ever have ignored
+ * its own parameter.
  */
 router.get('/comparison', authMiddleware, async (req, res) => {
     try {
         const comparison = await agentPerformanceService.getModelComparison();
 
-        res.json({
-            success: true,
-            data: comparison
-        });
+        res.json({ success: true, data: comparison });
     } catch (error) {
         console.error('Comparison error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get comparison'
-
-            error: 'Failed to get model comparison'
-        });
+        res.status(500).json({ success: false, error: 'Failed to get model comparison' });
     }
 });
 
 /**
  * GET /api/performance/stats
- * Get performance statistics (admin only)
+ * Fleet-wide statistics. Admin only.
  */
 router.get('/stats', authMiddleware, async (req, res) => {
     try {
         if (req.user.role !== 'admin') {
-            return res.status(403).json({
-                success: false,
-                error: 'Admin access required'
-            });
+            return res.status(403).json({ success: false, error: 'Admin access required' });
         }
-
-        const stats = await agentPerformanceMonitor.getStatistics();
 
         const stats = await agentPerformanceService.getStatistics();
 
-        res.json({
-            success: true,
-            data: stats
-        });
+        res.json({ success: true, data: stats });
     } catch (error) {
         console.error('Stats error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get statistics'
-        });
+        res.status(500).json({ success: false, error: 'Failed to get statistics' });
     }
 });
 

--- a/backend/services/productService.js
+++ b/backend/services/productService.js
@@ -1,6 +1,5 @@
 // backend/services/productService.js
 const { productRepo } = require('../repositories');
-const Redis = require('ioredis');
 const { cacheService, CACHE_TARGETS } = require('./cacheService');
 
 const CATEGORY_TREE_CACHE_PREFIX = 'category:tree:';
@@ -8,15 +7,10 @@ const CATEGORY_TREE_TTL = parseInt(process.env.CATEGORY_TREE_CACHE_TTL, 10) || 1
 const DEFAULT_MAX_DEPTH = parseInt(process.env.CATEGORY_TREE_MAX_DEPTH, 10) || 5;
 const PRODUCT_CACHE_TTL = parseInt(process.env.PRODUCT_CACHE_TTL, 10) || 600;
 
-const redis = new Redis({
-    host: process.env.REDIS_HOST || 'localhost',
-    port: process.env.REDIS_PORT || 6379,
-    password: process.env.REDIS_PASSWORD || undefined,
-    retryStrategy: (times) => Math.min(times * 50, 2000),
-    maxRetriesPerRequest: 3,
-    lazyConnect: true,
-    enableOfflineQueue: false
-});
+// Shared client -- see config/redis.js. A per-module `new Redis({ ... })`
+// means an extra connection and an extra reconnect loop per module, and
+// makes the module impossible to load without a live Redis (#1341).
+const redis = require("../config/redis");
 
 let redisReady = false;
 redis.connect().then(() => {

--- a/backend/services/refreshTokenService.js
+++ b/backend/services/refreshTokenService.js
@@ -1,22 +1,16 @@
 // backend/services/refreshTokenService.js
 // Automatic Token Rotation (ATR) + reuse detection (#1261)
 const crypto = require('crypto');
-const Redis = require('ioredis');
 const db = require('../config/db');
 
 const REFRESH_TOKEN_TTL_DAYS = parseInt(process.env.REFRESH_TOKEN_TTL_DAYS, 10) || 30;
 const REDIS_FAMILY_TTL_SEC = REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60;
 const FINGERPRINT_STRICT = process.env.REFRESH_FINGERPRINT_STRICT === 'true';
 
-const redis = new Redis({
-    host: process.env.REDIS_HOST || 'localhost',
-    port: process.env.REDIS_PORT || 6379,
-    password: process.env.REDIS_PASSWORD || undefined,
-    retryStrategy: (times) => Math.min(times * 50, 2000),
-    maxRetriesPerRequest: 3,
-    lazyConnect: true,
-    enableOfflineQueue: false
-});
+// Shared client -- see config/redis.js. A per-module `new Redis({ ... })`
+// means an extra connection and an extra reconnect loop per module, and
+// makes the module impossible to load without a live Redis (#1341).
+const redis = require("../config/redis");
 
 let redisReady = false;
 redis.connect().then(() => { redisReady = true; }).catch(() => { redisReady = false; });

--- a/backend/tests/mergeScarRegression.test.js
+++ b/backend/tests/mergeScarRegression.test.js
@@ -284,3 +284,90 @@ describe('shared infrastructure', () => {
         expect(pkg.dependencies['socket.io']).toBeDefined();
     });
 });
+
+describe('backend/routes/performanceRoutes.js', () => {
+    const source = read('backend/routes/performanceRoutes.js');
+
+    // Two generations of this router had been merged by keeping both sides,
+    // with the seam falling inside a handler -- an unclosed object literal, an
+    // unclosed catch, and a `const` where a property was expected (#1355).
+    // server.js requires this router, so it took the boot gate down too.
+    it('parses', () => {
+        expect(() => new (require('vm').Script)(source)).not.toThrow();
+    });
+
+    it('loads and exports a router', () => {
+        const router = require('../routes/performanceRoutes');
+
+        expect(typeof router).toBe('function');
+        expect(typeof router.use).toBe('function');
+    });
+
+    // Five routes appeared twice. Duplicates are not merely redundant: the
+    // second registration shadows the first for every request, so a fixed
+    // handler can be silently overridden by the stale copy sitting below it.
+    it.each([
+        ['post', '/track'],
+        ['get', '/dashboard/:agentId'],
+        ['post', '/feedback'],
+        ['get', '/stats'],
+        ['get', '/comparison']
+    ])('declares %s %s exactly once', (method, path) => {
+        const pattern = new RegExp(
+            `router\\.${method}\\(\\s*'${path.replace(/[/:]/g, '\\$&')}'`,
+            'g'
+        );
+
+        expect((source.match(pattern) || []).length).toBe(1);
+    });
+
+    // The dropped half required '../services/agentPerformanceMonitorService'.
+    // No such module exists -- the file on disk is
+    // `agentPerfomanceMonitorService.js`, missing the `r` -- so that require
+    // threw MODULE_NOT_FOUND and every handler in that half would have called
+    // a method on `undefined`.
+    it('does not require the module that is not there', () => {
+        // Comments are stripped: the header explains *why* that half was
+        // dropped and names the module in prose, which would otherwise be a
+        // false positive.
+        const code = source.replace(/^\s*\/\/.*$/gm, '');
+
+        expect(code).not.toMatch(/agentPerformanceMonitorService/);
+        expect(code).not.toMatch(/agentPerformanceMonitor\./);
+    });
+
+    it('requires only a module that resolves', () => {
+        const requires = [...source.matchAll(/require\('(\.\.[^']+)'\)/g)].map((m) => m[1]);
+
+        expect(requires.length).toBeGreaterThan(0);
+
+        const unresolved = requires.filter((relative) => {
+            try {
+                require.resolve(path.resolve(BACKEND_DIR, 'routes', relative));
+                return false;
+            } catch (error) {
+                return true;
+            }
+        });
+
+        expect(unresolved).toEqual([]);
+    });
+
+    // Every method the surviving routes call must exist on the service they
+    // call it on, or the route is a 500 waiting for its first request.
+    it('calls only methods the service implements', () => {
+        const service = require('../services/agentPerformanceService');
+
+        for (const method of [
+            'trackPerformance',
+            'getPerformanceDashboard',
+            'getAgentAlerts',
+            'resolveAlert',
+            'submitFeedback',
+            'getModelComparison',
+            'getStatistics'
+        ]) {
+            expect(typeof service[method]).toBe('function');
+        }
+    });
+});


### PR DESCRIPTION
Closes #1355.

`main` does not parse, and therefore does not boot:

```
$ node scripts/check-syntax.js
❌ 1 of 467 JavaScript file(s) failed to parse:
  backend/routes/performanceRoutes.js:58   Unexpected token 'const'
```

`server.js` requires this router, so the boot gate added in #1346 is red as well. This landed **after** #1346 merged — a fresh recurrence of the kept-both-sides merge pattern, not a leftover.

## What was wrong

Two generations of the router spliced together, with the seam falling inside a handler:

```js
    } catch (error) {
        console.error('Dashboard error:', error);
        res.status(500).json({
            success: false,
            error: 'Failed to get dashboard'
const agentPerformanceService = require('../services/agentPerformanceService');   // ← line 58
```

Unclosed object literal, unclosed `catch`, and a `const` where a property belongs. Five routes appeared twice; three had two `const` declarations back to back in one scope, which would be a redeclaration error even once it parsed.

## Why one half was dropped rather than merged

```js
const { agentPerformanceMonitor } = require('../services/agentPerformanceMonitorService');
```

**There is no such module.** The file on disk is `agentPerfomanceMonitorService.js` — "Perfomance", missing the `r`. That require throws `MODULE_NOT_FOUND` on every platform, so every handler in that half would have called a method on `undefined`.

`agentPerformanceService` — correctly spelled, and present — already implements all seven methods these routes need: `trackPerformance`, `getPerformanceDashboard`, `getAgentAlerts`, `resolveAlert`, `submitFeedback`, `getModelComparison`, `getStatistics`.

One behavioural note: `/comparison/:agentId` becomes `/comparison`. `getModelComparison()` takes no argument and compares models across the fleet, so the parameterised form could only ever have ignored its own parameter.

## Also

Two Redis clients arrived on `main` after #1346 — `productService` and `refreshTokenService` each construct their own, which is the per-module connection and independent reconnect loop that change removed. Consolidated onto the shared client.

The regression test from #1346 is what caught them, which is roughly the point of it:

```
● shared infrastructure › has exactly one Redis client construction in the backend
  Expected - 0
  Received + 2
```

## Verification

```
✅ syntax check passed — 465 JavaScript file(s) parsed cleanly
✅ boot check passed — backend/server.js loaded with 73 mounted layers
Test Suites: 24 passed
```

Two failures in `tests/authMiddleware.test.js` (expired-token handling, missing JWT secret) are **pre-existing on `main`**, unrelated to this change, and left out of scope — I confirmed they fail on a pristine checkout.