### PR TITLE
Data Retention & GDPR/DPDP Erasure Workflow

### DIFF
--- a/backend/controllers/admin.controller.js
+++ b/backend/controllers/admin.controller.js
@@ -498,6 +498,80 @@ const getAdminLogs = async (req, res) => {
     }
 };
 
+// =====================
+// GDPR / DPDP ERASURE TRACKER (#1397)
+// =====================
+const dataErasureService = require("../services/dataErasureService");
+
+const listErasureRequests = async (req, res) => {
+    try {
+        const page = safeNumber(req.query.page) || 1;
+        const limit = safeNumber(req.query.limit) || 20;
+        const status = req.query.status ? sanitizeString(req.query.status) : null;
+
+        const result = await dataErasureService.listErasureRequests({
+            status,
+            page,
+            limit
+        });
+
+        return res.status(200).json({
+            success: true,
+            requests: result.requests,
+            total: result.total,
+            page: result.page,
+            limit: result.limit
+        });
+    } catch (error) {
+        logger.error("Admin list erasure requests error:", {
+            error: error.message,
+            adminId: req.user?.id
+        });
+        return res.status(500).json({
+            success: false,
+            message: "Failed to list erasure requests"
+        });
+    }
+};
+
+const getErasureRequest = async (req, res) => {
+    try {
+        const id = sanitizeString(req.params.id || "");
+        const erasure = await dataErasureService.getErasureStatus(id, {
+            asAdmin: true
+        });
+        return res.status(200).json({
+            success: true,
+            erasure
+        });
+    } catch (error) {
+        const status = error.status || 500;
+        return res.status(status).json({
+            success: false,
+            code: error.code || "ERASURE_ERROR",
+            message: error.message || "Failed to fetch erasure request"
+        });
+    }
+};
+
+const verifyErasureReceiptAdmin = async (req, res) => {
+    try {
+        const receiptId = sanitizeString(req.params.receiptId || "");
+        const receipt = await dataErasureService.verifyReceipt(receiptId);
+        return res.status(200).json({
+            success: true,
+            receipt
+        });
+    } catch (error) {
+        const status = error.status || 500;
+        return res.status(status).json({
+            success: false,
+            code: error.code || "ERASURE_ERROR",
+            message: error.message || "Failed to verify receipt"
+        });
+    }
+};
+
 
 module.exports = {
     getDashboardStats,
@@ -508,5 +582,8 @@ module.exports = {
     bulkUpdateUserRole,
     deleteUser,
     verifyUserEmail,
-    getAdminLogs
+    getAdminLogs,
+    listErasureRequests,
+    getErasureRequest,
+    verifyErasureReceiptAdmin
 };

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -858,6 +858,116 @@ const getMe = async (req, res) => {
     }
 };
 
