### PR TITLE
Hold account lockout state in Redis

### DIFF
--- a/backend/config/rateLimiters.js
+++ b/backend/config/rateLimiters.js
@@ -1,5 +1,7 @@
 // src/config/rateLimiters.js
 const rateLimit = require('express-rate-limit');
+// Shared, restart-durable counters instead of the library's in-process default.
+const { createRateLimitStore } = require('./redisRateLimitStore');
 
 // Global API limiter - 120 requests per minute
 const apiLimiter = rateLimit({
@@ -7,6 +9,7 @@ const apiLimiter = rateLimit({
   max: 120,
   standardHeaders: true,
   legacyHeaders: false,
+  store: createRateLimitStore('rl:api'),
   message: {
     success: false,
     errorCode: "API_RATE_LIMIT_EXCEEDED",
@@ -20,6 +23,7 @@ const adminLimiter = rateLimit({
   max: 100,
   standardHeaders: true,
   legacyHeaders: false,
+  store: createRateLimitStore('rl:admin'),
   message: {
     success: false,
     errorCode: "ADMIN_RATE_LIMIT_EXCEEDED",
@@ -33,6 +37,7 @@ const mcpLimiter = rateLimit({
   max: 10, // 10 requests per minute
   standardHeaders: true,
   legacyHeaders: false,
+  store: createRateLimitStore('rl:mcp'),
   message: {
     success: false,
     errorCode: "MCP_RATE_LIMIT_EXCEEDED",

--- a/backend/config/redisRateLimitStore.js
+++ b/backend/config/redisRateLimitStore.js
@@ -1,0 +1,229 @@
+// backend/config/redisRateLimitStore.js
+//
+// An `express-rate-limit` store backed by the shared Redis client.
+//
+// Every limiter in this backend relied on the library's default MemoryStore, so
+// the counters lived in one process's heap. A restart or a redeploy handed
+// every caller a fresh quota, and with N instances behind the load balancer the
+// effective limit was N times the configured one. Holding the counters in Redis
+// makes a limit mean what it says regardless of how many processes serve it and
+// how often they restart.
+//
+// This implements the Store interface of express-rate-limit v8, the major
+// version pinned in package.json: `init(options)`,
+// `increment(key) -> { totalHits, resetTime }`, `decrement(key)`,
+// `resetKey(key)` and `resetAll()`. There is no `rate-limit-redis` dependency
+// on purpose -- the client we already own is enough and the interface is four
+// methods wide.
+
+const redis = require('./redis');
+const logger = require('./logger');
+
+// INCR followed by a separate PEXPIRE has two races. A concurrent request can
+// observe the incremented counter before the TTL exists, and a crash between
+// the two commands leaves a key that never expires, which is a permanent lock
+// out for that caller. Running both inside one script makes the pair atomic and
+// costs a single round trip. PTTL is re-read rather than branching on
+// `hits == 1` so a key that has somehow lost its TTL is repaired instead of
+// leaking forever.
+const INCREMENT_SCRIPT = `
+local hits = redis.call('INCR', KEYS[1])
+local ttl = redis.call('PTTL', KEYS[1])
+if ttl < 0 then
+    redis.call('PEXPIRE', KEYS[1], ARGV[1])
+    ttl = tonumber(ARGV[1])
+end
+return { hits, ttl }
+`;
+
+// Decrementing is only meaningful while the window is still open. Recreating an
+// expired key here would resurrect a window with no TTL attached to it.
+const DECREMENT_SCRIPT = `
+if redis.call('EXISTS', KEYS[1]) == 1 then
+    return redis.call('DECR', KEYS[1])
+end
+return 0
+`;
+
+const DEFAULT_WINDOW_MS = 60 * 1000;
+const OUTAGE_LOG_INTERVAL_MS = 60 * 1000;
+const SCAN_BATCH = 100;
+
+// A long outage must not turn the in-process fallback into a memory leak, so
+// expired entries are swept once the map grows past this.
+const FALLBACK_SWEEP_THRESHOLD = 10000;
+
+class RedisRateLimitStore {
+    /**
+     * @param {object} config
+     * @param {string} config.prefix namespace for this limiter's keys. Two
+     *   limiters sharing a prefix would share a counter, so every limiter must
+     *   pass its own.
+     * @param {object} [config.client] ioredis client, defaults to the shared one.
+     */
+    constructor({ prefix, client = redis } = {}) {
+        if (!prefix) {
+            throw new Error(
+                'RedisRateLimitStore requires a prefix so limiters do not share counters'
+            );
+        }
+
+        this.prefix = prefix;
+        this.client = client;
+        this.windowMs = DEFAULT_WINDOW_MS;
+
+        // The counters live in Redis and are shared by every instance, which is
+        // the entire point of this store. `localKeys = false` tells
+        // express-rate-limit it does not own them.
+        this.localKeys = false;
+
+        this.fallbackHits = new Map();
+        this.lastOutageLogAt = 0;
+    }
+
+    /** Called by express-rate-limit once, with the limiter's resolved options. */
+    init(options) {
+        this.windowMs = options.windowMs;
+    }
+
+    redisKey(key) {
+        return `${this.prefix}:${key}`;
+    }
+
+    async increment(key) {
+        try {
+            const [hits, ttl] = await this.client.eval(
+                INCREMENT_SCRIPT,
+                1,
+                this.redisKey(key),
+                this.windowMs
+            );
+
+            return {
+                totalHits: Number(hits),
+                resetTime: new Date(Date.now() + Number(ttl))
+            };
+        } catch (error) {
+            this.reportOutage('increment', error);
+            return this.incrementLocally(key);
+        }
+    }
+
+    async decrement(key) {
+        try {
+            await this.client.eval(DECREMENT_SCRIPT, 1, this.redisKey(key));
+        } catch (error) {
+            this.reportOutage('decrement', error);
+
+            const entry = this.fallbackHits.get(key);
+            if (entry && entry.totalHits > 0) {
+                entry.totalHits -= 1;
+            }
+        }
+    }
+
+    async resetKey(key) {
+        this.fallbackHits.delete(key);
+
+        try {
+            await this.client.del(this.redisKey(key));
+        } catch (error) {
+            this.reportOutage('resetKey', error);
+        }
+    }
+
+    async resetAll() {
+        this.fallbackHits.clear();
+
+        try {
+            // SCAN rather than KEYS: this runs against a shared Redis and KEYS
+            // blocks the server for the length of the keyspace.
+            let cursor = '0';
+            do {
+                const [nextCursor, keys] = await this.client.scan(
+                    cursor,
+                    'MATCH',
+                    `${this.prefix}:*`,
+                    'COUNT',
+                    SCAN_BATCH
+                );
+                cursor = nextCursor;
+
+                if (keys.length > 0) {
+                    await this.client.del(...keys);
+                }
+            } while (cursor !== '0');
+        } catch (error) {
+            this.reportOutage('resetAll', error);
+        }
+    }
+
+    /**
+     * Deliberate degradation when Redis is unreachable: count in this process
+     * rather than rejecting traffic.
+     *
+     * Failing closed would turn a Redis outage into a total outage -- every
+     * request answered with 429, including the ones that have nothing to do
+     * with abuse. The rest of this backend degrades the same way (promo
+     * validation falls back to the stored `used_count`, the Socket.IO adapter
+     * logs and carries on), so failing closed here would also be inconsistent.
+     *
+     * The fallback still enforces the configured limit, just per process, which
+     * is precisely the behaviour that shipped before this store existed. The
+     * worst case during an outage is therefore the old weakness rather than a
+     * new one. It is logged at error level so the degradation is visible, and
+     * throttled so a sustained outage does not flood the log the way the
+     * unthrottled Redis error handler used to.
+     */
+    reportOutage(operation, error) {
+        const now = Date.now();
+        if (now - this.lastOutageLogAt < OUTAGE_LOG_INTERVAL_MS) {
+            return;
+        }
+
+        this.lastOutageLogAt = now;
+        logger.error(
+            `Rate limit store unavailable (${this.prefix}.${operation}): ${error.message}. `
+            + 'Falling back to per-process counting; limits are no longer shared across instances.'
+        );
+    }
+
+    incrementLocally(key) {
+        const now = Date.now();
+
+        if (this.fallbackHits.size > FALLBACK_SWEEP_THRESHOLD) {
+            this.sweepFallback(now);
+        }
+
+        const entry = this.fallbackHits.get(key);
+        if (!entry || entry.resetTime <= now) {
+            const resetTime = now + this.windowMs;
+            this.fallbackHits.set(key, { totalHits: 1, resetTime });
+            return { totalHits: 1, resetTime: new Date(resetTime) };
+        }
+
+        entry.totalHits += 1;
+        return { totalHits: entry.totalHits, resetTime: new Date(entry.resetTime) };
+    }
+
+    sweepFallback(now) {
+        for (const [key, entry] of this.fallbackHits) {
+            if (entry.resetTime <= now) {
+                this.fallbackHits.delete(key);
+            }
+        }
+    }
+}
+
+/**
+ * Build a store for one limiter. Each limiter needs its own instance so that,
+ * for example, the login and signup counters for the same address stay
+ * separate.
+ */
+const createRateLimitStore = (prefix, client = redis) =>
+    new RedisRateLimitStore({ prefix, client });
+
+module.exports = {
+    RedisRateLimitStore,
+    createRateLimitStore
+};

--- a/backend/config/trustProxy.js
+++ b/backend/config/trustProxy.js
@@ -1,0 +1,68 @@
+// backend/config/trustProxy.js
+//
+// Express's `trust proxy` setting decides what `req.ip` is, and `req.ip` is
+// what the rate limiters bucket on. Getting it wrong is silently exploitable in
+// both directions:
+//
+//   * too little trust and every request behind the load balancer reports the
+//     proxy's address, so all callers share one bucket and a single noisy
+//     client throttles everybody;
+//   * too much trust ("trust proxy: true" trusts the whole X-Forwarded-For
+//     chain) and a caller can append any address it likes, choosing its own
+//     bucket on every request and evading the limit entirely.
+//
+// The correct value is a deployment fact, not a code constant, so it is read
+// from the environment. The default stays 1 -- one trusted hop, the value this
+// app already ran with -- so deployments that do not set TRUST_PROXY keep their
+// current behaviour.
+//
+// TRUST_PROXY accepts:
+//   unset            -> 1        (trust exactly one proxy hop)
+//   an integer       -> that many hops
+//   "false" / "0"    -> trust nothing; use the socket address
+//   an address list  -> "10.0.0.0/8, loopback" and similar, passed to Express
+//   "true"           -> trust the entire chain (logged loudly; see above)
+
+const logger = require('./logger');
+
+const DEFAULT_TRUSTED_HOPS = 1;
+
+/**
+ * Resolve the value to hand to `app.set('trust proxy', ...)`.
+ *
+ * @param {string|undefined} rawValue typically process.env.TRUST_PROXY
+ * @returns {number|boolean|string}
+ */
+const resolveTrustProxy = (rawValue) => {
+    const value = (rawValue || '').trim();
+
+    if (!value) {
+        return DEFAULT_TRUSTED_HOPS;
+    }
+
+    const normalized = value.toLowerCase();
+
+    if (normalized === 'false' || normalized === 'off') {
+        return false;
+    }
+
+    if (normalized === 'true' || normalized === 'on') {
+        logger.warn(
+            'TRUST_PROXY=true trusts every hop in X-Forwarded-For, which lets a caller '
+            + 'choose the address the rate limiters key on. Prefer a hop count or an '
+            + 'explicit list of proxy addresses.'
+        );
+        return true;
+    }
+
+    if (/^\d+$/.test(normalized)) {
+        return Number(normalized);
+    }
+
+    // Anything else is an address, CIDR or named subnet list; Express parses
+    // these itself and throws on a malformed entry at startup rather than
+    // mis-resolving addresses at request time.
+    return value;
+};
+
+module.exports = { resolveTrustProxy, DEFAULT_TRUSTED_HOPS };

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -10,6 +10,9 @@ const { sanitizeString, safeArray } = require("../utils/helpers");
 const { getClearCookieOptions } = require("../config/cookieConfig");
 const refreshTokenService = require("../services/refreshTokenService");
 const agentIdentityService = require("../services/agentIdentityService");
+// Lockout state lives in Redis so it survives a restart and is observed by
+// every instance; the policy it enforces is unchanged.
+const loginLockoutService = require("../services/loginLockoutService");
 
 // Appwrite SDK
 const { Client, Account, ID, Databases } = require('node-appwrite');
@@ -24,11 +27,11 @@ const OTP_EXPIRY_MINUTES = parseInt(process.env.OTP_EXPIRY_MINUTES) || 10;
 const OTP_RATE_LIMIT_WINDOW = 5 * 60 * 1000; // 5 minutes
 const OTP_RATE_LIMIT_MAX = 3; // Max 3 OTP requests per window
 const CLEANUP_INTERVAL = 5 * 60 * 1000; // 5 minutes
-const MAX_LOGIN_ATTEMPTS = 5;
-const LOGIN_LOCKOUT_DURATION = 15 * 60 * 1000; // 15 minutes
-// Window in which the failed attempts must accumulate to trip the lockout.
-// Failures older than this roll off so isolated mistakes never reach the threshold.
-const LOGIN_ATTEMPT_WINDOW = 15 * 60 * 1000; // 15 minutes
+const {
+    MAX_LOGIN_ATTEMPTS,
+    LOGIN_LOCKOUT_DURATION,
+    LOGIN_ATTEMPT_WINDOW
+} = loginLockoutService;
 
 // ==================== VALIDATION PATTERNS ====================
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -37,7 +40,6 @@ const otpRegex = /^\d{6}$/;
 
 // ==================== RATE LIMITING ====================
 const otpRateLimiter = new Map();
-const loginAttempts = new Map();
 
 // ==================== PENDING SIGNUPS CACHE ====================
 const pendingSignups = new Map();
@@ -142,57 +144,12 @@ function isOTPRateLimited(email) {
     return false;
 }
 
-function isLoginLocked(email) {
-    const now = Date.now();
-    const record = loginAttempts.get(email);
-
-    if (!record) return false;
-
-    // Only an active lockout blocks login. Counting failures within the
-    // window is not itself a lock — that is what let a single mistyped
-    // password lock the account before.
-    if (record.lockoutUntil && now < record.lockoutUntil) {
-        return true;
-    }
-
-    // No active lockout: drop the record once the lockout has expired or the
-    // rolling attempt window has elapsed, so the counter restarts cleanly.
-    if ((record.lockoutUntil && now >= record.lockoutUntil) || now > record.windowExpires) {
-        loginAttempts.delete(email);
-    }
-    return false;
-}
-
-function recordLoginFailure(email) {
-    const now = Date.now();
-    const record = loginAttempts.get(email);
-
-    // Start a fresh window on the first failure or after the previous window
-    // rolled off without reaching the threshold.
-    if (!record || now > record.windowExpires) {
-        loginAttempts.set(email, {
-            attempts: 1,
-            windowExpires: now + LOGIN_ATTEMPT_WINDOW,
-            lockoutUntil: null
-        });
-        return;
-    }
-
-    record.attempts++;
-    // The lockout only starts once the threshold is reached within the window.
-    if (record.attempts >= MAX_LOGIN_ATTEMPTS) {
-        record.lockoutUntil = now + LOGIN_LOCKOUT_DURATION;
-    }
-}
-
-function resetLoginAttempts(email) {
-    loginAttempts.delete(email);
-}
-
-// Test-only: drop all tracked attempts so cases start from a clean slate.
-function clearLoginAttempts() {
-    loginAttempts.clear();
-}
+const {
+    isLoginLocked,
+    recordLoginFailure,
+    resetLoginAttempts,
+    clearLoginAttempts
+} = loginLockoutService;
 
 // ==================== 1. SIGNUP (Send OTP) ====================
 const signup = async (req, res) => {
@@ -344,7 +301,7 @@ const login = async (req, res) => {
         }
 
         // Check login lockout
-        if (isLoginLocked(cleanEmail)) {
+        if (await isLoginLocked(cleanEmail)) {
             return res.status(429).json({ 
                 success: false, 
                 message: "Too many failed attempts. Account locked for 15 minutes." 
@@ -353,7 +310,7 @@ const login = async (req, res) => {
 
         const [users] = await db.query(`SELECT * FROM users WHERE email = ? LIMIT 1`, [cleanEmail]);
         if (!safeArray(users).length) {
-            recordLoginFailure(cleanEmail);
+            await recordLoginFailure(cleanEmail);
             return res.status(401).json({ success: false, message: "Invalid credentials" });
         }
 
@@ -364,12 +321,12 @@ const login = async (req, res) => {
 
         const isMatch = await bcrypt.compare(password, user.password);
         if (!isMatch) {
-            recordLoginFailure(cleanEmail);
+            await recordLoginFailure(cleanEmail);
             return res.status(401).json({ success: false, message: "Invalid credentials" });
         }
 
         // Reset login attempts on success
-        resetLoginAttempts(cleanEmail);
+        await resetLoginAttempts(cleanEmail);
 
         // Check if 2FA is enabled
         if (user.is_2fa_enabled === 1) {

--- a/backend/middleware/rateLimiter.js
+++ b/backend/middleware/rateLimiter.js
@@ -1,12 +1,21 @@
 const rateLimit = require("express-rate-limit");
 // `ipKeyGenerator` normalises an address before it is used as a bucket key.
-// For IPv6 it collapses the address to its /64 subnet, so a client cannot walk
+// For IPv6 it collapses the address to its /56 subnet, so a client cannot walk
 // through the enormous address space it is typically allocated and get a fresh
 // quota on every request. Raw `req.ip` gives every IPv6 address its own bucket,
 // which is an effective bypass of any IP-based limit.
 const { ipKeyGenerator } = require("express-rate-limit");
+// Counters live in Redis rather than the library's default in-process store, so
+// a restart no longer hands every caller a fresh quota and every instance sees
+// the same totals. See config/redisRateLimitStore.js for the Redis-outage
+// behaviour.
+const { createRateLimitStore } = require("../config/redisRateLimitStore");
 
 // ==================== CONSTANTS FROM ENV ====================
+// Shared Redis keyspace for the auth limiters, kept distinct from the rest of
+// the backend's keys.
+const KEY_NAMESPACE = "rl:auth";
+
 const DEFAULT_WINDOW_MS =
     parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10)
     || 15 * 60 * 1000; // 15 minutes
@@ -44,19 +53,32 @@ const OTP_WINDOW_MS =
     || 5 * 60 * 1000; // 5 minutes
 
 // ==================== CUSTOM KEY GENERATOR ====================
+// A limit is only as good as the identity it counts against, so the identity is
+// picked deliberately here.
+//
+// An authenticated request is bucketed on the account. Bucketing it on the
+// address instead means one abusive account can exhaust the budget of every
+// other user behind the same corporate NAT or mobile carrier gateway.
+//
+// Everything else falls back to the client address. `req.ip` is only
+// trustworthy because `trust proxy` is configured explicitly at startup (see
+// config/trustProxy.js); without that it is either the load balancer's address
+// for everyone or a value the caller supplied in X-Forwarded-For.
+//
+// `req.body.userId` used to take part in this key. It is caller-supplied, so
+// anyone could mint a fresh bucket on every request just by varying it -- a
+// complete bypass of the unauthenticated limits, which are the ones that
+// matter. Only an identity the server established itself is used now.
 const customKeyGenerator = (req) => {
-    const userId =
-        req.user?.id
-        || req.body?.userId
-        || "anonymous";
+    if (req.user?.id) {
+        return `user:${req.user.id}`;
+    }
 
     const address = req.ip || req.socket?.remoteAddress;
 
     // Normalise before bucketing. An IPv6 client is typically handed a whole
-    // /64, so keying on the raw address hands out a fresh quota per request.
-    const ip = address ? ipKeyGenerator(address) : "unknown";
-
-    return `${ip}_${userId}`;
+    // subnet, so keying on the raw address hands out a fresh quota per request.
+    return address ? `ip:${ipKeyGenerator(address)}` : "ip:unknown";
 };
 
 // ==================== ON LIMIT REACHED CALLBACK ====================
@@ -93,7 +115,12 @@ const createRateLimitHandler = (
 };
 
 // shared limiter factory
+//
+// `name` namespaces the limiter's counters in Redis. Without it the login and
+// signup limiters would share a bucket for the same client, so five failed
+// logins would also consume the signup budget.
 const createLimiter = ({
+    name,
     windowMs,
     max,
     message,
@@ -107,6 +134,7 @@ const createLimiter = ({
         max,
         standardHeaders: true,
         legacyHeaders: false,
+        store: createRateLimitStore(`${KEY_NAMESPACE}:${name}`),
         keyGenerator,
         ...(skip ? { skip } : {}),
         handler: createRateLimitHandler(
@@ -125,6 +153,7 @@ const skipSuccessfulAttempts = () => {
 
 // ==================== LOGIN LIMITER ====================
 const loginLimiter = createLimiter({
+    name: "login",
     windowMs: DEFAULT_WINDOW_MS,
     max: LOGIN_MAX,
     message: `Too many login attempts. Please try again after ${DEFAULT_WINDOW_MS / 60000} minutes.`,
@@ -134,6 +163,7 @@ const loginLimiter = createLimiter({
 
 // ==================== SIGNUP LIMITER ====================
 const signupLimiter = createLimiter({
+    name: "signup",
     windowMs: DEFAULT_WINDOW_MS,
     max: SIGNUP_MAX,
     message: `Too many signup attempts. Please try again after ${DEFAULT_WINDOW_MS / 60000} minutes.`,
@@ -142,6 +172,7 @@ const signupLimiter = createLimiter({
 
 // ==================== REFRESH TOKEN LIMITER ====================
 const refreshTokenLimiter = createLimiter({
+    name: "refresh-token",
     windowMs: DEFAULT_WINDOW_MS,
     max: REFRESH_TOKEN_MAX,
     message: `Too many refresh requests. Please try again after ${DEFAULT_WINDOW_MS / 60000} minutes.`,
@@ -150,6 +181,7 @@ const refreshTokenLimiter = createLimiter({
 
 // ==================== FORGOT PASSWORD LIMITER ====================
 const forgotPasswordLimiter = createLimiter({
+    name: "forgot-password",
     windowMs: DEFAULT_WINDOW_MS,
     max: FORGOT_PASSWORD_MAX,
     message: `Too many password reset requests. Please try again after ${DEFAULT_WINDOW_MS / 60000} minutes.`,
@@ -158,6 +190,7 @@ const forgotPasswordLimiter = createLimiter({
 
 // ==================== OTP VERIFICATION LIMITER ====================
 const otpVerifyLimiter = createLimiter({
+    name: "otp-verify",
     windowMs: OTP_WINDOW_MS,
     max: OTP_VERIFY_MAX,
     message: `Too many OTP verification attempts. Please try again after ${OTP_WINDOW_MS / 60000} minutes.`,
@@ -166,6 +199,7 @@ const otpVerifyLimiter = createLimiter({
 
 // ==================== RESET PASSWORD LIMITER ====================
 const resetPasswordLimiter = createLimiter({
+    name: "reset-password",
     windowMs: DEFAULT_WINDOW_MS,
     max: RESET_PASSWORD_MAX,
     message: `Too many reset password attempts. Please try again after ${DEFAULT_WINDOW_MS / 60000} minutes.`,
@@ -174,6 +208,7 @@ const resetPasswordLimiter = createLimiter({
 
 // ==================== OTP REQUEST LIMITER ====================
 const otpRequestLimiter = createLimiter({
+    name: "otp-request",
     windowMs: OTP_WINDOW_MS,
     max: OTP_REQUEST_MAX,
     message: `Too many OTP requests. Please try again after ${OTP_WINDOW_MS / 60000} minutes.`,
@@ -189,6 +224,7 @@ const suspiciousIpKeyGenerator = (req) => {
 };
 
 const suspiciousIpLimiter = createLimiter({
+    name: "suspicious-ip",
     windowMs: 60 * 60 * 1000, // 1 hour
     max: 50,
     message: "Too many requests from this IP. Please try again later.",

--- a/backend/server.js
+++ b/backend/server.js
@@ -31,6 +31,7 @@ const setupProcessEventHandlers = require('./utils/processEventHandlers');
 const setupGracefulShutdown = require('./utils/gracefulShutdown');
 
 const { apiLimiter, adminLimiter, mcpLimiter } = require('./config/rateLimiters');
+const { resolveTrustProxy } = require('./config/trustProxy');
 
 const helmet = require("helmet");
 const corsMiddleware = require("./middleware/corsMiddleware");
@@ -207,7 +208,10 @@ if (!fs.existsSync(logDir)) {
 const errorLogStream = fs.createWriteStream(path.join(logDir, "error.log"), { flags: "a" });
 
 // 7. Express App Configuration & Global Middlewares
-app.set("trust proxy", 1);
+// `trust proxy` decides what req.ip resolves to and therefore what the rate
+// limiters count against, so it is a deployment setting rather than a constant.
+// The default is unchanged (one trusted hop); see config/trustProxy.js.
+app.set("trust proxy", resolveTrustProxy(process.env.TRUST_PROXY));
 app.disable("x-powered-by");
 
 // Add correlation ID middleware before any other middlewares

--- a/backend/services/loginLockoutService.js
+++ b/backend/services/loginLockoutService.js
@@ -1,0 +1,268 @@
+// backend/services/loginLockoutService.js
+//
+// Failed-sign-in accounting and account lockout, held in Redis.
+//
+// This state used to be a `Map` in the auth controller's module scope, which
+// meant a restart cleared every lockout and an attacker only had to be spread
+// across instances to get MAX_LOGIN_ATTEMPTS tries per instance instead of
+// MAX_LOGIN_ATTEMPTS in total. The policy below -- threshold, rolling window,
+// lockout duration -- is unchanged; only where the counters live has moved.
+//
+// The Redis-outage behaviour matches config/redisRateLimitStore.js: fall back
+// to per-process counting and log loudly. Rejecting every sign-in while Redis
+// is down would lock every customer out of the site over a cache outage, and
+// the per-process fallback is exactly what this code did before.
+
+const crypto = require('crypto');
+const redis = require('../config/redis');
+const logger = require('../config/logger');
+
+const MAX_LOGIN_ATTEMPTS = 5;
+const LOGIN_LOCKOUT_DURATION = 15 * 60 * 1000; // 15 minutes
+// Window in which the failed attempts must accumulate to trip the lockout.
+// Failures older than this roll off so isolated mistakes never reach the threshold.
+const LOGIN_ATTEMPT_WINDOW = 15 * 60 * 1000; // 15 minutes
+
+const KEY_PREFIX = 'auth:lockout';
+const OUTAGE_LOG_INTERVAL_MS = 60 * 1000;
+const SCAN_BATCH = 100;
+
+// Lua numbers are doubles, and `tostring` renders a millisecond timestamp as
+// "1.7672256e+12", so writing one to Redis unformatted silently loses the low
+// digits. Every numeric write below goes through %d for that reason.
+const RECORD_FAILURE_SCRIPT = `
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local maxAttempts = tonumber(ARGV[3])
+local lockoutMs = tonumber(ARGV[4])
+
+local attempts = tonumber(redis.call('HGET', key, 'attempts')) or 0
+local windowExpires = tonumber(redis.call('HGET', key, 'windowExpires')) or 0
+local lockoutUntil = tonumber(redis.call('HGET', key, 'lockoutUntil')) or 0
+
+if attempts == 0 or now > windowExpires then
+    attempts = 1
+    windowExpires = now + window
+    lockoutUntil = 0
+else
+    attempts = attempts + 1
+    if attempts >= maxAttempts then
+        lockoutUntil = now + lockoutMs
+    end
+end
+
+redis.call('HSET', key,
+    'attempts', string.format('%d', attempts),
+    'windowExpires', string.format('%d', windowExpires),
+    'lockoutUntil', string.format('%d', lockoutUntil))
+
+local expiresAt = windowExpires
+if lockoutUntil > expiresAt then
+    expiresAt = lockoutUntil
+end
+redis.call('PEXPIRE', key, string.format('%d', expiresAt - now))
+
+return { attempts, string.format('%d', lockoutUntil) }
+`;
+
+// Reading and expiring the record in one script keeps two instances from
+// disagreeing about whether a lockout has elapsed.
+const IS_LOCKED_SCRIPT = `
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+
+if redis.call('EXISTS', key) == 0 then
+    return 0
+end
+
+local windowExpires = tonumber(redis.call('HGET', key, 'windowExpires')) or 0
+local lockoutUntil = tonumber(redis.call('HGET', key, 'lockoutUntil')) or 0
+
+-- Only an active lockout blocks login. Accumulating failures inside the window
+-- is not itself a lock; that is what let a single mistyped password lock the
+-- account before.
+if lockoutUntil > 0 and now < lockoutUntil then
+    return 1
+end
+
+-- No active lockout: drop the record once the lockout has expired or the
+-- rolling attempt window has elapsed, so the counter restarts cleanly.
+if (lockoutUntil > 0 and now >= lockoutUntil) or now > windowExpires then
+    redis.call('DEL', key)
+end
+
+return 0
+`;
+
+/**
+ * Normalise the account identifier before it becomes a key.
+ *
+ * Sign-in looks the account up by a lowercased email, so the counter has to be
+ * keyed the same way -- otherwise "User@x.com" and "user@x.com" resolve to one
+ * account but two independent budgets, and the threshold is trivially doubled.
+ *
+ * The value is hashed rather than embedded: the identifier is attacker-supplied
+ * on a public endpoint, so hashing both keeps arbitrary input out of the
+ * keyspace and avoids parking a list of user emails in Redis where a
+ * `SCAN auth:lockout:*` would enumerate them.
+ */
+const lockoutKey = (email) => {
+    const normalized = String(email || '').trim().toLowerCase();
+    const digest = crypto.createHash('sha256').update(normalized).digest('hex');
+    return `${KEY_PREFIX}:${digest}`;
+};
+
+// Per-process fallback, used only while Redis is unreachable.
+const fallbackAttempts = new Map();
+let lastOutageLogAt = 0;
+
+const reportOutage = (operation, error) => {
+    const now = Date.now();
+    if (now - lastOutageLogAt < OUTAGE_LOG_INTERVAL_MS) {
+        return;
+    }
+
+    lastOutageLogAt = now;
+    logger.error(
+        `Login lockout store unavailable (${operation}): ${error.message}. `
+        + 'Falling back to per-process attempt counting; lockouts are not shared '
+        + 'across instances and will not survive a restart.'
+    );
+};
+
+const isLockedLocally = (key, now) => {
+    const record = fallbackAttempts.get(key);
+    if (!record) return false;
+
+    if (record.lockoutUntil && now < record.lockoutUntil) {
+        return true;
+    }
+
+    if ((record.lockoutUntil && now >= record.lockoutUntil) || now > record.windowExpires) {
+        fallbackAttempts.delete(key);
+    }
+    return false;
+};
+
+const recordFailureLocally = (key, now) => {
+    const record = fallbackAttempts.get(key);
+
+    if (!record || now > record.windowExpires) {
+        fallbackAttempts.set(key, {
+            attempts: 1,
+            windowExpires: now + LOGIN_ATTEMPT_WINDOW,
+            lockoutUntil: null
+        });
+        return;
+    }
+
+    record.attempts++;
+    if (record.attempts >= MAX_LOGIN_ATTEMPTS) {
+        record.lockoutUntil = now + LOGIN_LOCKOUT_DURATION;
+    }
+};
+
+/**
+ * Is this account currently locked out?
+ *
+ * @param {string} email
+ * @returns {Promise<boolean>}
+ */
+const isLoginLocked = async (email) => {
+    const key = lockoutKey(email);
+    const now = Date.now();
+
+    try {
+        const locked = await redis.eval(IS_LOCKED_SCRIPT, 1, key, now);
+        return Number(locked) === 1;
+    } catch (error) {
+        reportOutage('isLoginLocked', error);
+        return isLockedLocally(key, now);
+    }
+};
+
+/**
+ * Count one failed sign-in, starting the lockout if the threshold is reached
+ * inside the rolling window.
+ *
+ * @param {string} email
+ * @returns {Promise<void>}
+ */
+const recordLoginFailure = async (email) => {
+    const key = lockoutKey(email);
+    const now = Date.now();
+
+    try {
+        await redis.eval(
+            RECORD_FAILURE_SCRIPT,
+            1,
+            key,
+            now,
+            LOGIN_ATTEMPT_WINDOW,
+            MAX_LOGIN_ATTEMPTS,
+            LOGIN_LOCKOUT_DURATION
+        );
+    } catch (error) {
+        reportOutage('recordLoginFailure', error);
+        recordFailureLocally(key, now);
+    }
+};
+
+/**
+ * Clear the counter after a successful sign-in.
+ *
+ * @param {string} email
+ * @returns {Promise<void>}
+ */
+const resetLoginAttempts = async (email) => {
+    const key = lockoutKey(email);
+    fallbackAttempts.delete(key);
+
+    try {
+        await redis.del(key);
+    } catch (error) {
+        reportOutage('resetLoginAttempts', error);
+    }
+};
+
+/**
+ * Drop every tracked attempt. Test-only: production keys expire on their own.
+ *
+ * @returns {Promise<void>}
+ */
+const clearLoginAttempts = async () => {
+    fallbackAttempts.clear();
+
+    try {
+        // SCAN rather than KEYS so this cannot block a shared Redis.
+        let cursor = '0';
+        do {
+            const [nextCursor, keys] = await redis.scan(
+                cursor,
+                'MATCH',
+                `${KEY_PREFIX}:*`,
+                'COUNT',
+                SCAN_BATCH
+            );
+            cursor = nextCursor;
+
+            if (keys.length > 0) {
+                await redis.del(...keys);
+            }
+        } while (cursor !== '0');
+    } catch (error) {
+        reportOutage('clearLoginAttempts', error);
+    }
+};
+
+module.exports = {
+    isLoginLocked,
+    recordLoginFailure,
+    resetLoginAttempts,
+    clearLoginAttempts,
+    lockoutKey,
+    MAX_LOGIN_ATTEMPTS,
+    LOGIN_LOCKOUT_DURATION,
+    LOGIN_ATTEMPT_WINDOW
+};

--- a/backend/tests/loginLockout.test.js
+++ b/backend/tests/loginLockout.test.js
@@ -25,6 +25,24 @@ jest.mock('../config/db', () => ({
     query: jest.fn()
 }));
 
+// The lockout counters live in Redis now (#1365). This suite pins the policy
+// itself -- threshold, rolling window, lockout duration, clear on success -- and
+// deliberately runs it against an unreachable Redis, because the per-process
+// fallback that serves an outage has to enforce exactly the same policy as the
+// shared path. The Redis path is covered in loginLockoutService.test.js.
+jest.mock('../config/redis', () => ({
+    eval: jest.fn().mockRejectedValue(new Error('ECONNREFUSED')),
+    del: jest.fn().mockRejectedValue(new Error('ECONNREFUSED')),
+    scan: jest.fn().mockRejectedValue(new Error('ECONNREFUSED'))
+}));
+
+jest.mock('../config/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
 const { _loginGuard } = require('../controllers/authController');
 const {
     isLoginLocked,
@@ -39,14 +57,14 @@ const {
 describe('Login lockout state machine', () => {
     const email = 'user@example.com';
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.useFakeTimers();
         jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
-        clearLoginAttempts();
+        await clearLoginAttempts();
     });
 
-    afterEach(() => {
-        clearLoginAttempts();
+    afterEach(async () => {
+        await clearLoginAttempts();
         jest.useRealTimers();
     });
 
@@ -55,72 +73,85 @@ describe('Login lockout state machine', () => {
         expect(typeof recordLoginFailure).toBe('function');
         expect(typeof resetLoginAttempts).toBe('function');
         expect(MAX_LOGIN_ATTEMPTS).toBe(5);
+        expect(LOGIN_LOCKOUT_DURATION).toBe(15 * 60 * 1000);
+        expect(LOGIN_ATTEMPT_WINDOW).toBe(15 * 60 * 1000);
     });
 
-    test('MAX_LOGIN_ATTEMPTS - 1 failures do NOT lock the account', () => {
+    test('MAX_LOGIN_ATTEMPTS - 1 failures do NOT lock the account', async () => {
         for (let i = 0; i < MAX_LOGIN_ATTEMPTS - 1; i++) {
-            recordLoginFailure(email);
-            expect(isLoginLocked(email)).toBe(false);
+            await recordLoginFailure(email);
+            expect(await isLoginLocked(email)).toBe(false);
         }
     });
 
-    test('the MAX_LOGIN_ATTEMPTS-th failure locks the account', () => {
+    test('the MAX_LOGIN_ATTEMPTS-th failure locks the account', async () => {
         for (let i = 0; i < MAX_LOGIN_ATTEMPTS - 1; i++) {
-            recordLoginFailure(email);
+            await recordLoginFailure(email);
         }
-        expect(isLoginLocked(email)).toBe(false);
+        expect(await isLoginLocked(email)).toBe(false);
 
-        recordLoginFailure(email);
-        expect(isLoginLocked(email)).toBe(true);
+        await recordLoginFailure(email);
+        expect(await isLoginLocked(email)).toBe(true);
     });
 
-    test('a successful login before the threshold clears the counter', () => {
+    test('a successful login before the threshold clears the counter', async () => {
         for (let i = 0; i < MAX_LOGIN_ATTEMPTS - 1; i++) {
-            recordLoginFailure(email);
+            await recordLoginFailure(email);
         }
-        expect(isLoginLocked(email)).toBe(false);
+        expect(await isLoginLocked(email)).toBe(false);
 
         // Success resets the counter, so it takes a full MAX run again to lock.
-        resetLoginAttempts(email);
+        await resetLoginAttempts(email);
 
         for (let i = 0; i < MAX_LOGIN_ATTEMPTS - 1; i++) {
-            recordLoginFailure(email);
-            expect(isLoginLocked(email)).toBe(false);
+            await recordLoginFailure(email);
+            expect(await isLoginLocked(email)).toBe(false);
         }
-        recordLoginFailure(email);
-        expect(isLoginLocked(email)).toBe(true);
+        await recordLoginFailure(email);
+        expect(await isLoginLocked(email)).toBe(true);
     });
 
-    test('after the lockout window elapses, isLoginLocked returns false again', () => {
+    test('after the lockout window elapses, isLoginLocked returns false again', async () => {
         for (let i = 0; i < MAX_LOGIN_ATTEMPTS; i++) {
-            recordLoginFailure(email);
+            await recordLoginFailure(email);
         }
-        expect(isLoginLocked(email)).toBe(true);
+        expect(await isLoginLocked(email)).toBe(true);
 
         // Still locked one tick before expiry.
         jest.advanceTimersByTime(LOGIN_LOCKOUT_DURATION - 1);
-        expect(isLoginLocked(email)).toBe(true);
+        expect(await isLoginLocked(email)).toBe(true);
 
         // Lockout has now elapsed: login is allowed and the record is cleared.
         jest.advanceTimersByTime(2);
-        expect(isLoginLocked(email)).toBe(false);
+        expect(await isLoginLocked(email)).toBe(false);
 
         // A subsequent single failure must not re-lock.
-        recordLoginFailure(email);
-        expect(isLoginLocked(email)).toBe(false);
+        await recordLoginFailure(email);
+        expect(await isLoginLocked(email)).toBe(false);
     });
 
-    test('failures spread beyond the rolling window do not accumulate to a lock', () => {
+    test('failures spread beyond the rolling window do not accumulate to a lock', async () => {
         // Four failures, then let the window roll off before the fifth.
         for (let i = 0; i < MAX_LOGIN_ATTEMPTS - 1; i++) {
-            recordLoginFailure(email);
+            await recordLoginFailure(email);
         }
-        expect(isLoginLocked(email)).toBe(false);
+        expect(await isLoginLocked(email)).toBe(false);
 
         jest.advanceTimersByTime(LOGIN_ATTEMPT_WINDOW + 1);
 
         // This failure starts a brand-new window rather than tripping the lock.
-        recordLoginFailure(email);
-        expect(isLoginLocked(email)).toBe(false);
+        await recordLoginFailure(email);
+        expect(await isLoginLocked(email)).toBe(false);
+    });
+
+    test('a differently cased or padded address is the same account', async () => {
+        // Sign-in resolves the account by lowercased email, so the counter has
+        // to agree -- otherwise the threshold doubles for anyone who alternates.
+        for (let i = 0; i < MAX_LOGIN_ATTEMPTS - 1; i++) {
+            await recordLoginFailure('User@Example.com');
+        }
+        await recordLoginFailure('  user@example.com  ');
+
+        expect(await isLoginLocked(email)).toBe(true);
     });
 });

--- a/backend/tests/loginLockoutService.test.js
+++ b/backend/tests/loginLockoutService.test.js
@@ -1,0 +1,175 @@
+// backend/tests/loginLockoutService.test.js
+//
+// The shared half of the lockout (#1365): what the service actually asks Redis
+// to do, and that the account identity it keys on cannot be varied by the
+// caller. The policy itself is pinned in loginLockout.test.js.
+
+jest.mock('../config/redis', () => ({
+    eval: jest.fn().mockResolvedValue(0),
+    del: jest.fn().mockResolvedValue(1),
+    scan: jest.fn().mockResolvedValue(['0', []])
+}));
+
+jest.mock('../config/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+const crypto = require('crypto');
+const redis = require('../config/redis');
+const logger = require('../config/logger');
+const {
+    isLoginLocked,
+    recordLoginFailure,
+    resetLoginAttempts,
+    lockoutKey,
+    MAX_LOGIN_ATTEMPTS,
+    LOGIN_LOCKOUT_DURATION,
+    LOGIN_ATTEMPT_WINDOW
+} = require('../services/loginLockoutService');
+
+const EMAIL = 'user@example.com';
+const EXPECTED_KEY =
+    `auth:lockout:${crypto.createHash('sha256').update(EMAIL).digest('hex')}`;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    redis.eval.mockResolvedValue(0);
+    redis.del.mockResolvedValue(1);
+});
+
+describe('lockout key derivation', () => {
+    test('normalises case and surrounding whitespace to one account', () => {
+        expect(lockoutKey('User@Example.com')).toBe(EXPECTED_KEY);
+        expect(lockoutKey('  USER@EXAMPLE.COM  ')).toBe(EXPECTED_KEY);
+    });
+
+    test('keeps the raw identifier out of the keyspace', () => {
+        // The value arrives on a public endpoint, so it is hashed rather than
+        // interpolated: nothing attacker-supplied lands in a key name, and a
+        // SCAN of the namespace does not enumerate customer addresses.
+        expect(lockoutKey(EMAIL)).not.toContain(EMAIL);
+        expect(lockoutKey(EMAIL)).toMatch(/^auth:lockout:[0-9a-f]{64}$/);
+    });
+
+    test('different accounts never collide', () => {
+        expect(lockoutKey('a@example.com')).not.toBe(lockoutKey('b@example.com'));
+    });
+});
+
+describe('recordLoginFailure', () => {
+    test('applies the configured threshold, window and lockout duration', async () => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+        await recordLoginFailure(EMAIL);
+
+        const [script, keyCount, key, now, window, maxAttempts, lockoutMs] =
+            redis.eval.mock.calls[0];
+
+        expect(keyCount).toBe(1);
+        expect(key).toBe(EXPECTED_KEY);
+        expect(now).toBe(Date.now());
+        expect(window).toBe(LOGIN_ATTEMPT_WINDOW);
+        expect(maxAttempts).toBe(MAX_LOGIN_ATTEMPTS);
+        expect(lockoutMs).toBe(LOGIN_LOCKOUT_DURATION);
+        // The record must carry an expiry of its own; the old in-memory map
+        // relied on a sweeper interval that a shared store does not have.
+        expect(script).toMatch(/PEXPIRE/);
+
+        jest.useRealTimers();
+    });
+
+    test('reads and writes the counter in a single atomic step', async () => {
+        await recordLoginFailure(EMAIL);
+
+        // Two instances racing on the same account must not each read four
+        // failures and write five.
+        expect(redis.eval).toHaveBeenCalledTimes(1);
+    });
+
+    test('sends no attempt count of its own, so a restart cannot reset the tally', async () => {
+        await recordLoginFailure(EMAIL);
+        await recordLoginFailure(EMAIL);
+
+        // The running total is read and advanced inside Redis; this process
+        // contributes only the clock and the policy constants, which is what
+        // makes the count outlive the process that started it.
+        const [first, second] = redis.eval.mock.calls;
+        expect(first[2]).toBe(second[2]);
+        expect(first.slice(4)).toEqual([
+            LOGIN_ATTEMPT_WINDOW,
+            MAX_LOGIN_ATTEMPTS,
+            LOGIN_LOCKOUT_DURATION
+        ]);
+    });
+});
+
+describe('isLoginLocked', () => {
+    test('reports a lock when the shared record says so', async () => {
+        redis.eval.mockResolvedValue(1);
+
+        expect(await isLoginLocked(EMAIL)).toBe(true);
+        expect(redis.eval.mock.calls[0][2]).toBe(EXPECTED_KEY);
+    });
+
+    test('reports no lock otherwise', async () => {
+        redis.eval.mockResolvedValue(0);
+
+        expect(await isLoginLocked(EMAIL)).toBe(false);
+    });
+
+    test('an unknown account is not locked', async () => {
+        redis.eval.mockResolvedValue(0);
+
+        expect(await isLoginLocked('nobody@example.com')).toBe(false);
+    });
+});
+
+describe('resetLoginAttempts', () => {
+    test('a successful sign-in removes the shared counter', async () => {
+        await resetLoginAttempts(EMAIL);
+
+        expect(redis.del).toHaveBeenCalledWith(EXPECTED_KEY);
+    });
+
+    test('clears the counter for the normalised account, not the typed string', async () => {
+        await resetLoginAttempts('  User@Example.com ');
+
+        expect(redis.del).toHaveBeenCalledWith(EXPECTED_KEY);
+    });
+});
+
+describe('when Redis is unavailable', () => {
+    const outage = new Error('ECONNREFUSED');
+
+    // The reporting assertion lives on the first case to reach the degraded
+    // path, because the warning is throttled per process to keep a sustained
+    // outage from flooding the log.
+    test('sign-in is not blocked wholesale, and the degradation is reported', async () => {
+        redis.eval.mockRejectedValue(outage);
+
+        // Failing closed here would lock every customer out of the site for the
+        // duration of a cache outage.
+        await expect(isLoginLocked(EMAIL)).resolves.toBe(false);
+        expect(logger.error).toHaveBeenCalledTimes(1);
+        expect(logger.error.mock.calls[0][0]).toMatch(/per-process/);
+    });
+
+    test('failures are still counted, in this process', async () => {
+        redis.eval.mockRejectedValue(outage);
+
+        for (let i = 0; i < MAX_LOGIN_ATTEMPTS; i++) {
+            await recordLoginFailure(EMAIL);
+        }
+
+        expect(await isLoginLocked(EMAIL)).toBe(true);
+    });
+
+    test('a reset does not throw out of the sign-in path', async () => {
+        redis.del.mockRejectedValue(outage);
+
+        await expect(resetLoginAttempts(EMAIL)).resolves.toBeUndefined();
+    });
+});

--- a/backend/tests/rateLimitClientIdentity.test.js
+++ b/backend/tests/rateLimitClientIdentity.test.js
@@ -1,0 +1,149 @@
+// backend/tests/rateLimitClientIdentity.test.js
+//
+// What a limiter counts against decides whether it works at all (#1365): a key
+// the caller can influence is not a limit, and a key that collapses every
+// client onto one bucket throttles innocent traffic. These cover the key
+// derivation and the trust-proxy setting that feeds it.
+
+jest.mock('../config/redis', () => ({
+    eval: jest.fn().mockResolvedValue([1, 60000]),
+    del: jest.fn().mockResolvedValue(1),
+    scan: jest.fn().mockResolvedValue(['0', []])
+}));
+
+jest.mock('../config/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+const logger = require('../config/logger');
+const { customKeyGenerator } = require('../middleware/rateLimiter');
+const { resolveTrustProxy, DEFAULT_TRUSTED_HOPS } = require('../config/trustProxy');
+
+/** Minimal shape of what the key generator reads off a request. */
+const buildRequest = ({ ip, headers = {}, user, body = {}, remoteAddress } = {}) => ({
+    ip,
+    headers,
+    user,
+    body,
+    socket: { remoteAddress }
+});
+
+describe('rate limit key derivation', () => {
+    test('an authenticated request is counted against the account', () => {
+        const key = customKeyGenerator(
+            buildRequest({ ip: '203.0.113.7', user: { id: 42 } })
+        );
+
+        expect(key).toBe('user:42');
+    });
+
+    test('the same account is one bucket wherever it connects from', () => {
+        const fromOffice = customKeyGenerator(
+            buildRequest({ ip: '203.0.113.7', user: { id: 42 } })
+        );
+        const fromPhone = customKeyGenerator(
+            buildRequest({ ip: '198.51.100.4', user: { id: 42 } })
+        );
+
+        expect(fromOffice).toBe(fromPhone);
+    });
+
+    test('an unauthenticated request is counted against the client address', () => {
+        const key = customKeyGenerator(buildRequest({ ip: '203.0.113.7' }));
+
+        expect(key).toBe('ip:203.0.113.7');
+    });
+
+    test('two addresses behind one NAT do not share an authenticated budget', () => {
+        const alice = customKeyGenerator(
+            buildRequest({ ip: '203.0.113.7', user: { id: 1 } })
+        );
+        const bob = customKeyGenerator(
+            buildRequest({ ip: '203.0.113.7', user: { id: 2 } })
+        );
+
+        expect(alice).not.toBe(bob);
+    });
+
+    test('a forwarded header does not let the caller choose its own bucket', () => {
+        // Express resolves req.ip according to `trust proxy`. Reading
+        // X-Forwarded-For directly instead would hand the caller a fresh
+        // counter on every request just by changing the header.
+        const first = customKeyGenerator(buildRequest({
+            ip: '203.0.113.7',
+            headers: { 'x-forwarded-for': '9.9.9.9' }
+        }));
+        const second = customKeyGenerator(buildRequest({
+            ip: '203.0.113.7',
+            headers: { 'x-forwarded-for': '8.8.8.8, 7.7.7.7' }
+        }));
+
+        expect(first).toBe('ip:203.0.113.7');
+        expect(second).toBe(first);
+    });
+
+    test('a caller-supplied user id in the body does not mint a new bucket', () => {
+        const first = customKeyGenerator(
+            buildRequest({ ip: '203.0.113.7', body: { userId: 'a' } })
+        );
+        const second = customKeyGenerator(
+            buildRequest({ ip: '203.0.113.7', body: { userId: 'b' } })
+        );
+
+        expect(first).toBe(second);
+        expect(first).toBe('ip:203.0.113.7');
+    });
+
+    test('IPv6 clients are bucketed by prefix, not by individual address', () => {
+        // A single IPv6 client is normally handed a whole subnet, so keying on
+        // the exact address is an unlimited supply of fresh quotas.
+        const first = customKeyGenerator(
+            buildRequest({ ip: '2001:db8:abcd:0012:0000:0000:0000:0001' })
+        );
+        const second = customKeyGenerator(
+            buildRequest({ ip: '2001:db8:abcd:0012:ffff:ffff:ffff:ffff' })
+        );
+
+        expect(first).toBe(second);
+        expect(first).not.toContain('ffff:ffff:ffff:ffff');
+    });
+
+    test('falls back to the socket address, then to a fixed key', () => {
+        expect(customKeyGenerator(buildRequest({ remoteAddress: '203.0.113.7' })))
+            .toBe('ip:203.0.113.7');
+        expect(customKeyGenerator(buildRequest({}))).toBe('ip:unknown');
+    });
+});
+
+describe('trust proxy resolution', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('defaults to a single trusted hop when unset', () => {
+        expect(resolveTrustProxy(undefined)).toBe(DEFAULT_TRUSTED_HOPS);
+        expect(resolveTrustProxy('')).toBe(DEFAULT_TRUSTED_HOPS);
+    });
+
+    test('accepts a hop count for deployments behind more than one proxy', () => {
+        expect(resolveTrustProxy('2')).toBe(2);
+    });
+
+    test('accepts a direct deployment that trusts no forwarded header at all', () => {
+        expect(resolveTrustProxy('false')).toBe(false);
+        expect(resolveTrustProxy('off')).toBe(false);
+    });
+
+    test('passes an address or subnet list through to Express', () => {
+        expect(resolveTrustProxy('10.0.0.0/8, loopback')).toBe('10.0.0.0/8, loopback');
+    });
+
+    test('warns when asked to trust the whole forwarded chain', () => {
+        expect(resolveTrustProxy('true')).toBe(true);
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+        expect(logger.warn.mock.calls[0][0]).toMatch(/X-Forwarded-For/);
+    });
+});

--- a/backend/tests/redisRateLimitStore.test.js
+++ b/backend/tests/redisRateLimitStore.test.js
@@ -1,0 +1,195 @@
+// backend/tests/redisRateLimitStore.test.js
+//
+// The Redis-backed express-rate-limit store (#1365). The client is mocked at
+// the module boundary, as every other suite here does, so nothing opens a
+// socket.
+
+jest.mock('../config/redis', () => ({
+    eval: jest.fn(),
+    del: jest.fn().mockResolvedValue(1),
+    scan: jest.fn().mockResolvedValue(['0', []])
+}));
+
+jest.mock('../config/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+const redis = require('../config/redis');
+const logger = require('../config/logger');
+const { RedisRateLimitStore, createRateLimitStore } = require('../config/redisRateLimitStore');
+
+const WINDOW_MS = 15 * 60 * 1000;
+
+const buildStore = (prefix = 'rl:test') => {
+    const store = createRateLimitStore(prefix);
+    store.init({ windowMs: WINDOW_MS });
+    return store;
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    redis.del.mockResolvedValue(1);
+    redis.scan.mockResolvedValue(['0', []]);
+});
+
+describe('RedisRateLimitStore key namespacing', () => {
+    test('refuses to build a store without a prefix, which would share counters', () => {
+        expect(() => new RedisRateLimitStore({})).toThrow(/prefix/);
+    });
+
+    test('two limiters with different prefixes address different Redis keys', async () => {
+        redis.eval.mockResolvedValue([1, WINDOW_MS]);
+
+        await buildStore('rl:auth:login').increment('ip:203.0.113.7');
+        await buildStore('rl:auth:signup').increment('ip:203.0.113.7');
+
+        const [loginCall, signupCall] = redis.eval.mock.calls;
+        expect(loginCall[2]).toBe('rl:auth:login:ip:203.0.113.7');
+        expect(signupCall[2]).toBe('rl:auth:signup:ip:203.0.113.7');
+        expect(loginCall[2]).not.toBe(signupCall[2]);
+    });
+});
+
+describe('RedisRateLimitStore.increment', () => {
+    test('reports the shared counter and the window end from a single round trip', async () => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00Z'));
+        redis.eval.mockResolvedValue([3, 120000]);
+
+        const result = await buildStore().increment('ip:203.0.113.7');
+
+        expect(redis.eval).toHaveBeenCalledTimes(1);
+        expect(result.totalHits).toBe(3);
+        expect(result.resetTime).toEqual(new Date(Date.now() + 120000));
+
+        jest.useRealTimers();
+    });
+
+    test('applies the window the limiter was initialised with as the key TTL', async () => {
+        redis.eval.mockResolvedValue([1, WINDOW_MS]);
+
+        await buildStore().increment('ip:203.0.113.7');
+
+        const [script, keyCount, , windowArg] = redis.eval.mock.calls[0];
+        expect(keyCount).toBe(1);
+        expect(windowArg).toBe(WINDOW_MS);
+        // The increment and the expiry have to be one atomic unit; a key that
+        // misses its TTL never lets its caller back in.
+        expect(script).toMatch(/INCR/);
+        expect(script).toMatch(/PEXPIRE/);
+    });
+
+    test('counts hits from every instance, so the count is not per process', async () => {
+        redis.eval.mockResolvedValueOnce([7, WINDOW_MS]);
+
+        // A freshly started process sees the total accumulated elsewhere rather
+        // than starting from one.
+        const result = await buildStore().increment('ip:203.0.113.7');
+
+        expect(result.totalHits).toBe(7);
+    });
+});
+
+describe('RedisRateLimitStore reset behaviour', () => {
+    test('resetKey drops only this limiter\'s namespaced key', async () => {
+        await buildStore('rl:auth:login').resetKey('ip:203.0.113.7');
+
+        expect(redis.del).toHaveBeenCalledWith('rl:auth:login:ip:203.0.113.7');
+    });
+
+    test('decrement gives a hit back without recreating an expired window', async () => {
+        redis.eval.mockResolvedValue(2);
+
+        await buildStore().decrement('ip:203.0.113.7');
+
+        const [script] = redis.eval.mock.calls[0];
+        expect(script).toMatch(/EXISTS/);
+        expect(script).toMatch(/DECR/);
+    });
+
+    test('resetAll walks the namespace with SCAN and deletes what it finds', async () => {
+        redis.scan
+            .mockResolvedValueOnce(['12', ['rl:test:a', 'rl:test:b']])
+            .mockResolvedValueOnce(['0', ['rl:test:c']]);
+
+        await buildStore().resetAll();
+
+        expect(redis.scan).toHaveBeenCalledTimes(2);
+        expect(redis.del).toHaveBeenCalledWith('rl:test:a', 'rl:test:b');
+        expect(redis.del).toHaveBeenCalledWith('rl:test:c');
+    });
+});
+
+describe('RedisRateLimitStore when Redis is unavailable', () => {
+    // The deliberate choice is to degrade to per-process counting rather than
+    // reject traffic: failing closed would answer every request with 429 for the
+    // duration of a cache outage.
+    const outage = new Error('ECONNREFUSED');
+
+    test('still enforces the limit, counting within this process', async () => {
+        redis.eval.mockRejectedValue(outage);
+        const store = buildStore();
+
+        const first = await store.increment('ip:203.0.113.7');
+        const second = await store.increment('ip:203.0.113.7');
+
+        expect(first.totalHits).toBe(1);
+        expect(second.totalHits).toBe(2);
+    });
+
+    test('does not reject the request', async () => {
+        redis.eval.mockRejectedValue(outage);
+
+        await expect(buildStore().increment('ip:203.0.113.7')).resolves.toBeDefined();
+    });
+
+    test('keeps separate callers in separate buckets while degraded', async () => {
+        redis.eval.mockRejectedValue(outage);
+        const store = buildStore();
+
+        await store.increment('ip:203.0.113.7');
+        const other = await store.increment('ip:198.51.100.4');
+
+        expect(other.totalHits).toBe(1);
+    });
+
+    test('expires the local window so a caller is not held past it', async () => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00Z'));
+        redis.eval.mockRejectedValue(outage);
+        const store = buildStore();
+
+        await store.increment('ip:203.0.113.7');
+        jest.advanceTimersByTime(WINDOW_MS + 1);
+        const afterWindow = await store.increment('ip:203.0.113.7');
+
+        expect(afterWindow.totalHits).toBe(1);
+
+        jest.useRealTimers();
+    });
+
+    test('says so loudly, but only once per outage interval', async () => {
+        redis.eval.mockRejectedValue(outage);
+        const store = buildStore();
+
+        await store.increment('ip:203.0.113.7');
+        await store.increment('ip:203.0.113.7');
+        await store.increment('ip:198.51.100.4');
+
+        expect(logger.error).toHaveBeenCalledTimes(1);
+        expect(logger.error.mock.calls[0][0]).toMatch(/per-process/);
+    });
+
+    test('a successful sign-in still clears the local counter', async () => {
+        redis.eval.mockRejectedValue(outage);
+        redis.del.mockRejectedValue(outage);
+        const store = buildStore();
+
+        await store.increment('ip:203.0.113.7');
+        await store.resetKey('ip:203.0.113.7');
+        const afterReset = await store.increment('ip:203.0.113.7');
+
+        expect(afterReset.totalHits).toBe(1);
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

> Stacked on top of #1367. Review that one first — this diff shrinks to the lockout service, the controller wiring and the tests once it merges.

Failed sign-in accounting and account lockout move out of process memory into the same shared store the rate limiters now use.

**Why.** The state was a `Map` in the auth controller's module scope. A restart or redeploy cleared every active lockout, and because each instance kept its own tally, an attacker spread across instances got the full attempt budget on each one rather than one budget in total. A lockout that a redeploy clears is not a lockout.

**What is deliberately unchanged.** The policy: same threshold, same rolling window in which failures must accumulate, same lockout duration, same responses and status codes. Only the location of the counters has moved. A successful sign-in clears the counter exactly as before.

**Key hygiene.** The account identifier is trimmed and lowercased before it becomes a key, matching how sign-in resolves the account — otherwise alternating the case of an address hands a caller two independent budgets and quietly doubles the threshold. It is hashed rather than embedded, so nothing attacker-supplied lands in a key name and a scan of the namespace does not enumerate customer addresses. Records carry their own expiry, so the keyspace cannot grow without bound now that the in-process sweeper no longer covers it.

---

## 🔗 Related Issue

Closes #1365

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Not applicable — this is a backend change with no visual surface.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Behaviour when Redis is unreachable.** Same deliberate choice as the rate limiters: degrade to per-process counting with a throttled error log rather than reject. Failing closed here would lock every customer out of the site for the duration of a cache outage.

**Coverage.** The store's increment, expiry and reset behaviour; the limiter key derivation, including that neither a forwarded header nor a body-supplied user id lets a caller choose its own bucket; and the lockout threshold, window roll-off, expiry and clear-on-success. The policy suite runs against an unreachable Redis on purpose, since the fallback that serves an outage has to enforce the identical policy. The Redis client is mocked at the module boundary throughout, as the other suites here do. No dependencies added.

**Caller-visible change.** The internal login-guard helpers keep their existing shape but are now asynchronous, so callers must await them. The only production caller is the sign-in handler, updated here, and the existing suite is updated to match.

**Left alone on purpose.** The separate in-process OTP throttle is a second limit on endpoints that the now-shared limiters already front; moving it would mean re-deciding its policy rather than relocating its state, which belongs in its own change. The unverified-signup cache is unrelated to abuse control.

**Note on CI.** `backend/routes/performanceRoutes.js` does not parse on `main`, which fails the syntax gate for every branch regardless of its contents. That file is untouched here and is being fixed separately in #1356.
