### PR TITLE
Hold rate limit counters in Redis and pin down the limiter key

### DIFF
--- a/backend/config/rateLimiters.js
+++ b/backend/config/rateLimiters.js
@@ -1,5 +1,7 @@
 // src/config/rateLimiters.js
 const rateLimit = require('express-rate-limit');
+// Shared, restart-durable counters instead of the library's in-process default.
+const { createRateLimitStore } = require('./redisRateLimitStore');
 
 // Global API limiter - 120 requests per minute
 const apiLimiter = rateLimit({
@@ -7,6 +9,7 @@ const apiLimiter = rateLimit({
   max: 120,
   standardHeaders: true,
   legacyHeaders: false,
+  store: createRateLimitStore('rl:api'),
   message: {
     success: false,
     errorCode: "API_RATE_LIMIT_EXCEEDED",
@@ -20,6 +23,7 @@ const adminLimiter = rateLimit({
   max: 100,
   standardHeaders: true,
   legacyHeaders: false,
+  store: createRateLimitStore('rl:admin'),
   message: {
     success: false,
     errorCode: "ADMIN_RATE_LIMIT_EXCEEDED",
@@ -33,6 +37,7 @@ const mcpLimiter = rateLimit({
   max: 10, // 10 requests per minute
   standardHeaders: true,
   legacyHeaders: false,
+  store: createRateLimitStore('rl:mcp'),
   message: {
     success: false,
     errorCode: "MCP_RATE_LIMIT_EXCEEDED",

--- a/backend/config/redisRateLimitStore.js
+++ b/backend/config/redisRateLimitStore.js
@@ -1,0 +1,229 @@
+// backend/config/redisRateLimitStore.js
+//
+// An `express-rate-limit` store backed by the shared Redis client.
+//
+// Every limiter in this backend relied on the library's default MemoryStore, so
+// the counters lived in one process's heap. A restart or a redeploy handed
+// every caller a fresh quota, and with N instances behind the load balancer the
+// effective limit was N times the configured one. Holding the counters in Redis
+// makes a limit mean what it says regardless of how many processes serve it and
+// how often they restart.
+//
+// This implements the Store interface of express-rate-limit v8, the major
+// version pinned in package.json: `init(options)`,
+// `increment(key) -> { totalHits, resetTime }`, `decrement(key)`,
+// `resetKey(key)` and `resetAll()`. There is no `rate-limit-redis` dependency
+// on purpose -- the client we already own is enough and the interface is four
+// methods wide.
+
+const redis = require('./redis');
+const logger = require('./logger');
+
+// INCR followed by a separate PEXPIRE has two races. A concurrent request can
+// observe the incremented counter before the TTL exists, and a crash between
+// the two commands leaves a key that never expires, which is a permanent lock
+// out for that caller. Running both inside one script makes the pair atomic and
+// costs a single round trip. PTTL is re-read rather than branching on
+// `hits == 1` so a key that has somehow lost its TTL is repaired instead of
+// leaking forever.
+const INCREMENT_SCRIPT = `
+local hits = redis.call('INCR', KEYS[1])
+local ttl = redis.call('PTTL', KEYS[1])
+if ttl < 0 then
+    redis.call('PEXPIRE', KEYS[1], ARGV[1])
+    ttl = tonumber(ARGV[1])
+end
+return { hits, ttl }
+`;
+
+// Decrementing is only meaningful while the window is still open. Recreating an
+// expired key here would resurrect a window with no TTL attached to it.
+const DECREMENT_SCRIPT = `
+if redis.call('EXISTS', KEYS[1]) == 1 then
+    return redis.call('DECR', KEYS[1])
+end
+return 0
+`;
+
+const DEFAULT_WINDOW_MS = 60 * 1000;
+const OUTAGE_LOG_INTERVAL_MS = 60 * 1000;
+const SCAN_BATCH = 100;
+
+// A long outage must not turn the in-process fallback into a memory leak, so
+// expired entries are swept once the map grows past this.
+const FALLBACK_SWEEP_THRESHOLD = 10000;
+
+class RedisRateLimitStore {
+    /**
+     * @param {object} config
+     * @param {string} config.prefix namespace for this limiter's keys. Two
+     *   limiters sharing a prefix would share a counter, so every limiter must
+     *   pass its own.
+     * @param {object} [config.client] ioredis client, defaults to the shared one.
+     */
+    constructor({ prefix, client = redis } = {}) {
+        if (!prefix) {
+            throw new Error(
+                'RedisRateLimitStore requires a prefix so limiters do not share counters'
+            );
+        }
+
+        this.prefix = prefix;
+        this.client = client;
+        this.windowMs = DEFAULT_WINDOW_MS;
+
+        // The counters live in Redis and are shared by every instance, which is
+        // the entire point of this store. `localKeys = false` tells
+        // express-rate-limit it does not own them.
+        this.localKeys = false;
+
+        this.fallbackHits = new Map();
+        this.lastOutageLogAt = 0;
+    }
+
+    /** Called by express-rate-limit once, with the limiter's resolved options. */
+    init(options) {
+        this.windowMs = options.windowMs;
+    }
+
+    redisKey(key) {
+        return `${this.prefix}:${key}`;
+    }
+
+    async increment(key) {
+        try {
+            const [hits, ttl] = await this.client.eval(
+                INCREMENT_SCRIPT,
+                1,
+                this.redisKey(key),
+                this.windowMs
+            );
+
+            return {
+                totalHits: Number(hits),
+                resetTime: new Date(Date.now() + Number(ttl))
+            };
+        } catch (error) {
+            this.reportOutage('increment', error);
+            return this.incrementLocally(key);
+        }
+    }
+
+    async decrement(key) {
+        try {
+            await this.client.eval(DECREMENT_SCRIPT, 1, this.redisKey(key));
+        } catch (error) {
+            this.reportOutage('decrement', error);
+
+            const entry = this.fallbackHits.get(key);
+            if (entry && entry.totalHits > 0) {
+                entry.totalHits -= 1;
+            }
+        }
+    }
+
+    async resetKey(key) {
+        this.fallbackHits.delete(key);
+
+        try {
+            await this.client.del(this.redisKey(key));
+        } catch (error) {
+            this.reportOutage('resetKey', error);
+        }
+    }
+
+    async resetAll() {
+        this.fallbackHits.clear();
+
+        try {
+            // SCAN rather than KEYS: this runs against a shared Redis and KEYS
+            // blocks the server for the length of the keyspace.
+            let cursor = '0';
+            do {
+                const [nextCursor, keys] = await this.client.scan(
+                    cursor,
+                    'MATCH',
+                    `${this.prefix}:*`,
+                    'COUNT',
+                    SCAN_BATCH
+                );
+                cursor = nextCursor;
+
+                if (keys.length > 0) {
+                    await this.client.del(...keys);
+                }
+            } while (cursor !== '0');
+        } catch (error) {
+            this.reportOutage('resetAll', error);
+        }
+    }
+
+    /**
+     * Deliberate degradation when Redis is unreachable: count in this process
+     * rather than rejecting traffic.
+     *
+     * Failing closed would turn a Redis outage into a total outage -- every
+     * request answered with 429, including the ones that have nothing to do
+     * with abuse. The rest of this backend degrades the same way (promo
+     * validation falls back to the stored `used_count`, the Socket.IO adapter
+     * logs and carries on), so failing closed here would also be inconsistent.
+     *
+     * The fallback still enforces the configured limit, just per process, which
+     * is precisely the behaviour that shipped before this store existed. The
+     * worst case during an outage is therefore the old weakness rather than a
+     * new one. It is logged at error level so the degradation is visible, and
+     * throttled so a sustained outage does not flood the log the way the
+     * unthrottled Redis error handler used to.
+     */
+    reportOutage(operation, error) {
+        const now = Date.now();
+        if (now - this.lastOutageLogAt < OUTAGE_LOG_INTERVAL_MS) {
+            return;
+        }
+
+        this.lastOutageLogAt = now;
+        logger.error(
+            `Rate limit store unavailable (${this.prefix}.${operation}): ${error.message}. `
+            + 'Falling back to per-process counting; limits are no longer shared across instances.'
+        );
+    }
+
+    incrementLocally(key) {
+        const now = Date.now();
+
+        if (this.fallbackHits.size > FALLBACK_SWEEP_THRESHOLD) {
+            this.sweepFallback(now);
+        }
+
+        const entry = this.fallbackHits.get(key);
+        if (!entry || entry.resetTime <= now) {
+            const resetTime = now + this.windowMs;
+            this.fallbackHits.set(key, { totalHits: 1, resetTime });
+            return { totalHits: 1, resetTime: new Date(resetTime) };
+        }
+
+        entry.totalHits += 1;
+        return { totalHits: entry.totalHits, resetTime: new Date(entry.resetTime) };
+    }
+
+    sweepFallback(now) {
+        for (const [key, entry] of this.fallbackHits) {
+            if (entry.resetTime <= now) {
+                this.fallbackHits.delete(key);
+            }
+        }
+    }
+}
+
+/**
+ * Build a store for one limiter. Each limiter needs its own instance so that,
+ * for example, the login and signup counters for the same address stay
+ * separate.
+ */
+const createRateLimitStore = (prefix, client = redis) =>
+    new RedisRateLimitStore({ prefix, client });
+
+module.exports = {
+    RedisRateLimitStore,
+    createRateLimitStore
+};

--- a/backend/config/trustProxy.js
+++ b/backend/config/trustProxy.js
@@ -1,0 +1,68 @@
+// backend/config/trustProxy.js
+//
+// Express's `trust proxy` setting decides what `req.ip` is, and `req.ip` is
+// what the rate limiters bucket on. Getting it wrong is silently exploitable in
+// both directions:
+//
+//   * too little trust and every request behind the load balancer reports the
+//     proxy's address, so all callers share one bucket and a single noisy
+//     client throttles everybody;
+//   * too much trust ("trust proxy: true" trusts the whole X-Forwarded-For
+//     chain) and a caller can append any address it likes, choosing its own
+//     bucket on every request and evading the limit entirely.
+//
+// The correct value is a deployment fact, not a code constant, so it is read
+// from the environment. The default stays 1 -- one trusted hop, the value this
+// app already ran with -- so deployments that do not set TRUST_PROXY keep their
+// current behaviour.
+//
+// TRUST_PROXY accepts:
+//   unset            -> 1        (trust exactly one proxy hop)
+//   an integer       -> that many hops
+//   "false" / "0"    -> trust nothing; use the socket address
+//   an address list  -> "10.0.0.0/8, loopback" and similar, passed to Express
+//   "true"           -> trust the entire chain (logged loudly; see above)
+
+const logger = require('./logger');
+
+const DEFAULT_TRUSTED_HOPS = 1;
+
+/**
+ * Resolve the value to hand to `app.set('trust proxy', ...)`.
+ *
+ * @param {string|undefined} rawValue typically process.env.TRUST_PROXY
+ * @returns {number|boolean|string}
+ */
+const resolveTrustProxy = (rawValue) => {
+    const value = (rawValue || '').trim();
+
+    if (!value) {
+        return DEFAULT_TRUSTED_HOPS;
+    }
+
+    const normalized = value.toLowerCase();
+
+    if (normalized === 'false' || normalized === 'off') {
+        return false;
+    }
+
+    if (normalized === 'true' || normalized === 'on') {
+        logger.warn(
+            'TRUST_PROXY=true trusts every hop in X-Forwarded-For, which lets a caller '
+            + 'choose the address the rate limiters key on. Prefer a hop count or an '
+            + 'explicit list of proxy addresses.'
+        );
+        return true;
+    }
+
+    if (/^\d+$/.test(normalized)) {
+        return Number(normalized);
+    }
+
+    // Anything else is an address, CIDR or named subnet list; Express parses
+    // these itself and throws on a malformed entry at startup rather than
+    // mis-resolving addresses at request time.
+    return value;
+};
+
+module.exports = { resolveTrustProxy, DEFAULT_TRUSTED_HOPS };

--- a/backend/middleware/rateLimiter.js
+++ b/backend/middleware/rateLimiter.js
@@ -1,12 +1,21 @@
 const rateLimit = require("express-rate-limit");
 // `ipKeyGenerator` normalises an address before it is used as a bucket key.
-// For IPv6 it collapses the address to its /64 subnet, so a client cannot walk
+// For IPv6 it collapses the address to its /56 subnet, so a client cannot walk
 // through the enormous address space it is typically allocated and get a fresh
 // quota on every request. Raw `req.ip` gives every IPv6 address its own bucket,
 // which is an effective bypass of any IP-based limit.
 const { ipKeyGenerator } = require("express-rate-limit");
+// Counters live in Redis rather than the library's default in-process store, so
+// a restart no longer hands every caller a fresh quota and every instance sees
+// the same totals. See config/redisRateLimitStore.js for the Redis-outage
+// behaviour.
+const { createRateLimitStore } = require("../config/redisRateLimitStore");
 
 // ==================== CONSTANTS FROM ENV ====================
+// Shared Redis keyspace for the auth limiters, kept distinct from the rest of
+// the backend's keys.
+const KEY_NAMESPACE = "rl:auth";
+
 const DEFAULT_WINDOW_MS =
     parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10)
     || 15 * 60 * 1000; // 15 minutes
@@ -44,19 +53,32 @@ const OTP_WINDOW_MS =
     || 5 * 60 * 1000; // 5 minutes
 
 // ==================== CUSTOM KEY GENERATOR ====================
+// A limit is only as good as the identity it counts against, so the identity is
+// picked deliberately here.
+//
+// An authenticated request is bucketed on the account. Bucketing it on the
+// address instead means one abusive account can exhaust the budget of every
+// other user behind the same corporate NAT or mobile carrier gateway.
+//
+// Everything else falls back to the client address. `req.ip` is only
+// trustworthy because `trust proxy` is configured explicitly at startup (see
+// config/trustProxy.js); without that it is either the load balancer's address
+// for everyone or a value the caller supplied in X-Forwarded-For.
+//
+// `req.body.userId` used to take part in this key. It is caller-supplied, so
+// anyone could mint a fresh bucket on every request just by varying it -- a
+// complete bypass of the unauthenticated limits, which are the ones that
+// matter. Only an identity the server established itself is used now.
 const customKeyGenerator = (req) => {
-    const userId =
-        req.user?.id
-        || req.body?.userId
-        || "anonymous";
+    if (req.user?.id) {
+        return `user:${req.user.id}`;
+    }
 
     const address = req.ip || req.socket?.remoteAddress;
 
     // Normalise before bucketing. An IPv6 client is typically handed a whole
-    // /64, so keying on the raw address hands out a fresh quota per request.
-    const ip = address ? ipKeyGenerator(address) : "unknown";
-
-    return `${ip}_${userId}`;
+    // subnet, so keying on the raw address hands out a fresh quota per request.
+    return address ? `ip:${ipKeyGenerator(address)}` : "ip:unknown";
 };
 
 // ==================== ON LIMIT REACHED CALLBACK ====================
@@ -93,7 +115,12 @@ const createRateLimitHandler = (
 };
 
 // shared limiter factory
+//
+// `name` namespaces the limiter's counters in Redis. Without it the login and
+// signup limiters would share a bucket for the same client, so five failed
+// logins would also consume the signup budget.
 const createLimiter = ({
+    name,
     windowMs,
     max,
     message,
@@ -107,6 +134,7 @@ const createLimiter = ({
         max,
         standardHeaders: true,
         legacyHeaders: false,
+        store: createRateLimitStore(`${KEY_NAMESPACE}:${name}`),
         keyGenerator,
         ...(skip ? { skip } : {}),
         handler: createRateLimitHandler(
@@ -125,6 +153,7 @@ const skipSuccessfulAttempts = () => {
 
 // ==================== LOGIN LIMITER ====================
 const loginLimiter = createLimiter({
+    name: "login",
     windowMs: DEFAULT_WINDOW_MS,
     max: LOGIN_MAX,
     message: `Too many login attempts. Please try again after ${DEFAULT_WINDOW_MS / 60000} minutes.`,
@@ -134,6 +163,7 @@ const loginLimiter = createLimiter({
 
 // ==================== SIGNUP LIMITER ====================
 const signupLimiter = createLimiter({
+    name: "signup",
     windowMs: DEFAULT_WINDOW_MS,
     max: SIGNUP_MAX,
     message: `Too many signup attempts. Please try again after ${DEFAULT_WINDOW_MS / 60000} minutes.`,
@@ -142,6 +172,7 @@ const signupLimiter = createLimiter({
 
 // ==================== REFRESH TOKEN LIMITER ====================
 const refreshTokenLimiter = createLimiter({
+    name: "refresh-token",
     windowMs: DEFAULT_WINDOW_MS,
     max: REFRESH_TOKEN_MAX,
     message: `Too many refresh requests. Please try again after ${DEFAULT_WINDOW_MS / 60000} minutes.`,
@@ -150,6 +181,7 @@ const refreshTokenLimiter = createLimiter({
 
 // ==================== FORGOT PASSWORD LIMITER ====================
 const forgotPasswordLimiter = createLimiter({
+    name: "forgot-password",
     windowMs: DEFAULT_WINDOW_MS,
     max: FORGOT_PASSWORD_MAX,
     message: `Too many password reset requests. Please try again after ${DEFAULT_WINDOW_MS / 60000} minutes.`,
@@ -158,6 +190,7 @@ const forgotPasswordLimiter = createLimiter({
 
 // ==================== OTP VERIFICATION LIMITER ====================
 const otpVerifyLimiter = createLimiter({
+    name: "otp-verify",
     windowMs: OTP_WINDOW_MS,
     max: OTP_VERIFY_MAX,
     message: `Too many OTP verification attempts. Please try again after ${OTP_WINDOW_MS / 60000} minutes.`,
@@ -166,6 +199,7 @@ const otpVerifyLimiter = createLimiter({
 
 // ==================== RESET PASSWORD LIMITER ====================
 const resetPasswordLimiter = createLimiter({
+    name: "reset-password",
     windowMs: DEFAULT_WINDOW_MS,
     max: RESET_PASSWORD_MAX,
     message: `Too many reset password attempts. Please try again after ${DEFAULT_WINDOW_MS / 60000} minutes.`,
@@ -174,6 +208,7 @@ const resetPasswordLimiter = createLimiter({
 
 // ==================== OTP REQUEST LIMITER ====================
 const otpRequestLimiter = createLimiter({
+    name: "otp-request",
     windowMs: OTP_WINDOW_MS,
     max: OTP_REQUEST_MAX,
     message: `Too many OTP requests. Please try again after ${OTP_WINDOW_MS / 60000} minutes.`,
@@ -189,6 +224,7 @@ const suspiciousIpKeyGenerator = (req) => {
 };
 
 const suspiciousIpLimiter = createLimiter({
+    name: "suspicious-ip",
     windowMs: 60 * 60 * 1000, // 1 hour
     max: 50,
     message: "Too many requests from this IP. Please try again later.",

--- a/backend/server.js
+++ b/backend/server.js
@@ -31,6 +31,7 @@ const setupProcessEventHandlers = require('./utils/processEventHandlers');
 const setupGracefulShutdown = require('./utils/gracefulShutdown');
 
 const { apiLimiter, adminLimiter, mcpLimiter } = require('./config/rateLimiters');
+const { resolveTrustProxy } = require('./config/trustProxy');
 
 const helmet = require("helmet");
 const corsMiddleware = require("./middleware/corsMiddleware");
@@ -207,7 +208,10 @@ if (!fs.existsSync(logDir)) {
 const errorLogStream = fs.createWriteStream(path.join(logDir, "error.log"), { flags: "a" });
 
 // 7. Express App Configuration & Global Middlewares
-app.set("trust proxy", 1);
+// `trust proxy` decides what req.ip resolves to and therefore what the rate
+// limiters count against, so it is a deployment setting rather than a constant.
+// The default is unchanged (one trusted hop); see config/trustProxy.js.
+app.set("trust proxy", resolveTrustProxy(process.env.TRUST_PROXY));
 app.disable("x-powered-by");
 
 // Add correlation ID middleware before any other middlewares


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

Rate limit counters move from `express-rate-limit`'s in-process default store into Redis, and the identity each limit is counted against is made explicit.

**Why the counters had to move.** They lived in one process's heap. A restart or redeploy cleared every limit, so a caller being throttled only had to wait for the next deploy. And with several instances serving traffic, each enforced the configured limit independently, so the limit actually in force was a multiple of the documented one. These are the limiters guarding sign-in, sign-up, token renewal and password reset, which is where a limit is the control that matters.

**Why the key had to change.** It mixed the client address with a user id taken from the request body — a value the caller supplies, so anyone could mint a fresh counter on every request simply by varying it. That is a complete bypass of the unauthenticated limits. Authenticated requests are now counted against the account, so a single abusive user cannot exhaust the budget of everyone else behind the same corporate NAT or carrier gateway, and unauthenticated endpoints stay keyed on the proxy-resolved client address, normalised by prefix for IPv6.

**Trust proxy.** `trust proxy` is now read from configuration rather than left at its default, keeping the single trusted hop this app already ran with, so existing deployments are unaffected. It decides what `req.ip` is and therefore what the limiters count, and getting it wrong is silently exploitable in either direction: too little trust collapses every client onto one bucket, too much lets a caller pick its own.

Limits, windows, headers and 429 response bodies are unchanged. Each limiter has its own Redis namespace, so failed sign-ins no longer draw down the sign-up budget.

---

## 🔗 Related Issue

Part of #1365

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] Security fix
- [ ] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Not applicable — this is a backend change with no visual surface.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**No new dependency.** `rate-limit-redis` is not in the project and was not added. The store is written directly against the `ioredis` client the backend already shares, implementing the `Store` contract for the `express-rate-limit` major version in use here. Each operation is a single `EVAL`: increment, read the remaining TTL, and set one only when it is missing — which also repairs a key that somehow lost its expiry instead of leaving a caller throttled indefinitely.

**Behaviour when Redis is unreachable.** The limiters fall back to counting within the process and log the degradation at error level, throttled to avoid flooding. Failing closed was considered and rejected: it would answer every request with 429 for the duration of a cache outage, turning a degraded dependency into a total one. The fallback still enforces the configured limit, just per process — which is exactly what shipped before this change — so an outage degrades to the previous weakness rather than to something worse. This also matches how the rest of the codebase already treats Redis being down: promo validation falls back to the stored usage count, and the Socket.IO adapter logs the failure and carries on.

**Note on CI.** `backend/routes/performanceRoutes.js` does not parse on `main`, which fails the syntax gate for every branch regardless of its contents. That file is untouched here and is being fixed separately in #1356.
