### PR TITLE
Give the cart an identity

### DIFF
--- a/backend/controllers/cartController.js
+++ b/backend/controllers/cartController.js
@@ -9,6 +9,7 @@ const {
     normalizeCartLines,
     resolveCartOwnership
 } = require("../services/cart.service");
+const cartLifecycle = require("../services/cartLifecycleService");
 
 const cartController = {
     // Get the logged-in user's cart (joined with product data)
@@ -81,6 +82,8 @@ const cartController = {
             // up front so the ones created below match the synced lines.
             await inventoryReservationService.releaseUserLocks(userId, null, connection);
 
+            const cartId = await cartLifecycle.resolveActiveCart(userId, connection);
+
             let placeholders = [];
             let values = [];
 
@@ -116,9 +119,10 @@ const cartController = {
                         });
                     }
 
-                    placeholders.push("(?, ?, ?, ?, ?, ?)");
+                    placeholders.push("(?, ?, ?, ?, ?, ?, ?)");
                     values.push(
                         userId,
+                        cartId,
                         line.productId,
                         line.variantId,
                         line.color,
@@ -136,10 +140,12 @@ const cartController = {
 
             if (placeholders.length) {
                 await connection.query(
-                    `INSERT INTO cart_items (user_id, product_id, variant_id, color, size, quantity) VALUES ${placeholders.join(",")}`,
+                    `INSERT INTO cart_items (user_id, cart_id, product_id, variant_id, color, size, quantity) VALUES ${placeholders.join(",")}`,
                     values
                 );
             }
+
+            await cartLifecycle.touchCart(cartId, connection);
 
             await connection.commit();
 
@@ -182,6 +188,8 @@ const cartController = {
 
             await connection.beginTransaction();
 
+            const cartId = await cartLifecycle.resolveActiveCart(userId, connection);
+
             const reserved = await inventoryReservationService.reserveStock(userId, line.productId, line.quantity, connection, line);
             if (!reserved) {
                 await connection.rollback();
@@ -200,12 +208,16 @@ const cartController = {
                 mergeCartLines(existingLines, [line])
                     .find((candidate) => cartLineKey(candidate) === key) || line;
 
+            // Updating cart_id on conflict also adopts any line left behind by
+            // a database that predates the cart record.
             await connection.query(
-                `INSERT INTO cart_items (user_id, product_id, variant_id, color, size, quantity)
-                 VALUES (?, ?, ?, ?, ?, ?)
-                 ON DUPLICATE KEY UPDATE quantity = VALUES(quantity)`,
-                [userId, line.productId, line.variantId, line.color, line.size, mergedLine.quantity]
+                `INSERT INTO cart_items (user_id, cart_id, product_id, variant_id, color, size, quantity)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)
+                 ON DUPLICATE KEY UPDATE quantity = VALUES(quantity), cart_id = VALUES(cart_id)`,
+                [userId, cartId, line.productId, line.variantId, line.color, line.size, mergedLine.quantity]
             );
+
+            await cartLifecycle.touchCart(cartId, connection);
 
             await connection.commit();
             return res.status(200).json({ success: true, message: "Product added to cart and reserved for 15 minutes" });
@@ -251,6 +263,12 @@ const cartController = {
                 return res.status(400).json({ success: false, message: "Requested quantity exceeds available stock" });
             }
 
+            const cartId = await cartLifecycle.resolveActiveCart(userId, connection);
+
+            // Quantity only. Folding cart_id into the SET would make
+            // affectedRows non-zero for a line whose quantity did not change,
+            // turning today's "Product not found in cart" answer into a
+            // success. Adoption of pre-#1364 lines is the migration's job.
             const [result] = await connection.query(
                 "UPDATE cart_items SET quantity = ? WHERE user_id = ? AND product_id = ? AND variant_id = ? AND color = ? AND size = ?",
                 [line.quantity, userId, line.productId, line.variantId, line.color, line.size]
@@ -260,6 +278,8 @@ const cartController = {
                 await connection.rollback();
                 return res.status(404).json({ success: false, message: "Product not found in cart" });
             }
+
+            await cartLifecycle.touchCart(cartId, connection);
 
             await connection.commit();
             return res.status(200).json({ success: true, message: "Cart item updated" });
@@ -301,6 +321,12 @@ const cartController = {
             // The line is gone, so the stock it was holding must go with it.
             await inventoryReservationService.releaseLineLocks(userId, line);
 
+            // Removing a line is shopper activity. Touch rather than resolve:
+            // taking things out of the cart is no reason to create one.
+            await cartLifecycle.touchCart(
+                await cartLifecycle.findActiveCartId(userId)
+            );
+
             return res.status(200).json({ success: true, message: "Product removed from cart" });
         } catch (error) {
             console.error("REMOVE CART ITEM ERROR:", error);
@@ -314,6 +340,14 @@ const cartController = {
             const userId = req.user.id;
             await promisePool.query("DELETE FROM cart_items WHERE user_id = ?", [userId]);
             await inventoryReservationService.releaseUserLocks(userId);
+
+            // The cart stays active and empty. Emptying it is a decision the
+            // shopper just made, not a cart to close: closing it here would
+            // report a deliberate clear-out as an abandonment.
+            await cartLifecycle.touchCart(
+                await cartLifecycle.findActiveCartId(userId)
+            );
+
             return res.status(200).json({ success: true, message: "Cart cleared" });
         } catch (error) {
             console.error("CLEAR CART ERROR:", error);

--- a/backend/services/cartLifecycleService.js
+++ b/backend/services/cartLifecycleService.js
@@ -1,0 +1,141 @@
+// backend/services/cartLifecycleService.js
+//
+// The cart as a record with an identity (#1364).
+//
+// Until now the only cart storage was `cart_items`, keyed by user. Lines
+// existed; a cart did not. Nothing could be said about a basket as a whole --
+// when it started, whether it turned into an order, whether it was walked away
+// from -- because there was no row to say it about.
+//
+// This module owns that row. Every cart write goes through `resolveActiveCart`
+// so lines are always attached to a cart, and `touchCart` records that the
+// shopper did something, which is the clock abandonment is later measured
+// against.
+//
+// Guest carts: `carts.user_id` is nullable so a pre-sign-in basket can be
+// persisted later, but nothing creates one yet -- every cart endpoint is behind
+// authentication. Resolving a cart therefore requires an account, and says so
+// rather than quietly inventing an ownerless row.
+
+const crypto = require('crypto');
+const db = require('../config/db');
+const { safeUUID } = require('../utils/helpers');
+
+const CART_STATUS = Object.freeze({
+    ACTIVE: 'active',
+    CONVERTED: 'converted',
+    ABANDONED: 'abandoned'
+});
+
+// mysql2's code for a unique-key collision.
+const DUPLICATE_ENTRY = 'ER_DUP_ENTRY';
+
+/**
+ * Run against the caller's transaction when there is one, the pool otherwise.
+ *
+ * Cart writes happen inside checkout and sync transactions, and resolving the
+ * cart has to join those rather than open a second connection that cannot see
+ * their uncommitted rows.
+ */
+function runner(connection) {
+    return connection || db;
+}
+
+/**
+ * The id of the account's active cart, or null.
+ *
+ * @param {string} userId
+ * @param {object} [connection]
+ * @param {boolean} [lockRow] - Take a locking read, which also reads the
+ *   latest committed row rather than the transaction's snapshot.
+ * @returns {Promise<string|null>}
+ */
+async function findActiveCartId(userId, connection, lockRow = false) {
+    const owner = safeUUID(userId);
+
+    if (!owner) return null;
+
+    const [rows] = await runner(connection).query(
+        `SELECT id FROM carts
+         WHERE user_id = ? AND status = ?
+         LIMIT 1${lockRow ? ' FOR UPDATE' : ''}`,
+        [owner, CART_STATUS.ACTIVE]
+    );
+
+    return rows.length ? rows[0].id : null;
+}
+
+/**
+ * The account's active cart, created if it has none.
+ *
+ * At most one active cart per account is guaranteed by a unique key on the
+ * table (see the `active_marker` generated column), so a race between two
+ * concurrent add-to-cart requests surfaces as a duplicate-entry error on the
+ * loser rather than as two carts. The loser re-reads with a locking read,
+ * which sees the winner's committed row even under REPEATABLE READ, where the
+ * transaction's own snapshot would not.
+ *
+ * @param {string} userId
+ * @param {object} [connection]
+ * @returns {Promise<string>} Cart id.
+ */
+async function resolveActiveCart(userId, connection) {
+    const owner = safeUUID(userId);
+
+    if (!owner) {
+        throw new Error('An active cart can only be resolved for a signed-in account');
+    }
+
+    const existing = await findActiveCartId(owner, connection);
+
+    if (existing) return existing;
+
+    const cartId = crypto.randomUUID();
+
+    try {
+        await runner(connection).query(
+            `INSERT INTO carts (id, user_id, status, last_activity_at)
+             VALUES (?, ?, ?, NOW())`,
+            [cartId, owner, CART_STATUS.ACTIVE]
+        );
+
+        return cartId;
+    } catch (error) {
+        if (error && error.code === DUPLICATE_ENTRY) {
+            const winner = await findActiveCartId(owner, connection, true);
+
+            if (winner) return winner;
+        }
+
+        throw error;
+    }
+}
+
+/**
+ * Record that the shopper touched the cart.
+ *
+ * `last_activity_at` is set explicitly rather than by ON UPDATE CURRENT_TIMESTAMP
+ * so that a status change -- an abandonment sweep, say -- does not read as
+ * shopper activity.
+ *
+ * @param {string} cartId
+ * @param {object} [connection]
+ * @returns {Promise<void>}
+ */
+async function touchCart(cartId, connection) {
+    const id = safeUUID(cartId);
+
+    if (!id) return;
+
+    await runner(connection).query(
+        'UPDATE carts SET last_activity_at = NOW() WHERE id = ? AND status = ?',
+        [id, CART_STATUS.ACTIVE]
+    );
+}
+
+module.exports = {
+    CART_STATUS,
+    findActiveCartId,
+    resolveActiveCart,
+    touchCart
+};

--- a/migrations/0027_cart_lifecycle.sql
+++ b/migrations/0027_cart_lifecycle.sql
@@ -1,0 +1,165 @@
+-- ============================================
+-- CART LIFECYCLE
+-- ============================================
+--
+-- Before this, the only cart storage was `cart_items`, keyed by user. Lines
+-- existed; a cart did not. Nothing in the schema could say when a basket
+-- started, whether it turned into an order, or whether it was walked away
+-- from -- while reporting code and the cleanup job both spoke as though a
+-- `carts` table were already there.
+
+-- ============================================
+-- CARTS
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS carts (
+    -- CHAR(36) to match users.id and orders.id, both of which this table
+    -- references. A CHAR(36)/INT mismatch is how a foreign key in this schema
+    -- has failed before.
+    id CHAR(36) PRIMARY KEY,
+
+    -- Nullable so a pre-sign-in basket can be persisted without inventing a
+    -- fake account. Nothing creates one yet: every cart endpoint is behind
+    -- authentication.
+    user_id CHAR(36),
+
+    status ENUM('active', 'converted', 'abandoned') NOT NULL DEFAULT 'active',
+
+    -- At most one active cart per account, enforced by the database rather
+    -- than by application code alone.
+    --
+    -- MySQL has no partial indexes, so only an *active* cart stores its
+    -- user_id in this column; every other row stores NULL, and NULLs do not
+    -- collide in a UNIQUE index. The generated column keeps the marker in
+    -- lockstep with status with no way for application code to get the two out
+    -- of step. Guest carts hold NULL user_id and so never collide with each
+    -- other -- there is no account holding the single slot.
+    active_marker CHAR(36)
+        GENERATED ALWAYS AS (
+            CASE WHEN status = 'active' THEN user_id ELSE NULL END
+        ) STORED,
+
+    -- The order this cart turned into. ON DELETE SET NULL rather than CASCADE:
+    -- losing an order must not delete the record that a cart converted.
+    converted_order_id CHAR(36),
+    converted_at DATETIME,
+    abandoned_at DATETIME,
+
+    -- Written by the cart service on every shopper action, deliberately
+    -- without ON UPDATE CURRENT_TIMESTAMP: a status change written by the
+    -- abandonment sweep is not shopper activity and must not look like it.
+    last_activity_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_carts_one_active (active_marker),
+
+    CONSTRAINT fk_carts_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_carts_order
+        FOREIGN KEY (converted_order_id) REFERENCES orders(id) ON DELETE SET NULL,
+
+    INDEX idx_carts_user_status (user_id, status),
+    -- The sweep's access path: oldest untouched active carts first.
+    INDEX idx_carts_status_activity (status, last_activity_at),
+    -- The reporting access path: cohorts of carts by the window they started in.
+    INDEX idx_carts_status_created (status, created_at),
+    INDEX idx_carts_converted_order (converted_order_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================
+-- ATTACH THE LINES TO THE CART
+-- ============================================
+--
+-- `cart_id` is nullable, because every existing row is keyed by user alone and
+-- an existing database must not break at the moment this runs. The backfill
+-- below fills it in; code written after this migration always supplies it.
+--
+-- The primary key of `cart_items` is deliberately left alone. It is what stops
+-- the same line -- product plus variant plus colour plus size -- appearing
+-- twice for one shopper, and that guarantee is independent of which cart the
+-- line belongs to. Migration 0020 established that key; this migration only
+-- adds a reference alongside it.
+
+DELIMITER //
+
+CREATE PROCEDURE AddCartLifecycleColumns()
+BEGIN
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'cart_items'
+        AND COLUMN_NAME = 'cart_id'
+    ) THEN
+        ALTER TABLE cart_items
+        ADD COLUMN cart_id CHAR(36) NULL AFTER user_id;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'cart_items'
+        AND INDEX_NAME = 'idx_cart_items_cart'
+    ) THEN
+        CREATE INDEX idx_cart_items_cart ON cart_items (cart_id);
+    END IF;
+
+    -- The foreign key is added after its index exists, so InnoDB adopts that
+    -- index rather than creating a second one for the constraint.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'cart_items'
+        AND CONSTRAINT_NAME = 'fk_cart_items_cart'
+    ) THEN
+        ALTER TABLE cart_items
+        ADD CONSTRAINT fk_cart_items_cart
+        FOREIGN KEY (cart_id) REFERENCES carts(id) ON DELETE CASCADE;
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL AddCartLifecycleColumns();
+DROP PROCEDURE AddCartLifecycleColumns;
+
+-- ============================================
+-- BACKFILL
+-- ============================================
+--
+-- Every shopper who already has lines gets one active cart holding them, dated
+-- from the lines themselves so the cart does not look brand new the moment this
+-- runs -- which would otherwise hide a year-old basket from the abandonment
+-- sweep.
+--
+-- Guarded on NOT EXISTS so re-running is a no-op rather than a unique-key
+-- violation on uq_carts_one_active.
+
+INSERT INTO carts (id, user_id, status, last_activity_at, created_at)
+SELECT
+    UUID(),
+    ci.user_id,
+    'active',
+    MAX(ci.updated_at),
+    MIN(ci.created_at)
+FROM cart_items ci
+WHERE ci.cart_id IS NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM carts c
+      WHERE c.user_id = ci.user_id AND c.status = 'active'
+  )
+GROUP BY ci.user_id;
+
+-- Point the orphaned lines at the cart that was just created for their owner.
+-- On a large `cart_items` this is the expensive statement in the migration;
+-- run it in batches (add `LIMIT` and repeat until zero rows change) if the
+-- table is big enough for a single pass to hold locks longer than the
+-- deployment window allows.
+
+UPDATE cart_items ci
+JOIN carts c
+  ON c.user_id = ci.user_id
+ AND c.status = 'active'
+SET ci.cart_id = c.id
+WHERE ci.cart_id IS NULL;


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

The only cart storage today is `cart_items`, keyed by user. Lines exist; a cart does not. Nothing in the schema can say when a basket started, what became of it, or whether it was left behind — which is why anything downstream that wants to talk about a cart as a whole has nothing to point at. This adds the missing row and nothing else.

**The table.** A `carts` table with a UUID primary key, a nullable owner, a status covering `active` / `converted` / `abandoned`, an activity clock, and a nullable reference to the order it converts into.

**One active cart per account, enforced by the database.** MySQL has no partial indexes, so a generated column holds the owner's id only while the cart is active and NULL otherwise; NULLs do not collide in a unique index. This is the same mechanism the saved address book already uses for its one-default rule, so it is an existing convention here rather than a new trick.

**The lines.** `cart_items` gains a nullable `cart_id`. Nullable on purpose: every existing row is keyed by user alone and must not break the moment the migration runs. The primary key is untouched, so the guarantee that a given line appears once per shopper is unaffected by which cart it belongs to.

**The seam.** A small service that resolves the caller's active cart or creates one, and records shopper activity against it. Every cart write now goes through it.

**What does not change.** Adding to cart, viewing the cart, updating quantities, removing a line, clearing, and checkout all behave exactly as they do today. The cart read is untouched. The one place where stamping `cart_id` would have altered an answer — a quantity update that changes nothing now reporting success instead of "not in cart" — is deliberately left as it was, with a comment saying so.

---

## 🔗 Related Issue

Part of #1364

---

## 🛠️ Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [ ] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Not applicable — this is a backend and schema change with no visual surface.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Migration.** `migrations/0027_cart_lifecycle.sql` creates the table, adds the column and its index and foreign key, and backfills one active cart per shopper who already has lines, dated from the lines themselves so a year-old basket does not look brand new. It takes the next number in the sequence and guards its conditional DDL through the `INFORMATION_SCHEMA` procedure idiom the neighbouring migrations use, so re-running it is a no-op and it does not depend on `ALTER TABLE ... IF NOT EXISTS`, which MySQL does not accept. Nothing already applied is edited. Foreign key types and collations were checked against their targets: everything referenced is `CHAR(36)` and `utf8mb4_unicode_ci` on both sides, which matters here because a type mismatch between `INT` and `CHAR(36)` keys has already made a migration in this repository unrunnable once.

**Relationship to the existing cart line key.** Migration `0020` widened the `cart_items` primary key to the full line identity. That key is untouched here; this migration only adds a reference alongside it, so the guarantee that a given line appears once per shopper is unaffected by which cart the line belongs to.

**Risk a reviewer should weigh.** The statement pointing existing lines at their new cart is a single unbounded `UPDATE` over `cart_items`. On a small table that is fine; on a large one it holds locks for the duration. The migration says so and gives the batching recipe rather than guessing at any particular deployment's tolerance.

**Guest carts.** The owner column is nullable so a pre-sign-in basket could be persisted later, but nothing creates one. Every cart endpoint sits behind authentication, and resolving a cart says as much rather than inventing an ownerless row. Merging a guest basket at sign-in is a product decision, not a lifecycle one.

**Rebased.** This branch has been brought onto current `main`, which now carries the versioned migration sequence. The schema change is expressed as the next numbered migration rather than as an edit to a baseline file, and the branch merges cleanly.
