### PR TITLE
Chaos & Resilience Harness for Checkout Dependencies

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -198,6 +198,19 @@ FEATURE_PAYMENTS_ENABLED=true
 FEATURE_NOTIFICATIONS_ENABLED=true
 
 # ============================================
+# CHAOS & RESILIENCE HARNESS (#1398)
+# ============================================
+# Dev/test only. Forced off when NODE_ENV=production.
+# Leave CHAOS_ENABLED=false unless you are deliberately injecting faults.
+CHAOS_ENABLED=false
+CHAOS_PAYMENT=false
+CHAOS_REDIS=false
+CHAOS_DB=false
+CHAOS_LATENCY_MS=0
+CHAOS_ERROR_RATE=0
+CHAOS_FORCE_STATUS=500
+
+# ============================================
 # PAYMENT GATEWAY
 # ============================================
 

--- a/backend/config/envValidator.js
+++ b/backend/config/envValidator.js
@@ -37,7 +37,18 @@ const ENV_CONFIG = {
         { name: 'CORS_ORIGINS', type: 'string', default: '*' },
         { name: 'RATE_LIMIT_WINDOW', type: 'number', default: 60000 },
         { name: 'RATE_LIMIT_MAX', type: 'number', default: 100 },
-        { name: 'SESSION_SECRET', type: 'string', default: '' }
+        { name: 'SESSION_SECRET', type: 'string', default: '' },
+        // Chaos & resilience harness (#1398) — never enable in production.
+        // Master switch; dependency flags are no-ops unless this is true.
+        { name: 'CHAOS_ENABLED', type: 'boolean', default: false },
+        { name: 'CHAOS_PAYMENT', type: 'boolean', default: false },
+        { name: 'CHAOS_REDIS', type: 'boolean', default: false },
+        { name: 'CHAOS_DB', type: 'boolean', default: false },
+        { name: 'CHAOS_LATENCY_MS', type: 'number', default: 0 },
+        // No default: when unset, chaosProxy treats an enabled dependency as
+        // error_rate=1. A default of 0 here would silently disable injection.
+        { name: 'CHAOS_ERROR_RATE', type: 'number' },
+        { name: 'CHAOS_FORCE_STATUS', type: 'number', default: 500 }
     ]
 };
 
