### PR TITLE
API Contract Test Suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,9 +96,45 @@ until it finishes.
 ---
 
 ## Testing
-- Backend: test endpoints using Postman.
+- Backend: run ```cd backend && npm test``` (Jest). Contract suite only:
+  ```npm run test:contract```.
 - Frontend: test forms, cart, checkout, orders, wishlist, and profile.
 - Ensure all features work both logged-in and logged-out.
+
+### API contract suite (#1395)
+
+Core HTTP contracts live in ```backend/openapi/ecommerce.openapi.yaml```.
+CI-friendly checks under ```backend/tests/contract/``` assert:
+
+- OpenAPI document shape and required paths
+- Fixture payloads for **401 / 409 / 422** (and happy paths) against schemas
+- Pact-like **consumer** expectations for auth, cart, checkout, products, orders
+
+Optional OpenAPI lint (Spectral, via npx):
+
+```
+cd backend
+npm run lint:openapi
+```
+
+See ```backend/docs/api-contract.md``` for layout details.
+
+### Breaking-change checklist (API)
+
+Before merging a PR that changes request/response JSON for auth, cart,
+checkout, products, or orders, confirm:
+
+1. [ ] ```backend/openapi/ecommerce.openapi.yaml``` updated (schemas, status codes, examples)
+2. [ ] Contract fixtures under ```backend/tests/contract/fixtures/``` updated when envelopes change
+3. [ ] Consumer expectations in ```backend/tests/contract/consumer.pactlike.test.js``` still pass
+4. [ ] ```npm run test:contract``` is green locally
+5. [ ] Frontend callers (```frontend/scripts/*.js```) updated if field names/codes changed
+6. [ ] Error ```code``` values (e.g. ```INVENTORY_CONFLICT```, ```TOTAL_MISMATCH```) are not renamed without a migration note in the PR
+7. [ ] Pagination fields (```total```, ```page```, ```limit```, ```totalPages```) remain present on list endpoints
+8. [ ] Envelope always includes ```success``` (boolean); errors include ```message```
+
+Renaming or removing a documented field without the checklist above is a
+**breaking contract change** and should be called out in the PR title/body.
 
 ---
 

--- a/backend/docs/api-contract.md
+++ b/backend/docs/api-contract.md
@@ -1,0 +1,27 @@
+# API contract suite (#1395)
+
+Published OpenAPI lives at [`../openapi/ecommerce.openapi.yaml`](../openapi/ecommerce.openapi.yaml).
+
+## Run
+
+```bash
+cd backend
+npm test -- --testPathPattern=contract --coverage=false
+```
+
+Optional Spectral lint (downloads CLI via npx when needed):
+
+```bash
+cd backend
+npm run lint:openapi
+```
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `openapi/ecommerce.openapi.yaml` | Source of truth for auth/cart/checkout/products/orders |
+| `tests/contract/*.test.js` | Document, fixture, and consumer (Pact-like) checks |
+| `tests/contract/fixtures/` | Example 401 / 409 / 422 (+ happy-path) payloads |
+
+When you change a response envelope, update the OpenAPI schema **and** the matching fixture or consumer expectation in the same PR.

--- a/backend/openapi/.spectral.yaml
+++ b/backend/openapi/.spectral.yaml
@@ -1,0 +1,12 @@
+# Spectral rules for backend/openapi/ecommerce.openapi.yaml (#1395)
+# Optional: npm run lint:openapi
+
+extends: ["spectral:oas"]
+
+rules:
+  operation-operationId: error
+  operation-tags: warn
+  info-contact: off
+  oas3-api-servers: warn
+  operation-description: off
+  tag-description: off