+// ==================== GDPR / DPDP ERASURE (#1397) ====================
+
+const dataErasureService = require("../services/dataErasureService");
+
+/**
+ * POST /api/auth/erasure/request
+ * Authenticated user opens a staged erasure request; confirmation email sent.
+ */
+const requestDataErasure = async (req, res) => {
+    try {
+        const { ip, userAgent } = clientMeta(req);
+        const result = await dataErasureService.requestErasure(req.user.id, {
+            reason: req.body?.reason,
+            ip,
+            userAgent
+        });
+        return res.status(201).json({
+            success: true,
+            message: result.message,
+            requestId: result.requestId,
+            status: result.status,
+            expiresAt: result.expiresAt,
+            emailDelivered: result.emailDelivered,
+            ...(result.confirmationToken
+                ? { confirmationToken: result.confirmationToken }
+                : {})
+        });
+    } catch (error) {
+        const status = error.status || 500;
+        return res.status(status).json({
+            success: false,
+            code: error.code || "ERASURE_ERROR",
+            message: error.message || "Failed to create erasure request"
+        });
+    }
+};
+
+/**
+ * POST /api/auth/erasure/confirm
+ * Confirm with the emailed token — runs soft-delete → anonymize → purge → receipt.
+ */
+const confirmDataErasure = async (req, res) => {
+    try {
+        const token = sanitizeString(req.body?.token || req.body?.confirmationToken || "");
+        const requestId = sanitizeString(req.body?.requestId || "") || null;
+        const result = await dataErasureService.confirmErasure(token, { requestId });
+        return res.status(200).json({
+            success: true,
+            message: result.message,
+            receiptId: result.receiptId,
+            requestId: result.requestId,
+            status: result.status,
+            summary: result.summary
+        });
+    } catch (error) {
+        const status = error.status || 500;
+        return res.status(status).json({
+            success: false,
+            code: error.code || "ERASURE_ERROR",
+            message: error.message || "Failed to confirm erasure"
+        });
+    }
+};
+
+/**
+ * GET /api/auth/erasure/:requestId
+ * Authenticated user checks their own erasure request status.
+ */
+const getMyErasureStatus = async (req, res) => {
+    try {
+        const requestId = sanitizeString(req.params.requestId || "");
+        const status = await dataErasureService.getErasureStatus(requestId, {
+            userId: req.user.id,
+            asAdmin: false
+        });
+        return res.status(200).json({
+            success: true,
+            erasure: status
+        });
+    } catch (error) {
+        const status = error.status || 500;
+        return res.status(status).json({
+            success: false,
+            code: error.code || "ERASURE_ERROR",
+            message: error.message || "Failed to fetch erasure status"
+        });
+    }
+};
+
+/**
+ * GET /api/auth/erasure/receipt/:receiptId
+ * Public verification of an erasure receipt (no PII).
+ */
+const verifyErasureReceipt = async (req, res) => {
+    try {
+        const receiptId = sanitizeString(req.params.receiptId || "");
+        const receipt = await dataErasureService.verifyReceipt(receiptId);
+        return res.status(200).json({
+            success: true,
+            receipt
+        });
+    } catch (error) {
+        const status = error.status || 500;
+        return res.status(status).json({
+            success: false,
+            code: error.code || "ERASURE_ERROR",
+            message: error.message || "Failed to verify receipt"
+        });
+    }
+};
 
 // ==================== EXPORTS ====================
 module.exports = {
@@ -873,7 +983,11 @@ module.exports = {
     validateToken,  
     getSecurityAudit, 
     getFraudStatus,
-    getMe
+    getMe,
+    requestDataErasure,
+    confirmDataErasure,
+    getMyErasureStatus,
+    verifyErasureReceipt
 };
 
 // Internal login-guard helpers exposed for unit testing only. Not part of the

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -10,7 +10,10 @@ const {
     bulkUpdateUserRole,  
     deleteUser,
     getAdminLogs,
-    verifyUserEmail
+    verifyUserEmail,
+    listErasureRequests,
+    getErasureRequest,
+    verifyErasureReceiptAdmin
 } = require("../controllers/admin.controller");
 
 const authMiddleware = require("../middleware/authMiddleware");
@@ -45,5 +48,10 @@ router.post("/users/verify-email", verifyUserEmail);
 
 // ==================== ADMIN LOGS ====================
 router.get("/logs", getAdminLogs);
+
+// ==================== GDPR / DPDP ERASURE TRACKER (#1397) ====================
+router.get("/erasure-requests", listErasureRequests);
+router.get("/erasure-requests/:id", getErasureRequest);
+router.get("/erasure-receipts/:receiptId", verifyErasureReceiptAdmin);
 
 module.exports = router;

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -15,6 +15,10 @@ const {
     changePassword,
     getSecurityAudit,
     getFraudStatus,
+    requestDataErasure,
+    confirmDataErasure,
+    getMyErasureStatus,
+    verifyErasureReceipt,
     //verify2FA,
     //generate2FA,
     //enable2FA,
@@ -183,6 +187,46 @@ router.post(
     applyCaptchaCheck,
     validateChangePassword,
     changePassword
+);
+
+// ======================== GDPR / DPDP ERASURE (#1397) ========================
+
+/**
+ * POST /api/auth/erasure/request
+ * Open a staged erasure request (confirmation email sent).
+ */
+router.post(
+    "/erasure/request",
+    authMiddleware,
+    requestDataErasure
+);
+
+/**
+ * POST /api/auth/erasure/confirm
+ * Confirm with emailed token → soft-delete → anonymize → purge → receipt.
+ */
+router.post(
+    "/erasure/confirm",
+    confirmDataErasure
+);
+
+/**
+ * GET /api/auth/erasure/receipt/:receiptId
+ * Public receipt verification (no PII).
+ */
+router.get(
+    "/erasure/receipt/:receiptId",
+    verifyErasureReceipt
+);
+
+/**
+ * GET /api/auth/erasure/:requestId
+ * Authenticated status check for the caller's own request.
+ */
+router.get(
+    "/erasure/:requestId",
+    authMiddleware,
+    getMyErasureStatus
 );
 
 // ======================== SESSION ROUTES ========================

--- a/backend/services/dataErasureService.js
+++ b/backend/services/dataErasureService.js
@@ -1,0 +1,649 @@
+/**
+ * Data Retention & GDPR / DPDP Erasure Workflow (#1397).
+ *
+ * Staged flow:
+ *   1. authenticate request  → pending_confirmation + confirmation email
+ *   2. soft-delete user      → is_active=0, deleted_at set
+ *   3. anonymize PII         → orders keep legal totals; PII redacted
+ *   4. purge tokens/sessions → refresh_tokens, auth_sessions, carts, wishlist
+ *   5. issue erasure receipt → receipt_id returned to the user
+ *
+ * Order rows are intentionally retained (tax / dispute / accounting). Only
+ * personally identifiable fields are overwritten with stable anonymized values
+ * keyed by the receipt id.
+ */
+
+"use strict";
+
+const crypto = require("crypto");
+const bcrypt = require("bcryptjs");
+const db = require("../config/db");
+const { withTransaction } = require("../config/db");
+const { sanitizeString, safeArray } = require("../utils/helpers");
+const refreshTokenService = require("./refreshTokenService");
+
+const CONFIRMATION_TTL_HOURS = Math.max(
+    1,
+    parseInt(process.env.ERASURE_CONFIRM_TTL_HOURS, 10) || 24
+);
+
+const STATUS = Object.freeze({
+    PENDING: "pending_confirmation",
+    CONFIRMED: "confirmed",
+    SOFT_DELETED: "soft_deleted",
+    ANONYMIZING: "anonymizing",
+    PURGING: "purging",
+    COMPLETED: "completed",
+    FAILED: "failed",
+    CANCELLED: "cancelled"
+});
+
+const ANON = Object.freeze({
+    name: "Erased User",
+    phone: null,
+    address: "[REDACTED]",
+    city: "[REDACTED]",
+    state: "[REDACTED]",
+    zip: "[REDACTED]",
+    country: null
+});
+
+class ErasureError extends Error {
+    constructor(message, { status = 400, code = "ERASURE_ERROR" } = {}) {
+        super(message);
+        this.name = "ErasureError";
+        this.status = status;
+        this.code = code;
+    }
+}
+
+function sha256(value) {
+    return crypto.createHash("sha256").update(String(value)).digest("hex");
+}
+
+function mintReceiptId() {
+    const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+    const suffix = crypto.randomBytes(4).toString("hex").toUpperCase();
+    return `ER-${stamp}-${suffix}`;
+}
+
+function anonymizedEmail(receiptId) {
+    // Unique + non-deliverable so UNIQUE(email) on users stays satisfied.
+    return `erased+${receiptId.toLowerCase()}@erased.invalid`;
+}
+
+function redactedAddressJson() {
+    return JSON.stringify({
+        line1: ANON.address,
+        city: ANON.city,
+        state: ANON.state,
+        zip: ANON.zip,
+        redacted: true
+    });
+}
+
+async function sendConfirmationEmail({ to, confirmToken, requestId }) {
+    const frontend = (process.env.FRONTEND_URL || "http://localhost:5500").replace(/\/$/, "");
+    const confirmUrl = `${frontend}/signin.html?erasureConfirm=${encodeURIComponent(confirmToken)}&requestId=${encodeURIComponent(requestId)}`;
+    const subject = "Confirm your data erasure request";
+    const body =
+        `You requested erasure of your account under our GDPR / DPDP workflow.\n\n` +
+        `Confirm within ${CONFIRMATION_TTL_HOURS} hours using this link:\n${confirmUrl}\n\n` +
+        `Or submit token ${confirmToken} to POST /api/auth/erasure/confirm.\n\n` +
+        `If you did not request this, you can ignore this email — nothing will be deleted.`;
+
+    const host = process.env.SMTP_HOST;
+    const user = process.env.SMTP_USER;
+    const pass = process.env.SMTP_PASS;
+
+    if (host && user && pass) {
+        try {
+            const nodemailer = require("nodemailer");
+            const transporter = nodemailer.createTransport({
+                host,
+                port: Number(process.env.SMTP_PORT) || 587,
+                secure: false,
+                auth: { user, pass }
+            });
+            await transporter.sendMail({
+                from: process.env.SMTP_FROM || user,
+                to,
+                subject,
+                text: body
+            });
+            return { delivered: true, channel: "smtp" };
+        } catch (err) {
+            console.error("Erasure confirmation email failed:", err.message);
+            // Fall through to log channel so the workflow is still testable.
+        }
+    }
+
+    console.info("[erasure] confirmation email (SMTP not configured):\n", {
+        to,
+        subject,
+        confirmUrl,
+        requestId
+    });
+    return { delivered: false, channel: "log", confirmUrl };
+}
+
+async function appendStage(connection, requestId, stage, detail = {}) {
+    const [rows] = await connection.query(
+        "SELECT stages_json FROM erasure_requests WHERE id = ?",
+        [requestId]
+    );
+    const stages = rows[0]?.stages_json
+        ? (typeof rows[0].stages_json === "string"
+            ? JSON.parse(rows[0].stages_json)
+            : rows[0].stages_json)
+        : [];
+    stages.push({
+        stage,
+        at: new Date().toISOString(),
+        ...detail
+    });
+    await connection.query(
+        "UPDATE erasure_requests SET stages_json = ?, updated_at = NOW() WHERE id = ?",
+        [JSON.stringify(stages), requestId]
+    );
+    return stages;
+}
+
+async function setStatus(connection, requestId, status, extra = {}) {
+    const sets = ["status = ?", "updated_at = NOW()"];
+    const params = [status];
+    if (extra.errorMessage !== undefined) {
+        sets.push("error_message = ?");
+        params.push(extra.errorMessage);
+    }
+    if (extra.receiptId !== undefined) {
+        sets.push("receipt_id = ?");
+        params.push(extra.receiptId);
+    }
+    if (extra.confirmedAt) {
+        sets.push("confirmed_at = NOW()");
+    }
+    if (extra.completedAt) {
+        sets.push("completed_at = NOW()");
+    }
+    params.push(requestId);
+    await connection.query(
+        `UPDATE erasure_requests SET ${sets.join(", ")} WHERE id = ?`,
+        params
+    );
+}
+
+/**
+ * Step 1 — authenticated user opens an erasure request + confirmation email.
+ */
+async function requestErasure(userId, { reason = null, ip = null, userAgent = null } = {}) {
+    const [users] = await db.query(
+        `SELECT id, email, name, role, is_active, deleted_at
+         FROM users WHERE id = ? LIMIT 1`,
+        [userId]
+    );
+    const user = users[0];
+    if (!user) {
+        throw new ErasureError("User not found", { status: 404, code: "USER_NOT_FOUND" });
+    }
+    if (user.role === "admin" || user.role === "superadmin") {
+        throw new ErasureError("Admin accounts cannot self-erase via this workflow", {
+            status: 403,
+            code: "ADMIN_ERASURE_FORBIDDEN"
+        });
+    }
+    if (user.deleted_at) {
+        throw new ErasureError("Account is already erased or pending deletion", {
+            status: 409,
+            code: "ALREADY_ERASED"
+        });
+    }
+
+    const [open] = await db.query(
+        `SELECT id, status FROM erasure_requests
+         WHERE user_id = ? AND status IN (?, ?, ?, ?, ?)
+         ORDER BY created_at DESC LIMIT 1`,
+        [
+            userId,
+            STATUS.PENDING,
+            STATUS.CONFIRMED,
+            STATUS.SOFT_DELETED,
+            STATUS.ANONYMIZING,
+            STATUS.PURGING
+        ]
+    );
+    if (open[0]) {
+        throw new ErasureError("An erasure request is already in progress", {
+            status: 409,
+            code: "ERASURE_IN_PROGRESS"
+        });
+    }
+
+    const requestId = crypto.randomUUID();
+    const confirmToken = crypto.randomBytes(32).toString("hex");
+    const tokenHash = sha256(confirmToken);
+    const expiresAt = new Date(Date.now() + CONFIRMATION_TTL_HOURS * 60 * 60 * 1000);
+
+    await db.query(
+        `INSERT INTO erasure_requests (
+            id, user_id, status, confirmation_token_hash, confirmation_expires_at,
+            reason, requested_ip, user_agent, original_email_hash, stages_json
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+            requestId,
+            userId,
+            STATUS.PENDING,
+            tokenHash,
+            expiresAt,
+            reason ? sanitizeString(reason).slice(0, 500) : null,
+            ip ? String(ip).slice(0, 45) : null,
+            userAgent ? String(userAgent).slice(0, 512) : null,
+            sha256(String(user.email).toLowerCase()),
+            JSON.stringify([
+                {
+                    stage: "requested",
+                    at: new Date().toISOString()
+                }
+            ])
+        ]
+    );
+
+    const emailResult = await sendConfirmationEmail({
+        to: user.email,
+        confirmToken,
+        requestId
+    });
+
+    return {
+        requestId,
+        status: STATUS.PENDING,
+        expiresAt: expiresAt.toISOString(),
+        emailDelivered: Boolean(emailResult.delivered),
+        // Token is only returned when SMTP is off so local/dev can confirm.
+        // Production with SMTP relies on the email link alone.
+        confirmationToken: emailResult.delivered ? undefined : confirmToken,
+        message:
+            "Erasure request created. Confirm via the email we sent to complete deletion."
+    };
+}
+
+/**
+ * Steps 2–5 — confirm token and run soft-delete → anonymize → purge → receipt.
+ */
+async function confirmErasure(confirmToken, { requestId = null } = {}) {
+    if (!confirmToken || String(confirmToken).length < 16) {
+        throw new ErasureError("Invalid confirmation token", {
+            status: 400,
+            code: "INVALID_TOKEN"
+        });
+    }
+
+    const tokenHash = sha256(confirmToken);
+    const params = [tokenHash, STATUS.PENDING];
+    let sql =
+        `SELECT * FROM erasure_requests
+         WHERE confirmation_token_hash = ? AND status = ?`;
+    if (requestId) {
+        sql += " AND id = ?";
+        params.push(requestId);
+    }
+    sql += " LIMIT 1";
+
+    const [rows] = await db.query(sql, params);
+    const request = rows[0];
+    if (!request) {
+        throw new ErasureError("Erasure request not found or already processed", {
+            status: 404,
+            code: "REQUEST_NOT_FOUND"
+        });
+    }
+    if (new Date(request.confirmation_expires_at).getTime() < Date.now()) {
+        await db.query(
+            `UPDATE erasure_requests SET status = ?, error_message = ?, updated_at = NOW() WHERE id = ?`,
+            [STATUS.CANCELLED, "Confirmation token expired", request.id]
+        );
+        throw new ErasureError("Confirmation token has expired. Please request erasure again.", {
+            status: 410,
+            code: "TOKEN_EXPIRED"
+        });
+    }
+
+    const receiptId = mintReceiptId();
+    const anonEmail = anonymizedEmail(receiptId);
+    const burnedPassword = await bcrypt.hash(crypto.randomBytes(32).toString("hex"), 10);
+
+    let summary;
+
+    try {
+        summary = await withTransaction(async (connection) => {
+            await setStatus(connection, request.id, STATUS.CONFIRMED, { confirmedAt: true });
+            await appendStage(connection, request.id, "confirmed");
+
+            // --- soft-delete -------------------------------------------------
+            await setStatus(connection, request.id, STATUS.SOFT_DELETED);
+            await connection.query(
+                `UPDATE users SET
+                    is_active = 0,
+                    deleted_at = NOW(),
+                    delete_reason = ?,
+                    password = ?,
+                    name = ?,
+                    phone = NULL,
+                    address = ?,
+                    city = ?,
+                    state = ?,
+                    zip = ?,
+                    avatar = NULL
+                 WHERE id = ?`,
+                [
+                    `GDPR/DPDP erasure ${receiptId}`,
+                    burnedPassword,
+                    ANON.name,
+                    ANON.address,
+                    ANON.city,
+                    ANON.state,
+                    ANON.zip,
+                    request.user_id
+                ]
+            );
+            await appendStage(connection, request.id, "soft_deleted");
+
+            // --- anonymize order PII (retain legal totals / status) ----------
+            await setStatus(connection, request.id, STATUS.ANONYMIZING);
+            const [orderResult] = await connection.query(
+                `UPDATE orders SET
+                    customer_name = ?,
+                    customer_email = ?,
+                    customer_phone = NULL,
+                    city = ?,
+                    state = ?,
+                    zip = ?,
+                    full_address = ?,
+                    billing_address = ?,
+                    shipping_address = ?,
+                    ip_address = NULL,
+                    user_agent = NULL,
+                    notes = NULL
+                 WHERE user_id = ?`,
+                [
+                    ANON.name,
+                    anonEmail,
+                    ANON.city,
+                    ANON.state,
+                    ANON.zip,
+                    ANON.address,
+                    redactedAddressJson(),
+                    redactedAddressJson(),
+                    request.user_id
+                ]
+            );
+            const ordersAnonymized = orderResult?.affectedRows || 0;
+            await appendStage(connection, request.id, "orders_anonymized", {
+                ordersAnonymized
+            });
+
+            // Finish user email anonymization after orders (unique email).
+            await connection.query(
+                `UPDATE users SET email = ? WHERE id = ?`,
+                [anonEmail, request.user_id]
+            );
+            await appendStage(connection, request.id, "user_anonymized");
+
+            // --- purge tokens, sessions, carts, wishlist ---------------------
+            await setStatus(connection, request.id, STATUS.PURGING);
+
+            const [rt] = await connection.query(
+                `DELETE FROM refresh_tokens WHERE user_id = ?`,
+                [request.user_id]
+            );
+            let sessionsPurged = 0;
+            try {
+                const [as] = await connection.query(
+                    `DELETE FROM auth_sessions WHERE user_id = ?`,
+                    [request.user_id]
+                );
+                sessionsPurged = as?.affectedRows || 0;
+            } catch (_) {
+                /* table may be absent on older DBs */
+            }
+
+            const [cart] = await connection.query(
+                `DELETE FROM cart_items WHERE user_id = ?`,
+                [request.user_id]
+            );
+            let wishlistPurged = 0;
+            try {
+                const [wl] = await connection.query(
+                    `DELETE FROM wishlist_items WHERE user_id = ?`,
+                    [request.user_id]
+                );
+                wishlistPurged = wl?.affectedRows || 0;
+            } catch (_) { /* ignore */ }
+
+            // Best-effort inventory lock cleanup
+            try {
+                await connection.query(
+                    `DELETE FROM inventory_locks WHERE user_id = ?`,
+                    [request.user_id]
+                );
+            } catch (_) { /* ignore */ }
+
+            await appendStage(connection, request.id, "purged", {
+                refreshTokens: rt?.affectedRows || 0,
+                sessions: sessionsPurged,
+                cartItems: cart?.affectedRows || 0,
+                wishlistItems: wishlistPurged
+            });
+
+            // --- receipt -----------------------------------------------------
+            const receiptRowId = crypto.randomUUID();
+            const summaryPayload = {
+                receiptId,
+                requestId: request.id,
+                userId: request.user_id,
+                ordersAnonymized,
+                refreshTokensPurged: rt?.affectedRows || 0,
+                sessionsPurged,
+                cartItemsPurged: cart?.affectedRows || 0,
+                wishlistItemsPurged: wishlistPurged,
+                framework: ["GDPR", "DPDP"],
+                completedAt: new Date().toISOString()
+            };
+
+            await connection.query(
+                `INSERT INTO erasure_receipts (id, receipt_id, erasure_request_id, user_id, summary_json)
+                 VALUES (?, ?, ?, ?, ?)`,
+                [
+                    receiptRowId,
+                    receiptId,
+                    request.id,
+                    request.user_id,
+                    JSON.stringify(summaryPayload)
+                ]
+            );
+
+            await setStatus(connection, request.id, STATUS.COMPLETED, {
+                receiptId,
+                completedAt: true
+            });
+            await appendStage(connection, request.id, "completed", { receiptId });
+
+            return summaryPayload;
+        });
+    } catch (err) {
+        try {
+            await db.query(
+                `UPDATE erasure_requests SET status = ?, error_message = ?, updated_at = NOW() WHERE id = ?`,
+                [STATUS.FAILED, String(err.message || err).slice(0, 1000), request.id]
+            );
+        } catch (_) { /* ignore */ }
+        throw err;
+    }
+
+    // Revoke live JWT families outside the txn (may touch Redis).
+    try {
+        if (typeof refreshTokenService.revokeAllUserFamilies === "function") {
+            await refreshTokenService.revokeAllUserFamilies(
+                request.user_id,
+                "gdpr_erasure"
+            );
+        }
+    } catch (err) {
+        console.warn("Erasure post-purge token revoke warning:", err.message);
+    }
+
+    return {
+        success: true,
+        receiptId: summary.receiptId,
+        requestId: request.id,
+        status: STATUS.COMPLETED,
+        summary,
+        message:
+            "Your data erasure is complete. Keep this receipt ID for your records."
+    };
+}
+
+/**
+ * User or admin: fetch a single request (user may only see their own).
+ */
+async function getErasureStatus(requestId, { userId = null, asAdmin = false } = {}) {
+    const [rows] = await db.query(
+        `SELECT id, user_id, status, receipt_id, reason, stages_json,
+                error_message, confirmed_at, completed_at, created_at, updated_at,
+                confirmation_expires_at
+         FROM erasure_requests WHERE id = ? LIMIT 1`,
+        [requestId]
+    );
+    const row = rows[0];
+    if (!row) {
+        throw new ErasureError("Erasure request not found", {
+            status: 404,
+            code: "REQUEST_NOT_FOUND"
+        });
+    }
+    if (!asAdmin && userId && row.user_id !== userId) {
+        throw new ErasureError("Erasure request not found", {
+            status: 404,
+            code: "REQUEST_NOT_FOUND"
+        });
+    }
+
+    const stages = row.stages_json
+        ? (typeof row.stages_json === "string"
+            ? JSON.parse(row.stages_json)
+            : row.stages_json)
+        : [];
+
+    return {
+        id: row.id,
+        userId: asAdmin ? row.user_id : undefined,
+        status: row.status,
+        receiptId: row.receipt_id,
+        reason: row.reason,
+        stages,
+        errorMessage: row.error_message,
+        confirmedAt: row.confirmed_at,
+        completedAt: row.completed_at,
+        expiresAt: row.confirmation_expires_at,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at
+    };
+}
+
+/**
+ * Admin status tracker — paginated list.
+ */
+async function listErasureRequests({ status = null, page = 1, limit = 20 } = {}) {
+    const safePage = Math.max(1, parseInt(page, 10) || 1);
+    const safeLimit = Math.min(100, Math.max(1, parseInt(limit, 10) || 20));
+    const offset = (safePage - 1) * safeLimit;
+
+    const where = [];
+    const params = [];
+    if (status) {
+        where.push("status = ?");
+        params.push(sanitizeString(status));
+    }
+    const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+
+    const [countRows] = await db.query(
+        `SELECT COUNT(*) AS total FROM erasure_requests ${whereSql}`,
+        params
+    );
+    const [rows] = await db.query(
+        `SELECT id, user_id, status, receipt_id, reason, error_message,
+                confirmed_at, completed_at, created_at, updated_at
+         FROM erasure_requests
+         ${whereSql}
+         ORDER BY created_at DESC
+         LIMIT ? OFFSET ?`,
+        [...params, safeLimit, offset]
+    );
+
+    return {
+        requests: safeArray(rows).map((r) => ({
+            id: r.id,
+            userId: r.user_id,
+            status: r.status,
+            receiptId: r.receipt_id,
+            reason: r.reason,
+            errorMessage: r.error_message,
+            confirmedAt: r.confirmed_at,
+            completedAt: r.completed_at,
+            createdAt: r.created_at,
+            updatedAt: r.updated_at
+        })),
+        total: countRows[0]?.total || 0,
+        page: safePage,
+        limit: safeLimit
+    };
+}
+
+/**
+ * Verify a receipt id without exposing PII.
+ */
+async function verifyReceipt(receiptId) {
+    const [rows] = await db.query(
+        `SELECT receipt_id, erasure_request_id, summary_json, issued_at
+         FROM erasure_receipts WHERE receipt_id = ? LIMIT 1`,
+        [sanitizeString(receiptId)]
+    );
+    const row = rows[0];
+    if (!row) {
+        throw new ErasureError("Receipt not found", {
+            status: 404,
+            code: "RECEIPT_NOT_FOUND"
+        });
+    }
+    const summary = row.summary_json
+        ? (typeof row.summary_json === "string"
+            ? JSON.parse(row.summary_json)
+            : row.summary_json)
+        : {};
+    return {
+        valid: true,
+        receiptId: row.receipt_id,
+        requestId: row.erasure_request_id,
+        issuedAt: row.issued_at,
+        framework: summary.framework || ["GDPR", "DPDP"],
+        ordersAnonymized: summary.ordersAnonymized ?? null,
+        completedAt: summary.completedAt || row.issued_at
+    };
+}
+
+module.exports = {
+    STATUS,
+    ErasureError,
+    requestErasure,
+    confirmErasure,
+    getErasureStatus,
+    listErasureRequests,
+    verifyReceipt,
+    // test helpers
+    _internal: {
+        sha256,
+        mintReceiptId,
+        anonymizedEmail,
+        sendConfirmationEmail
+    }
+};

--- a/backend/sql/erasure_requests.sql
+++ b/backend/sql/erasure_requests.sql
@@ -1,0 +1,68 @@
+-- ============================================
+-- DATA RETENTION & GDPR / DPDP ERASURE (#1397)
+-- ============================================
+--
+-- Staged erasure workflow:
+--   pending_confirmation → confirmed → soft_deleted → anonymizing → purging → completed
+--
+-- Legal order rows are retained with PII anonymized (not hard-deleted).
+-- Refresh tokens, sessions, and carts are cascade-purged.
+--
+-- user_id is CHAR(36) to match users.id.
+-- This file is the feature schema; also folded into migrations/0026_*.sql
+-- so `npm run migrate` applies it on a fresh database.
+
+CREATE TABLE IF NOT EXISTS erasure_requests (
+    id CHAR(36) PRIMARY KEY,
+    user_id CHAR(36) NOT NULL,
+    status ENUM(
+        'pending_confirmation',
+        'confirmed',
+        'soft_deleted',
+        'anonymizing',
+        'purging',
+        'completed',
+        'failed',
+        'cancelled'
+    ) NOT NULL DEFAULT 'pending_confirmation',
+    confirmation_token_hash CHAR(64) NOT NULL,
+    confirmation_expires_at DATETIME NOT NULL,
+    confirmed_at DATETIME NULL,
+    receipt_id VARCHAR(64) NULL,
+    reason VARCHAR(500) NULL,
+    requested_ip VARCHAR(45) NULL,
+    user_agent VARCHAR(512) NULL,
+    -- One-way hash of the email at request time (audit without retaining PII).
+    original_email_hash CHAR(64) NULL,
+    stages_json JSON NULL,
+    error_message TEXT NULL,
+    completed_at DATETIME NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_erasure_receipt (receipt_id),
+    INDEX idx_erasure_user (user_id),
+    INDEX idx_erasure_status (status),
+    INDEX idx_erasure_token (confirmation_token_hash),
+    INDEX idx_erasure_created (created_at),
+
+    CONSTRAINT fk_erasure_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Append-only receipt ledger so a completed erasure can be verified later
+-- without re-exposing PII.
+CREATE TABLE IF NOT EXISTS erasure_receipts (
+    id CHAR(36) PRIMARY KEY,
+    receipt_id VARCHAR(64) NOT NULL,
+    erasure_request_id CHAR(36) NOT NULL,
+    user_id CHAR(36) NULL,
+    summary_json JSON NULL,
+    issued_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_receipt_id (receipt_id),
+    INDEX idx_receipt_request (erasure_request_id),
+    INDEX idx_receipt_issued (issued_at),
+
+    CONSTRAINT fk_receipt_request FOREIGN KEY (erasure_request_id)
+        REFERENCES erasure_requests(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/tests/dataErasure.test.js
+++ b/backend/tests/dataErasure.test.js
@@ -1,0 +1,233 @@
+/**
+ * GDPR / DPDP erasure workflow tests (#1397).
+ */
+
+jest.mock("../config/db", () => {
+    const query = jest.fn();
+    const withTransaction = jest.fn();
+    return {
+        query,
+        withTransaction,
+        getConnection: jest.fn()
+    };
+});
+
+jest.mock("../services/refreshTokenService", () => ({
+    revokeAllUserFamilies: jest.fn(async () => ({ revokedFamilies: 1 }))
+}));
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.SMTP_HOST;
+    delete process.env.SMTP_USER;
+    delete process.env.SMTP_PASS;
+});
+
+afterEach(() => {
+    jest.resetModules();
+});
+
+function mockConnectionResponder() {
+    const calls = [];
+    const query = jest.fn(async (sql, params = []) => {
+        calls.push({ sql, params });
+
+        if (/SELECT stages_json FROM erasure_requests/i.test(sql)) {
+            return [[{ stages_json: "[]" }]];
+        }
+        if (/UPDATE erasure_requests SET/i.test(sql)) {
+            return [{ affectedRows: 1 }];
+        }
+        if (/UPDATE users SET/i.test(sql)) {
+            return [{ affectedRows: 1 }];
+        }
+        if (/UPDATE orders SET/i.test(sql)) {
+            return [{ affectedRows: 2 }];
+        }
+        if (/DELETE FROM refresh_tokens/i.test(sql)) {
+            return [{ affectedRows: 3 }];
+        }
+        if (/DELETE FROM auth_sessions/i.test(sql)) {
+            return [{ affectedRows: 1 }];
+        }
+        if (/DELETE FROM cart_items/i.test(sql)) {
+            return [{ affectedRows: 4 }];
+        }
+        if (/DELETE FROM wishlist_items/i.test(sql)) {
+            return [{ affectedRows: 2 }];
+        }
+        if (/DELETE FROM inventory_locks/i.test(sql)) {
+            return [{ affectedRows: 0 }];
+        }
+        if (/INSERT INTO erasure_receipts/i.test(sql)) {
+            return [{ affectedRows: 1 }];
+        }
+        return [{ affectedRows: 1 }];
+    });
+    return { query, calls };
+}
+
+describe("dataErasureService.requestErasure", () => {
+    test("creates pending request and returns confirmation token when SMTP is off", async () => {
+        const db = require("../config/db");
+        db.query
+            .mockResolvedValueOnce([[{
+                id: "user-1",
+                email: "shopper@example.com",
+                name: "Shopper",
+                role: "customer",
+                is_active: 1,
+                deleted_at: null
+            }]])
+            .mockResolvedValueOnce([[]])
+            .mockResolvedValueOnce([{ affectedRows: 1 }]);
+
+        const service = require("../services/dataErasureService");
+        const result = await service.requestErasure("user-1", {
+            reason: "Please delete my data",
+            ip: "127.0.0.1"
+        });
+
+        expect(result.requestId).toBeTruthy();
+        expect(result.status).toBe("pending_confirmation");
+        expect(result.emailDelivered).toBe(false);
+        expect(result.confirmationToken).toMatch(/^[a-f0-9]{64}$/);
+        expect(db.query).toHaveBeenCalledWith(
+            expect.stringMatching(/INSERT INTO erasure_requests/i),
+            expect.any(Array)
+        );
+    });
+
+    test("rejects admin self-erasure", async () => {
+        const db = require("../config/db");
+        db.query.mockResolvedValueOnce([[{
+            id: "admin-1",
+            email: "admin@example.com",
+            name: "Admin",
+            role: "admin",
+            is_active: 1,
+            deleted_at: null
+        }]]);
+
+        const service = require("../services/dataErasureService");
+        await expect(service.requestErasure("admin-1")).rejects.toMatchObject({
+            code: "ADMIN_ERASURE_FORBIDDEN",
+            status: 403
+        });
+    });
+});
+
+describe("dataErasureService.confirmErasure", () => {
+    test("soft-deletes, anonymizes orders, purges tokens/carts, issues receipt", async () => {
+        const db = require("../config/db");
+        const refresh = require("../services/refreshTokenService");
+        const service = require("../services/dataErasureService");
+
+        const token = "a".repeat(64);
+        const tokenHash = service._internal.sha256(token);
+
+        db.query.mockResolvedValueOnce([[{
+            id: "req-1",
+            user_id: "user-1",
+            status: "pending_confirmation",
+            confirmation_token_hash: tokenHash,
+            confirmation_expires_at: new Date(Date.now() + 60_000),
+            stages_json: "[]"
+        }]]);
+
+        const { query: connQuery, calls } = mockConnectionResponder();
+        db.withTransaction.mockImplementation(async (fn) => fn({ query: connQuery }));
+
+        const result = await service.confirmErasure(token, { requestId: "req-1" });
+
+        expect(result.success).toBe(true);
+        expect(result.receiptId).toMatch(/^ER-\d{8}-[A-F0-9]+$/);
+        expect(result.status).toBe("completed");
+        expect(result.summary.ordersAnonymized).toBe(2);
+        expect(result.summary.refreshTokensPurged).toBe(3);
+        expect(result.summary.cartItemsPurged).toBe(4);
+
+        expect(calls.some(({ sql }) => /UPDATE users SET\s+is_active = 0/i.test(sql))).toBe(true);
+        expect(calls.some(({ sql }) => /UPDATE orders SET/i.test(sql) && /customer_email/i.test(sql))).toBe(true);
+        expect(calls.some(({ sql, params }) =>
+            /DELETE FROM refresh_tokens WHERE user_id/i.test(sql) && params[0] === "user-1"
+        )).toBe(true);
+        expect(calls.some(({ sql }) => /INSERT INTO erasure_receipts/i.test(sql))).toBe(true);
+
+        expect(refresh.revokeAllUserFamilies).toHaveBeenCalledWith("user-1", "gdpr_erasure");
+    });
+
+    test("rejects expired confirmation tokens", async () => {
+        const db = require("../config/db");
+        const service = require("../services/dataErasureService");
+        const token = "b".repeat(64);
+
+        db.query
+            .mockResolvedValueOnce([[{
+                id: "req-expired",
+                user_id: "user-1",
+                status: "pending_confirmation",
+                confirmation_token_hash: service._internal.sha256(token),
+                confirmation_expires_at: new Date(Date.now() - 1000)
+            }]])
+            .mockResolvedValueOnce([{ affectedRows: 1 }]);
+
+        await expect(service.confirmErasure(token)).rejects.toMatchObject({
+            code: "TOKEN_EXPIRED",
+            status: 410
+        });
+    });
+});
+
+describe("admin list + receipt verify", () => {
+    test("listErasureRequests returns paginated tracker rows", async () => {
+        const db = require("../config/db");
+        db.query
+            .mockResolvedValueOnce([[{ total: 1 }]])
+            .mockResolvedValueOnce([[{
+                id: "req-1",
+                user_id: "user-1",
+                status: "completed",
+                receipt_id: "ER-20260101-ABCD",
+                reason: null,
+                error_message: null,
+                confirmed_at: new Date(),
+                completed_at: new Date(),
+                created_at: new Date(),
+                updated_at: new Date()
+            }]]);
+
+        const service = require("../services/dataErasureService");
+        const result = await service.listErasureRequests({ page: 1, limit: 10 });
+        expect(result.total).toBe(1);
+        expect(result.requests[0].receiptId).toBe("ER-20260101-ABCD");
+    });
+
+    test("verifyReceipt returns non-PII summary", async () => {
+        const db = require("../config/db");
+        db.query.mockResolvedValueOnce([[{
+            receipt_id: "ER-20260101-ABCD",
+            erasure_request_id: "req-1",
+            summary_json: JSON.stringify({
+                framework: ["GDPR", "DPDP"],
+                ordersAnonymized: 2,
+                completedAt: "2026-01-01T00:00:00.000Z"
+            }),
+            issued_at: new Date("2026-01-01T00:00:00.000Z")
+        }]]);
+
+        const service = require("../services/dataErasureService");
+        const receipt = await service.verifyReceipt("ER-20260101-ABCD");
+        expect(receipt.valid).toBe(true);
+        expect(receipt.ordersAnonymized).toBe(2);
+        expect(receipt.framework).toEqual(["GDPR", "DPDP"]);
+    });
+});
+
+describe("anonymization helpers", () => {
+    test("anonymized email is unique per receipt and non-deliverable", () => {
+        const service = require("../services/dataErasureService");
+        const email = service._internal.anonymizedEmail("ER-20260101-FFFF");
+        expect(email).toBe("erased+er-20260101-ffff@erased.invalid");
+    });
+});

--- a/migrations/0026_erasure_requests.sql
+++ b/migrations/0026_erasure_requests.sql
@@ -1,0 +1,56 @@
+-- ============================================
+-- DATA RETENTION & GDPR / DPDP ERASURE (#1397)
+-- ============================================
+-- Folded from backend/sql/erasure_requests.sql so migrate applies it.
+
+CREATE TABLE IF NOT EXISTS erasure_requests (
+    id CHAR(36) PRIMARY KEY,
+    user_id CHAR(36) NOT NULL,
+    status ENUM(
+        'pending_confirmation',
+        'confirmed',
+        'soft_deleted',
+        'anonymizing',
+        'purging',
+        'completed',
+        'failed',
+        'cancelled'
+    ) NOT NULL DEFAULT 'pending_confirmation',
+    confirmation_token_hash CHAR(64) NOT NULL,
+    confirmation_expires_at DATETIME NOT NULL,
+    confirmed_at DATETIME NULL,
+    receipt_id VARCHAR(64) NULL,
+    reason VARCHAR(500) NULL,
+    requested_ip VARCHAR(45) NULL,
+    user_agent VARCHAR(512) NULL,
+    original_email_hash CHAR(64) NULL,
+    stages_json JSON NULL,
+    error_message TEXT NULL,
+    completed_at DATETIME NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_erasure_receipt (receipt_id),
+    INDEX idx_erasure_user (user_id),
+    INDEX idx_erasure_status (status),
+    INDEX idx_erasure_token (confirmation_token_hash),
+    INDEX idx_erasure_created (created_at),
+
+    CONSTRAINT fk_erasure_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS erasure_receipts (
+    id CHAR(36) PRIMARY KEY,
+    receipt_id VARCHAR(64) NOT NULL,
+    erasure_request_id CHAR(36) NOT NULL,
+    user_id CHAR(36) NULL,
+    summary_json JSON NULL,
+    issued_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_receipt_id (receipt_id),
+    INDEX idx_receipt_request (erasure_request_id),
+    INDEX idx_receipt_issued (issued_at),
+
+    CONSTRAINT fk_receipt_request FOREIGN KEY (erasure_request_id)
+        REFERENCES erasure_requests(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
# #1397 issue resolved

## Description

This PR adds a staged GDPR/DPDP data erasure workflow under `backend/services` and admin tools.

## Features

- Erasure request + confirmation email
- Anonymization strategy for legal order records
- Cascade purge of refresh tokens, sessions & carts
- Erasure receipt ID for the user
- Admin status tracker for erasure requests