### PR TITLE
Repair unparsable performance router blocking the parse gate

### DIFF
--- a/backend/routes/performanceRoutes.js
+++ b/backend/routes/performanceRoutes.js
@@ -3,86 +3,7 @@ const express = require('express');
 const router = express.Router();
 const authMiddleware = require('../middleware/authMiddleware');
 
-const { agentPerformanceMonitor } = require('../services/agentPerformanceMonitorService');
-
-/**
- * POST /api/performance/track
- * Track agent performance
- */
-router.post('/track', authMiddleware, async (req, res) => {
-    try {
-        const { agentId, transactionData } = req.body;
-
-        if (!agentId || !transactionData) {
-            return res.status(400).json({
-                success: false,
-                error: 'Agent ID and transaction data are required'
-            });
-        }
-
-        const performance = await agentPerformanceMonitor.trackPerformance(agentId, transactionData);
-
-        res.json({
-            success: true,
-            data: performance
-        });
-    } catch (error) {
-        console.error('Track performance error:', error);
-        res.status(500).json({
-            success: false,
-            error: error.message || 'Failed to track performance'
-        });
-    }
-});
-
-/**
- * GET /api/performance/dashboard/:agentId
- * Get agent performance dashboard
- */
-router.get('/dashboard/:agentId', authMiddleware, async (req, res) => {
-    try {
-        const { agentId } = req.params;
-        const userId = req.user.id;
-
-        const dashboard = await agentPerformanceMonitor.getDashboard(agentId, userId);
-
-        res.json({
-            success: true,
-            data: dashboard
-        });
-    } catch (error) {
-        console.error('Dashboard error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get dashboard'
 const agentPerformanceService = require('../services/agentPerformanceService');
-
-/**
- * GET /api/performance/dashboard/:agentId
- * Get agent performance dashboard
- */
-router.get('/dashboard/:agentId', authMiddleware, async (req, res) => {
-    try {
-        const { agentId } = req.params;
-        const userId = req.user.id;
-
-        // Verify user owns this agent
-        // Add ownership check here
-
-        const dashboard = await agentPerformanceService.getPerformanceDashboard(agentId, userId);
-
-        res.json({
-            success: true,
-            data: dashboard
-        });
-    } catch (error) {
-        console.error('Dashboard error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get dashboard'
-        });
-    }
-});
 
 /**
  * POST /api/performance/track
@@ -110,7 +31,30 @@ router.post('/track', authMiddleware, async (req, res) => {
         res.status(500).json({
             success: false,
             error: 'Failed to track performance'
+        });
+    }
+});
 
+/**
+ * GET /api/performance/dashboard/:agentId
+ * Get agent performance dashboard
+ */
+router.get('/dashboard/:agentId', authMiddleware, async (req, res) => {
+    try {
+        const { agentId } = req.params;
+        const userId = req.user.id;
+
+        const dashboard = await agentPerformanceService.getPerformanceDashboard(agentId, userId);
+
+        res.json({
+            success: true,
+            data: dashboard
+        });
+    } catch (error) {
+        console.error('Dashboard error:', error);
+        res.status(500).json({
+            success: false,
+            error: 'Failed to get dashboard'
         });
     }
 });
@@ -124,15 +68,12 @@ router.post('/feedback', authMiddleware, async (req, res) => {
         const { agentId, feedback } = req.body;
         const userId = req.user.id;
 
-
         if (!agentId || !feedback) {
             return res.status(400).json({
                 success: false,
                 error: 'Agent ID and feedback are required'
             });
         }
-
-        const result = await agentPerformanceMonitor.submitFeedback(agentId, req.user.id, feedback);
 
         const result = await agentPerformanceService.submitFeedback(agentId, userId, feedback);
 
@@ -153,9 +94,9 @@ router.post('/feedback', authMiddleware, async (req, res) => {
  * GET /api/performance/alerts/:agentId
  * Get agent performance alerts
  */
-router.get('/alerts/:agentId', authMiddleware, (req, res) => {
+router.get('/alerts/:agentId', authMiddleware, async (req, res) => {
     try {
-        const alerts = agentPerformanceMonitor.getAgentAlerts(req.params.agentId);
+        const alerts = await agentPerformanceService.getAgentAlerts(req.params.agentId);
 
         res.json({
             success: true,
@@ -171,13 +112,6 @@ router.get('/alerts/:agentId', authMiddleware, (req, res) => {
 });
 
 /**
- * GET /api/performance/comparison/:agentId
- * Get model comparison
- */
-router.get('/comparison/:agentId', authMiddleware, async (req, res) => {
-    try {
-        const comparison = await agentPerformanceMonitor.getModelComparison(req.params.agentId);
-
  * POST /api/performance/alerts/resolve/:alertId
  * Resolve performance alert
  */
@@ -217,8 +151,6 @@ router.get('/comparison', authMiddleware, async (req, res) => {
         console.error('Comparison error:', error);
         res.status(500).json({
             success: false,
-            error: 'Failed to get comparison'
-
             error: 'Failed to get model comparison'
         });
     }
@@ -236,8 +168,6 @@ router.get('/stats', authMiddleware, async (req, res) => {
                 error: 'Admin access required'
             });
         }
-
-        const stats = await agentPerformanceMonitor.getStatistics();
 
         const stats = await agentPerformanceService.getStatistics();
 


### PR DESCRIPTION
The performance router does not parse, so the syntax gate fails on every pull
request against the default branch regardless of what that pull request changes.

A merge kept both sides of this file. Two implementations written against
different services are interleaved: route handlers are cut off mid-object, two
endpoints are declared twice, a couple of blocks declare the same constant
twice, and one object is missing a separator between its members. One of the two
services it reaches for does not exist in the tree at all, and the router sits on
the server's require path, so this would have stopped the server booting even if
it had parsed.

Resolved onto the service that is actually present, keeping the union of the
distinct endpoints rather than dropping any: tracking, dashboard, feedback,
listing alerts, resolving an alert, model comparison, and admin statistics. The
comparison endpoint keeps the form that matches the service, which compares
across agents rather than taking one. Alert listing is awaited, which the
duplicate it replaced failed to do and would have serialised a promise into the
response.

Behaviour of the surviving endpoints is otherwise unchanged.

## Verification
Every method the router calls is present on the exported service. The repository
parse gate passes across the tree. No other file is touched.

Closes #1355