--- a/backend/openapi/ecommerce.openapi.yaml
+++ b/backend/openapi/ecommerce.openapi.yaml
@@ -1,0 +1,1006 @@
+openapi: 3.0.3
+info:
+  title: E-commerce Core API
+  description: |
+    Contract surface for auth, products, cart, checkout, and orders.
+    All JSON responses use the shared envelope (`success`, `message`, …).
+    Maintained for CI contract tests (#1395) — keep in sync with Express routes.
+  version: 1.0.0
+  contact:
+    name: E-commerce contributors
+
+servers:
+  - url: http://localhost:5000/api
+    description: Local development
+  - url: https://e-commerce-production-d546.up.railway.app/api
+    description: Production (Railway)
+
+tags:
+  - name: Auth
+  - name: Products
+  - name: Cart
+  - name: Checkout
+  - name: Orders
+
+paths:
+  /auth/status:
+    get:
+      tags: [Auth]
+      summary: Auth API health
+      operationId: getAuthStatus
+      responses:
+        "200":
+          description: Auth service is up
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessEnvelope"
+              example:
+                success: true
+                message: Auth API running
+
+  /auth/login:
+    post:
+      tags: [Auth]
+      summary: Sign in
+      operationId: login
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+      responses:
+        "200":
+          description: Login succeeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LoginSuccess"
+        "401":
+          description: Invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+              examples:
+                unauthorized:
+                  $ref: "#/components/examples/Unauthorized401"
+        "422":
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationErrorEnvelope"
+              examples:
+                validation:
+                  $ref: "#/components/examples/Validation422"
+
+  /auth/signup:
+    post:
+      tags: [Auth]
+      summary: Begin signup (OTP flow)
+      operationId: signup
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SignupRequest"
+      responses:
+        "200":
+          description: OTP sent / signup pending
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessEnvelope"
+        "422":
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationErrorEnvelope"
+
+  /auth/me:
+    get:
+      tags: [Auth]
+      summary: Current user
+      operationId: getMe
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Authenticated user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MeSuccess"
+        "401":
+          description: Missing or invalid token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+              examples:
+                unauthorized:
+                  $ref: "#/components/examples/Unauthorized401"
+
+  /auth/refresh-token:
+    post:
+      tags: [Auth]
+      summary: Rotate refresh token
+      operationId: refreshToken
+      responses:
+        "200":
+          description: New access token issued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenRefreshSuccess"
+        "401":
+          description: Refresh token missing or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /products:
+    get:
+      tags: [Products]
+      summary: List products (paginated)
+      operationId: listProducts
+      parameters:
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/limit"
+        - name: sort
+          in: query
+          schema:
+            type: string
+        - name: search
+          in: query
+          schema:
+            type: string
+        - name: category
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Product page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProductListSuccess"
+
+  /products/{id}:
+    get:
+      tags: [Products]
+      summary: Product detail
+      operationId: getProduct
+      parameters:
+        - $ref: "#/components/parameters/productId"
+      responses:
+        "200":
+          description: Product found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProductDetailSuccess"
+        "404":
+          description: Product not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /products/status/check:
+    get:
+      tags: [Products]
+      summary: Product API health
+      operationId: getProductStatus
+      responses:
+        "200":
+          description: Product service is up
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessEnvelope"
+
+  /cart:
+    get:
+      tags: [Cart]
+      summary: Get authenticated cart
+      operationId: getCart
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Cart contents
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CartSuccess"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /cart/add:
+    post:
+      tags: [Cart]
+      summary: Add line with inventory reservation
+      operationId: addCartItem
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CartAddRequest"
+      responses:
+        "200":
+          description: Item reserved and added
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessEnvelope"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "409":
+          description: Inventory conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryConflictEnvelope"
+              examples:
+                conflict:
+                  $ref: "#/components/examples/InventoryConflict409"
+
+  /cart/sync:
+    post:
+      tags: [Cart]
+      summary: Sync client cart to server
+      operationId: syncCart
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [items]
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/CartLineInput"
+      responses:
+        "200":
+          description: Cart synced
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessEnvelope"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /checkout/quote:
+    post:
+      tags: [Checkout]
+      summary: Server-authoritative basket quote
+      operationId: checkoutQuote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CheckoutQuoteRequest"
+      responses:
+        "200":
+          description: Priced breakdown
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CheckoutQuoteSuccess"
+        "400":
+          description: Could not price basket
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /checkout/challenge/issue:
+    post:
+      tags: [Checkout]
+      summary: Issue bot-resistance PoW challenge
+      operationId: issueCheckoutChallenge
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [idempotencyKey]
+              properties:
+                idempotencyKey:
+                  type: string
+                  minLength: 8
+                riskScore:
+                  type: number
+                riskLevel:
+                  type: string
+      responses:
+        "201":
+          description: Challenge issued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChallengeIssuedSuccess"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /orders:
+    post:
+      tags: [Orders]
+      summary: Create order (COD / UPI)
+      operationId: createOrder
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateOrderRequest"
+      responses:
+        "201":
+          description: Order created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrderCreatedSuccess"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "409":
+          description: Inventory or total mismatch
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/InventoryConflictEnvelope"
+                  - $ref: "#/components/schemas/TotalMismatchEnvelope"
+              examples:
+                inventory:
+                  $ref: "#/components/examples/InventoryConflict409"
+                totalMismatch:
+                  $ref: "#/components/examples/TotalMismatch409"
+        "422":
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationErrorEnvelope"
+
+  /orders/create-payment-intent:
+    post:
+      tags: [Orders]
+      summary: Create order + Stripe payment intent
+      operationId: createPaymentIntent
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateOrderRequest"
+      responses:
+        "201":
+          description: Payment intent created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaymentIntentSuccess"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "409":
+          description: Inventory or total mismatch
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryConflictEnvelope"
+
+  /orders/my-orders:
+    get:
+      tags: [Orders]
+      summary: List current user orders
+      operationId: listMyOrders
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/limit"
+      responses:
+        "200":
+          description: Paginated orders
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MyOrdersSuccess"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  parameters:
+    page:
+      name: page
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    limit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+    productId:
+      name: id
+      in: path
+      required: true
+      description: Product UUID (CHAR(36))
+      schema:
+        type: string
+        format: uuid
+
+  examples:
+    Unauthorized401:
+      summary: Missing or invalid JWT
+      value:
+        success: false
+        message: Unauthorized
+    InventoryConflict409:
+      summary: Stock lock conflict
+      value:
+        success: false
+        code: INVENTORY_CONFLICT
+        message: Inventory locks expired or insufficient stock
+        productId: "550e8400-e29b-41d4-a716-446655440000"
+        availableStock: 2
+        requested: 5
+    TotalMismatch409:
+      summary: Client total disagrees with server quote
+      value:
+        success: false
+        code: TOTAL_MISMATCH
+        message: Submitted total does not match server price
+        submittedTotal: 999
+        computedTotal: 1048
+    Validation422:
+      summary: Request body failed validation
+      value:
+        success: false
+        message: Validation failed
+        details:
+          - email is required
+          - password must be at least 8 characters
+
+  schemas:
+    SuccessEnvelope:
+      type: object
+      required: [success]
+      additionalProperties: true
+      properties:
+        success:
+          type: boolean
+          const: true
+        message:
+          type: string
+
+    ErrorEnvelope:
+      type: object
+      required: [success, message]
+      additionalProperties: true
+      properties:
+        success:
+          type: boolean
+          const: false
+        message:
+          type: string
+        code:
+          type: string
+
+    ValidationErrorEnvelope:
+      type: object
+      required: [success, message]
+      properties:
+        success:
+          type: boolean
+          const: false
+        message:
+          type: string
+        details:
+          type: array
+          items:
+            type: string
+        errors:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+
+    InventoryConflictEnvelope:
+      type: object
+      required: [success, code, message]
+      properties:
+        success:
+          type: boolean
+          const: false
+        code:
+          type: string
+          enum: [INVENTORY_CONFLICT]
+        message:
+          type: string
+        productId:
+          oneOf:
+            - type: string
+            - type: "null"
+        availableStock:
+          type: number
+          nullable: true
+        requested:
+          type: number
+          nullable: true
+
+    TotalMismatchEnvelope:
+      type: object
+      required: [success, code, message]
+      properties:
+        success:
+          type: boolean
+          const: false
+        code:
+          type: string
+          enum: [TOTAL_MISMATCH]
+        message:
+          type: string
+        submittedTotal:
+          type: number
+        computedTotal:
+          type: number
+
+    PaginationMeta:
+      type: object
+      required: [total, page, limit, totalPages]
+      properties:
+        total:
+          type: integer
+          minimum: 0
+        page:
+          type: integer
+          minimum: 1
+        limit:
+          type: integer
+          minimum: 1
+        totalPages:
+          type: integer
+          minimum: 1
+        hasNextPage:
+          type: boolean
+        hasPrevPage:
+          type: boolean
+
+    LoginRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 1
+
+    SignupRequest:
+      type: object
+      required: [name, email, password]
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 8
+
+    UserSummary:
+      type: object
+      required: [id, email]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+
+    LoginSuccess:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          const: true
+        message:
+          type: string
+        token:
+          type: string
+        accessToken:
+          type: string
+        refreshToken:
+          type: string
+        user:
+          $ref: "#/components/schemas/UserSummary"
+
+    MeSuccess:
+      type: object
+      required: [success, user]
+      properties:
+        success:
+          type: boolean
+          const: true
+        user:
+          $ref: "#/components/schemas/UserSummary"
+
+    TokenRefreshSuccess:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          const: true
+        token:
+          type: string
+        accessToken:
+          type: string
+        refreshToken:
+          type: string
+
+    Product:
+      type: object
+      required: [id, name, price]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        price:
+          type: number
+        stock:
+          type: number
+        category:
+          type: string
+        image:
+          type: string
+        description:
+          type: string
+
+    ProductListSuccess:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          const: true
+        products:
+          type: array
+          items:
+            $ref: "#/components/schemas/Product"
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Product"
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
+        totalPages:
+          type: integer
+        hasNextPage:
+          type: boolean
+        hasPrevPage:
+          type: boolean
+        message:
+          type: string
+
+    ProductDetailSuccess:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          const: true
+        product:
+          $ref: "#/components/schemas/Product"
+        data:
+          $ref: "#/components/schemas/Product"
+        message:
+          type: string
+
+    CartLineInput:
+      type: object
+      required: [productId, quantity]
+      properties:
+        productId:
+          type: string
+        quantity:
+          type: integer
+          minimum: 1
+        variantId:
+          type: integer
+        color:
+          type: string
+        size:
+          type: string
+
+    CartAddRequest:
+      allOf:
+        - $ref: "#/components/schemas/CartLineInput"
+
+    CartItem:
+      type: object
+      properties:
+        productId:
+          type: string
+        quantity:
+          type: integer
+        name:
+          type: string
+        price:
+          type: number
+        color:
+          type: string
+        size:
+          type: string
+
+    CartSuccess:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          const: true
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CartItem"
+        cart:
+          type: array
+          items:
+            $ref: "#/components/schemas/CartItem"
+        message:
+          type: string
+
+    PriceBreakdown:
+      type: object
+      required: [subtotal, tax, shipping, discount, total]
+      properties:
+        subtotal:
+          type: number
+        tax:
+          type: number
+        shipping:
+          type: number
+        discount:
+          type: number
+        total:
+          type: number
+        promoCode:
+          type: string
+          nullable: true
+        currency:
+          type: string
+
+    CheckoutQuoteRequest:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CartLineInput"
+        promoCode:
+          type: string
+
+    CheckoutQuoteSuccess:
+      type: object
+      required: [success, breakdown]
+      properties:
+        success:
+          type: boolean
+          const: true
+        breakdown:
+          $ref: "#/components/schemas/PriceBreakdown"
+        promoMessage:
+          type: string
+          nullable: true
+
+    ChallengeIssuedSuccess:
+      type: object
+      required: [success, challenge]
+      properties:
+        success:
+          type: boolean
+          const: true
+        message:
+          type: string
+        challenge:
+          type: object
+          required: [challengeId, idempotencyKey, difficulty, algorithm]
+          properties:
+            challengeId:
+              type: string
+            idempotencyKey:
+              type: string
+            difficulty:
+              type: integer
+            algorithm:
+              type: string
+            prefix:
+              type: string
+            expiresAt:
+              type: string
+            ttlSec:
+              type: integer
+            puzzle:
+              type: string
+
+    CreateOrderRequest:
+      type: object
+      required: [customer, address, items, total, paymentMethod]
+      properties:
+        customer:
+          type: object
+          required: [name, email]
+          properties:
+            name:
+              type: string
+            email:
+              type: string
+              format: email
+            phone:
+              type: string
+        address:
+          type: object
+          required: [fullAddress]
+          properties:
+            city:
+              type: string
+            state:
+              type: string
+            zip:
+              type: string
+            fullAddress:
+              type: string
+        addressId:
+          type: string
+          nullable: true
+        items:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/CartLineInput"
+        total:
+          type: number
+          exclusiveMinimum: 0
+        paymentMethod:
+          type: string
+          enum: [cod, card, upi, paypal]
+        promoCode:
+          type: string
+        idempotencyKey:
+          type: string
+
+    OrderCreatedSuccess:
+      type: object
+      required: [success, orderId]
+      properties:
+        success:
+          type: boolean
+          const: true
+        message:
+          type: string
+        orderId:
+          type: string
+        breakdown:
+          $ref: "#/components/schemas/PriceBreakdown"
+        addressId:
+          type: string
+          nullable: true
+
+    PaymentIntentSuccess:
+      type: object
+      required: [success, clientSecret, orderId]
+      properties:
+        success:
+          type: boolean
+          const: true
+        clientSecret:
+          type: string
+        orderId:
+          type: string
+        breakdown:
+          $ref: "#/components/schemas/PriceBreakdown"
+
+    MyOrdersSuccess:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          const: true
+        orders:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
+        totalPages:
+          type: integer
+        message:
+          type: string

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -35,6 +35,7 @@
         "helmet": "^8.2.0",
         "ioredis": "^5.11.1",
         "joi": "^18.2.3",
+        "js-yaml": "^4.3.1",
         "json2csv": "^6.0.0-alpha.2",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.7.4",
@@ -2107,6 +2108,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
@@ -3555,14 +3580,10 @@
       "license": "MIT"
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -7639,14 +7660,22 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "dev": true,
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,9 @@
     "test:ci": "jest --coverage --ci --maxWorkers=2",
     "test:verbose": "jest --verbose",
     "test:only": "jest --onlyChanged",
-    "test:update": "jest --updateSnapshot"
+    "test:update": "jest --updateSnapshot",
+    "test:contract": "jest --testPathPattern=contract --coverage=false",
+    "lint:openapi": "npx --yes @stoplight/spectral-cli lint openapi/ecommerce.openapi.yaml -r openapi/.spectral.yaml"
   },
   "keywords": [],
   "author": "",