@@ -173,6 +184,19 @@ function validateEnv() {
         if (config.type) {
             process.env[config.name] = String(parseValue(value, config.type));
         }
+    }
+
+    // Chaos harness must never run in production (#1398). Force-disable and warn
+    // if someone sets CHAOS_ENABLED=true under NODE_ENV=production.
+    if (process.env.NODE_ENV === 'production' && parseValue(process.env.CHAOS_ENABLED, 'boolean')) {
+        process.env.CHAOS_ENABLED = 'false';
+        process.env.CHAOS_PAYMENT = 'false';
+        process.env.CHAOS_REDIS = 'false';
+        process.env.CHAOS_DB = 'false';
+        warnings.push({
+            name: 'CHAOS_ENABLED',
+            message: 'CHAOS_ENABLED was set in production and has been forced off'
+        });
     }
 
     // Check for unknown variables

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -774,10 +774,28 @@ const createPaymentIntent = async (req, res) => {
         // Charge what the engine priced, never what the browser claimed.
         const chargeableTotal = result.breakdown.total;
 
-        const paymentIntentResult = await paymentService.createPaymentIntent(chargeableTotal, CURRENCY.code, { orderId: result.orderId, userId: req.user.id });
+        // Charge via chaos-aware payment helper so injected / real failures
+        // always release inventory locks and roll back the order txn (#1398).
+        const chaosProxy = require("../services/chaosProxy");
+        const paymentIntentResult = await chaosProxy.chargeWithLockRelease({
+            charge: () =>
+                paymentService.createPaymentIntent(chargeableTotal, CURRENCY.code, {
+                    orderId: result.orderId,
+                    userId: req.user.id
+                }),
+            rollback: async () => {
+                await connection.rollback();
+            },
+            releaseLocks: async () => {
+                await inventoryReservationService.releaseUserLocks(req.user.id);
+            }
+        });
         if (!paymentIntentResult.success) {
-            await connection.rollback();
-            return res.status(500).json({ success: false, message: paymentIntentResult.error });
+            return res.status(paymentIntentResult.status || 500).json({
+                success: false,
+                message: paymentIntentResult.error || "Payment service temporarily unavailable. Please try again.",
+                code: paymentIntentResult.code || "PAYMENT_UNAVAILABLE"
+            });
         }
 
         await connection.query("UPDATE orders SET payment_intent_id = ? WHERE id = ?", [paymentIntentResult.paymentIntentId, result.orderId]);

--- a/backend/services/chaosProxy.js
+++ b/backend/services/chaosProxy.js
@@ -1,0 +1,380 @@
+/**
+ * Chaos & Resilience Harness for checkout dependencies (#1398).
+ *
+ * Injects latency / errors into payment, Redis, and MySQL adapters so
+ * timeouts, retries, and graceful degradation can be verified in
+ * development / test only.
+ *
+ * Safety
+ * ------
+ * Chaos is a no-op unless ALL of the following hold:
+ *   1. CHAOS_ENABLED=true
+ *   2. NODE_ENV is not "production"
+ *
+ * Per-dependency flags (optional, default off when chaos is enabled):
+ *   CHAOS_PAYMENT=true|false
+ *   CHAOS_REDIS=true|false
+ *   CHAOS_DB=true|false
+ *
+ * Injection knobs (optional):
+ *   CHAOS_LATENCY_MS     — artificial delay before the real call (default 0)
+ *   CHAOS_ERROR_RATE     — 0..1 probability of a forced failure (default 1
+ *                          when the dependency flag is on and no rate set,
+ *                          otherwise 0)
+ *   CHAOS_FORCE_STATUS   — HTTP-ish status stamped on injected errors
+ *                          (default 500 for payment, 503 for redis/db)
+ *
+ * Timeout / retry policy (documented + enforced by withChaos / withRetry)
+ * ----------------------------------------------------------------------
+ * Payment : 8s timeout, 2 retries, exponential backoff 200ms → 800ms
+ * Redis   : 1.5s timeout, 1 retry,  100ms backoff
+ * DB      : 5s timeout, 1 retry,  150ms backoff
+ *
+ * User-facing messages stay stable so the storefront can show a clear
+ * toast instead of raw provider noise.
+ */
+
+"use strict";
+
+const DEPENDENCIES = Object.freeze({
+    PAYMENT: "payment",
+    REDIS: "redis",
+    DB: "db"
+});
+
+/**
+ * Documented resilience policy for checkout dependencies.
+ * Kept in one place so services and tests share the same numbers.
+ */
+const RESILIENCE_POLICY = Object.freeze({
+    payment: Object.freeze({
+        timeoutMs: 8000,
+        retries: 2,
+        backoffMs: 200,
+        maxBackoffMs: 800,
+        forceStatus: 500,
+        userMessage: "Payment service temporarily unavailable. Please try again."
+    }),
+    redis: Object.freeze({
+        timeoutMs: 1500,
+        retries: 1,
+        backoffMs: 100,
+        maxBackoffMs: 400,
+        forceStatus: 503,
+        // Redis is a cache / pre-lock — degrade, don't hard-fail checkout.
+        userMessage: "Checkout is running slower than usual. Please wait a moment.",
+        degrade: true
+    }),
+    db: Object.freeze({
+        timeoutMs: 5000,
+        retries: 1,
+        backoffMs: 150,
+        maxBackoffMs: 600,
+        forceStatus: 503,
+        userMessage: "We could not complete checkout right now. Please try again."
+    })
+});
+
+class ChaosError extends Error {
+    constructor({ dependency, status, message, cause } = {}) {
+        super(message || `Chaos injected failure for ${dependency}`);
+        this.name = "ChaosError";
+        this.code = "CHAOS_INJECTED";
+        this.dependency = dependency;
+        this.status = status || 500;
+        this.cause = cause || null;
+        this.userMessage =
+            (RESILIENCE_POLICY[dependency] && RESILIENCE_POLICY[dependency].userMessage) ||
+            message;
+    }
+
+    toJSON() {
+        return {
+            success: false,
+            code: this.code,
+            message: this.userMessage,
+            dependency: this.dependency,
+            status: this.status
+        };
+    }
+}
+
+function envFlag(name) {
+    const raw = process.env[name];
+    if (raw === undefined || raw === null || raw === "") return false;
+    return String(raw).toLowerCase() === "true" || raw === "1";
+}
+
+function envNumber(name, fallback) {
+    const raw = process.env[name];
+    if (raw === undefined || raw === null || raw === "") return fallback;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * Master gate. Always false in production, even if CHAOS_ENABLED leaks in.
+ */
+function isChaosEnabled() {
+    if (process.env.NODE_ENV === "production") return false;
+    return envFlag("CHAOS_ENABLED");
+}
+
+function isDependencyChaosEnabled(dependency) {
+    if (!isChaosEnabled()) return false;
+    const key = {
+        payment: "CHAOS_PAYMENT",
+        redis: "CHAOS_REDIS",
+        db: "CHAOS_DB"
+    }[dependency];
+    if (!key) return false;
+    return envFlag(key);
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function shouldInjectError(dependency) {
+    if (!isDependencyChaosEnabled(dependency)) return false;
+    const rate = envNumber("CHAOS_ERROR_RATE", 1);
+    if (rate <= 0) return false;
+    if (rate >= 1) return true;
+    return Math.random() < rate;
+}
+
+function latencyMs() {
+    if (!isChaosEnabled()) return 0;
+    return Math.max(0, envNumber("CHAOS_LATENCY_MS", 0));
+}
+
+function forcedStatus(dependency) {
+    const fromEnv = envNumber("CHAOS_FORCE_STATUS", NaN);
+    if (Number.isFinite(fromEnv)) return fromEnv;
+    return (RESILIENCE_POLICY[dependency] && RESILIENCE_POLICY[dependency].forceStatus) || 500;
+}
+
+/**
+ * Race a promise against a timeout. Rejects with ChaosError-shaped timeout.
+ */
+function withTimeout(promise, timeoutMs, dependency) {
+    if (!timeoutMs || timeoutMs <= 0) return promise;
+
+    let timer;
+    const timeoutPromise = new Promise((_, reject) => {
+        timer = setTimeout(() => {
+            reject(
+                new ChaosError({
+                    dependency,
+                    status: 504,
+                    message: `${dependency} timed out after ${timeoutMs}ms`
+                })
+            );
+        }, timeoutMs);
+    });
+
+    return Promise.race([promise, timeoutPromise]).finally(() => {
+        if (timer) clearTimeout(timer);
+    });
+}
+
+/**
+ * Retry with exponential backoff. Non-retryable ChaosError from injection
+ * still goes through retries so tests can assert the policy; callers that
+ * want fail-fast can pass retries: 0.
+ */
+async function withRetry(fn, { retries = 0, backoffMs = 100, maxBackoffMs = 800 } = {}) {
+    let attempt = 0;
+    let delay = backoffMs;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        try {
+            return await fn(attempt);
+        } catch (err) {
+            if (attempt >= retries) throw err;
+            await sleep(delay);
+            delay = Math.min(delay * 2, maxBackoffMs);
+            attempt += 1;
+        }
+    }
+}
+
+/**
+ * Wrap a dependency call with optional chaos injection + timeout + retry.
+ *
+ * @param {string} dependency  one of DEPENDENCIES values
+ * @param {Function} fn        async () => result
+ * @param {object} [overrides] policy overrides
+ */
+async function withChaos(dependency, fn, overrides = {}) {
+    const policy = {
+        ...(RESILIENCE_POLICY[dependency] || {}),
+        ...overrides
+    };
+
+    const runOnce = async () => {
+        const delay = latencyMs();
+        if (delay > 0 && isDependencyChaosEnabled(dependency)) {
+            await sleep(delay);
+        }
+
+        if (shouldInjectError(dependency)) {
+            throw new ChaosError({
+                dependency,
+                status: forcedStatus(dependency),
+                message: `Chaos: forced ${dependency} failure`
+            });
+        }
+
+        return fn();
+    };
+
+    return withRetry(
+        (attempt) => withTimeout(runOnce(), policy.timeoutMs, dependency),
+        {
+            retries: policy.retries || 0,
+            backoffMs: policy.backoffMs || 100,
+            maxBackoffMs: policy.maxBackoffMs || 800
+        }
+    );
+}
+
+/**
+ * Redis helper: on chaos / outage, return a degraded result instead of
+ * throwing when the policy says degrade:true. Checkout can continue without
+ * the distributed pre-lock.
+ */
+async function withRedisChaos(fn, { fallback = null } = {}) {
+    const policy = RESILIENCE_POLICY.redis;
+    try {
+        return await withChaos(DEPENDENCIES.REDIS, fn);
+    } catch (err) {
+        if (policy.degrade) {
+            return typeof fallback === "function" ? fallback(err) : fallback;
+        }
+        throw err;
+    }
+}
+
+/**
+ * MySQL helper used by checkout paths that want a uniform error envelope.
+ */
+async function withDbChaos(fn) {
+    return withChaos(DEPENDENCIES.DB, fn);
+}
+
+/**
+ * Payment helper that always returns the payment service envelope
+ * `{ success, ... }` so controllers don't have to special-case ChaosError.
+ *
+ * @param {Function} fn
+ * @param {object} [overrides]  passed through to withChaos (e.g. { retries: 0 })
+ */
+async function withPaymentChaos(fn, overrides = {}) {
+    try {
+        return await withChaos(DEPENDENCIES.PAYMENT, fn, overrides);
+    } catch (err) {
+        const userMessage =
+            err.userMessage ||
+            RESILIENCE_POLICY.payment.userMessage;
+        return {
+            success: false,
+            error: userMessage,
+            code: err.code || "PAYMENT_UNAVAILABLE",
+            status: err.status || 500,
+            dependency: DEPENDENCIES.PAYMENT
+        };
+    }
+}
+
+/**
+ * Checkout payment step with guaranteed inventory lock cleanup on failure.
+ *
+ * Controllers should prefer this over calling createPaymentIntent alone so a
+ * chaos (or real) payment failure never leaves reserved stock stranded.
+ *
+ * @param {object} opts
+ * @param {Function} opts.charge           async () => { success, ... }
+ * @param {Function} opts.releaseLocks     async () => void  — release reservations
+ * @param {Function} [opts.rollback]       async () => void  — txn rollback
+ */
+async function chargeWithLockRelease({ charge, releaseLocks, rollback } = {}) {
+    if (typeof charge !== "function") {
+        throw new TypeError("chargeWithLockRelease requires a charge function");
+    }
+
+    let result;
+    try {
+        result = await charge();
+    } catch (err) {
+        if (typeof rollback === "function") {
+            try { await rollback(); } catch (_) { /* ignore */ }
+        }
+        if (typeof releaseLocks === "function") {
+            try { await releaseLocks(); } catch (_) { /* ignore */ }
+        }
+        return {
+            success: false,
+            error:
+                err.userMessage ||
+                RESILIENCE_POLICY.payment.userMessage,
+            code: err.code || "PAYMENT_UNAVAILABLE",
+            status: err.status || 500,
+            locksReleased: true
+        };
+    }
+
+    if (!result || result.success !== true) {
+        if (typeof rollback === "function") {
+            try { await rollback(); } catch (_) { /* ignore */ }
+        }
+        if (typeof releaseLocks === "function") {
+            try { await releaseLocks(); } catch (_) { /* ignore */ }
+        }
+        return {
+            success: false,
+            error:
+                (result && (result.error || result.message)) ||
+                RESILIENCE_POLICY.payment.userMessage,
+            code: (result && result.code) || "PAYMENT_UNAVAILABLE",
+            status: (result && result.status) || 500,
+            locksReleased: true
+        };
+    }
+
+    return { ...result, locksReleased: false };
+}
+
+/**
+ * Snapshot of the active chaos configuration (for /health-style debug or tests).
+ */
+function getChaosStatus() {
+    return {
+        enabled: isChaosEnabled(),
+        nodeEnv: process.env.NODE_ENV || null,
+        dependencies: {
+            payment: isDependencyChaosEnabled(DEPENDENCIES.PAYMENT),
+            redis: isDependencyChaosEnabled(DEPENDENCIES.REDIS),
+            db: isDependencyChaosEnabled(DEPENDENCIES.DB)
+        },
+        latencyMs: latencyMs(),
+        errorRate: envNumber("CHAOS_ERROR_RATE", isChaosEnabled() ? 1 : 0),
+        policy: RESILIENCE_POLICY
+    };
+}
+
+module.exports = {
+    DEPENDENCIES,
+    RESILIENCE_POLICY,
+    ChaosError,
+    isChaosEnabled,
+    isDependencyChaosEnabled,
+    withChaos,
+    withRetry,
+    withTimeout,
+    withRedisChaos,
+    withDbChaos,
+    withPaymentChaos,
+    chargeWithLockRelease,
+    getChaosStatus
+};

--- a/backend/services/payment.service.js
+++ b/backend/services/payment.service.js
@@ -1,22 +1,32 @@
 let stripeInstance = null;
 
+const chaosProxy = require("./chaosProxy");
+const CURRENCY = require("../config/currency");
+
 const getStripe = () => {
     if (!stripeInstance) {
         const apiKey = process.env.STRIPE_SECRET_KEY;
         if (!apiKey) {
             throw new Error("STRIPE_SECRET_KEY is not defined in the environment variables.");
         }
-        stripeInstance = require('stripe')(apiKey);
+        stripeInstance = require("stripe")(apiKey);
     }
     return stripeInstance;
 };
 
-const CURRENCY = require('../config/currency');
-
 /**
  * Payment Service Abstraction
- * This wrapper encapsulates Stripe logic to allow easier testing and 
+ * This wrapper encapsulates Stripe logic to allow easier testing and
  * future migration to other payment providers if needed.
+ *
+ * Resilience (#1398)
+ * ------------------
+ * createPaymentIntent runs through chaosProxy.withPaymentChaos so that:
+ *   - CHAOS_ENABLED + CHAOS_PAYMENT can inject latency / 500s in non-prod
+ *   - timeouts + retries follow RESILIENCE_POLICY.payment
+ *   - failures always return { success: false, error: <user-facing> }
+ * Controllers should pair this with chaosProxy.chargeWithLockRelease so
+ * inventory locks are released when payment fails.
  */
 
 /**
@@ -36,28 +46,32 @@ const toMinorUnits = (amount, minorUnitExponent = CURRENCY.minorUnitExponent) =>
 };
 
 const createPaymentIntent = async (amount, currency = CURRENCY.code, metadata = {}) => {
-    try {
-        const stripe = getStripe();
-        const paymentIntent = await stripe.paymentIntents.create({
-            amount: toMinorUnits(amount),
-            // Stripe wants the ISO code lowercased; the configuration holds it
-            // in its canonical uppercase form.
-            currency: String(currency).toLowerCase(),
-            metadata,
-        });
-        
-        return {
-            success: true,
-            clientSecret: paymentIntent.client_secret,
-            paymentIntentId: paymentIntent.id
-        };
-    } catch (error) {
-        console.error('Error creating payment intent:', error);
-        return {
-            success: false,
-            error: error.message
-        };
-    }
+    return chaosProxy.withPaymentChaos(async () => {
+        try {
+            const stripe = getStripe();
+            const paymentIntent = await stripe.paymentIntents.create({
+                amount: toMinorUnits(amount),
+                // Stripe wants the ISO code lowercased; the configuration holds it
+                // in its canonical uppercase form.
+                currency: String(currency).toLowerCase(),
+                metadata
+            });
+
+            return {
+                success: true,
+                clientSecret: paymentIntent.client_secret,
+                paymentIntentId: paymentIntent.id
+            };
+        } catch (error) {
+            console.error("Error creating payment intent:", error);
+            return {
+                success: false,
+                error: error.message,
+                code: "PAYMENT_PROVIDER_ERROR",
+                status: 500
+            };
+        }
+    });
 };
 
 const constructWebhookEvent = (rawBody, signature) => {
@@ -70,7 +84,7 @@ const constructWebhookEvent = (rawBody, signature) => {
         );
         return { success: true, event };
     } catch (error) {
-        console.error('Webhook signature verification failed.', error.message);
+        console.error("Webhook signature verification failed.", error.message);
         return { success: false, error: error.message };
     }
 };

--- a/backend/tests/checkoutResilience.test.js
+++ b/backend/tests/checkoutResilience.test.js
@@ -1,0 +1,282 @@
+/**
+ * Checkout resilience / chaos harness tests (#1398).
+ *
+ * Covers:
+ *  - Chaos disabled unless CHAOS_ENABLED=true (and never in production)
+ *  - Payment 500 injection → stable user-facing error envelope
+ *  - Redis down → graceful degradation (no hard checkout crash)
+ *  - chargeWithLockRelease releases inventory locks on payment failure
+ */
+
+const ORIGINAL_ENV = { ...process.env };
+
+function resetChaosEnv() {
+    delete process.env.CHAOS_ENABLED;
+    delete process.env.CHAOS_PAYMENT;
+    delete process.env.CHAOS_REDIS;
+    delete process.env.CHAOS_DB;
+    delete process.env.CHAOS_LATENCY_MS;
+    delete process.env.CHAOS_ERROR_RATE;
+    delete process.env.CHAOS_FORCE_STATUS;
+    process.env.NODE_ENV = "test";
+}
+
+afterEach(() => {
+    resetChaosEnv();
+    for (const key of Object.keys(process.env)) {
+        if (!(key in ORIGINAL_ENV)) delete process.env[key];
+    }
+    Object.assign(process.env, ORIGINAL_ENV);
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.dontMock("stripe");
+});
+
+beforeEach(() => {
+    resetChaosEnv();
+});
+
+describe("chaosProxy safety gates", () => {
+    test("is disabled by default", () => {
+        const chaos = require("../services/chaosProxy");
+        expect(chaos.isChaosEnabled()).toBe(false);
+        expect(chaos.isDependencyChaosEnabled("payment")).toBe(false);
+    });
+
+    test("stays disabled in production even when CHAOS_ENABLED=true", () => {
+        process.env.NODE_ENV = "production";
+        process.env.CHAOS_ENABLED = "true";
+        process.env.CHAOS_PAYMENT = "true";
+        jest.resetModules();
+        const chaos = require("../services/chaosProxy");
+        expect(chaos.isChaosEnabled()).toBe(false);
+        expect(chaos.isDependencyChaosEnabled("payment")).toBe(false);
+    });
+
+    test("enables per-dependency flags only when master switch is on", () => {
+        process.env.CHAOS_ENABLED = "true";
+        process.env.CHAOS_PAYMENT = "true";
+        jest.resetModules();
+        const chaos = require("../services/chaosProxy");
+        expect(chaos.isChaosEnabled()).toBe(true);
+        expect(chaos.isDependencyChaosEnabled("payment")).toBe(true);
+        expect(chaos.isDependencyChaosEnabled("redis")).toBe(false);
+    });
+});
+
+describe("payment chaos (500)", () => {
+    test("withPaymentChaos returns a user-visible error envelope", async () => {
+        process.env.CHAOS_ENABLED = "true";
+        process.env.CHAOS_PAYMENT = "true";
+        jest.resetModules();
+        const chaos = require("../services/chaosProxy");
+
+        const result = await chaos.withPaymentChaos(async () => ({
+            success: true,
+            clientSecret: "should-not-reach"
+        }), { retries: 0 });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/payment service temporarily unavailable/i);
+        expect(result.code).toBe("CHAOS_INJECTED");
+        expect(result.status).toBe(500);
+    });
+
+    test("createPaymentIntent surfaces chaos failure without calling Stripe", async () => {
+        process.env.CHAOS_ENABLED = "true";
+        process.env.CHAOS_PAYMENT = "true";
+        process.env.STRIPE_SECRET_KEY =
+            process.env.STRIPE_SECRET_KEY || "sk_test_00000000000000000000000000";
+
+        const mockCreate = jest.fn(async () => ({
+            id: "pi_should_not_run",
+            client_secret: "cs_x"
+        }));
+        jest.resetModules();
+        jest.doMock("stripe", () => jest.fn(() => ({
+            paymentIntents: { create: mockCreate },
+            webhooks: { constructEvent: jest.fn() }
+        })));
+
+        const { createPaymentIntent } = require("../services/payment.service");
+        const result = await createPaymentIntent(100, "INR", { orderId: "o1" });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/payment service temporarily unavailable/i);
+        expect(mockCreate).not.toHaveBeenCalled();
+    });
+});
+
+describe("Redis down — graceful degradation", () => {
+    test("withRedisChaos returns fallback instead of throwing", async () => {
+        process.env.CHAOS_ENABLED = "true";
+        process.env.CHAOS_REDIS = "true";
+        jest.resetModules();
+        const chaos = require("../services/chaosProxy");
+
+        const fallback = { ok: true, degraded: true };
+        const result = await chaos.withRedisChaos(
+            async () => {
+                throw new Error("should be replaced by chaos");
+            },
+            { fallback }
+        );
+
+        expect(result).toEqual(fallback);
+    });
+
+    test("withRedisChaos can use a fallback factory", async () => {
+        process.env.CHAOS_ENABLED = "true";
+        process.env.CHAOS_REDIS = "true";
+        jest.resetModules();
+        const chaos = require("../services/chaosProxy");
+
+        const result = await chaos.withRedisChaos(
+            async () => ({ ok: true }),
+            {
+                fallback: (err) => ({
+                    ok: false,
+                    degraded: true,
+                    reason: err.code
+                })
+            }
+        );
+
+        expect(result.degraded).toBe(true);
+        expect(result.reason).toBe("CHAOS_INJECTED");
+    });
+});
+
+describe("inventory locks release on payment chaos fail", () => {
+    test("chargeWithLockRelease rolls back and releases locks when payment fails", async () => {
+        process.env.CHAOS_ENABLED = "true";
+        process.env.CHAOS_PAYMENT = "true";
+        jest.resetModules();
+        const chaos = require("../services/chaosProxy");
+
+        const rollback = jest.fn(async () => {});
+        const releaseLocks = jest.fn(async () => {});
+
+        const result = await chaos.chargeWithLockRelease({
+            charge: () =>
+                chaos.withPaymentChaos(
+                    async () => ({
+                        success: true,
+                        paymentIntentId: "pi_x"
+                    }),
+                    { retries: 0 }
+                ),
+            rollback,
+            releaseLocks
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.locksReleased).toBe(true);
+        expect(rollback).toHaveBeenCalledTimes(1);
+        expect(releaseLocks).toHaveBeenCalledTimes(1);
+    });
+
+    test("chargeWithLockRelease does not release locks on success", async () => {
+        resetChaosEnv();
+        jest.resetModules();
+        const chaos = require("../services/chaosProxy");
+
+        const rollback = jest.fn(async () => {});
+        const releaseLocks = jest.fn(async () => {});
+
+        const result = await chaos.chargeWithLockRelease({
+            charge: async () => ({
+                success: true,
+                paymentIntentId: "pi_ok",
+                clientSecret: "cs_ok"
+            }),
+            rollback,
+            releaseLocks
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.locksReleased).toBe(false);
+        expect(rollback).not.toHaveBeenCalled();
+        expect(releaseLocks).not.toHaveBeenCalled();
+    });
+
+    test("no stock corruption path: failed charge never reports success", async () => {
+        process.env.CHAOS_ENABLED = "true";
+        process.env.CHAOS_PAYMENT = "true";
+        jest.resetModules();
+        const chaos = require("../services/chaosProxy");
+
+        const stock = { reserved: 2, committed: 0 };
+        const result = await chaos.chargeWithLockRelease({
+            charge: () =>
+                chaos.withPaymentChaos(
+                    async () => {
+                        stock.committed += 2;
+                        return { success: true, paymentIntentId: "pi_x" };
+                    },
+                    { retries: 0 }
+                ),
+            rollback: async () => {
+                stock.committed = 0;
+            },
+            releaseLocks: async () => {
+                stock.reserved = 0;
+            }
+        });
+
+        expect(result.success).toBe(false);
+        expect(stock.committed).toBe(0);
+        expect(stock.reserved).toBe(0);
+    });
+});
+
+describe("resilience policy documentation", () => {
+    test("exposes timeout/retry policy for payment, redis, and db", () => {
+        const chaos = require("../services/chaosProxy");
+        expect(chaos.RESILIENCE_POLICY.payment.timeoutMs).toBe(8000);
+        expect(chaos.RESILIENCE_POLICY.payment.retries).toBe(2);
+        expect(chaos.RESILIENCE_POLICY.redis.degrade).toBe(true);
+        expect(chaos.RESILIENCE_POLICY.db.timeoutMs).toBe(5000);
+    });
+});
+
+describe("envValidator chaos keys", () => {
+    test("documents CHAOS_* optional vars and forces them off in production", () => {
+        const { ENV_CONFIG } = require("../config/envValidator");
+        const names = ENV_CONFIG.optional.map((c) => c.name);
+        expect(names).toEqual(
+            expect.arrayContaining([
+                "CHAOS_ENABLED",
+                "CHAOS_PAYMENT",
+                "CHAOS_REDIS",
+                "CHAOS_DB",
+                "CHAOS_LATENCY_MS",
+                "CHAOS_ERROR_RATE",
+                "CHAOS_FORCE_STATUS"
+            ])
+        );
+    });
+
+    test("validateEnv force-disables chaos under NODE_ENV=production", () => {
+        process.env.NODE_ENV = "production";
+        process.env.CHAOS_ENABLED = "true";
+        process.env.CHAOS_PAYMENT = "true";
+        process.env.DB_HOST = "localhost";
+        process.env.DB_PORT = "3306";
+        process.env.DB_USER = "u";
+        process.env.DB_PASSWORD = "p";
+        process.env.DB_NAME = "ecommerce";
+        process.env.JWT_SECRET = "test_jwt_secret_at_least_32_characters_long";
+        process.env.JWT_REFRESH_SECRET = "test_jwt_refresh_secret_at_least_32_characters_long";
+        process.env.PORT = "5000";
+        process.env.FRONTEND_URL = "http://localhost:5500";
+
+        jest.resetModules();
+        const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
+        const { validateEnv } = require("../config/envValidator");
+        validateEnv();
+        expect(process.env.CHAOS_ENABLED).toBe("false");
+        expect(process.env.CHAOS_PAYMENT).toBe("false");
+        exitSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
# #1398 issue resolved

## Description

This PR adds a Chaos & Resilience Harness for checkout dependencies (payment / Redis / DB) under `backend/services` and `backend/tests`.

## Features

- Chaos flags per dependency (`CHAOS_PAYMENT`, `CHAOS_REDIS`, `CHAOS_DB`)
- Timeout/retry policy documented in `chaosProxy.js`
- Jest resilience scenarios (payment 500, Redis down)
- Inventory locks released on chaos/payment failure
- Safety: disabled unless `CHAOS_ENABLED=true` (forced off in production)