@@ -47,6 +49,7 @@
     "helmet": "^8.2.0",
     "ioredis": "^5.11.1",
     "joi": "^18.2.3",
+    "js-yaml": "^4.3.1",
     "json2csv": "^6.0.0-alpha.2",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.7.4",

--- a/backend/tests/contract/consumer.pactlike.test.js
+++ b/backend/tests/contract/consumer.pactlike.test.js
@@ -1,0 +1,181 @@
+/**
+ * Pact-like consumer contract checks (#1395).
+ *
+ * These encode what the vanilla JS storefront (consumer) expects from the
+ * Express API (provider). They do not spin a live server — they freeze the
+ * response shapes the UI already depends on and validate them against the
+ * published OpenAPI schemas so frontend/backend drift fails in CI.
+ */
+
+const {
+    loadOpenApi,
+    createAjv,
+    compileSchema,
+    assertValid
+} = require("./helpers/loadOpenApi");
+
+describe("consumer contracts (storefront expectations)", () => {
+    let openapi;
+    let ajv;
+
+    beforeAll(() => {
+        openapi = loadOpenApi();
+        ajv = createAjv();
+    });
+
+    describe("auth consumer", () => {
+        test("login success exposes token + user for localStorage", () => {
+            const body = {
+                success: true,
+                message: "Login successful",
+                token: "access.jwt.token",
+                refreshToken: "refresh.jwt.token",
+                user: {
+                    id: "u-1",
+                    name: "Ada",
+                    email: "ada@example.com",
+                    role: "customer"
+                }
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "LoginSuccess"),
+                body,
+                "auth login consumer"
+            );
+            expect(body.token || body.accessToken).toBeTruthy();
+            expect(body.user.email).toContain("@");
+        });
+
+        test("401 login failure is a flat error envelope (no nested data required)", () => {
+            const body = { success: false, message: "Invalid credentials" };
+            assertValid(
+                compileSchema(ajv, openapi, "ErrorEnvelope"),
+                body,
+                "auth 401 consumer"
+            );
+            expect(body.success).toBe(false);
+        });
+    });
+
+    describe("products consumer", () => {
+        test("list payload keeps pagination fields the shop grid reads", () => {
+            const body = {
+                success: true,
+                products: [
+                    {
+                        id: "550e8400-e29b-41d4-a716-446655440010",
+                        name: "Tee",
+                        price: 499,
+                        stock: 12,
+                        category: "mens"
+                    }
+                ],
+                total: 1,
+                page: 1,
+                limit: 20,
+                totalPages: 1,
+                hasNextPage: false,
+                hasPrevPage: false
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "ProductListSuccess"),
+                body,
+                "products list consumer"
+            );
+        });
+    });
+
+    describe("cart consumer", () => {
+        test("add-to-cart success is a SuccessEnvelope the toast can show", () => {
+            const body = {
+                success: true,
+                message: "Product added to cart and reserved for 15 minutes"
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "SuccessEnvelope"),
+                body,
+                "cart add consumer"
+            );
+        });
+
+        test("inventory 409 carries code the checkout UI branches on", () => {
+            const body = {
+                success: false,
+                code: "INVENTORY_CONFLICT",
+                message: "Insufficient stock",
+                productId: "p-1",
+                availableStock: 0,
+                requested: 2
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "InventoryConflictEnvelope"),
+                body,
+                "cart 409 consumer"
+            );
+            expect(body.code).toBe("INVENTORY_CONFLICT");
+        });
+    });
+
+    describe("checkout consumer", () => {
+        test("quote returns breakdown.total used to submit orders", () => {
+            const body = {
+                success: true,
+                breakdown: {
+                    subtotal: 1000,
+                    tax: 180,
+                    shipping: 0,
+                    discount: 50,
+                    total: 1130,
+                    promoCode: "SAVE50",
+                    currency: "INR"
+                },
+                promoMessage: null
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "CheckoutQuoteSuccess"),
+                body,
+                "checkout quote consumer"
+            );
+            expect(typeof body.breakdown.total).toBe("number");
+        });
+    });
+
+    describe("orders consumer", () => {
+        test("create order success exposes orderId for success.html redirect", () => {
+            const body = {
+                success: true,
+                message: "Order placed successfully",
+                orderId: "550e8400-e29b-41d4-a716-446655440099",
+                breakdown: {
+                    subtotal: 1000,
+                    tax: 180,
+                    shipping: 49,
+                    discount: 0,
+                    total: 1229
+                },
+                addressId: null
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "OrderCreatedSuccess"),
+                body,
+                "orders create consumer"
+            );
+            expect(body.orderId).toBeTruthy();
+        });
+
+        test("TOTAL_MISMATCH 409 matches what checkout.js refreshes on", () => {
+            const body = {
+                success: false,
+                code: "TOTAL_MISMATCH",
+                message: "Submitted total does not match server price",
+                submittedTotal: 100,
+                computedTotal: 120
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "TotalMismatchEnvelope"),
+                body,
+                "orders 409 consumer"
+            );
+        });
+    });
+});

--- a/backend/tests/contract/envelope.contract.test.js
+++ b/backend/tests/contract/envelope.contract.test.js
@@ -1,0 +1,76 @@
+/**
+ * Fixture ↔ OpenAPI schema contract tests (#1395).
+ * Example payloads for 401 / 409 / 422 (and happy paths) must match the spec.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const {
+    loadOpenApi,
+    createAjv,
+    compileSchema,
+    assertValid
+} = require("./helpers/loadOpenApi");
+
+const FIXTURES = path.join(__dirname, "fixtures");
+
+function readFixture(name) {
+    return JSON.parse(fs.readFileSync(path.join(FIXTURES, name), "utf8"));
+}
+
+describe("contract fixtures vs OpenAPI schemas", () => {
+    let openapi;
+    let ajv;
+
+    beforeAll(() => {
+        openapi = loadOpenApi();
+        ajv = createAjv();
+    });
+
+    test("401 unauthorized matches ErrorEnvelope", () => {
+        const validate = compileSchema(ajv, openapi, "ErrorEnvelope");
+        assertValid(validate, readFixture("401.unauthorized.json"), "401 fixture");
+    });
+
+    test("409 inventory conflict matches InventoryConflictEnvelope", () => {
+        const validate = compileSchema(ajv, openapi, "InventoryConflictEnvelope");
+        assertValid(
+            validate,
+            readFixture("409.inventory-conflict.json"),
+            "409 inventory fixture"
+        );
+    });
+
+    test("409 total mismatch matches TotalMismatchEnvelope", () => {
+        const validate = compileSchema(ajv, openapi, "TotalMismatchEnvelope");
+        assertValid(
+            validate,
+            readFixture("409.total-mismatch.json"),
+            "409 total mismatch fixture"
+        );
+    });
+
+    test("422 validation matches ValidationErrorEnvelope", () => {
+        const validate = compileSchema(ajv, openapi, "ValidationErrorEnvelope");
+        assertValid(validate, readFixture("422.validation.json"), "422 fixture");
+    });
+
+    test("200 login success matches LoginSuccess", () => {
+        const validate = compileSchema(ajv, openapi, "LoginSuccess");
+        assertValid(validate, readFixture("200.login-success.json"), "login fixture");
+    });
+
+    test("200 checkout quote matches CheckoutQuoteSuccess", () => {
+        const validate = compileSchema(ajv, openapi, "CheckoutQuoteSuccess");
+        assertValid(
+            validate,
+            readFixture("200.checkout-quote.json"),
+            "checkout quote fixture"
+        );
+    });
+
+    test("rejecting a broken envelope (missing success) fails validation", () => {
+        const validate = compileSchema(ajv, openapi, "ErrorEnvelope");
+        expect(validate({ message: "no success flag" })).toBe(false);
+    });
+});

--- a/backend/tests/contract/fixtures/200.checkout-quote.json
+++ b/backend/tests/contract/fixtures/200.checkout-quote.json
@@ -1,0 +1,13 @@
+{
+  "success": true,
+  "breakdown": {
+    "subtotal": 999,
+    "tax": 179.82,
+    "shipping": 49,
+    "discount": 0,
+    "total": 1227.82,
+    "promoCode": null,
+    "currency": "INR"
+  },
+  "promoMessage": null
+}

--- a/backend/tests/contract/fixtures/200.login-success.json
+++ b/backend/tests/contract/fixtures/200.login-success.json
@@ -1,0 +1,12 @@
+{
+  "success": true,
+  "message": "Login successful",
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.example",
+  "refreshToken": "refresh_example_token",
+  "user": {
+    "id": "550e8400-e29b-41d4-a716-446655440001",
+    "name": "Shopper",
+    "email": "shopper@example.com",
+    "role": "customer"
+  }
+}

--- a/backend/tests/contract/fixtures/401.unauthorized.json
+++ b/backend/tests/contract/fixtures/401.unauthorized.json
@@ -1,0 +1,4 @@
+{
+  "success": false,
+  "message": "Unauthorized"
+}

--- a/backend/tests/contract/fixtures/409.inventory-conflict.json
+++ b/backend/tests/contract/fixtures/409.inventory-conflict.json
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "code": "INVENTORY_CONFLICT",
+  "message": "Inventory locks expired or insufficient stock",
+  "productId": "550e8400-e29b-41d4-a716-446655440000",
+  "availableStock": 2,
+  "requested": 5
+}

--- a/backend/tests/contract/fixtures/409.total-mismatch.json
+++ b/backend/tests/contract/fixtures/409.total-mismatch.json
@@ -1,0 +1,7 @@
+{
+  "success": false,
+  "code": "TOTAL_MISMATCH",
+  "message": "Submitted total does not match server price",
+  "submittedTotal": 999,
+  "computedTotal": 1048
+}

--- a/backend/tests/contract/fixtures/422.validation.json
+++ b/backend/tests/contract/fixtures/422.validation.json
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "message": "Validation failed",
+  "details": [
+    "email is required",
+    "password must be at least 8 characters"
+  ]
+}

--- a/backend/tests/contract/helpers/loadOpenApi.js
+++ b/backend/tests/contract/helpers/loadOpenApi.js
@@ -1,0 +1,107 @@
+/**
+ * OpenAPI loader + AJV helpers for contract tests (#1395).
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const OPENAPI_PATH = path.join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "openapi",
+    "ecommerce.openapi.yaml"
+);
+
+function loadYaml(filePath) {
+    const raw = fs.readFileSync(filePath, "utf8");
+    let yaml;
+    try {
+        yaml = require("js-yaml");
+    } catch (err) {
+        throw new Error(
+            "js-yaml is required for OpenAPI contract tests. Run `npm install` in backend/."
+        );
+    }
+    return yaml.load(raw);
+}
+
+function loadOpenApi() {
+    const doc = loadYaml(OPENAPI_PATH);
+    if (!doc || doc.openapi !== "3.0.3") {
+        throw new Error("Expected OpenAPI 3.0.3 document at openapi/ecommerce.openapi.yaml");
+    }
+    return doc;
+}
+
+function createAjv() {
+    const Ajv = require("ajv");
+    const addFormats = require("ajv-formats");
+    const ajv = new Ajv({
+        allErrors: true,
+        strict: false,
+        validateSchema: false
+    });
+    addFormats(ajv);
+    return ajv;
+}
+
+/**
+ * Compile a component schema by name, resolving local $refs within components.
+ */
+function compileSchema(ajv, openapi, schemaName) {
+    const components = openapi.components || {};
+    const schemas = components.schemas || {};
+    if (!schemas[schemaName]) {
+        throw new Error(`Unknown schema: ${schemaName}`);
+    }
+
+    // Register every component schema once so $ref resolution works.
+    if (!ajv.getSchema("https://ecommerce.local/openapi.json")) {
+        ajv.addSchema(
+            {
+                $id: "https://ecommerce.local/openapi.json",
+                components: { schemas }
+            },
+            "https://ecommerce.local/openapi.json"
+        );
+    }
+
+    const ref = {
+        $ref: `https://ecommerce.local/openapi.json#/components/schemas/${schemaName}`
+    };
+    return ajv.compile(ref);
+}
+
+function assertValid(validate, payload, label) {
+    const ok = validate(payload);
+    if (!ok) {
+        const details = (validate.errors || [])
+            .map((e) => `${e.instancePath || "/"} ${e.message}`)
+            .join("; ");
+        throw new Error(`${label} failed schema validation: ${details}`);
+    }
+}
+
+function listCorePaths(openapi) {
+    return Object.keys(openapi.paths || {}).sort();
+}
+
+function responseStatusesFor(openapi, pathKey, method) {
+    const op = openapi.paths?.[pathKey]?.[method];
+    if (!op) return [];
+    return Object.keys(op.responses || {}).map(String);
+}
+
+module.exports = {
+    OPENAPI_PATH,
+    loadOpenApi,
+    createAjv,
+    compileSchema,
+    assertValid,
+    listCorePaths,
+    responseStatusesFor
+};

--- a/backend/tests/contract/openapi.document.test.js
+++ b/backend/tests/contract/openapi.document.test.js
@@ -1,0 +1,77 @@
+/**
+ * OpenAPI document structure contract (#1395).
+ */
+
+const path = require("path");
+const fs = require("fs");
+const {
+    OPENAPI_PATH,
+    loadOpenApi,
+    listCorePaths,
+    responseStatusesFor
+} = require("./helpers/loadOpenApi");
+
+describe("OpenAPI document", () => {
+    test("ecommerce.openapi.yaml exists", () => {
+        expect(fs.existsSync(OPENAPI_PATH)).toBe(true);
+    });
+
+    test("is OpenAPI 3.0.3 with core tags and security scheme", () => {
+        const doc = loadOpenApi();
+        expect(doc.info.title).toMatch(/e-commerce/i);
+        expect(doc.tags.map((t) => t.name)).toEqual(
+            expect.arrayContaining(["Auth", "Products", "Cart", "Checkout", "Orders"])
+        );
+        expect(doc.components.securitySchemes.bearerAuth.scheme).toBe("bearer");
+    });
+
+    test("publishes core auth/cart/checkout/products/orders paths", () => {
+        const doc = loadOpenApi();
+        const paths = listCorePaths(doc);
+        expect(paths).toEqual(
+            expect.arrayContaining([
+                "/auth/login",
+                "/auth/me",
+                "/auth/status",
+                "/products",
+                "/products/{id}",
+                "/cart",
+                "/cart/add",
+                "/checkout/quote",
+                "/orders",
+                "/orders/create-payment-intent",
+                "/orders/my-orders"
+            ])
+        );
+    });
+
+    test("documents 401/409/422 on critical write paths", () => {
+        const doc = loadOpenApi();
+        expect(responseStatusesFor(doc, "/auth/login", "post")).toEqual(
+            expect.arrayContaining(["200", "401", "422"])
+        );
+        expect(responseStatusesFor(doc, "/cart/add", "post")).toEqual(
+            expect.arrayContaining(["200", "401", "409"])
+        );
+        expect(responseStatusesFor(doc, "/orders", "post")).toEqual(
+            expect.arrayContaining(["201", "401", "409", "422"])
+        );
+    });
+
+    test("defines shared envelope and pagination schemas", () => {
+        const doc = loadOpenApi();
+        const schemas = Object.keys(doc.components.schemas);
+        expect(schemas).toEqual(
+            expect.arrayContaining([
+                "SuccessEnvelope",
+                "ErrorEnvelope",
+                "ValidationErrorEnvelope",
+                "InventoryConflictEnvelope",
+                "TotalMismatchEnvelope",
+                "PaginationMeta",
+                "PriceBreakdown",
+                "CreateOrderRequest"
+            ])
+        );
+    });
+});


### PR DESCRIPTION
# #1395 issue resolved

## Description

This PR adds an OpenAPI 3 contract suite and CI-friendly Jest checks under `backend/openapi`, `backend/tests/contract`, and `CONTRIBUTING.md`.

## Features

- OpenAPI 3 spec for core auth/cart/checkout/products/orders routes
- Jest contract tests for status codes, envelope shape, and critical schemas
- Example fixtures for 401 / 409 / 422
- Breaking-change checklist in CONTRIBUTING
- Optional Spectral lint (`npm run lint:openapi`)