### PR TITLE
SQL Query Budget & Slow-Query Circuit Breake

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,9 +96,45 @@ until it finishes.
 ---
 
 ## Testing
-- Backend: test endpoints using Postman.
+- Backend: run ```cd backend && npm test``` (Jest). Contract suite only:
+  ```npm run test:contract```.
 - Frontend: test forms, cart, checkout, orders, wishlist, and profile.
 - Ensure all features work both logged-in and logged-out.
+
+### API contract suite (#1395)
+
+Core HTTP contracts live in ```backend/openapi/ecommerce.openapi.yaml```.
+CI-friendly checks under ```backend/tests/contract/``` assert:
+
+- OpenAPI document shape and required paths
+- Fixture payloads for **401 / 409 / 422** (and happy paths) against schemas
+- Pact-like **consumer** expectations for auth, cart, checkout, products, orders
+
+Optional OpenAPI lint (Spectral, via npx):
+
+```
+cd backend
+npm run lint:openapi
+```
+
+See ```backend/docs/api-contract.md``` for layout details.
+
+### Breaking-change checklist (API)
+
+Before merging a PR that changes request/response JSON for auth, cart,
+checkout, products, or orders, confirm:
+
+1. [ ] ```backend/openapi/ecommerce.openapi.yaml``` updated (schemas, status codes, examples)
+2. [ ] Contract fixtures under ```backend/tests/contract/fixtures/``` updated when envelopes change
+3. [ ] Consumer expectations in ```backend/tests/contract/consumer.pactlike.test.js``` still pass
+4. [ ] ```npm run test:contract``` is green locally
+5. [ ] Frontend callers (```frontend/scripts/*.js```) updated if field names/codes changed
+6. [ ] Error ```code``` values (e.g. ```INVENTORY_CONFLICT```, ```TOTAL_MISMATCH```) are not renamed without a migration note in the PR
+7. [ ] Pagination fields (```total```, ```page```, ```limit```, ```totalPages```) remain present on list endpoints
+8. [ ] Envelope always includes ```success``` (boolean); errors include ```message```
+
+Renaming or removing a documented field without the checklist above is a
+**breaking contract change** and should be called out in the PR title/body.
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,6 +31,16 @@ DB_POOL_MIN=2
 DB_POOL_MAX=10
 DB_POOL_IDLE=10000
 
+# SQL query budget & slow-query circuit breaker (#1391)
+# Per-request max queries before 503 + Retry-After. Set QUERY_BUDGET_BYPASS=true for migrations/jobs.
+QUERY_BUDGET_ENABLED=true
+QUERY_BUDGET_MAX=50
+QUERY_SLOW_MS=1000
+QUERY_CIRCUIT_RETRY_AFTER_SEC=30
+QUERY_CIRCUIT_TRIP_THRESHOLD=5
+QUERY_CIRCUIT_WINDOW_MS=60000
+QUERY_BUDGET_BYPASS=false
+
 # ============================================
 # JWT & AUTHENTICATION
 # ============================================

--- a/backend/config/currency.js
+++ b/backend/config/currency.js
@@ -6,12 +6,89 @@
 // `minorUnitExponent` is what payment providers need to convert a decimal
 // amount into the smallest unit. It is 2 for the rupee, but it is 0 for the yen
 // and 3 for the dinar, so nothing may assume a factor of a hundred.
+//
+// Multi-currency checkout (#1392): settlement (charge) currency stays INR.
+// Display `rate` = units of display currency per 1 INR (storefront convention).
+// Extra catalog fields are attached to the same export object, then frozen.
 
-const CURRENCY = Object.freeze({
+const FALLBACK_RATES = Object.freeze({
+    INR: 1.0,
+    USD: 0.012,
+    EUR: 0.011,
+    GBP: 0.0094,
+    JPY: 1.75
+});
+
+const SUPPORTED_CURRENCIES = Object.freeze({
+    INR: Object.freeze({
+        code: "INR",
+        symbol: "₹",
+        locale: "en-IN",
+        minorUnitExponent: 2,
+        name: "Indian Rupee"
+    }),
+    USD: Object.freeze({
+        code: "USD",
+        symbol: "$",
+        locale: "en-US",
+        minorUnitExponent: 2,
+        name: "US Dollar"
+    }),
+    EUR: Object.freeze({
+        code: "EUR",
+        symbol: "€",
+        locale: "de-DE",
+        minorUnitExponent: 2,
+        name: "Euro"
+    }),
+    GBP: Object.freeze({
+        code: "GBP",
+        symbol: "£",
+        locale: "en-GB",
+        minorUnitExponent: 2,
+        name: "British Pound"
+    }),
+    JPY: Object.freeze({
+        code: "JPY",
+        symbol: "¥",
+        locale: "ja-JP",
+        minorUnitExponent: 0,
+        name: "Japanese Yen"
+    })
+});
+
+function isSupportedCurrency(code) {
+    return Boolean(SUPPORTED_CURRENCIES[String(code || "").toUpperCase()]);
+}
+
+function getCurrencyMeta(code = "INR") {
+    const key = String(code || "INR").toUpperCase();
+    return SUPPORTED_CURRENCIES[key] || SUPPORTED_CURRENCIES.INR;
+}
+
+function getFallbackRate(displayCurrency) {
+    const key = String(displayCurrency || "INR").toUpperCase();
+    if (key === "INR") return 1;
+    return FALLBACK_RATES[key] ?? null;
+}
+
+const CURRENCY = {
     code: "INR",
     symbol: "₹",
     minorUnitExponent: 2,
     locale: "en-IN",
-});
+    // catalog / helpers (#1392) — same module.exports identity for require()
+    FALLBACK_RATES,
+    SUPPORTED_CURRENCIES,
+    SETTLEMENT_CURRENCY: null, // filled below
+    isSupportedCurrency,
+    getCurrencyMeta,
+    getFallbackRate
+};
+
+CURRENCY.SETTLEMENT_CURRENCY = CURRENCY;
+CURRENCY.CURRENCY = CURRENCY;
+
+Object.freeze(CURRENCY);
 
 module.exports = CURRENCY;

--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,6 +1,11 @@
 const mysql = require("mysql2");
 require("dotenv").config();
 const logger = require("../utils/logger");
+const {
+  recordQueryExecution,
+  QueryBudgetError,
+  runWithQueryBudgetBypass
+} = require("../middleware/queryBudgetMiddleware");
 
 const requiredEnvVars = ["DB_HOST", "DB_USER", "DB_PASSWORD", "DB_NAME"];
 
@@ -73,8 +78,78 @@ function createPool() {
   pool = mysql.createPool(DB_CONFIG);
   promisePool = pool.promise();
   promisePool.promise = promisePool;
+  installQueryBudgetWrapper(promisePool);
   originalQuery = promisePool.query.bind(promisePool);
   return { pool, promisePool };
+}
+
+/**
+ * Wrap pool + checked-out connections so every SQL statement counts toward the
+ * per-request query budget and slow queries are attributed (#1391).
+ */
+function installQueryBudgetWrapper(pp) {
+  if (!pp || pp.__queryBudgetWrapped) {
+    return pp;
+  }
+
+  const rawQuery = pp.query.bind(pp);
+  const rawExecute = pp.execute ? pp.execute.bind(pp) : null;
+  const rawGetConnection = pp.getConnection.bind(pp);
+
+  async function instrumented(rawFn, args) {
+    const sql = typeof args[0] === "string" ? args[0] : args[0]?.sql;
+    const params = Array.isArray(args[1]) ? args[1] : [];
+
+    // Reserve a budget slot before hitting MySQL (#1391)
+    recordQueryExecution({ phase: "begin", sql, params });
+
+    const startTime = Date.now();
+    try {
+      const result = await rawFn(...args);
+      const durationMs = Date.now() - startTime;
+      recordQueryExecution({ phase: "finish", sql, durationMs, params });
+      return result;
+    } catch (error) {
+      const durationMs = Date.now() - startTime;
+      if (!(error instanceof QueryBudgetError)) {
+        try {
+          recordQueryExecution({ phase: "finish", sql, durationMs, params, error });
+        } catch (_) {
+          /* finish must not mask the original SQL error */
+        }
+      }
+      throw error;
+    }
+  }
+
+  function wrapConnection(connection) {
+    if (!connection || connection.__queryBudgetWrapped) {
+      return connection;
+    }
+    const connQuery = connection.query.bind(connection);
+    const connExecute = connection.execute
+      ? connection.execute.bind(connection)
+      : null;
+
+    connection.query = (...args) => instrumented(connQuery, args);
+    if (connExecute) {
+      connection.execute = (...args) => instrumented(connExecute, args);
+    }
+    connection.__queryBudgetWrapped = true;
+    return connection;
+  }
+
+  pp.query = (...args) => instrumented(rawQuery, args);
+  if (rawExecute) {
+    pp.execute = (...args) => instrumented(rawExecute, args);
+  }
+  pp.getConnection = async (...args) => {
+    const connection = await rawGetConnection(...args);
+    return wrapConnection(connection);
+  };
+
+  pp.__queryBudgetWrapped = true;
+  return pp;
 }
 
 createPool();
@@ -328,12 +403,17 @@ async function query(sql, params = []) {
   pendingQueries++;
   
   try {
-    const [results] = await originalQuery(sql, params);
+    // Goes through the budget-wrapped pool.query (#1391)
+    const [results] = await promisePool.query(sql, params);
     logQuery(sql, params, startTime);
     return [results, null];
   } catch (error) {
     logger.error(`Query error: ${error.message}`);
     logQuery(sql, params, startTime, error);
+
+    if (error instanceof QueryBudgetError || error.code === "QUERY_BUDGET_EXCEEDED") {
+      throw error;
+    }
     
     if (['PROTOCOL_CONNECTION_LOST', 'ECONNRESET', 'ETIMEDOUT'].includes(error.code)) {
       logger.warn('Connection lost during query. Attempting to reconnect...');
@@ -550,6 +630,8 @@ module.exports.shutdown = shutdown;
 module.exports.withTransaction = withTransaction;
 module.exports.DB_CONFIG = DB_CONFIG;
 module.exports.RETRY_CONFIG = RETRY_CONFIG;
+module.exports.runWithQueryBudgetBypass = runWithQueryBudgetBypass;
+module.exports.installQueryBudgetWrapper = installQueryBudgetWrapper;
 
 process.on('uncaughtException', async (error) => {
   logger.error(`Uncaught exception: ${error.message}`);

--- a/backend/controllers/admin.controller.js
+++ b/backend/controllers/admin.controller.js
@@ -689,6 +689,30 @@ const listImpersonationAudit = async (req, res) => {
     }
 };
 
+/**
+ * GET /api/admin/query-budget
+ * Top SQL query-budget offenders + open circuits (#1391).
+ */
+const getQueryBudgetMetrics = async (req, res) => {
+    try {
+        const {
+            getQueryBudgetMetrics: loadMetrics
+        } = require("../middleware/queryBudgetMiddleware");
+        const limit = Math.min(parseInt(req.query.limit, 10) || 20, 100);
+        const metrics = loadMetrics(limit);
+        return res.status(200).json({
+            success: true,
+            message: "Query budget metrics",
+            ...metrics
+        });
+    } catch (error) {
+        return res.status(500).json({
+            success: false,
+            message: error.message || "Failed to load query budget metrics"
+        });
+    }
+};
+
 
 module.exports = {
     getDashboardStats,
@@ -705,5 +729,6 @@ module.exports = {
     verifyErasureReceiptAdmin,
     startImpersonation,
     revokeImpersonation,
-    listImpersonationAudit
+    listImpersonationAudit,
+    getQueryBudgetMetrics
 };

--- a/backend/controllers/admin.controller.js
+++ b/backend/controllers/admin.controller.js
@@ -572,6 +572,123 @@ const verifyErasureReceiptAdmin = async (req, res) => {
     }
 };
 
+// =====================
+// ADMIN IMPERSONATION (#1393)
+// =====================
+const impersonationService = require("../services/impersonationService");
+
+function adminClientMeta(req) {
+    const ip =
+        req.ip ||
+        req.headers["x-forwarded-for"]?.toString().split(",")[0]?.trim() ||
+        null;
+    const userAgent = req.headers["user-agent"] || "";
+    return { ip, userAgent };
+}
+
+/**
+ * POST /api/admin/impersonate
+ * Body: { userId, reason, ticketId, ttlMinutes? }
+ */
+const startImpersonation = async (req, res) => {
+    try {
+        const { ip, userAgent } = adminClientMeta(req);
+        const result = await impersonationService.mintImpersonationToken({
+            actorAdmin: req.user,
+            subjectUserId: req.body?.userId || req.body?.subjectUserId,
+            reason: req.body?.reason,
+            ticketId: req.body?.ticketId || req.body?.ticket,
+            ttlMinutes: req.body?.ttlMinutes,
+            ip,
+            userAgent
+        });
+
+        logger.info("Admin impersonation minted", {
+            adminId: result.actorAdminId,
+            subjectUserId: result.subjectUserId,
+            grantId: result.grantId,
+            ticketId: result.ticketId
+        });
+
+        return res.status(201).json({
+            success: true,
+            message:
+                "Impersonation token minted. Use as Bearer token; responses include X-Impersonating.",
+            ...result
+        });
+    } catch (error) {
+        logger.error("Admin impersonation mint error:", {
+            error: error.message,
+            adminId: req.user?.id
+        });
+        return res.status(error.status || 500).json({
+            success: false,
+            code: error.code || "IMPERSONATION_ERROR",
+            message: error.message || "Failed to start impersonation"
+        });
+    }
+};
+
+/**
+ * POST /api/admin/impersonate/revoke
+ * Body: { grantId? , jti? }
+ */
+const revokeImpersonation = async (req, res) => {
+    try {
+        const { ip, userAgent } = adminClientMeta(req);
+        const result = await impersonationService.revokeImpersonationGrant({
+            grantId: req.body?.grantId,
+            jti: req.body?.jti,
+            revokedBy: req.user,
+            ip,
+            userAgent
+        });
+
+        return res.status(200).json({
+            success: true,
+            message: result.alreadyRevoked
+                ? "Impersonation grant was already revoked"
+                : "Impersonation grant revoked",
+            ...result
+        });
+    } catch (error) {
+        return res.status(error.status || 500).json({
+            success: false,
+            code: error.code || "IMPERSONATION_ERROR",
+            message: error.message || "Failed to revoke impersonation"
+        });
+    }
+};
+
+/**
+ * GET /api/admin/impersonate/audit
+ */
+const listImpersonationAudit = async (req, res) => {
+    try {
+        const result = await impersonationService.listImpersonationAudit({
+            grantId: req.query.grantId || null,
+            actorAdminId: req.query.actorAdminId || null,
+            subjectUserId: req.query.subjectUserId || null,
+            page: req.query.page,
+            limit: req.query.limit
+        });
+
+        return res.status(200).json({
+            success: true,
+            ...result
+        });
+    } catch (error) {
+        logger.error("Admin impersonation audit list error:", {
+            error: error.message,
+            adminId: req.user?.id
+        });
+        return res.status(500).json({
+            success: false,
+            message: "Failed to list impersonation audit"
+        });
+    }
+};
+
 
 module.exports = {
     getDashboardStats,
@@ -585,5 +702,8 @@ module.exports = {
     getAdminLogs,
     listErasureRequests,
     getErasureRequest,
-    verifyErasureReceiptAdmin
+    verifyErasureReceiptAdmin,
+    startImpersonation,
+    revokeImpersonation,
+    listImpersonationAudit
 };

--- a/backend/controllers/checkoutController.js
+++ b/backend/controllers/checkoutController.js
@@ -1,0 +1,225 @@
+/**
+ * Checkout controller — quotes + mid-session FX lock (#1392).
+ */
+
+"use strict";
+
+const db = require("../config/db");
+const { resolveOrderLines } = require("../services/order.service");
+const { validatePromo } = require("../services/promo.service");
+const pricing = require("../services/pricing.service");
+const { safeArray, sanitizeString, safeNumber } = require("../utils/helpers");
+const CURRENCY = require("../config/currency");
+const { isSupportedCurrency, getCurrencyMeta, SUPPORTED_CURRENCIES } = CURRENCY;
+const fxLockService = require("../services/fxLockService");
+
+/**
+ * POST /api/checkout/quote
+ * Prices the basket in settlement currency and optionally locks FX for display.
+ */
+async function quoteCheckout(req, res) {
+    try {
+        const { items, promoCode, currency, lockFx } = req.body || {};
+        const requestedItems = safeArray(items);
+        const displayCurrency = sanitizeString(
+            currency || req.query?.currency || CURRENCY.code
+        ).toUpperCase() || CURRENCY.code;
+
+        if (displayCurrency && !isSupportedCurrency(displayCurrency)) {
+            return res.status(400).json({
+                success: false,
+                code: "FX_CURRENCY_UNSUPPORTED",
+                message: `Unsupported currency: ${displayCurrency}`
+            });
+        }
+
+        if (!requestedItems.length) {
+            const empty = pricing.quote({ items: [] });
+            return res.status(200).json({
+                success: true,
+                breakdown: empty,
+                displayCurrency,
+                fxLock: null
+            });
+        }
+
+        const lines = await resolveOrderLines(db, requestedItems, {
+            lockRows: false,
+            enforceStock: false
+        });
+
+        const requestedCode = promoCode ? sanitizeString(promoCode) : "";
+        let promo = null;
+        let promoMessage = null;
+
+        if (requestedCode) {
+            const { subtotal } = pricing.priceLineItems(lines);
+            const validation = await validatePromo(requestedCode, subtotal);
+            if (validation.valid) {
+                promo = validation.promo;
+            } else {
+                promoMessage = validation.message;
+            }
+        }
+
+        const breakdown = pricing.quote({
+            items: lines,
+            promo,
+            promoCode: promo ? promo.code : null
+        });
+
+        let fxLock = null;
+        const shouldLock =
+            lockFx !== false &&
+            displayCurrency &&
+            displayCurrency !== CURRENCY.code;
+
+        if (shouldLock || lockFx === true) {
+            const locked = await fxLockService.createFxLock({
+                displayCurrency: displayCurrency || CURRENCY.code,
+                baseTotal: breakdown.total
+            });
+            fxLock = locked.lock;
+            fxLock.token = locked.token;
+        }
+
+        const meta = getCurrencyMeta(displayCurrency);
+        const rate = fxLock ? fxLock.rate : (await fxLockService.getSpotRate(displayCurrency)).rate;
+
+        return res.status(200).json({
+            success: true,
+            breakdown,
+            promoMessage,
+            displayCurrency,
+            currency: meta,
+            fx: {
+                baseCurrency: CURRENCY.code,
+                displayCurrency,
+                rate,
+                displayTotal: fxLockService.toDisplayAmount(
+                    breakdown.total,
+                    rate,
+                    displayCurrency
+                )
+            },
+            fxLock
+        });
+    } catch (error) {
+        console.error("Quote error:", error);
+        const status = error.status || 400;
+        return res.status(status).json({
+            success: false,
+            code: error.code || "QUOTE_FAILED",
+            error: error.message || "Could not price this basket",
+            message: error.message || "Could not price this basket"
+        });
+    }
+}
+
+/**
+ * POST /api/checkout/fx/lock
+ * Explicitly mint/refresh an FX lock for the active display currency.
+ */
+async function lockFxRate(req, res) {
+    try {
+        const displayCurrency = sanitizeString(
+            req.body?.currency || req.body?.displayCurrency || ""
+        ).toUpperCase();
+        const baseTotal =
+            req.body?.baseTotal !== undefined
+                ? safeNumber(req.body.baseTotal)
+                : null;
+
+        if (!displayCurrency || !isSupportedCurrency(displayCurrency)) {
+            return res.status(400).json({
+                success: false,
+                code: "FX_CURRENCY_UNSUPPORTED",
+                message: "A supported display currency is required"
+            });
+        }
+
+        const locked = await fxLockService.createFxLock({
+            displayCurrency,
+            baseTotal: baseTotal > 0 ? baseTotal : null,
+            quoteId: sanitizeString(req.body?.quoteId || "") || null
+        });
+
+        return res.status(201).json({
+            success: true,
+            message: "FX rate locked for checkout",
+            fxLock: { ...locked.lock, token: locked.token }
+        });
+    } catch (error) {
+        return res.status(error.status || 500).json({
+            success: false,
+            code: error.code || "FX_LOCK_FAILED",
+            message: error.message || "Failed to lock FX rate"
+        });
+    }
+}
+
+/**
+ * POST /api/checkout/fx/validate
+ * Ensure a lock is still valid before place-order.
+ */
+async function validateFxLock(req, res) {
+    try {
+        const token = sanitizeString(
+            req.body?.fxLockToken || req.body?.token || ""
+        );
+        const displayCurrency = req.body?.currency
+            ? sanitizeString(req.body.currency).toUpperCase()
+            : null;
+        const baseTotal =
+            req.body?.baseTotal !== undefined
+                ? safeNumber(req.body.baseTotal)
+                : null;
+
+        const lock = await fxLockService.validateFxLock(token, {
+            displayCurrency,
+            baseTotal: baseTotal > 0 ? baseTotal : null
+        });
+
+        return res.status(200).json({
+            success: true,
+            message: "FX lock is valid",
+            lock
+        });
+    } catch (error) {
+        return res.status(error.status || 400).json({
+            success: false,
+            code: error.code || "FX_LOCK_INVALID",
+            message: error.message || "FX lock validation failed"
+        });
+    }
+}
+
+/**
+ * GET /api/checkout/fx/rates
+ * Spot (or fallback) rates for the currency switcher.
+ */
+async function getFxRates(req, res) {
+    try {
+        const bundle = await fxLockService.fetchProviderRates();
+        return res.status(200).json({
+            success: true,
+            base: bundle.base,
+            source: bundle.source,
+            rates: bundle.rates,
+            fetchedAt: bundle.fetchedAt,
+            currencies: SUPPORTED_CURRENCIES
+        });
+    } catch (error) {
+        return res.status(500).json({
+            success: false,
+            message: error.message || "Failed to load FX rates"
+        });
+    }
+}
+
+module.exports = {
+    quoteCheckout,
+    lockFxRate,
+    validateFxLock,
+    getFxRates
+};

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -28,6 +28,51 @@ const {
 // Saved address book (#1347).
 const addressService = require("../services/addressService");
 
+// Mid-session FX lock (#1392)
+const fxLockService = require("../services/fxLockService");
+
+/**
+ * When the shopper browses in a non-settlement currency, checkout must present
+ * a still-valid FX lock token so the displayed conversion cannot silently drift.
+ * Settlement (charge) stays in CURRENCY.code (INR).
+ */
+async function assertFxLockForCheckout({
+    fxLockToken,
+    displayCurrency,
+    baseTotal
+}) {
+    const currency = sanitizeString(displayCurrency || CURRENCY.code).toUpperCase()
+        || CURRENCY.code;
+
+    if (!currency || currency === CURRENCY.code) {
+        return { required: false, lock: null, audit: null };
+    }
+
+    if (!CURRENCY.isSupportedCurrency(currency)) {
+        const err = new Error(`Unsupported currency: ${currency}`);
+        err.status = 400;
+        err.code = "FX_CURRENCY_UNSUPPORTED";
+        throw err;
+    }
+
+    const token = sanitizeString(fxLockToken || "");
+    if (!token) {
+        const err = new Error(
+            "FX rate lock is required for multi-currency checkout. Refresh the summary and try again."
+        );
+        err.status = 409;
+        err.code = "FX_LOCK_MISSING";
+        throw err;
+    }
+
+    const lock = await fxLockService.validateFxLock(token, {
+        displayCurrency: currency,
+        baseTotal: baseTotal != null ? safeNumber(baseTotal) : null
+    });
+
+    return { required: true, lock, token };
+}
+
 // create order
 const createOrder =
     async (
@@ -47,7 +92,10 @@ const createOrder =
                 promoCode,
                 // Saved address book (#1347). A signed-in shopper can send an
                 // id instead of retyping the whole address.
-                addressId
+                addressId,
+                // Mid-session FX lock (#1392)
+                fxLockToken,
+                currency: displayCurrency
             } = req.body;
 
             // Resolve a saved address into the same flat shape the manual form
@@ -161,6 +209,22 @@ const createOrder =
                     });
             }
 
+            // Mid-session FX lock (#1392): reject expired / missing locks before charge
+            let fxContext = { required: false, lock: null, token: null };
+            try {
+                fxContext = await assertFxLockForCheckout({
+                    fxLockToken,
+                    displayCurrency,
+                    baseTotal: total
+                });
+            } catch (fxErr) {
+                return res.status(fxErr.status || 400).json({
+                    success: false,
+                    code: fxErr.code || "FX_LOCK_INVALID",
+                    message: fxErr.message
+                });
+            }
+
             // begin transaction
             await connection.beginTransaction();
 
@@ -217,6 +281,19 @@ const createOrder =
                 await addressService.markAddressUsed(req.user.id, addressId);
             }
 
+            let fxCaptureAudit = null;
+            if (fxContext.required && fxContext.token) {
+                try {
+                    fxCaptureAudit = await fxLockService.auditCapture({
+                        fxLockToken: fxContext.token,
+                        settlementTotal: result.breakdown.total,
+                        orderId: result.orderId
+                    });
+                } catch (auditErr) {
+                    console.warn("FX capture audit skipped:", auditErr.message);
+                }
+            }
+
             return res.status(201)
                 .json({
                     success: true,
@@ -227,7 +304,9 @@ const createOrder =
                     orderId:
                         result.orderId,
                     breakdown:
-                        result.breakdown
+                        result.breakdown,
+                    fxLock: fxContext.lock || null,
+                    fxCaptureAudit
                 });
 
         } catch (error) {
@@ -719,7 +798,15 @@ const createPaymentIntent = async (req, res) => {
     try {
         connection = await db.getConnection();
 
-        const { customer, address, items, total, promoCode } = req.body;
+        const {
+            customer,
+            address,
+            items,
+            total,
+            promoCode,
+            fxLockToken,
+            currency: displayCurrency
+        } = req.body;
 
         if (!customer || !customer.name || !customer.email) {
             return res.status(400).json({ success: false, message: "Customer information required" });
@@ -733,6 +820,21 @@ const createPaymentIntent = async (req, res) => {
         // Shape check only; the charged amount comes from the order service.
         if (safeNumber(total) <= 0) {
             return res.status(400).json({ success: false, message: "Invalid order total" });
+        }
+
+        let fxContext = { required: false, lock: null, token: null };
+        try {
+            fxContext = await assertFxLockForCheckout({
+                fxLockToken,
+                displayCurrency,
+                baseTotal: total
+            });
+        } catch (fxErr) {
+            return res.status(fxErr.status || 400).json({
+                success: false,
+                code: fxErr.code || "FX_LOCK_INVALID",
+                message: fxErr.message
+            });
         }
 
         await connection.beginTransaction();
@@ -772,6 +874,8 @@ const createPaymentIntent = async (req, res) => {
         await inventoryReservationService.consumeLocks(req.user.id, items, connection);
 
         // Charge what the engine priced, never what the browser claimed.
+        // Settlement currency is always the configured base (INR) — FX lock
+        // only governs the display rate the shopper saw (#1392).
         const chargeableTotal = result.breakdown.total;
 
         const paymentIntentResult = await paymentService.createPaymentIntent(chargeableTotal, CURRENCY.code, { orderId: result.orderId, userId: req.user.id });
@@ -784,11 +888,26 @@ const createPaymentIntent = async (req, res) => {
 
         await connection.commit();
 
+        let fxCaptureAudit = null;
+        if (fxContext.required && fxContext.token) {
+            try {
+                fxCaptureAudit = await fxLockService.auditCapture({
+                    fxLockToken: fxContext.token,
+                    settlementTotal: chargeableTotal,
+                    orderId: result.orderId
+                });
+            } catch (auditErr) {
+                console.warn("FX capture audit skipped:", auditErr.message);
+            }
+        }
+
         return res.status(201).json({
             success: true,
             clientSecret: paymentIntentResult.clientSecret,
             orderId: result.orderId,
-            breakdown: result.breakdown
+            breakdown: result.breakdown,
+            fxLock: fxContext.lock || null,
+            fxCaptureAudit
         });
 
     } catch (error) {

--- a/backend/docs/api-contract.md
+++ b/backend/docs/api-contract.md
@@ -1,0 +1,27 @@
+# API contract suite (#1395)
+
+Published OpenAPI lives at [`../openapi/ecommerce.openapi.yaml`](../openapi/ecommerce.openapi.yaml).
+
+## Run
+
+```bash
+cd backend
+npm test -- --testPathPattern=contract --coverage=false
+```
+
+Optional Spectral lint (downloads CLI via npx when needed):
+
+```bash
+cd backend
+npm run lint:openapi
+```
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `openapi/ecommerce.openapi.yaml` | Source of truth for auth/cart/checkout/products/orders |
+| `tests/contract/*.test.js` | Document, fixture, and consumer (Pact-like) checks |
+| `tests/contract/fixtures/` | Example 401 / 409 / 422 (+ happy-path) payloads |
+
+When you change a response envelope, update the OpenAPI schema **and** the matching fixture or consumer expectation in the same PR.

--- a/backend/jobs/priceDropJob.js
+++ b/backend/jobs/priceDropJob.js
@@ -1,0 +1,64 @@
+/**
+ * Wishlist price-drop notification cron worker (#1394).
+ *
+ * Periodically syncs wishlist baselines, detects price drops, and enqueues
+ * notifications through wishlistNotifyService (broker + email + dedupe).
+ */
+
+"use strict";
+
+const cron = require("node-cron");
+const logger = require("../utils/logger");
+const wishlistNotifyService = require("../services/wishlistNotifyService");
+
+// Every 15 minutes — frequent enough for sale windows, cheap on the DB.
+const PRICE_DROP_CRON = process.env.PRICE_DROP_CRON || "*/15 * * * *";
+
+let scheduledTask = null;
+
+async function runPriceDropJob() {
+    logger.info("Price-drop job: starting scan…");
+    try {
+        const result = await wishlistNotifyService.runPriceDropScan();
+        logger.info(
+            `Price-drop job: candidates=${result.candidates} notified=${result.notified} skipped=${result.skipped}`
+        );
+        return result;
+    } catch (error) {
+        logger.error(`Price-drop job failed: ${error.message}`);
+        throw error;
+    }
+}
+
+function startPriceDropJob() {
+    if (process.env.NODE_ENV === "test") {
+        return null;
+    }
+    if (process.env.PRICE_DROP_JOB_ENABLED === "false") {
+        logger.info("Price-drop job disabled via PRICE_DROP_JOB_ENABLED=false");
+        return null;
+    }
+    if (scheduledTask) {
+        return scheduledTask;
+    }
+
+    scheduledTask = cron.schedule(PRICE_DROP_CRON, () => {
+        runPriceDropJob().catch(() => {});
+    });
+    logger.info(`Price-drop job scheduled (${PRICE_DROP_CRON})`);
+    return scheduledTask;
+}
+
+function stopPriceDropJob() {
+    if (scheduledTask) {
+        scheduledTask.stop();
+        scheduledTask = null;
+    }
+}
+
+module.exports = {
+    runPriceDropJob,
+    startPriceDropJob,
+    stopPriceDropJob,
+    PRICE_DROP_CRON
+};

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -92,7 +92,11 @@ async function authMiddleware(req, res, next) {
         req.user = decoded;
         req.tokenFamilyId = decoded.fid || null;
         req.tokenJti = decoded.jti || null;
-        next();
+
+        // Time-boxed admin impersonation watermark + audit (#1393).
+        // No-op for normal sessions.
+        const { impersonationMiddleware } = require("./impersonationMiddleware");
+        return impersonationMiddleware(req, res, next);
     } catch (error) {
         return res.status(401).json({
             success: false,
@@ -140,6 +144,20 @@ async function optionalAuth(req, res, next) {
         req.user = decoded;
         req.tokenFamilyId = decoded.fid || null;
         req.tokenJti = decoded.jti || null;
+
+        // Optional auth: validate impersonation quietly; drop the user on failure.
+        if (decoded.impersonation) {
+            const impersonationService = require("../services/impersonationService");
+            const validation = await impersonationService.validateImpersonationClaims(decoded);
+            if (!validation.ok) {
+                delete req.user;
+                delete req.tokenFamilyId;
+                delete req.tokenJti;
+                return next();
+            }
+            const { impersonationMiddleware } = require("./impersonationMiddleware");
+            return impersonationMiddleware(req, res, next);
+        }
     } catch (error) {
         // Ignore invalid tokens for optional auth
     }

--- a/backend/middleware/errorHandler.js
+++ b/backend/middleware/errorHandler.js
@@ -62,6 +62,24 @@ const globalErrorHandler = (errorLogStream) => {
       });
     }
 
+    // Handle SQL query budget / slow-query circuit breaker (#1391)
+    if (
+      err.code === "QUERY_BUDGET_EXCEEDED" ||
+      err.code === "QUERY_CIRCUIT_OPEN" ||
+      err.errorCode === "QUERY_BUDGET_EXCEEDED" ||
+      err.errorCode === "QUERY_CIRCUIT_OPEN"
+    ) {
+      const retryAfter = err.retryAfter || 30;
+      res.setHeader("Retry-After", String(retryAfter));
+      return res.status(503).json({
+        success: false,
+        errorCode: err.errorCode || err.code,
+        code: err.errorCode || err.code,
+        message: err.message || "Query budget exceeded. Please retry shortly.",
+        retryAfter
+      });
+    }
+
     // Default error response
     return res.status(err.status || 500).json({
       success: false,

--- a/backend/middleware/impersonationMiddleware.js
+++ b/backend/middleware/impersonationMiddleware.js
@@ -1,0 +1,129 @@
+/**
+ * Impersonation context middleware (#1393).
+ *
+ * When the access token carries impersonation claims:
+ *  - validates the time-boxed grant (auto-expiry + revoke)
+ *  - watermarks the response with X-Impersonating / related headers
+ *  - appends an immutable audit row for each request (actorAdminId + subjectUserId)
+ *
+ * Safe no-op for normal (non-impersonation) sessions.
+ */
+
+"use strict";
+
+const impersonationService = require("../services/impersonationService");
+
+function clientMeta(req) {
+    const ip =
+        req.ip ||
+        req.headers["x-forwarded-for"]?.toString().split(",")[0]?.trim() ||
+        req.connection?.remoteAddress ||
+        null;
+    const userAgent = req.headers["user-agent"] || "";
+    return { ip, userAgent };
+}
+
+function setWatermarkHeaders(res, ctx) {
+    res.setHeader("X-Impersonating", ctx.subjectUserId);
+    res.setHeader("X-Impersonation-Actor", ctx.actorAdminId);
+    res.setHeader("X-Impersonation-Grant", ctx.grantId);
+    if (ctx.ticketId) {
+        res.setHeader("X-Impersonation-Ticket", String(ctx.ticketId).slice(0, 100));
+    }
+}
+
+/**
+ * Express middleware — call after auth has set req.user.
+ */
+async function impersonationMiddleware(req, res, next) {
+    try {
+        const decoded = req.user;
+        if (!decoded || !decoded.impersonation) {
+            return next();
+        }
+
+        const validation = await impersonationService.validateImpersonationClaims(decoded);
+        if (!validation.ok) {
+            const { ip, userAgent } = clientMeta(req);
+            if (decoded.grantId && decoded.actorAdminId && decoded.subjectUserId) {
+                await impersonationService
+                    .appendAudit({
+                        grantId: decoded.grantId,
+                        actorAdminId: decoded.actorAdminId,
+                        subjectUserId: decoded.subjectUserId,
+                        action: impersonationService.ACTIONS.DENY,
+                        method: req.method,
+                        path: req.originalUrl || req.url,
+                        statusCode: validation.status || 401,
+                        ip,
+                        userAgent,
+                        meta: { code: validation.code }
+                    })
+                    .catch(() => {});
+            }
+
+            return res.status(validation.status || 401).json({
+                success: false,
+                code: validation.code,
+                message: validation.message || "Impersonation not allowed"
+            });
+        }
+
+        const grant = validation.grant;
+        const ctx = {
+            grantId: grant.id,
+            actorAdminId: grant.actor_admin_id,
+            subjectUserId: grant.subject_user_id,
+            reason: grant.reason,
+            ticketId: grant.ticket_id,
+            expiresAt: grant.expires_at
+        };
+
+        req.impersonation = ctx;
+        // Preserve real admin identity for any downstream that needs both.
+        req.actorAdminId = ctx.actorAdminId;
+        req.subjectUserId = ctx.subjectUserId;
+
+        // Ensure req.user.id is the subject (token already uses subject id).
+        req.user.id = ctx.subjectUserId;
+        req.user.userId = ctx.subjectUserId;
+
+        setWatermarkHeaders(res, ctx);
+
+        // Audit every action under this grant when the response finishes.
+        const { ip, userAgent } = clientMeta(req);
+        res.on("finish", () => {
+            impersonationService
+                .appendAudit({
+                    grantId: ctx.grantId,
+                    actorAdminId: ctx.actorAdminId,
+                    subjectUserId: ctx.subjectUserId,
+                    action: impersonationService.ACTIONS.REQUEST,
+                    method: req.method,
+                    path: req.originalUrl || req.url,
+                    statusCode: res.statusCode,
+                    ip,
+                    userAgent,
+                    meta: {
+                        ticketId: ctx.ticketId
+                    }
+                })
+                .catch((err) => {
+                    console.error("Impersonation audit append failed:", err.message);
+                });
+        });
+
+        return next();
+    } catch (error) {
+        console.error("impersonationMiddleware error:", error);
+        return res.status(500).json({
+            success: false,
+            message: "Impersonation middleware failure"
+        });
+    }
+}
+
+module.exports = {
+    impersonationMiddleware,
+    setWatermarkHeaders
+};

--- a/backend/middleware/queryBudgetMiddleware.js
+++ b/backend/middleware/queryBudgetMiddleware.js
@@ -1,0 +1,356 @@
+/**
+ * Per-request SQL query budget & slow-query circuit breaker (#1391).
+ *
+ * Uses AsyncLocalStorage so the mysql2 pool wrapper can attribute queries to
+ * the active HTTP request without monkey-patching Express handlers.
+ * Migrations / jobs (no ALS store, or explicit bypass) are not budgeted.
+ */
+
+"use strict";
+
+const { AsyncLocalStorage } = require("async_hooks");
+const { sanitizeSql, logSlowQuery } = require("../utils/slowQueryLogger");
+
+let metrics;
+try {
+    metrics = require("../config/metrics");
+} catch (_) {
+    metrics = null;
+}
+
+const queryBudgetAls = new AsyncLocalStorage();
+
+function envInt(name, fallback) {
+    const n = parseInt(process.env[name], 10);
+    return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function envBool(name, fallback = false) {
+    const v = process.env[name];
+    if (v === undefined || v === "") return fallback;
+    return ["1", "true", "yes", "on"].includes(String(v).toLowerCase());
+}
+
+const CONFIG = {
+    enabled: envBool("QUERY_BUDGET_ENABLED", true),
+    /** Max queries allowed per HTTP request before the circuit trips. */
+    maxQueries: envInt("QUERY_BUDGET_MAX", 50),
+    /** Duration (ms) above which a query is logged as slow. */
+    slowMs: envInt("QUERY_SLOW_MS", 1000),
+    /** Retry-After seconds when circuit is open. */
+    retryAfterSec: envInt("QUERY_CIRCUIT_RETRY_AFTER_SEC", 30),
+    /** Trips on a route within the window before route circuit opens. */
+    tripThreshold: envInt("QUERY_CIRCUIT_TRIP_THRESHOLD", 5),
+    tripWindowMs: envInt("QUERY_CIRCUIT_WINDOW_MS", 60_000),
+    /** Global bypass (migrations, one-off jobs, emergency). */
+    globalBypass: envBool("QUERY_BUDGET_BYPASS", false)
+};
+
+class QueryBudgetError extends Error {
+    constructor(message, { code = "QUERY_BUDGET_EXCEEDED", status = 503, retryAfter = CONFIG.retryAfterSec } = {}) {
+        super(message);
+        this.name = "QueryBudgetError";
+        this.code = code;
+        this.errorCode = code;
+        this.status = status;
+        this.retryAfter = retryAfter;
+    }
+}
+
+/** In-memory admin metrics — top offenders by route. */
+const offenderStats = new Map();
+/** routeKey -> { openUntil, trips: number[] } */
+const routeCircuits = new Map();
+
+function routeKey(method, path) {
+    return `${method || "?"} ${(path || "/").split("?")[0]}`;
+}
+
+function touchOffender(key, patch) {
+    const cur = offenderStats.get(key) || {
+        route: key,
+        requests: 0,
+        queries: 0,
+        budgetTrips: 0,
+        slowQueries: 0,
+        maxQueriesInRequest: 0,
+        lastSeenAt: null
+    };
+    if (patch.requests) cur.requests += patch.requests;
+    if (patch.queries) cur.queries += patch.queries;
+    if (patch.budgetTrips) cur.budgetTrips += patch.budgetTrips;
+    if (patch.slowQueries) cur.slowQueries += patch.slowQueries;
+    if (patch.maxQueriesInRequest != null) {
+        cur.maxQueriesInRequest = Math.max(
+            cur.maxQueriesInRequest,
+            patch.maxQueriesInRequest
+        );
+    }
+    cur.lastSeenAt = new Date().toISOString();
+    offenderStats.set(key, cur);
+    return cur;
+}
+
+function promInc(name, value = 1) {
+    if (metrics && typeof metrics.increment === "function") {
+        try {
+            metrics.increment(name, value);
+        } catch (_) {
+            /* never fail the request for metrics */
+        }
+    }
+}
+
+function isCircuitOpen(key) {
+    const state = routeCircuits.get(key);
+    if (!state || !state.openUntil) return false;
+    if (Date.now() >= state.openUntil) {
+        state.openUntil = 0;
+        return false;
+    }
+    return true;
+}
+
+function recordRouteTrip(key) {
+    const now = Date.now();
+    const state = routeCircuits.get(key) || { openUntil: 0, trips: [] };
+    state.trips = state.trips.filter((t) => now - t < CONFIG.tripWindowMs);
+    state.trips.push(now);
+    if (state.trips.length >= CONFIG.tripThreshold) {
+        state.openUntil = now + CONFIG.retryAfterSec * 1000;
+        state.trips = [];
+        promInc("query_budget.circuit_open");
+    }
+    routeCircuits.set(key, state);
+    return state;
+}
+
+function createRequestContext(req) {
+    const method = req.method || "GET";
+    const path = req.originalUrl || req.url || req.path || "/";
+    return {
+        bypass: false,
+        queryCount: 0,
+        slowCount: 0,
+        budgetTripped: false,
+        method,
+        route: path.split("?")[0],
+        routeKey: routeKey(method, path),
+        requestId: req.correlationId || req.requestId || null,
+        startedAt: Date.now()
+    };
+}
+
+/**
+ * Express middleware — opens ALS budget scope; short-circuits if route circuit is open.
+ */
+function queryBudgetMiddleware(req, res, next) {
+    if (!CONFIG.enabled || CONFIG.globalBypass) {
+        return next();
+    }
+
+    const key = routeKey(req.method, req.originalUrl || req.path);
+    if (isCircuitOpen(key)) {
+        const state = routeCircuits.get(key);
+        const retryAfter = Math.max(
+            1,
+            Math.ceil((((state && state.openUntil) || Date.now()) - Date.now()) / 1000)
+        );
+        res.setHeader("Retry-After", String(retryAfter));
+        res.setHeader("X-Query-Circuit", "open");
+        return res.status(503).json({
+            success: false,
+            code: "QUERY_CIRCUIT_OPEN",
+            errorCode: "QUERY_CIRCUIT_OPEN",
+            message:
+                "This route is temporarily protected after repeated query-budget trips. Retry shortly.",
+            retryAfter
+        });
+    }
+
+    const ctx = createRequestContext(req);
+
+    return queryBudgetAls.run(ctx, () => {
+        res.on("finish", () => {
+            touchOffender(ctx.routeKey, {
+                requests: 1,
+                queries: ctx.queryCount,
+                slowQueries: ctx.slowCount,
+                maxQueriesInRequest: ctx.queryCount,
+                budgetTrips: ctx.budgetTripped ? 1 : 0
+            });
+            if (ctx.queryCount > 0) {
+                res.setHeader("X-Query-Count", String(ctx.queryCount));
+            }
+            if (ctx.budgetTripped) {
+                res.setHeader("X-Query-Budget", "exceeded");
+            }
+        });
+        next();
+    });
+}
+
+/**
+ * Called by the mysql2 pool wrapper for every query.
+ * No ALS store / bypass → migrations & background jobs are unrestricted.
+ *
+ * @param {'begin'|'finish'} phase
+ *   begin  — reserve a budget slot (throws before SQL if exhausted)
+ *   finish — record duration / slow-query attribution after SQL returns
+ */
+function recordQueryExecution({
+    phase = "finish",
+    sql,
+    durationMs = 0,
+    params,
+    error = null
+} = {}) {
+    const ctx = queryBudgetAls.getStore();
+
+    if (!CONFIG.enabled || CONFIG.globalBypass) {
+        if (phase === "finish" && durationMs >= CONFIG.slowMs) {
+            logSlowQuery({
+                sql,
+                durationMs,
+                route: "background",
+                method: "-",
+                params
+            });
+        }
+        return { counted: false, queryCount: 0 };
+    }
+
+    if (!ctx || ctx.bypass) {
+        if (phase === "finish" && durationMs >= CONFIG.slowMs) {
+            logSlowQuery({
+                sql,
+                durationMs,
+                route: "bypass",
+                method: "-",
+                params
+            });
+        }
+        return { counted: false, queryCount: 0 };
+    }
+
+    if (phase === "begin") {
+        if (ctx.budgetTripped || ctx.queryCount >= CONFIG.maxQueries) {
+            ctx.budgetTripped = true;
+            if (ctx.queryCount >= CONFIG.maxQueries && !ctx._tripRecorded) {
+                ctx._tripRecorded = true;
+                recordRouteTrip(ctx.routeKey);
+                touchOffender(ctx.routeKey, { budgetTrips: 1 });
+                promInc("query_budget.exceeded");
+            }
+            throw new QueryBudgetError(
+                `SQL query budget exceeded (${ctx.queryCount}/${CONFIG.maxQueries}) on ${ctx.routeKey}. ` +
+                    `Blocked SQL: ${sanitizeSql(sql)}`,
+                { code: "QUERY_BUDGET_EXCEEDED", retryAfter: CONFIG.retryAfterSec }
+            );
+        }
+        ctx.queryCount += 1;
+        return { counted: true, queryCount: ctx.queryCount };
+    }
+
+    // finish
+    if (durationMs >= CONFIG.slowMs) {
+        ctx.slowCount += 1;
+        promInc("query_budget.slow_query");
+        logSlowQuery({
+            sql,
+            durationMs,
+            route: ctx.route,
+            method: ctx.method,
+            requestId: ctx.requestId,
+            params
+        });
+    }
+
+    return { counted: true, queryCount: ctx.queryCount };
+}
+
+/** Run work outside the per-request budget (migrations, cron, seed scripts). */
+function runWithQueryBudgetBypass(fn) {
+    return queryBudgetAls.run({ bypass: true, queryCount: 0, slowCount: 0 }, fn);
+}
+
+function getQueryBudgetMetrics(limit = 20) {
+    const offenders = [...offenderStats.values()]
+        .sort(
+            (a, b) =>
+                b.budgetTrips - a.budgetTrips ||
+                b.slowQueries - a.slowQueries ||
+                b.maxQueriesInRequest - a.maxQueriesInRequest
+        )
+        .slice(0, Math.max(1, limit));
+
+    const openCircuits = [];
+    for (const [route, state] of routeCircuits.entries()) {
+        if (state.openUntil && state.openUntil > Date.now()) {
+            openCircuits.push({
+                route,
+                openUntil: new Date(state.openUntil).toISOString(),
+                retryAfterSec: Math.ceil((state.openUntil - Date.now()) / 1000)
+            });
+        }
+    }
+
+    return {
+        config: {
+            enabled: CONFIG.enabled,
+            maxQueries: CONFIG.maxQueries,
+            slowMs: CONFIG.slowMs,
+            retryAfterSec: CONFIG.retryAfterSec,
+            tripThreshold: CONFIG.tripThreshold,
+            tripWindowMs: CONFIG.tripWindowMs,
+            globalBypass: CONFIG.globalBypass
+        },
+        topOffenders: offenders,
+        openCircuits,
+        generatedAt: new Date().toISOString()
+    };
+}
+
+function resetQueryBudgetState() {
+    offenderStats.clear();
+    routeCircuits.clear();
+}
+
+function getActiveBudgetContext() {
+    return queryBudgetAls.getStore() || null;
+}
+
+/** Test helper: run fn inside a synthetic request budget context. */
+function runWithQueryBudget(ctx, fn) {
+    return queryBudgetAls.run(
+        {
+            bypass: false,
+            queryCount: 0,
+            slowCount: 0,
+            budgetTripped: false,
+            method: "GET",
+            route: "/test",
+            routeKey: "GET /test",
+            requestId: "test",
+            startedAt: Date.now(),
+            ...ctx
+        },
+        fn
+    );
+}
+
+module.exports = {
+    CONFIG,
+    QueryBudgetError,
+    queryBudgetMiddleware,
+    recordQueryExecution,
+    runWithQueryBudgetBypass,
+    runWithQueryBudget,
+    getQueryBudgetMetrics,
+    resetQueryBudgetState,
+    getActiveBudgetContext,
+    queryBudgetAls,
+    // test seams
+    _offenderStats: offenderStats,
+    _routeCircuits: routeCircuits
+};

--- a/backend/openapi/.spectral.yaml
+++ b/backend/openapi/.spectral.yaml
@@ -1,0 +1,12 @@
+# Spectral rules for backend/openapi/ecommerce.openapi.yaml (#1395)
+# Optional: npm run lint:openapi
+
+extends: ["spectral:oas"]
+
+rules:
+  operation-operationId: error
+  operation-tags: warn
+  info-contact: off
+  oas3-api-servers: warn
+  operation-description: off
+  tag-description: off

--- a/backend/openapi/ecommerce.openapi.yaml
+++ b/backend/openapi/ecommerce.openapi.yaml
@@ -1,0 +1,1006 @@
+openapi: 3.0.3
+info:
+  title: E-commerce Core API
+  description: |
+    Contract surface for auth, products, cart, checkout, and orders.
+    All JSON responses use the shared envelope (`success`, `message`, …).
+    Maintained for CI contract tests (#1395) — keep in sync with Express routes.
+  version: 1.0.0
+  contact:
+    name: E-commerce contributors
+
+servers:
+  - url: http://localhost:5000/api
+    description: Local development
+  - url: https://e-commerce-production-d546.up.railway.app/api
+    description: Production (Railway)
+
+tags:
+  - name: Auth
+  - name: Products
+  - name: Cart
+  - name: Checkout
+  - name: Orders
+
+paths:
+  /auth/status:
+    get:
+      tags: [Auth]
+      summary: Auth API health
+      operationId: getAuthStatus
+      responses:
+        "200":
+          description: Auth service is up
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessEnvelope"
+              example:
+                success: true
+                message: Auth API running
+
+  /auth/login:
+    post:
+      tags: [Auth]
+      summary: Sign in
+      operationId: login
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+      responses:
+        "200":
+          description: Login succeeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LoginSuccess"
+        "401":
+          description: Invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+              examples:
+                unauthorized:
+                  $ref: "#/components/examples/Unauthorized401"
+        "422":
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationErrorEnvelope"
+              examples:
+                validation:
+                  $ref: "#/components/examples/Validation422"
+
+  /auth/signup:
+    post:
+      tags: [Auth]
+      summary: Begin signup (OTP flow)
+      operationId: signup
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SignupRequest"
+      responses:
+        "200":
+          description: OTP sent / signup pending
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessEnvelope"
+        "422":
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationErrorEnvelope"
+
+  /auth/me:
+    get:
+      tags: [Auth]
+      summary: Current user
+      operationId: getMe
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Authenticated user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MeSuccess"
+        "401":
+          description: Missing or invalid token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+              examples:
+                unauthorized:
+                  $ref: "#/components/examples/Unauthorized401"
+
+  /auth/refresh-token:
+    post:
+      tags: [Auth]
+      summary: Rotate refresh token
+      operationId: refreshToken
+      responses:
+        "200":
+          description: New access token issued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenRefreshSuccess"
+        "401":
+          description: Refresh token missing or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /products:
+    get:
+      tags: [Products]
+      summary: List products (paginated)
+      operationId: listProducts
+      parameters:
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/limit"
+        - name: sort
+          in: query
+          schema:
+            type: string
+        - name: search
+          in: query
+          schema:
+            type: string
+        - name: category
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Product page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProductListSuccess"
+
+  /products/{id}:
+    get:
+      tags: [Products]
+      summary: Product detail
+      operationId: getProduct
+      parameters:
+        - $ref: "#/components/parameters/productId"
+      responses:
+        "200":
+          description: Product found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProductDetailSuccess"
+        "404":
+          description: Product not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /products/status/check:
+    get:
+      tags: [Products]
+      summary: Product API health
+      operationId: getProductStatus
+      responses:
+        "200":
+          description: Product service is up
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessEnvelope"
+
+  /cart:
+    get:
+      tags: [Cart]
+      summary: Get authenticated cart
+      operationId: getCart
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Cart contents
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CartSuccess"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /cart/add:
+    post:
+      tags: [Cart]
+      summary: Add line with inventory reservation
+      operationId: addCartItem
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CartAddRequest"
+      responses:
+        "200":
+          description: Item reserved and added
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessEnvelope"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "409":
+          description: Inventory conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryConflictEnvelope"
+              examples:
+                conflict:
+                  $ref: "#/components/examples/InventoryConflict409"
+
+  /cart/sync:
+    post:
+      tags: [Cart]
+      summary: Sync client cart to server
+      operationId: syncCart
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [items]
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/CartLineInput"
+      responses:
+        "200":
+          description: Cart synced
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessEnvelope"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /checkout/quote:
+    post:
+      tags: [Checkout]
+      summary: Server-authoritative basket quote
+      operationId: checkoutQuote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CheckoutQuoteRequest"
+      responses:
+        "200":
+          description: Priced breakdown
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CheckoutQuoteSuccess"
+        "400":
+          description: Could not price basket
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /checkout/challenge/issue:
+    post:
+      tags: [Checkout]
+      summary: Issue bot-resistance PoW challenge
+      operationId: issueCheckoutChallenge
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [idempotencyKey]
+              properties:
+                idempotencyKey:
+                  type: string
+                  minLength: 8
+                riskScore:
+                  type: number
+                riskLevel:
+                  type: string
+      responses:
+        "201":
+          description: Challenge issued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChallengeIssuedSuccess"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /orders:
+    post:
+      tags: [Orders]
+      summary: Create order (COD / UPI)
+      operationId: createOrder
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateOrderRequest"
+      responses:
+        "201":
+          description: Order created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrderCreatedSuccess"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "409":
+          description: Inventory or total mismatch
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/InventoryConflictEnvelope"
+                  - $ref: "#/components/schemas/TotalMismatchEnvelope"
+              examples:
+                inventory:
+                  $ref: "#/components/examples/InventoryConflict409"
+                totalMismatch:
+                  $ref: "#/components/examples/TotalMismatch409"
+        "422":
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationErrorEnvelope"
+
+  /orders/create-payment-intent:
+    post:
+      tags: [Orders]
+      summary: Create order + Stripe payment intent
+      operationId: createPaymentIntent
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateOrderRequest"
+      responses:
+        "201":
+          description: Payment intent created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaymentIntentSuccess"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "409":
+          description: Inventory or total mismatch
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryConflictEnvelope"
+
+  /orders/my-orders:
+    get:
+      tags: [Orders]
+      summary: List current user orders
+      operationId: listMyOrders
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/limit"
+      responses:
+        "200":
+          description: Paginated orders
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MyOrdersSuccess"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  parameters:
+    page:
+      name: page
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    limit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+    productId:
+      name: id
+      in: path
+      required: true
+      description: Product UUID (CHAR(36))
+      schema:
+        type: string
+        format: uuid
+
+  examples:
+    Unauthorized401:
+      summary: Missing or invalid JWT
+      value:
+        success: false
+        message: Unauthorized
+    InventoryConflict409:
+      summary: Stock lock conflict
+      value:
+        success: false
+        code: INVENTORY_CONFLICT
+        message: Inventory locks expired or insufficient stock
+        productId: "550e8400-e29b-41d4-a716-446655440000"
+        availableStock: 2
+        requested: 5
+    TotalMismatch409:
+      summary: Client total disagrees with server quote
+      value:
+        success: false
+        code: TOTAL_MISMATCH
+        message: Submitted total does not match server price
+        submittedTotal: 999
+        computedTotal: 1048
+    Validation422:
+      summary: Request body failed validation
+      value:
+        success: false
+        message: Validation failed
+        details:
+          - email is required
+          - password must be at least 8 characters
+
+  schemas:
+    SuccessEnvelope:
+      type: object
+      required: [success]
+      additionalProperties: true
+      properties:
+        success:
+          type: boolean
+          const: true
+        message:
+          type: string
+
+    ErrorEnvelope:
+      type: object
+      required: [success, message]
+      additionalProperties: true
+      properties:
+        success:
+          type: boolean
+          const: false
+        message:
+          type: string
+        code:
+          type: string
+
+    ValidationErrorEnvelope:
+      type: object
+      required: [success, message]
+      properties:
+        success:
+          type: boolean
+          const: false
+        message:
+          type: string
+        details:
+          type: array
+          items:
+            type: string
+        errors:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+
+    InventoryConflictEnvelope:
+      type: object
+      required: [success, code, message]
+      properties:
+        success:
+          type: boolean
+          const: false
+        code:
+          type: string
+          enum: [INVENTORY_CONFLICT]
+        message:
+          type: string
+        productId:
+          oneOf:
+            - type: string
+            - type: "null"
+        availableStock:
+          type: number
+          nullable: true
+        requested:
+          type: number
+          nullable: true
+
+    TotalMismatchEnvelope:
+      type: object
+      required: [success, code, message]
+      properties:
+        success:
+          type: boolean
+          const: false
+        code:
+          type: string
+          enum: [TOTAL_MISMATCH]
+        message:
+          type: string
+        submittedTotal:
+          type: number
+        computedTotal:
+          type: number
+
+    PaginationMeta:
+      type: object
+      required: [total, page, limit, totalPages]
+      properties:
+        total:
+          type: integer
+          minimum: 0
+        page:
+          type: integer
+          minimum: 1
+        limit:
+          type: integer
+          minimum: 1
+        totalPages:
+          type: integer
+          minimum: 1
+        hasNextPage:
+          type: boolean
+        hasPrevPage:
+          type: boolean
+
+    LoginRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 1
+
+    SignupRequest:
+      type: object
+      required: [name, email, password]
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 8
+
+    UserSummary:
+      type: object
+      required: [id, email]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+
+    LoginSuccess:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          const: true
+        message:
+          type: string
+        token:
+          type: string
+        accessToken:
+          type: string
+        refreshToken:
+          type: string
+        user:
+          $ref: "#/components/schemas/UserSummary"
+
+    MeSuccess:
+      type: object
+      required: [success, user]
+      properties:
+        success:
+          type: boolean
+          const: true
+        user:
+          $ref: "#/components/schemas/UserSummary"
+
+    TokenRefreshSuccess:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          const: true
+        token:
+          type: string
+        accessToken:
+          type: string
+        refreshToken:
+          type: string
+
+    Product:
+      type: object
+      required: [id, name, price]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        price:
+          type: number
+        stock:
+          type: number
+        category:
+          type: string
+        image:
+          type: string
+        description:
+          type: string
+
+    ProductListSuccess:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          const: true
+        products:
+          type: array
+          items:
+            $ref: "#/components/schemas/Product"
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Product"
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
+        totalPages:
+          type: integer
+        hasNextPage:
+          type: boolean
+        hasPrevPage:
+          type: boolean
+        message:
+          type: string
+
+    ProductDetailSuccess:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          const: true
+        product:
+          $ref: "#/components/schemas/Product"
+        data:
+          $ref: "#/components/schemas/Product"
+        message:
+          type: string
+
+    CartLineInput:
+      type: object
+      required: [productId, quantity]
+      properties:
+        productId:
+          type: string
+        quantity:
+          type: integer
+          minimum: 1
+        variantId:
+          type: integer
+        color:
+          type: string
+        size:
+          type: string
+
+    CartAddRequest:
+      allOf:
+        - $ref: "#/components/schemas/CartLineInput"
+
+    CartItem:
+      type: object
+      properties:
+        productId:
+          type: string
+        quantity:
+          type: integer
+        name:
+          type: string
+        price:
+          type: number
+        color:
+          type: string
+        size:
+          type: string
+
+    CartSuccess:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          const: true
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CartItem"
+        cart:
+          type: array
+          items:
+            $ref: "#/components/schemas/CartItem"
+        message:
+          type: string
+
+    PriceBreakdown:
+      type: object
+      required: [subtotal, tax, shipping, discount, total]
+      properties:
+        subtotal:
+          type: number
+        tax:
+          type: number
+        shipping:
+          type: number
+        discount:
+          type: number
+        total:
+          type: number
+        promoCode:
+          type: string
+          nullable: true
+        currency:
+          type: string
+
+    CheckoutQuoteRequest:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CartLineInput"
+        promoCode:
+          type: string
+
+    CheckoutQuoteSuccess:
+      type: object
+      required: [success, breakdown]
+      properties:
+        success:
+          type: boolean
+          const: true
+        breakdown:
+          $ref: "#/components/schemas/PriceBreakdown"
+        promoMessage:
+          type: string
+          nullable: true
+
+    ChallengeIssuedSuccess:
+      type: object
+      required: [success, challenge]
+      properties:
+        success:
+          type: boolean
+          const: true
+        message:
+          type: string
+        challenge:
+          type: object
+          required: [challengeId, idempotencyKey, difficulty, algorithm]
+          properties:
+            challengeId:
+              type: string
+            idempotencyKey:
+              type: string
+            difficulty:
+              type: integer
+            algorithm:
+              type: string
+            prefix:
+              type: string
+            expiresAt:
+              type: string
+            ttlSec:
+              type: integer
+            puzzle:
+              type: string
+
+    CreateOrderRequest:
+      type: object
+      required: [customer, address, items, total, paymentMethod]
+      properties:
+        customer:
+          type: object
+          required: [name, email]
+          properties:
+            name:
+              type: string
+            email:
+              type: string
+              format: email
+            phone:
+              type: string
+        address:
+          type: object
+          required: [fullAddress]
+          properties:
+            city:
+              type: string
+            state:
+              type: string
+            zip:
+              type: string
+            fullAddress:
+              type: string
+        addressId:
+          type: string
+          nullable: true
+        items:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/CartLineInput"
+        total:
+          type: number
+          exclusiveMinimum: 0
+        paymentMethod:
+          type: string
+          enum: [cod, card, upi, paypal]
+        promoCode:
+          type: string
+        idempotencyKey:
+          type: string
+
+    OrderCreatedSuccess:
+      type: object
+      required: [success, orderId]
+      properties:
+        success:
+          type: boolean
+          const: true
+        message:
+          type: string
+        orderId:
+          type: string
+        breakdown:
+          $ref: "#/components/schemas/PriceBreakdown"
+        addressId:
+          type: string
+          nullable: true
+
+    PaymentIntentSuccess:
+      type: object
+      required: [success, clientSecret, orderId]
+      properties:
+        success:
+          type: boolean
+          const: true
+        clientSecret:
+          type: string
+        orderId:
+          type: string
+        breakdown:
+          $ref: "#/components/schemas/PriceBreakdown"
+
+    MyOrdersSuccess:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          const: true
+        orders:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
+        totalPages:
+          type: integer
+        message:
+          type: string

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -35,6 +35,7 @@
         "helmet": "^8.2.0",
         "ioredis": "^5.11.1",
         "joi": "^18.2.3",
+        "js-yaml": "^4.3.1",
         "json2csv": "^6.0.0-alpha.2",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.7.4",
@@ -2107,6 +2108,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
@@ -3555,14 +3580,10 @@
       "license": "MIT"
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -7639,14 +7660,22 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "dev": true,
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,9 @@
     "test:ci": "jest --coverage --ci --maxWorkers=2",
     "test:verbose": "jest --verbose",
     "test:only": "jest --onlyChanged",
-    "test:update": "jest --updateSnapshot"
+    "test:update": "jest --updateSnapshot",
+    "test:contract": "jest --testPathPattern=contract --coverage=false",
+    "lint:openapi": "npx --yes @stoplight/spectral-cli lint openapi/ecommerce.openapi.yaml -r openapi/.spectral.yaml"
   },
   "keywords": [],
   "author": "",
@@ -47,6 +49,7 @@
     "helmet": "^8.2.0",
     "ioredis": "^5.11.1",
     "joi": "^18.2.3",
+    "js-yaml": "^4.3.1",
     "json2csv": "^6.0.0-alpha.2",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.7.4",

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -16,7 +16,8 @@ const {
     verifyErasureReceiptAdmin,
     startImpersonation,
     revokeImpersonation,
-    listImpersonationAudit
+    listImpersonationAudit,
+    getQueryBudgetMetrics
 } = require("../controllers/admin.controller");
 
 const authMiddleware = require("../middleware/authMiddleware");
@@ -71,5 +72,8 @@ router.post("/impersonate", (req, res, next) => {
 });
 router.post("/impersonate/revoke", revokeImpersonation);
 router.get("/impersonate/audit", listImpersonationAudit);
+
+// SQL query budget / slow-query circuit metrics (#1391)
+router.get("/query-budget", getQueryBudgetMetrics);
 
 module.exports = router;

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -13,7 +13,10 @@ const {
     verifyUserEmail,
     listErasureRequests,
     getErasureRequest,
-    verifyErasureReceiptAdmin
+    verifyErasureReceiptAdmin,
+    startImpersonation,
+    revokeImpersonation,
+    listImpersonationAudit
 } = require("../controllers/admin.controller");
 
 const authMiddleware = require("../middleware/authMiddleware");
@@ -53,5 +56,20 @@ router.get("/logs", getAdminLogs);
 router.get("/erasure-requests", listErasureRequests);
 router.get("/erasure-requests/:id", getErasureRequest);
 router.get("/erasure-receipts/:receiptId", verifyErasureReceiptAdmin);
+
+// ==================== IMPERSONATION (#1393) ====================
+// Mint / revoke must be done as the real admin (not while already impersonating).
+router.post("/impersonate", (req, res, next) => {
+    if (req.user?.impersonation || req.impersonation) {
+        return res.status(403).json({
+            success: false,
+            code: "NESTED_IMPERSONATION_FORBIDDEN",
+            message: "End the current impersonation session before starting another"
+        });
+    }
+    return startImpersonation(req, res, next);
+});
+router.post("/impersonate/revoke", revokeImpersonation);
+router.get("/impersonate/audit", listImpersonationAudit);
 
 module.exports = router;

--- a/backend/routes/checkoutRoutes.js
+++ b/backend/routes/checkoutRoutes.js
@@ -1,69 +1,17 @@
 const express = require('express');
 const router = express.Router();
-const db = require('../config/db');
-const { resolveOrderLines } = require('../services/order.service');
-const { validatePromo } = require('../services/promo.service');
-const pricing = require('../services/pricing.service');
-const { safeArray, sanitizeString } = require('../utils/helpers');
+const { sanitizeString } = require('../utils/helpers');
 const authMiddleware = require('../middleware/authMiddleware');
 const powChallengeService = require('../services/powChallengeService');
+const checkoutController = require('../controllers/checkoutController');
 
-// Pricing only. Orders are created on the orders path, which is the one that
-// resolves prices under lock, enforces stock and consumes inventory holds.
-router.post('/quote', async (req, res) => {
-    try {
-        const { items, promoCode } = req.body;
-        const requestedItems = safeArray(items);
+// Pricing + mid-session FX lock (#1392). Orders still settle on the orders path.
+router.post('/quote', checkoutController.quoteCheckout);
 
-        if (!requestedItems.length) {
-            return res.status(200).json({
-                success: true,
-                breakdown: pricing.quote({ items: [] })
-            });
-        }
-
-        // Prices come from the database, never from the request body.
-        const lines = await resolveOrderLines(db, requestedItems, {
-            lockRows: false,
-            enforceStock: false
-        });
-
-        const requestedCode = promoCode ? sanitizeString(promoCode) : '';
-        let promo = null;
-        let promoMessage = null;
-
-        if (requestedCode) {
-            const { subtotal } = pricing.priceLineItems(lines);
-            const validation = await validatePromo(requestedCode, subtotal);
-
-            if (validation.valid) {
-                promo = validation.promo;
-            } else {
-                // An unusable code must not fail the quote — the shopper still
-                // needs to see what the basket costs without it.
-                promoMessage = validation.message;
-            }
-        }
-
-        const breakdown = pricing.quote({
-            items: lines,
-            promo,
-            promoCode: promo ? promo.code : null
-        });
-
-        return res.status(200).json({
-            success: true,
-            breakdown,
-            promoMessage
-        });
-    } catch (error) {
-        console.error('Quote error:', error);
-        return res.status(400).json({
-            success: false,
-            error: error.message || 'Could not price this basket'
-        });
-    }
-});
+// ==================== FX LOCK (#1392) ====================
+router.get('/fx/rates', checkoutController.getFxRates);
+router.post('/fx/lock', checkoutController.lockFxRate);
+router.post('/fx/validate', checkoutController.validateFxLock);
 
 // ==================== BOT-RESISTANT CHECKOUT CHALLENGE (#1396) ====================
 

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -16,6 +16,7 @@ const subscriptionRoutes = require("./subscriptionRoutes");
 const courierWebhookRoutes = require("./courierWebhookRoutes");
 const refundRoutes = require("./refundRoutes");
 const addressRoutes = require("./addressRoutes");
+const wishlistNotifyRoutes = require("./wishlistNotifyRoutes");
 
 router.use("/products", productRoutes);
 router.use("/auth", authRoutes);
@@ -24,6 +25,7 @@ router.use("/promos", promoRoutes);
 router.use("/admin", adminRoutes);
 router.use("/chat", chatRoutes);
 router.use("/wishlist", wishlistRoutes);
+router.use("/wishlist-notify", wishlistNotifyRoutes);
 router.use("/recommendations", recommendationRoutes);
 router.use("/cart", cartRoutes);
 router.use("/checkout", checkoutRoutes);

--- a/backend/routes/wishlistNotifyRoutes.js
+++ b/backend/routes/wishlistNotifyRoutes.js
@@ -1,0 +1,100 @@
+/**
+ * Wishlist price-drop preference center + unsubscribe (#1394).
+ */
+
+"use strict";
+
+const express = require("express");
+const router = express.Router();
+const authMiddleware = require("../middleware/authMiddleware");
+const wishlistNotifyService = require("../services/wishlistNotifyService");
+const { sanitizeString } = require("../utils/helpers");
+
+/**
+ * GET /api/wishlist-notify/preferences
+ */
+router.get("/preferences", authMiddleware, async (req, res) => {
+    try {
+        const preferences = await wishlistNotifyService.getPreferences(req.user.id);
+        return res.status(200).json({
+            success: true,
+            preferences
+        });
+    } catch (error) {
+        return res.status(500).json({
+            success: false,
+            message: error.message || "Failed to load notification preferences"
+        });
+    }
+});
+
+/**
+ * PUT /api/wishlist-notify/preferences
+ * Body: { priceDropEmail?, priceDropInApp?, unsubscribedAll? }
+ */
+router.put("/preferences", authMiddleware, async (req, res) => {
+    try {
+        const preferences = await wishlistNotifyService.updatePreferences(req.user.id, {
+            priceDropEmail: req.body?.priceDropEmail,
+            priceDropInApp: req.body?.priceDropInApp,
+            unsubscribedAll: req.body?.unsubscribedAll
+        });
+        return res.status(200).json({
+            success: true,
+            message: "Notification preferences updated",
+            preferences
+        });
+    } catch (error) {
+        return res.status(500).json({
+            success: false,
+            message: error.message || "Failed to update preferences"
+        });
+    }
+});
+
+/**
+ * POST /api/wishlist-notify/unsubscribe
+ * Public — signed link from email. Body/query: { token }
+ */
+router.post("/unsubscribe", async (req, res) => {
+    try {
+        const token = sanitizeString(
+            req.body?.token || req.query?.token || ""
+        );
+        const result = await wishlistNotifyService.unsubscribeWithToken(token);
+        return res.status(200).json({
+            success: true,
+            message: "You have been unsubscribed from price-drop notifications",
+            ...result
+        });
+    } catch (error) {
+        return res.status(error.status || 500).json({
+            success: false,
+            code: error.code || "UNSUBSCRIBE_FAILED",
+            message: error.message || "Unsubscribe failed"
+        });
+    }
+});
+
+/**
+ * POST /api/wishlist-notify/baselines/sync
+ * Authenticated — ensure baselines for the caller's wishlist (also done by cron).
+ */
+router.post("/baselines/sync", authMiddleware, async (req, res) => {
+    try {
+        // Sync all wishlists (worker path); cheap enough for a manual refresh.
+        const result = await wishlistNotifyService.syncBaselinesFromWishlist();
+        return res.status(200).json({
+            success: true,
+            message: "Wishlist price baselines synced",
+            ...result
+        });
+    } catch (error) {
+        return res.status(500).json({
+            success: false,
+            message: error.message || "Baseline sync failed"
+        });
+    }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -505,6 +505,13 @@ async function bootstrap() {
         } catch (err) {
             console.error("Warning: Failed to start stock-alert scheduler:", err.message);
         }
+
+        try {
+            const { startPriceDropJob } = require("./jobs/priceDropJob");
+            startPriceDropJob();
+        } catch (err) {
+            console.error("Warning: Failed to start wishlist price-drop job:", err.message);
+        }
     }
 
     // Start HTTP listening only after services finish initializations

--- a/backend/server.js
+++ b/backend/server.js
@@ -218,6 +218,10 @@ app.disable("x-powered-by");
 app.use(correlationIdMiddleware);
 app.use(logCompletionMiddleware);
 
+// Per-request SQL query budget (#1391) — must wrap handlers that touch the pool
+const { queryBudgetMiddleware } = require('./middleware/queryBudgetMiddleware');
+app.use(queryBudgetMiddleware);
+
 // Add response standardization middleware before routes
 app.use(standardizeResponse);
 

--- a/backend/services/fxLockService.js
+++ b/backend/services/fxLockService.js
@@ -1,0 +1,347 @@
+/**
+ * Mid-session FX rate lock for multi-currency checkout (#1392).
+ *
+ * Settlement (charge) currency is always the configured base (INR).
+ * Display currency rates are locked into a signed token for a TTL so the
+ * amount the shopper saw at quote time cannot silently drift before pay.
+ */
+
+"use strict";
+
+const crypto = require("crypto");
+const CURRENCY = require("../config/currency");
+const {
+    SETTLEMENT_CURRENCY,
+    FALLBACK_RATES,
+    SUPPORTED_CURRENCIES,
+    isSupportedCurrency,
+    getCurrencyMeta,
+    getFallbackRate
+} = CURRENCY;
+
+const FX_LOCK_TTL_SEC = Math.max(
+    60,
+    parseInt(process.env.FX_LOCK_TTL_SEC, 10) || 15 * 60
+);
+
+const FX_LOCK_SECRET =
+    process.env.FX_LOCK_SECRET ||
+    process.env.JWT_SECRET ||
+    "fx-lock-dev-secret";
+
+/** In-memory audit of lock vs spot at capture (also returned to callers). */
+const captureAuditLog = [];
+
+class FxLockError extends Error {
+    constructor(message, { status = 400, code = "FX_LOCK_ERROR" } = {}) {
+        super(message);
+        this.name = "FxLockError";
+        this.status = status;
+        this.code = code;
+    }
+}
+
+/**
+ * FX provider adapter — tries live fetch, falls back to configured rates.
+ * Override via FX_PROVIDER_URL (JSON: { rates: { USD: 0.012, ... } } relative to INR).
+ */
+async function fetchProviderRates() {
+    const url = process.env.FX_PROVIDER_URL;
+    if (!url) {
+        return {
+            source: "fallback",
+            base: SETTLEMENT_CURRENCY.code,
+            rates: { ...FALLBACK_RATES },
+            fetchedAt: new Date().toISOString()
+        };
+    }
+
+    try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 4000);
+        const res = await fetch(url, { signal: controller.signal });
+        clearTimeout(timer);
+        if (!res.ok) {
+            throw new Error(`FX provider HTTP ${res.status}`);
+        }
+        const body = await res.json();
+        const rates = body.rates || body;
+        const normalized = { INR: 1 };
+        for (const code of Object.keys(SUPPORTED_CURRENCIES)) {
+            if (code === "INR") continue;
+            const value = Number(rates[code]);
+            if (Number.isFinite(value) && value > 0) {
+                normalized[code] = value;
+            } else {
+                normalized[code] = FALLBACK_RATES[code];
+            }
+        }
+        return {
+            source: "provider",
+            base: SETTLEMENT_CURRENCY.code,
+            rates: normalized,
+            fetchedAt: new Date().toISOString()
+        };
+    } catch (err) {
+        console.warn("FX provider unavailable, using fallback rates:", err.message);
+        return {
+            source: "fallback",
+            base: SETTLEMENT_CURRENCY.code,
+            rates: { ...FALLBACK_RATES },
+            fetchedAt: new Date().toISOString(),
+            providerError: err.message
+        };
+    }
+}
+
+async function getSpotRate(displayCurrency) {
+    const code = String(displayCurrency || SETTLEMENT_CURRENCY.code).toUpperCase();
+    if (!isSupportedCurrency(code)) {
+        throw new FxLockError(`Unsupported currency: ${code}`, {
+            status: 400,
+            code: "FX_CURRENCY_UNSUPPORTED"
+        });
+    }
+    if (code === SETTLEMENT_CURRENCY.code) {
+        return {
+            displayCurrency: code,
+            baseCurrency: SETTLEMENT_CURRENCY.code,
+            rate: 1,
+            source: "settlement",
+            fetchedAt: new Date().toISOString()
+        };
+    }
+
+    const bundle = await fetchProviderRates();
+    const rate = bundle.rates[code] ?? getFallbackRate(code);
+    if (!rate) {
+        throw new FxLockError(`No rate for ${code}`, {
+            status: 503,
+            code: "FX_RATE_UNAVAILABLE"
+        });
+    }
+    return {
+        displayCurrency: code,
+        baseCurrency: SETTLEMENT_CURRENCY.code,
+        rate: Number(rate),
+        source: bundle.source,
+        fetchedAt: bundle.fetchedAt
+    };
+}
+
+function signPayload(payload) {
+    const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    const sig = crypto
+        .createHmac("sha256", FX_LOCK_SECRET)
+        .update(body)
+        .digest("base64url");
+    return `${body}.${sig}`;
+}
+
+function verifySignedToken(token) {
+    if (!token || typeof token !== "string" || !token.includes(".")) {
+        throw new FxLockError("FX lock token is required", {
+            status: 400,
+            code: "FX_LOCK_MISSING"
+        });
+    }
+    const [body, sig] = token.split(".");
+    const expected = crypto
+        .createHmac("sha256", FX_LOCK_SECRET)
+        .update(body)
+        .digest("base64url");
+    const a = Buffer.from(sig);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+        throw new FxLockError("FX lock token signature is invalid", {
+            status: 400,
+            code: "FX_LOCK_TAMPERED"
+        });
+    }
+    try {
+        return JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+    } catch (_) {
+        throw new FxLockError("FX lock token is malformed", {
+            status: 400,
+            code: "FX_LOCK_MALFORMED"
+        });
+    }
+}
+
+/**
+ * Create a signed mid-session FX lock for checkout.
+ *
+ * @param {object} opts
+ * @param {string} opts.displayCurrency
+ * @param {number} [opts.baseTotal]  Basket total in settlement currency (INR)
+ * @param {string} [opts.quoteId]
+ */
+async function createFxLock({
+    displayCurrency,
+    baseTotal = null,
+    quoteId = null
+} = {}) {
+    const spot = await getSpotRate(displayCurrency);
+    const now = Date.now();
+    const expiresAt = now + FX_LOCK_TTL_SEC * 1000;
+    const lockId = crypto.randomUUID();
+
+    const payload = {
+        v: 1,
+        lockId,
+        quoteId: quoteId || lockId,
+        displayCurrency: spot.displayCurrency,
+        baseCurrency: spot.baseCurrency,
+        rate: spot.rate,
+        source: spot.source,
+        baseTotal:
+            baseTotal === null || baseTotal === undefined
+                ? null
+                : Number(baseTotal),
+        lockedAt: new Date(now).toISOString(),
+        expiresAt: new Date(expiresAt).toISOString()
+    };
+
+    const token = signPayload(payload);
+    const meta = getCurrencyMeta(spot.displayCurrency);
+
+    return {
+        token,
+        lock: {
+            ...payload,
+            currency: meta,
+            ttlSec: FX_LOCK_TTL_SEC,
+            displayTotal:
+                payload.baseTotal !== null
+                    ? roundMoney(payload.baseTotal * payload.rate, meta.minorUnitExponent)
+                    : null
+        }
+    };
+}
+
+function roundMoney(amount, exponent = 2) {
+    const factor = 10 ** exponent;
+    return Math.round((Number(amount) || 0) * factor) / factor;
+}
+
+/**
+ * Validate a lock token for checkout. Rejects expired / tampered / currency mismatch.
+ * Optionally compares claimed base total within tolerance.
+ */
+async function validateFxLock(token, {
+    displayCurrency = null,
+    baseTotal = null,
+    tolerance = 0.05
+} = {}) {
+    const payload = verifySignedToken(token);
+
+    if (payload.v !== 1) {
+        throw new FxLockError("Unsupported FX lock version", {
+            status: 400,
+            code: "FX_LOCK_VERSION"
+        });
+    }
+
+    if (new Date(payload.expiresAt).getTime() <= Date.now()) {
+        throw new FxLockError(
+            "FX rate lock has expired. Please refresh checkout to lock a new rate.",
+            { status: 409, code: "FX_LOCK_EXPIRED" }
+        );
+    }
+
+    if (
+        displayCurrency &&
+        String(displayCurrency).toUpperCase() !== payload.displayCurrency
+    ) {
+        throw new FxLockError("Currency switcher changed after the FX lock was issued", {
+            status: 409,
+            code: "FX_LOCK_CURRENCY_MISMATCH"
+        });
+    }
+
+    if (
+        baseTotal !== null &&
+        baseTotal !== undefined &&
+        payload.baseTotal !== null &&
+        payload.baseTotal !== undefined
+    ) {
+        const delta = Math.abs(Number(baseTotal) - Number(payload.baseTotal));
+        if (delta > tolerance) {
+            throw new FxLockError("Basket total no longer matches the FX-locked quote", {
+                status: 409,
+                code: "FX_LOCK_TOTAL_MISMATCH"
+            });
+        }
+    }
+
+    return payload;
+}
+
+/**
+ * At payment capture: compare locked rate to current spot and record audit.
+ * Settlement amount is always in base currency (INR).
+ */
+async function auditCapture({
+    fxLockToken,
+    settlementTotal,
+    orderId = null
+} = {}) {
+    const locked = await validateFxLock(fxLockToken);
+    const spot = await getSpotRate(locked.displayCurrency);
+
+    const entry = {
+        id: crypto.randomUUID(),
+        orderId,
+        lockId: locked.lockId,
+        displayCurrency: locked.displayCurrency,
+        baseCurrency: locked.baseCurrency,
+        lockedRate: locked.rate,
+        spotRate: spot.rate,
+        rateDelta: Number((spot.rate - locked.rate).toFixed(8)),
+        settlementTotal: Number(settlementTotal),
+        displayTotalLocked: roundMoney(
+            Number(settlementTotal) * locked.rate,
+            getCurrencyMeta(locked.displayCurrency).minorUnitExponent
+        ),
+        displayTotalSpot: roundMoney(
+            Number(settlementTotal) * spot.rate,
+            getCurrencyMeta(locked.displayCurrency).minorUnitExponent
+        ),
+        capturedAt: new Date().toISOString(),
+        lockSource: locked.source,
+        spotSource: spot.source
+    };
+
+    captureAuditLog.push(entry);
+    if (captureAuditLog.length > 500) {
+        captureAuditLog.shift();
+    }
+
+    return entry;
+}
+
+function listRecentCaptureAudits(limit = 20) {
+    return captureAuditLog.slice(-limit).reverse();
+}
+
+/** Convert settlement (INR) amount to display using a locked or spot rate. */
+function toDisplayAmount(baseAmount, rate, displayCurrency) {
+    const meta = getCurrencyMeta(displayCurrency);
+    return roundMoney(Number(baseAmount) * Number(rate), meta.minorUnitExponent);
+}
+
+module.exports = {
+    FX_LOCK_TTL_SEC,
+    FxLockError,
+    fetchProviderRates,
+    getSpotRate,
+    createFxLock,
+    validateFxLock,
+    auditCapture,
+    listRecentCaptureAudits,
+    toDisplayAmount,
+    signPayload,
+    verifySignedToken,
+    // test seam
+    _captureAuditLog: captureAuditLog
+};

--- a/backend/services/impersonationService.js
+++ b/backend/services/impersonationService.js
@@ -1,0 +1,435 @@
+/**
+ * Admin impersonation grants — mint / revoke / audit (#1393).
+ */
+
+"use strict";
+
+const crypto = require("crypto");
+const jwt = require("jsonwebtoken");
+const db = require("../config/db");
+const { sanitizeString, safeInteger } = require("../utils/helpers");
+
+const DEFAULT_TTL_MINUTES = Math.max(
+    1,
+    parseInt(process.env.IMPERSONATION_TTL_MINUTES, 10) || 10
+);
+const MAX_TTL_MINUTES = Math.max(
+    DEFAULT_TTL_MINUTES,
+    parseInt(process.env.IMPERSONATION_MAX_TTL_MINUTES, 10) || 30
+);
+
+const ACTIONS = Object.freeze({
+    MINT: "mint",
+    REQUEST: "request",
+    REVOKE: "revoke",
+    EXPIRE: "expire",
+    DENY: "deny"
+});
+
+class ImpersonationError extends Error {
+    constructor(message, { status = 400, code = "IMPERSONATION_ERROR" } = {}) {
+        super(message);
+        this.name = "ImpersonationError";
+        this.status = status;
+        this.code = code;
+    }
+}
+
+function subjectId(userLike) {
+    return userLike?.id || userLike?.userId || null;
+}
+
+async function appendAudit({
+    grantId,
+    actorAdminId,
+    subjectUserId,
+    action,
+    method = null,
+    path = null,
+    statusCode = null,
+    ip = null,
+    userAgent = null,
+    meta = null
+}) {
+    await db.query(
+        `INSERT INTO admin_impersonation_audit
+            (grant_id, actor_admin_id, subject_user_id, action, method, path,
+             status_code, ip, user_agent, meta_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+            grantId,
+            actorAdminId,
+            subjectUserId,
+            action,
+            method ? String(method).slice(0, 16) : null,
+            path ? String(path).slice(0, 512) : null,
+            statusCode,
+            ip ? String(ip).slice(0, 45) : null,
+            userAgent ? String(userAgent).slice(0, 512) : null,
+            meta ? JSON.stringify(meta) : null
+        ]
+    );
+}
+
+async function getActiveGrantByJti(jti) {
+    const [rows] = await db.query(
+        `SELECT * FROM admin_impersonation_grants
+         WHERE jti = ? LIMIT 1`,
+        [jti]
+    );
+    return rows[0] || null;
+}
+
+/**
+ * Mint a short-lived impersonation access token.
+ * Subject claim is the target user; actorAdminId is preserved in claims + DB.
+ */
+async function mintImpersonationToken({
+    actorAdmin,
+    subjectUserId,
+    reason,
+    ticketId,
+    ttlMinutes,
+    ip = null,
+    userAgent = null
+}) {
+    const actorAdminId = subjectId(actorAdmin);
+    if (!actorAdminId) {
+        throw new ImpersonationError("Admin identity required", {
+            status: 401,
+            code: "ADMIN_REQUIRED"
+        });
+    }
+
+    const cleanReason = sanitizeString(reason || "");
+    const cleanTicket = sanitizeString(ticketId || "");
+    const cleanSubject = sanitizeString(subjectUserId || "");
+
+    if (!cleanSubject) {
+        throw new ImpersonationError("subject userId is required", {
+            status: 400,
+            code: "SUBJECT_REQUIRED"
+        });
+    }
+    if (cleanReason.length < 8) {
+        throw new ImpersonationError(
+            "A reason of at least 8 characters is required",
+            { status: 400, code: "REASON_REQUIRED" }
+        );
+    }
+    if (cleanTicket.length < 3) {
+        throw new ImpersonationError("A ticket id is required (min 3 characters)", {
+            status: 400,
+            code: "TICKET_REQUIRED"
+        });
+    }
+    if (cleanSubject === actorAdminId) {
+        throw new ImpersonationError("Cannot impersonate yourself", {
+            status: 400,
+            code: "SELF_IMPERSONATION"
+        });
+    }
+
+    const [subjects] = await db.query(
+        `SELECT id, email, name, role, is_active, deleted_at
+         FROM users WHERE id = ? LIMIT 1`,
+        [cleanSubject]
+    );
+    const subject = subjects[0];
+    if (!subject) {
+        throw new ImpersonationError("Subject user not found", {
+            status: 404,
+            code: "SUBJECT_NOT_FOUND"
+        });
+    }
+    if (subject.deleted_at || subject.is_active === 0) {
+        throw new ImpersonationError("Cannot impersonate an inactive or deleted user", {
+            status: 400,
+            code: "SUBJECT_INACTIVE"
+        });
+    }
+    if (subject.role === "admin" || subject.role === "superadmin") {
+        throw new ImpersonationError("Cannot impersonate admin accounts", {
+            status: 403,
+            code: "ADMIN_SUBJECT_FORBIDDEN"
+        });
+    }
+
+    let ttl = safeInteger(ttlMinutes, DEFAULT_TTL_MINUTES);
+    if (ttl < 1) ttl = 1;
+    if (ttl > MAX_TTL_MINUTES) ttl = MAX_TTL_MINUTES;
+
+    const grantId = crypto.randomUUID();
+    const jti = crypto.randomUUID();
+    const expiresAt = new Date(Date.now() + ttl * 60 * 1000);
+
+    await db.query(
+        `INSERT INTO admin_impersonation_grants
+            (id, actor_admin_id, subject_user_id, reason, ticket_id, jti, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+            grantId,
+            actorAdminId,
+            cleanSubject,
+            cleanReason.slice(0, 500),
+            cleanTicket.slice(0, 100),
+            jti,
+            expiresAt
+        ]
+    );
+
+    await appendAudit({
+        grantId,
+        actorAdminId,
+        subjectUserId: cleanSubject,
+        action: ACTIONS.MINT,
+        ip,
+        userAgent,
+        meta: { reason: cleanReason, ticketId: cleanTicket, ttlMinutes: ttl }
+    });
+
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+        throw new ImpersonationError("JWT_SECRET is not configured", {
+            status: 500,
+            code: "CONFIG_ERROR"
+        });
+    }
+
+    const token = jwt.sign(
+        {
+            id: subject.id,
+            email: subject.email,
+            role: subject.role,
+            impersonation: true,
+            actorAdminId,
+            subjectUserId: subject.id,
+            grantId,
+            reason: cleanReason.slice(0, 200),
+            ticketId: cleanTicket.slice(0, 100),
+            jti
+        },
+        secret,
+        { expiresIn: `${ttl}m` }
+    );
+
+    return {
+        token,
+        grantId,
+        jti,
+        expiresAt: expiresAt.toISOString(),
+        ttlMinutes: ttl,
+        actorAdminId,
+        subjectUserId: subject.id,
+        subject: {
+            id: subject.id,
+            email: subject.email,
+            name: subject.name,
+            role: subject.role
+        },
+        reason: cleanReason,
+        ticketId: cleanTicket
+    };
+}
+
+async function revokeImpersonationGrant({
+    grantId,
+    jti,
+    revokedBy,
+    ip = null,
+    userAgent = null
+}) {
+    let grant = null;
+    if (grantId) {
+        const [rows] = await db.query(
+            `SELECT * FROM admin_impersonation_grants WHERE id = ? LIMIT 1`,
+            [sanitizeString(grantId)]
+        );
+        grant = rows[0] || null;
+    } else if (jti) {
+        grant = await getActiveGrantByJti(sanitizeString(jti));
+    }
+
+    if (!grant) {
+        throw new ImpersonationError("Impersonation grant not found", {
+            status: 404,
+            code: "GRANT_NOT_FOUND"
+        });
+    }
+
+    if (grant.revoked_at) {
+        return { alreadyRevoked: true, grantId: grant.id };
+    }
+
+    const actorId = subjectId(revokedBy) || grant.actor_admin_id;
+    await db.query(
+        `UPDATE admin_impersonation_grants
+         SET revoked_at = NOW(), revoked_by = ?
+         WHERE id = ? AND revoked_at IS NULL`,
+        [actorId, grant.id]
+    );
+
+    await appendAudit({
+        grantId: grant.id,
+        actorAdminId: grant.actor_admin_id,
+        subjectUserId: grant.subject_user_id,
+        action: ACTIONS.REVOKE,
+        ip,
+        userAgent,
+        meta: { revokedBy: actorId }
+    });
+
+    return { alreadyRevoked: false, grantId: grant.id };
+}
+
+/**
+ * Validate an impersonation JWT payload against the grant row.
+ * @returns {{ ok: true, grant } | { ok: false, code, message, status }}
+ */
+async function validateImpersonationClaims(decoded) {
+    if (!decoded || !decoded.impersonation) {
+        return { ok: true, grant: null };
+    }
+
+    const grantId = decoded.grantId;
+    const jti = decoded.jti;
+    const actorAdminId = decoded.actorAdminId;
+    const subjectUserId = decoded.subjectUserId || decoded.id;
+
+    if (!grantId || !jti || !actorAdminId || !subjectUserId) {
+        return {
+            ok: false,
+            status: 401,
+            code: "IMPERSONATION_CLAIMS_INVALID",
+            message: "Impersonation token is missing required claims"
+        };
+    }
+
+    const grant = await getActiveGrantByJti(jti);
+    if (!grant || grant.id !== grantId) {
+        return {
+            ok: false,
+            status: 401,
+            code: "IMPERSONATION_GRANT_UNKNOWN",
+            message: "Impersonation grant not found"
+        };
+    }
+
+    if (grant.revoked_at) {
+        return {
+            ok: false,
+            status: 401,
+            code: "IMPERSONATION_REVOKED",
+            message: "Impersonation grant has been revoked"
+        };
+    }
+
+    if (new Date(grant.expires_at).getTime() <= Date.now()) {
+        await appendAudit({
+            grantId: grant.id,
+            actorAdminId: grant.actor_admin_id,
+            subjectUserId: grant.subject_user_id,
+            action: ACTIONS.EXPIRE,
+            meta: { source: "validate" }
+        }).catch(() => {});
+        return {
+            ok: false,
+            status: 401,
+            code: "IMPERSONATION_EXPIRED",
+            message: "Impersonation grant has expired"
+        };
+    }
+
+    if (
+        grant.actor_admin_id !== actorAdminId ||
+        grant.subject_user_id !== subjectUserId
+    ) {
+        return {
+            ok: false,
+            status: 401,
+            code: "IMPERSONATION_MISMATCH",
+            message: "Impersonation token does not match grant"
+        };
+    }
+
+    return { ok: true, grant };
+}
+
+async function listImpersonationAudit({
+    grantId = null,
+    actorAdminId = null,
+    subjectUserId = null,
+    page = 1,
+    limit = 50
+} = {}) {
+    const safePage = Math.max(1, safeInteger(page, 1));
+    const safeLimit = Math.min(100, Math.max(1, safeInteger(limit, 50)));
+    const offset = (safePage - 1) * safeLimit;
+
+    const where = [];
+    const params = [];
+    if (grantId) {
+        where.push("grant_id = ?");
+        params.push(sanitizeString(grantId));
+    }
+    if (actorAdminId) {
+        where.push("actor_admin_id = ?");
+        params.push(sanitizeString(actorAdminId));
+    }
+    if (subjectUserId) {
+        where.push("subject_user_id = ?");
+        params.push(sanitizeString(subjectUserId));
+    }
+    const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+
+    const [countRows] = await db.query(
+        `SELECT COUNT(*) AS total FROM admin_impersonation_audit ${whereSql}`,
+        params
+    );
+    const [rows] = await db.query(
+        `SELECT id, grant_id, actor_admin_id, subject_user_id, action, method,
+                path, status_code, ip, user_agent, meta_json, created_at
+         FROM admin_impersonation_audit
+         ${whereSql}
+         ORDER BY created_at DESC
+         LIMIT ? OFFSET ?`,
+        [...params, safeLimit, offset]
+    );
+
+    return {
+        entries: rows.map((r) => ({
+            id: r.id,
+            grantId: r.grant_id,
+            actorAdminId: r.actor_admin_id,
+            subjectUserId: r.subject_user_id,
+            action: r.action,
+            method: r.method,
+            path: r.path,
+            statusCode: r.status_code,
+            ip: r.ip,
+            userAgent: r.user_agent,
+            meta: r.meta_json
+                ? typeof r.meta_json === "string"
+                    ? JSON.parse(r.meta_json)
+                    : r.meta_json
+                : null,
+            createdAt: r.created_at
+        })),
+        total: countRows[0]?.total || 0,
+        page: safePage,
+        limit: safeLimit
+    };
+}
+
+module.exports = {
+    ACTIONS,
+    DEFAULT_TTL_MINUTES,
+    MAX_TTL_MINUTES,
+    ImpersonationError,
+    mintImpersonationToken,
+    revokeImpersonationGrant,
+    validateImpersonationClaims,
+    appendAudit,
+    listImpersonationAudit,
+    getActiveGrantByJti
+};

--- a/backend/services/wishlistNotifyService.js
+++ b/backend/services/wishlistNotifyService.js
@@ -1,0 +1,529 @@
+/**
+ * Wishlist → Price-Drop Notification Worker helpers (#1394).
+ *
+ * - Syncs baselines from wishlist_items + live product prices
+ * - Detects price drops vs baseline / last notified price
+ * - Publishes via notificationBroker (email + in-app)
+ * - Respects per-user preference center + signed unsubscribe tokens
+ * - Daily dedupe so the same SKU cannot spam a user more than once per day
+ */
+
+"use strict";
+
+const crypto = require("crypto");
+const db = require("../config/db");
+const {
+    notificationBroker,
+    NOTIFICATION_TYPES
+} = require("./notificationBrokerService");
+
+const UNSUBSCRIBE_SECRET =
+    process.env.PRICE_DROP_UNSUB_SECRET ||
+    process.env.JWT_SECRET ||
+    "price-drop-unsub-dev-secret";
+
+const MIN_DROP_PERCENT = Math.max(
+    0,
+    Number(process.env.PRICE_DROP_MIN_PERCENT) || 1
+);
+
+function sha256(value) {
+    return crypto.createHash("sha256").update(String(value)).digest("hex");
+}
+
+function mintRawToken() {
+    return crypto.randomBytes(32).toString("hex");
+}
+
+function dayKey(date = new Date()) {
+    return date.toISOString().slice(0, 10);
+}
+
+function dedupeKey(userId, productId, day = dayKey()) {
+    return `${userId}:${productId}:${day}`;
+}
+
+function signUnsubscribeToken(userId, rawToken) {
+    // token format: userId.raw.hmac — verifiable without a DB round-trip,
+    // while the hash in notification_preferences still gates reuse after rotate.
+    const body = `${userId}.${rawToken}`;
+    const sig = crypto
+        .createHmac("sha256", UNSUBSCRIBE_SECRET)
+        .update(body)
+        .digest("hex");
+    return `${body}.${sig}`;
+}
+
+function parseUnsubscribeToken(token) {
+    const parts = String(token || "").split(".");
+    if (parts.length !== 3) return null;
+    const [userId, rawToken, sig] = parts;
+    const body = `${userId}.${rawToken}`;
+    const expected = crypto
+        .createHmac("sha256", UNSUBSCRIBE_SECRET)
+        .update(body)
+        .digest("hex");
+    const a = Buffer.from(sig);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+        return null;
+    }
+    return { userId, rawToken, hash: sha256(rawToken) };
+}
+
+async function ensurePreferences(userId) {
+    const [rows] = await db.query(
+        `SELECT * FROM notification_preferences WHERE user_id = ? LIMIT 1`,
+        [userId]
+    );
+    if (rows[0]) {
+        return { prefs: rows[0], rawToken: null };
+    }
+
+    const rawToken = mintRawToken();
+    await db.query(
+        `INSERT INTO notification_preferences
+            (user_id, price_drop_email, price_drop_in_app, unsubscribed_all, unsubscribe_token_hash)
+         VALUES (?, 1, 1, 0, ?)`,
+        [userId, sha256(rawToken)]
+    );
+    const [created] = await db.query(
+        `SELECT * FROM notification_preferences WHERE user_id = ? LIMIT 1`,
+        [userId]
+    );
+    return { prefs: created[0], rawToken };
+}
+
+async function getPreferences(userId) {
+    const { prefs, rawToken } = await ensurePreferences(userId);
+    const unsubscribeToken =
+        rawToken
+            ? signUnsubscribeToken(userId, rawToken)
+            : null;
+
+    return {
+        userId,
+        priceDropEmail: Boolean(prefs.price_drop_email),
+        priceDropInApp: Boolean(prefs.price_drop_in_app),
+        unsubscribedAll: Boolean(prefs.unsubscribed_all),
+        // Fresh token when prefs were just created; otherwise a stable signed link.
+        unsubscribeToken:
+            rawToken
+                ? signUnsubscribeToken(userId, rawToken)
+                : buildStableUnsubscribeToken(userId),
+        unsubscribeUrl: buildUnsubscribeUrl(
+            rawToken
+                ? signUnsubscribeToken(userId, rawToken)
+                : buildStableUnsubscribeToken(userId)
+        ),
+        updatedAt: prefs.updated_at
+    };
+}
+
+async function updatePreferences(userId, patch = {}) {
+    await ensurePreferences(userId);
+
+    const email =
+        patch.priceDropEmail === undefined
+            ? null
+            : patch.priceDropEmail ? 1 : 0;
+    const inApp =
+        patch.priceDropInApp === undefined
+            ? null
+            : patch.priceDropInApp ? 1 : 0;
+    const unsubAll =
+        patch.unsubscribedAll === undefined
+            ? null
+            : patch.unsubscribedAll ? 1 : 0;
+
+    await db.query(
+        `UPDATE notification_preferences SET
+            price_drop_email = COALESCE(?, price_drop_email),
+            price_drop_in_app = COALESCE(?, price_drop_in_app),
+            unsubscribed_all = COALESCE(?, unsubscribed_all),
+            updated_at = NOW()
+         WHERE user_id = ?`,
+        [email, inApp, unsubAll, userId]
+    );
+
+    return getPreferences(userId);
+}
+
+async function rotateUnsubscribeToken(userId) {
+    const rawToken = mintRawToken();
+    await ensurePreferences(userId);
+    await db.query(
+        `UPDATE notification_preferences
+         SET unsubscribe_token_hash = ?, updated_at = NOW()
+         WHERE user_id = ?`,
+        [sha256(rawToken), userId]
+    );
+    return {
+        unsubscribeToken: signUnsubscribeToken(userId, rawToken),
+        unsubscribeUrl: buildUnsubscribeUrl(signUnsubscribeToken(userId, rawToken))
+    };
+}
+
+function buildStableUnsubscribeToken(userId) {
+    const sig = crypto
+        .createHmac("sha256", UNSUBSCRIBE_SECRET)
+        .update(`price-drop-unsub:${userId}`)
+        .digest("hex");
+    return `${userId}.${sig}`;
+}
+
+function parseStableUnsubscribeToken(token) {
+    const parts = String(token || "").split(".");
+    if (parts.length !== 2) return null;
+    const [userId, sig] = parts;
+    const expected = crypto
+        .createHmac("sha256", UNSUBSCRIBE_SECRET)
+        .update(`price-drop-unsub:${userId}`)
+        .digest("hex");
+    const a = Buffer.from(sig);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+        return null;
+    }
+    return { userId };
+}
+
+function buildUnsubscribeUrl(token) {
+    const frontend = (process.env.FRONTEND_URL || "http://localhost:5500").replace(/\/$/, "");
+    return `${frontend}/dashboard.html?tab=wishlist&unsubscribe=${encodeURIComponent(token)}`;
+}
+
+async function unsubscribeWithToken(token) {
+    const rotatable = parseUnsubscribeToken(token);
+    const stable = rotatable ? null : parseStableUnsubscribeToken(token);
+
+    let userId = null;
+    if (rotatable) {
+        const [rows] = await db.query(
+            `SELECT user_id, unsubscribe_token_hash FROM notification_preferences WHERE user_id = ?`,
+            [rotatable.userId]
+        );
+        if (!rows[0] || rows[0].unsubscribe_token_hash !== rotatable.hash) {
+            const err = new Error("Unsubscribe token is expired or already rotated");
+            err.status = 410;
+            err.code = "UNSUBSCRIBE_TOKEN_STALE";
+            throw err;
+        }
+        userId = rotatable.userId;
+    } else if (stable) {
+        userId = stable.userId;
+    } else {
+        const err = new Error("Invalid or tampered unsubscribe link");
+        err.status = 400;
+        err.code = "INVALID_UNSUBSCRIBE_TOKEN";
+        throw err;
+    }
+
+    await ensurePreferences(userId);
+    await db.query(
+        `UPDATE notification_preferences
+         SET unsubscribed_all = 1,
+             price_drop_email = 0,
+             price_drop_in_app = 0,
+             updated_at = NOW()
+         WHERE user_id = ?`,
+        [userId]
+    );
+
+    return { userId, unsubscribedAll: true };
+}
+
+/**
+ * Upsert a baseline when a product is wishlisted (or during sync).
+ * Does not lower the baseline on later syncs — only tracks last_seen_price —
+ * so a temporary spike does not erase a better historical baseline.
+ */
+async function upsertBaseline(userId, productId, currentPrice) {
+    const price = Number(currentPrice);
+    if (!Number.isFinite(price) || price < 0) {
+        throw new Error("Invalid product price for baseline");
+    }
+
+    await db.query(
+        `INSERT INTO price_drop_baselines
+            (user_id, product_id, baseline_price, last_seen_price)
+         VALUES (?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE
+            last_seen_price = VALUES(last_seen_price),
+            baseline_price = LEAST(baseline_price, VALUES(baseline_price)),
+            updated_at = NOW()`,
+        [userId, productId, price, price]
+    );
+}
+
+/**
+ * Pull active wishlist rows and ensure every line has a baseline.
+ */
+async function syncBaselinesFromWishlist() {
+    const [rows] = await db.query(
+        `SELECT w.user_id, w.product_id, p.price
+           FROM wishlist_items w
+           JOIN products p ON p.id = w.product_id
+          WHERE w.deleted_at IS NULL`
+    );
+
+    let synced = 0;
+    for (const row of rows) {
+        try {
+            await upsertBaseline(row.user_id, row.product_id, row.price);
+            synced += 1;
+        } catch (err) {
+            console.error(
+                `syncBaselinesFromWishlist failed for ${row.user_id}/${row.product_id}:`,
+                err.message
+            );
+        }
+    }
+    return { synced, total: rows.length };
+}
+
+function channelsForPrefs(prefs) {
+    if (!prefs || prefs.unsubscribed_all) return [];
+    const channels = [];
+    if (prefs.price_drop_in_app) channels.push("in_app");
+    if (prefs.price_drop_email) channels.push("email");
+    return channels;
+}
+
+async function alreadyNotifiedToday(userId, productId) {
+    const key = dedupeKey(userId, productId);
+    const [rows] = await db.query(
+        `SELECT id FROM price_drop_notification_log WHERE dedupe_key = ? LIMIT 1`,
+        [key]
+    );
+    return Boolean(rows[0]);
+}
+
+async function recordNotificationLog({
+    userId,
+    productId,
+    oldPrice,
+    newPrice,
+    channels
+}) {
+    const key = dedupeKey(userId, productId);
+    try {
+        await db.query(
+            `INSERT INTO price_drop_notification_log
+                (user_id, product_id, old_price, new_price, channels_json, dedupe_key)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+            [
+                userId,
+                productId,
+                oldPrice,
+                newPrice,
+                JSON.stringify(channels),
+                key
+            ]
+        );
+        return true;
+    } catch (err) {
+        // Duplicate dedupe_key → already sent today
+        if (err && (err.code === "ER_DUP_ENTRY" || /duplicate/i.test(err.message))) {
+            return false;
+        }
+        throw err;
+    }
+}
+
+async function sendPriceDropEmail({ to, productName, oldPrice, newPrice, unsubscribeUrl }) {
+    const host = process.env.SMTP_HOST;
+    const user = process.env.SMTP_USER;
+    const pass = process.env.SMTP_PASS;
+    const subject = `Price drop: ${productName}`;
+    const text =
+        `${productName} dropped from ${oldPrice} to ${newPrice}.\n\n` +
+        (unsubscribeUrl
+            ? `Manage preferences / unsubscribe: ${unsubscribeUrl}\n`
+            : "");
+
+    if (host && user && pass) {
+        try {
+            const nodemailer = require("nodemailer");
+            const transporter = nodemailer.createTransport({
+                host,
+                port: Number(process.env.SMTP_PORT) || 587,
+                secure: false,
+                auth: { user, pass }
+            });
+            await transporter.sendMail({
+                from: process.env.SMTP_FROM || user,
+                to,
+                subject,
+                text
+            });
+            return { delivered: true, channel: "smtp" };
+        } catch (err) {
+            console.error("Price-drop email failed:", err.message);
+        }
+    }
+
+    console.info("[price-drop] email (SMTP not configured):", {
+        to,
+        subject,
+        oldPrice,
+        newPrice
+    });
+    return { delivered: false, channel: "log" };
+}
+
+/**
+ * Core scan: wishlist baselines whose live price fell enough to notify.
+ */
+async function runPriceDropScan() {
+    await syncBaselinesFromWishlist();
+
+    const [candidates] = await db.query(
+        `SELECT b.user_id, b.product_id, b.baseline_price, b.last_seen_price,
+                b.last_notified_price, b.last_notified_at,
+                p.price AS current_price, p.name AS product_name,
+                u.email AS user_email, u.name AS user_name,
+                pref.price_drop_email, pref.price_drop_in_app, pref.unsubscribed_all,
+                pref.unsubscribe_token_hash
+           FROM price_drop_baselines b
+           JOIN products p ON p.id = b.product_id
+           JOIN users u ON u.id = b.user_id
+           JOIN wishlist_items w
+             ON w.user_id = b.user_id
+            AND w.product_id = b.product_id
+            AND w.deleted_at IS NULL
+           LEFT JOIN notification_preferences pref ON pref.user_id = b.user_id
+          WHERE p.price < b.baseline_price
+            AND (
+                  b.last_notified_price IS NULL
+               OR p.price < b.last_notified_price
+            )`
+    );
+
+    let notified = 0;
+    let skipped = 0;
+
+    for (const row of candidates) {
+        const current = Number(row.current_price);
+        const baseline = Number(row.baseline_price);
+        if (!(current < baseline)) {
+            skipped += 1;
+            continue;
+        }
+
+        const dropPct = ((baseline - current) / baseline) * 100;
+        if (dropPct < MIN_DROP_PERCENT) {
+            skipped += 1;
+            continue;
+        }
+
+        // Ensure prefs exist for channel resolution / unsubscribe links
+        const { prefs } = await ensurePreferences(row.user_id);
+        const channels = channelsForPrefs({
+            price_drop_email: prefs.price_drop_email,
+            price_drop_in_app: prefs.price_drop_in_app,
+            unsubscribed_all: prefs.unsubscribed_all
+        });
+
+        if (!channels.length) {
+            skipped += 1;
+            continue;
+        }
+
+        if (await alreadyNotifiedToday(row.user_id, row.product_id)) {
+            skipped += 1;
+            continue;
+        }
+
+        const logged = await recordNotificationLog({
+            userId: row.user_id,
+            productId: row.product_id,
+            oldPrice: baseline,
+            newPrice: current,
+            channels
+        });
+        if (!logged) {
+            skipped += 1;
+            continue;
+        }
+
+        try {
+            await notificationBroker.publish(
+                NOTIFICATION_TYPES.WISHLIST_PRICE_DROP,
+                {
+                    userId: row.user_id,
+                    productId: row.product_id,
+                    productName: row.product_name,
+                    oldPrice: baseline,
+                    newPrice: current,
+                    dropPercent: Number(dropPct.toFixed(2))
+                },
+                { channels }
+            );
+
+            if (channels.includes("email") && row.user_email) {
+                const unsubToken = buildStableUnsubscribeToken(row.user_id);
+                await sendPriceDropEmail({
+                    to: row.user_email,
+                    productName: row.product_name,
+                    oldPrice: baseline,
+                    newPrice: current,
+                    unsubscribeUrl: buildUnsubscribeUrl(unsubToken)
+                });
+            }
+
+            await db.query(
+                `UPDATE price_drop_baselines
+                 SET last_seen_price = ?,
+                     last_notified_at = NOW(),
+                     last_notified_price = ?,
+                     updated_at = NOW()
+                 WHERE user_id = ? AND product_id = ?`,
+                [current, current, row.user_id, row.product_id]
+            );
+
+            notified += 1;
+        } catch (err) {
+            console.error(
+                `price-drop notify failed ${row.user_id}/${row.product_id}:`,
+                err.message
+            );
+            // Allow retry tomorrow; dedupe row already written — delete so retry works same day?
+            // Keep dedupe to avoid broker storm; next day can fire if price still lower.
+        }
+    }
+
+    // Refresh last_seen_price for non-drop rows still on wishlist
+    await db.query(
+        `UPDATE price_drop_baselines b
+         JOIN products p ON p.id = b.product_id
+         SET b.last_seen_price = p.price, b.updated_at = NOW()`
+    );
+
+    return { candidates: candidates.length, notified, skipped };
+}
+
+module.exports = {
+    getPreferences,
+    updatePreferences,
+    rotateUnsubscribeToken,
+    unsubscribeWithToken,
+    upsertBaseline,
+    syncBaselinesFromWishlist,
+    runPriceDropScan,
+    buildUnsubscribeUrl,
+    buildStableUnsubscribeToken,
+    signUnsubscribeToken,
+    parseUnsubscribeToken,
+    parseStableUnsubscribeToken,
+    dedupeKey,
+    channelsForPrefs,
+    MIN_DROP_PERCENT,
+    // test seams
+    _internal: {
+        sha256,
+        mintRawToken,
+        dayKey,
+        sendPriceDropEmail
+    }
+};

--- a/backend/sql/admin_impersonation_audit.sql
+++ b/backend/sql/admin_impersonation_audit.sql
@@ -1,0 +1,51 @@
+-- ============================================
+-- ADMIN IMPERSONATION GRANTS & AUDIT (#1393)
+-- ============================================
+-- Time-boxed "view as user" grants with mandatory reason + ticket id.
+-- Audit rows are append-only (no UPDATE/DELETE from the application).
+--
+-- Also folded into migrations/0028_admin_impersonation_audit.sql.
+
+CREATE TABLE IF NOT EXISTS admin_impersonation_grants (
+    id CHAR(36) PRIMARY KEY,
+    actor_admin_id CHAR(36) NOT NULL,
+    subject_user_id CHAR(36) NOT NULL,
+    reason VARCHAR(500) NOT NULL,
+    ticket_id VARCHAR(100) NOT NULL,
+    jti CHAR(36) NOT NULL,
+    expires_at DATETIME NOT NULL,
+    revoked_at DATETIME NULL,
+    revoked_by CHAR(36) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_impersonation_jti (jti),
+    INDEX idx_imp_grant_actor (actor_admin_id),
+    INDEX idx_imp_grant_subject (subject_user_id),
+    INDEX idx_imp_grant_expires (expires_at),
+
+    CONSTRAINT fk_imp_grant_actor FOREIGN KEY (actor_admin_id)
+        REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_imp_grant_subject FOREIGN KEY (subject_user_id)
+        REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS admin_impersonation_audit (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    grant_id CHAR(36) NOT NULL,
+    actor_admin_id CHAR(36) NOT NULL,
+    subject_user_id CHAR(36) NOT NULL,
+    action VARCHAR(32) NOT NULL,
+    method VARCHAR(16) NULL,
+    path VARCHAR(512) NULL,
+    status_code INT NULL,
+    ip VARCHAR(45) NULL,
+    user_agent VARCHAR(512) NULL,
+    meta_json JSON NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    INDEX idx_imp_audit_grant (grant_id),
+    INDEX idx_imp_audit_actor (actor_admin_id),
+    INDEX idx_imp_audit_subject (subject_user_id),
+    INDEX idx_imp_audit_created (created_at),
+    INDEX idx_imp_audit_action (action)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/sql/price_drop_baselines.sql
+++ b/backend/sql/price_drop_baselines.sql
@@ -1,0 +1,59 @@
+-- ============================================
+-- WISHLIST PRICE-DROP BASELINES & PREFERENCES (#1394)
+-- ============================================
+-- Baselines capture the price when a product enters (or is synced from) the
+-- wishlist. The worker compares live product.price to baseline_price and
+-- enqueues notifications via the notification broker, respecting preferences
+-- and daily dedupe keys.
+--
+-- Also folded into migrations/0027_price_drop_baselines.sql for migrate.
+
+CREATE TABLE IF NOT EXISTS price_drop_baselines (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id CHAR(36) NOT NULL,
+    product_id CHAR(36) NOT NULL,
+    baseline_price DECIMAL(10,2) NOT NULL,
+    last_seen_price DECIMAL(10,2) NOT NULL,
+    last_notified_at DATETIME NULL,
+    last_notified_price DECIMAL(10,2) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_price_drop_user_product (user_id, product_id),
+    INDEX idx_pdb_product (product_id),
+    INDEX idx_pdb_notified (last_notified_at),
+
+    CONSTRAINT fk_pdb_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_pdb_product FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS notification_preferences (
+    user_id CHAR(36) PRIMARY KEY,
+    price_drop_email TINYINT(1) NOT NULL DEFAULT 1,
+    price_drop_in_app TINYINT(1) NOT NULL DEFAULT 1,
+    unsubscribed_all TINYINT(1) NOT NULL DEFAULT 0,
+    unsubscribe_token_hash CHAR(64) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_notif_pref_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Append-only log used for daily dedupe (one alert per user+product per day).
+CREATE TABLE IF NOT EXISTS price_drop_notification_log (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id CHAR(36) NOT NULL,
+    product_id CHAR(36) NOT NULL,
+    old_price DECIMAL(10,2) NOT NULL,
+    new_price DECIMAL(10,2) NOT NULL,
+    channels_json JSON NULL,
+    dedupe_key VARCHAR(128) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_price_drop_dedupe (dedupe_key),
+    INDEX idx_pdnl_user (user_id),
+    INDEX idx_pdnl_created (created_at),
+
+    CONSTRAINT fk_pdnl_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_pdnl_product FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/tests/contract/consumer.pactlike.test.js
+++ b/backend/tests/contract/consumer.pactlike.test.js
@@ -1,0 +1,181 @@
+/**
+ * Pact-like consumer contract checks (#1395).
+ *
+ * These encode what the vanilla JS storefront (consumer) expects from the
+ * Express API (provider). They do not spin a live server — they freeze the
+ * response shapes the UI already depends on and validate them against the
+ * published OpenAPI schemas so frontend/backend drift fails in CI.
+ */
+
+const {
+    loadOpenApi,
+    createAjv,
+    compileSchema,
+    assertValid
+} = require("./helpers/loadOpenApi");
+
+describe("consumer contracts (storefront expectations)", () => {
+    let openapi;
+    let ajv;
+
+    beforeAll(() => {
+        openapi = loadOpenApi();
+        ajv = createAjv();
+    });
+
+    describe("auth consumer", () => {
+        test("login success exposes token + user for localStorage", () => {
+            const body = {
+                success: true,
+                message: "Login successful",
+                token: "access.jwt.token",
+                refreshToken: "refresh.jwt.token",
+                user: {
+                    id: "u-1",
+                    name: "Ada",
+                    email: "ada@example.com",
+                    role: "customer"
+                }
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "LoginSuccess"),
+                body,
+                "auth login consumer"
+            );
+            expect(body.token || body.accessToken).toBeTruthy();
+            expect(body.user.email).toContain("@");
+        });
+
+        test("401 login failure is a flat error envelope (no nested data required)", () => {
+            const body = { success: false, message: "Invalid credentials" };
+            assertValid(
+                compileSchema(ajv, openapi, "ErrorEnvelope"),
+                body,
+                "auth 401 consumer"
+            );
+            expect(body.success).toBe(false);
+        });
+    });
+
+    describe("products consumer", () => {
+        test("list payload keeps pagination fields the shop grid reads", () => {
+            const body = {
+                success: true,
+                products: [
+                    {
+                        id: "550e8400-e29b-41d4-a716-446655440010",
+                        name: "Tee",
+                        price: 499,
+                        stock: 12,
+                        category: "mens"
+                    }
+                ],
+                total: 1,
+                page: 1,
+                limit: 20,
+                totalPages: 1,
+                hasNextPage: false,
+                hasPrevPage: false
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "ProductListSuccess"),
+                body,
+                "products list consumer"
+            );
+        });
+    });
+
+    describe("cart consumer", () => {
+        test("add-to-cart success is a SuccessEnvelope the toast can show", () => {
+            const body = {
+                success: true,
+                message: "Product added to cart and reserved for 15 minutes"
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "SuccessEnvelope"),
+                body,
+                "cart add consumer"
+            );
+        });
+
+        test("inventory 409 carries code the checkout UI branches on", () => {
+            const body = {
+                success: false,
+                code: "INVENTORY_CONFLICT",
+                message: "Insufficient stock",
+                productId: "p-1",
+                availableStock: 0,
+                requested: 2
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "InventoryConflictEnvelope"),
+                body,
+                "cart 409 consumer"
+            );
+            expect(body.code).toBe("INVENTORY_CONFLICT");
+        });
+    });
+
+    describe("checkout consumer", () => {
+        test("quote returns breakdown.total used to submit orders", () => {
+            const body = {
+                success: true,
+                breakdown: {
+                    subtotal: 1000,
+                    tax: 180,
+                    shipping: 0,
+                    discount: 50,
+                    total: 1130,
+                    promoCode: "SAVE50",
+                    currency: "INR"
+                },
+                promoMessage: null
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "CheckoutQuoteSuccess"),
+                body,
+                "checkout quote consumer"
+            );
+            expect(typeof body.breakdown.total).toBe("number");
+        });
+    });
+
+    describe("orders consumer", () => {
+        test("create order success exposes orderId for success.html redirect", () => {
+            const body = {
+                success: true,
+                message: "Order placed successfully",
+                orderId: "550e8400-e29b-41d4-a716-446655440099",
+                breakdown: {
+                    subtotal: 1000,
+                    tax: 180,
+                    shipping: 49,
+                    discount: 0,
+                    total: 1229
+                },
+                addressId: null
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "OrderCreatedSuccess"),
+                body,
+                "orders create consumer"
+            );
+            expect(body.orderId).toBeTruthy();
+        });
+
+        test("TOTAL_MISMATCH 409 matches what checkout.js refreshes on", () => {
+            const body = {
+                success: false,
+                code: "TOTAL_MISMATCH",
+                message: "Submitted total does not match server price",
+                submittedTotal: 100,
+                computedTotal: 120
+            };
+            assertValid(
+                compileSchema(ajv, openapi, "TotalMismatchEnvelope"),
+                body,
+                "orders 409 consumer"
+            );
+        });
+    });
+});

--- a/backend/tests/contract/envelope.contract.test.js
+++ b/backend/tests/contract/envelope.contract.test.js
@@ -1,0 +1,76 @@
+/**
+ * Fixture ↔ OpenAPI schema contract tests (#1395).
+ * Example payloads for 401 / 409 / 422 (and happy paths) must match the spec.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const {
+    loadOpenApi,
+    createAjv,
+    compileSchema,
+    assertValid
+} = require("./helpers/loadOpenApi");
+
+const FIXTURES = path.join(__dirname, "fixtures");
+
+function readFixture(name) {
+    return JSON.parse(fs.readFileSync(path.join(FIXTURES, name), "utf8"));
+}
+
+describe("contract fixtures vs OpenAPI schemas", () => {
+    let openapi;
+    let ajv;
+
+    beforeAll(() => {
+        openapi = loadOpenApi();
+        ajv = createAjv();
+    });
+
+    test("401 unauthorized matches ErrorEnvelope", () => {
+        const validate = compileSchema(ajv, openapi, "ErrorEnvelope");
+        assertValid(validate, readFixture("401.unauthorized.json"), "401 fixture");
+    });
+
+    test("409 inventory conflict matches InventoryConflictEnvelope", () => {
+        const validate = compileSchema(ajv, openapi, "InventoryConflictEnvelope");
+        assertValid(
+            validate,
+            readFixture("409.inventory-conflict.json"),
+            "409 inventory fixture"
+        );
+    });
+
+    test("409 total mismatch matches TotalMismatchEnvelope", () => {
+        const validate = compileSchema(ajv, openapi, "TotalMismatchEnvelope");
+        assertValid(
+            validate,
+            readFixture("409.total-mismatch.json"),
+            "409 total mismatch fixture"
+        );
+    });
+
+    test("422 validation matches ValidationErrorEnvelope", () => {
+        const validate = compileSchema(ajv, openapi, "ValidationErrorEnvelope");
+        assertValid(validate, readFixture("422.validation.json"), "422 fixture");
+    });
+
+    test("200 login success matches LoginSuccess", () => {
+        const validate = compileSchema(ajv, openapi, "LoginSuccess");
+        assertValid(validate, readFixture("200.login-success.json"), "login fixture");
+    });
+
+    test("200 checkout quote matches CheckoutQuoteSuccess", () => {
+        const validate = compileSchema(ajv, openapi, "CheckoutQuoteSuccess");
+        assertValid(
+            validate,
+            readFixture("200.checkout-quote.json"),
+            "checkout quote fixture"
+        );
+    });
+
+    test("rejecting a broken envelope (missing success) fails validation", () => {
+        const validate = compileSchema(ajv, openapi, "ErrorEnvelope");
+        expect(validate({ message: "no success flag" })).toBe(false);
+    });
+});

--- a/backend/tests/contract/fixtures/200.checkout-quote.json
+++ b/backend/tests/contract/fixtures/200.checkout-quote.json
@@ -1,0 +1,13 @@
+{
+  "success": true,
+  "breakdown": {
+    "subtotal": 999,
+    "tax": 179.82,
+    "shipping": 49,
+    "discount": 0,
+    "total": 1227.82,
+    "promoCode": null,
+    "currency": "INR"
+  },
+  "promoMessage": null
+}

--- a/backend/tests/contract/fixtures/200.login-success.json
+++ b/backend/tests/contract/fixtures/200.login-success.json
@@ -1,0 +1,12 @@
+{
+  "success": true,
+  "message": "Login successful",
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.example",
+  "refreshToken": "refresh_example_token",
+  "user": {
+    "id": "550e8400-e29b-41d4-a716-446655440001",
+    "name": "Shopper",
+    "email": "shopper@example.com",
+    "role": "customer"
+  }
+}

--- a/backend/tests/contract/fixtures/401.unauthorized.json
+++ b/backend/tests/contract/fixtures/401.unauthorized.json
@@ -1,0 +1,4 @@
+{
+  "success": false,
+  "message": "Unauthorized"
+}

--- a/backend/tests/contract/fixtures/409.inventory-conflict.json
+++ b/backend/tests/contract/fixtures/409.inventory-conflict.json
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "code": "INVENTORY_CONFLICT",
+  "message": "Inventory locks expired or insufficient stock",
+  "productId": "550e8400-e29b-41d4-a716-446655440000",
+  "availableStock": 2,
+  "requested": 5
+}

--- a/backend/tests/contract/fixtures/409.total-mismatch.json
+++ b/backend/tests/contract/fixtures/409.total-mismatch.json
@@ -1,0 +1,7 @@
+{
+  "success": false,
+  "code": "TOTAL_MISMATCH",
+  "message": "Submitted total does not match server price",
+  "submittedTotal": 999,
+  "computedTotal": 1048
+}

--- a/backend/tests/contract/fixtures/422.validation.json
+++ b/backend/tests/contract/fixtures/422.validation.json
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "message": "Validation failed",
+  "details": [
+    "email is required",
+    "password must be at least 8 characters"
+  ]
+}

--- a/backend/tests/contract/helpers/loadOpenApi.js
+++ b/backend/tests/contract/helpers/loadOpenApi.js
@@ -1,0 +1,107 @@
+/**
+ * OpenAPI loader + AJV helpers for contract tests (#1395).
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const OPENAPI_PATH = path.join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "openapi",
+    "ecommerce.openapi.yaml"
+);
+
+function loadYaml(filePath) {
+    const raw = fs.readFileSync(filePath, "utf8");
+    let yaml;
+    try {
+        yaml = require("js-yaml");
+    } catch (err) {
+        throw new Error(
+            "js-yaml is required for OpenAPI contract tests. Run `npm install` in backend/."
+        );
+    }
+    return yaml.load(raw);
+}
+
+function loadOpenApi() {
+    const doc = loadYaml(OPENAPI_PATH);
+    if (!doc || doc.openapi !== "3.0.3") {
+        throw new Error("Expected OpenAPI 3.0.3 document at openapi/ecommerce.openapi.yaml");
+    }
+    return doc;
+}
+
+function createAjv() {
+    const Ajv = require("ajv");
+    const addFormats = require("ajv-formats");
+    const ajv = new Ajv({
+        allErrors: true,
+        strict: false,
+        validateSchema: false
+    });
+    addFormats(ajv);
+    return ajv;
+}
+
+/**
+ * Compile a component schema by name, resolving local $refs within components.
+ */
+function compileSchema(ajv, openapi, schemaName) {
+    const components = openapi.components || {};
+    const schemas = components.schemas || {};
+    if (!schemas[schemaName]) {
+        throw new Error(`Unknown schema: ${schemaName}`);
+    }
+
+    // Register every component schema once so $ref resolution works.
+    if (!ajv.getSchema("https://ecommerce.local/openapi.json")) {
+        ajv.addSchema(
+            {
+                $id: "https://ecommerce.local/openapi.json",
+                components: { schemas }
+            },
+            "https://ecommerce.local/openapi.json"
+        );
+    }
+
+    const ref = {
+        $ref: `https://ecommerce.local/openapi.json#/components/schemas/${schemaName}`
+    };
+    return ajv.compile(ref);
+}
+
+function assertValid(validate, payload, label) {
+    const ok = validate(payload);
+    if (!ok) {
+        const details = (validate.errors || [])
+            .map((e) => `${e.instancePath || "/"} ${e.message}`)
+            .join("; ");
+        throw new Error(`${label} failed schema validation: ${details}`);
+    }
+}
+
+function listCorePaths(openapi) {
+    return Object.keys(openapi.paths || {}).sort();
+}
+
+function responseStatusesFor(openapi, pathKey, method) {
+    const op = openapi.paths?.[pathKey]?.[method];
+    if (!op) return [];
+    return Object.keys(op.responses || {}).map(String);
+}
+
+module.exports = {
+    OPENAPI_PATH,
+    loadOpenApi,
+    createAjv,
+    compileSchema,
+    assertValid,
+    listCorePaths,
+    responseStatusesFor
+};

--- a/backend/tests/contract/openapi.document.test.js
+++ b/backend/tests/contract/openapi.document.test.js
@@ -1,0 +1,77 @@
+/**
+ * OpenAPI document structure contract (#1395).
+ */
+
+const path = require("path");
+const fs = require("fs");
+const {
+    OPENAPI_PATH,
+    loadOpenApi,
+    listCorePaths,
+    responseStatusesFor
+} = require("./helpers/loadOpenApi");
+
+describe("OpenAPI document", () => {
+    test("ecommerce.openapi.yaml exists", () => {
+        expect(fs.existsSync(OPENAPI_PATH)).toBe(true);
+    });
+
+    test("is OpenAPI 3.0.3 with core tags and security scheme", () => {
+        const doc = loadOpenApi();
+        expect(doc.info.title).toMatch(/e-commerce/i);
+        expect(doc.tags.map((t) => t.name)).toEqual(
+            expect.arrayContaining(["Auth", "Products", "Cart", "Checkout", "Orders"])
+        );
+        expect(doc.components.securitySchemes.bearerAuth.scheme).toBe("bearer");
+    });
+
+    test("publishes core auth/cart/checkout/products/orders paths", () => {
+        const doc = loadOpenApi();
+        const paths = listCorePaths(doc);
+        expect(paths).toEqual(
+            expect.arrayContaining([
+                "/auth/login",
+                "/auth/me",
+                "/auth/status",
+                "/products",
+                "/products/{id}",
+                "/cart",
+                "/cart/add",
+                "/checkout/quote",
+                "/orders",
+                "/orders/create-payment-intent",
+                "/orders/my-orders"
+            ])
+        );
+    });
+
+    test("documents 401/409/422 on critical write paths", () => {
+        const doc = loadOpenApi();
+        expect(responseStatusesFor(doc, "/auth/login", "post")).toEqual(
+            expect.arrayContaining(["200", "401", "422"])
+        );
+        expect(responseStatusesFor(doc, "/cart/add", "post")).toEqual(
+            expect.arrayContaining(["200", "401", "409"])
+        );
+        expect(responseStatusesFor(doc, "/orders", "post")).toEqual(
+            expect.arrayContaining(["201", "401", "409", "422"])
+        );
+    });
+
+    test("defines shared envelope and pagination schemas", () => {
+        const doc = loadOpenApi();
+        const schemas = Object.keys(doc.components.schemas);
+        expect(schemas).toEqual(
+            expect.arrayContaining([
+                "SuccessEnvelope",
+                "ErrorEnvelope",
+                "ValidationErrorEnvelope",
+                "InventoryConflictEnvelope",
+                "TotalMismatchEnvelope",
+                "PaginationMeta",
+                "PriceBreakdown",
+                "CreateOrderRequest"
+            ])
+        );
+    });
+});

--- a/backend/tests/fxLock.test.js
+++ b/backend/tests/fxLock.test.js
@@ -1,0 +1,116 @@
+/**
+ * Mid-session FX lock (#1392) — signed rate tokens, TTL expiry, capture audit.
+ */
+
+process.env.FX_LOCK_SECRET = "test-fx-lock-secret";
+process.env.FX_LOCK_TTL_SEC = "900";
+delete process.env.FX_PROVIDER_URL;
+
+const fxLockService = require("../services/fxLockService");
+const CURRENCY = require("../config/currency");
+
+describe("fxLockService (#1392)", () => {
+    test("currency catalog exposes settlement INR and fallback rates", () => {
+        expect(CURRENCY.code).toBe("INR");
+        expect(CURRENCY.isSupportedCurrency("USD")).toBe(true);
+        expect(CURRENCY.getFallbackRate("USD")).toBeGreaterThan(0);
+        expect(CURRENCY.FALLBACK_RATES.INR).toBe(1);
+    });
+
+    test("createFxLock returns a signed token with TTL metadata", async () => {
+        const { token, lock } = await fxLockService.createFxLock({
+            displayCurrency: "USD",
+            baseTotal: 1000
+        });
+
+        expect(typeof token).toBe("string");
+        expect(token.includes(".")).toBe(true);
+        expect(lock.displayCurrency).toBe("USD");
+        expect(lock.baseCurrency).toBe("INR");
+        expect(lock.rate).toBeGreaterThan(0);
+        expect(lock.baseTotal).toBe(1000);
+        expect(lock.displayTotal).toBeCloseTo(1000 * lock.rate, 4);
+        expect(lock.ttlSec).toBeGreaterThanOrEqual(60);
+    });
+
+    test("validateFxLock accepts a fresh token", async () => {
+        const { token, lock } = await fxLockService.createFxLock({
+            displayCurrency: "EUR",
+            baseTotal: 500
+        });
+
+        const payload = await fxLockService.validateFxLock(token, {
+            displayCurrency: "EUR",
+            baseTotal: 500
+        });
+
+        expect(payload.lockId).toBe(lock.lockId);
+        expect(payload.rate).toBe(lock.rate);
+    });
+
+    test("validateFxLock rejects expired locks", async () => {
+        const { token } = await fxLockService.createFxLock({
+            displayCurrency: "GBP",
+            baseTotal: 200
+        });
+
+        const payload = fxLockService.verifySignedToken(token);
+        payload.expiresAt = new Date(Date.now() - 1000).toISOString();
+        const expiredToken = fxLockService.signPayload(payload);
+
+        await expect(
+            fxLockService.validateFxLock(expiredToken, { displayCurrency: "GBP" })
+        ).rejects.toMatchObject({ code: "FX_LOCK_EXPIRED", status: 409 });
+    });
+
+    test("validateFxLock rejects currency mismatch after switcher change", async () => {
+        const { token } = await fxLockService.createFxLock({
+            displayCurrency: "USD",
+            baseTotal: 100
+        });
+
+        await expect(
+            fxLockService.validateFxLock(token, { displayCurrency: "EUR" })
+        ).rejects.toMatchObject({ code: "FX_LOCK_CURRENCY_MISMATCH", status: 409 });
+    });
+
+    test("validateFxLock rejects tampered tokens", async () => {
+        const { token } = await fxLockService.createFxLock({
+            displayCurrency: "USD",
+            baseTotal: 50
+        });
+        const [body] = token.split(".");
+        const tampered = `${body}.not-a-valid-signature`;
+
+        await expect(fxLockService.validateFxLock(tampered)).rejects.toMatchObject({
+            code: "FX_LOCK_TAMPERED"
+        });
+    });
+
+    test("auditCapture records locked vs spot delta", async () => {
+        const { token } = await fxLockService.createFxLock({
+            displayCurrency: "USD",
+            baseTotal: 2500
+        });
+
+        const audit = await fxLockService.auditCapture({
+            fxLockToken: token,
+            settlementTotal: 2500,
+            orderId: "order-fx-test"
+        });
+
+        expect(audit.orderId).toBe("order-fx-test");
+        expect(audit.lockedRate).toBeGreaterThan(0);
+        expect(audit.spotRate).toBeGreaterThan(0);
+        expect(typeof audit.rateDelta).toBe("number");
+        expect(audit.settlementTotal).toBe(2500);
+        expect(audit.displayTotalLocked).toBeCloseTo(2500 * audit.lockedRate, 4);
+    });
+
+    test("fetchProviderRates falls back when FX_PROVIDER_URL is unset", async () => {
+        const bundle = await fxLockService.fetchProviderRates();
+        expect(bundle.source).toBe("fallback");
+        expect(bundle.base).toBe("INR");
+        expect(bundle.rates.USD).toBe(CURRENCY.FALLBACK_RATES.USD);
+    });
+});

--- a/backend/tests/impersonation.test.js
+++ b/backend/tests/impersonation.test.js
@@ -1,0 +1,241 @@
+/**
+ * Admin impersonation (#1393) unit tests.
+ */
+
+jest.mock("../config/db", () => ({
+    query: jest.fn()
+}));
+
+const jwt = require("jsonwebtoken");
+const db = require("../config/db");
+const impersonationService = require("../services/impersonationService");
+const { impersonationMiddleware } = require("../middleware/impersonationMiddleware");
+
+const SECRET = "test_jwt_secret_at_least_32_characters_long";
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.JWT_SECRET = SECRET;
+});
+
+function mockRes() {
+    const headers = {};
+    const res = {
+        statusCode: 200,
+        body: null,
+        headers,
+        setHeader(k, v) {
+            headers[k.toLowerCase()] = v;
+        },
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        },
+        on(event, cb) {
+            if (event === "finish") {
+                this._finish = cb;
+            }
+            return this;
+        },
+        finish() {
+            if (this._finish) this._finish();
+        }
+    };
+    return res;
+}
+
+describe("mintImpersonationToken", () => {
+    test("requires reason and ticket id", async () => {
+        await expect(
+            impersonationService.mintImpersonationToken({
+                actorAdmin: { id: "admin-1" },
+                subjectUserId: "user-1",
+                reason: "short",
+                ticketId: "AB"
+            })
+        ).rejects.toMatchObject({ code: "REASON_REQUIRED" });
+    });
+
+    test("mints a time-boxed JWT with impersonation claims", async () => {
+        db.query
+            .mockResolvedValueOnce([[{
+                id: "user-1",
+                email: "shopper@example.com",
+                name: "Shopper",
+                role: "customer",
+                is_active: 1,
+                deleted_at: null
+            }]])
+            .mockResolvedValueOnce([{ affectedRows: 1 }]) // insert grant
+            .mockResolvedValueOnce([{ affectedRows: 1 }]); // audit mint
+
+        const result = await impersonationService.mintImpersonationToken({
+            actorAdmin: { id: "admin-1", role: "admin" },
+            subjectUserId: "user-1",
+            reason: "Investigating checkout bug for support",
+            ticketId: "SUP-1234",
+            ttlMinutes: 5
+        });
+
+        expect(result.token).toBeTruthy();
+        expect(result.ttlMinutes).toBe(5);
+        expect(result.actorAdminId).toBe("admin-1");
+        expect(result.subjectUserId).toBe("user-1");
+
+        const decoded = jwt.verify(result.token, SECRET);
+        expect(decoded.impersonation).toBe(true);
+        expect(decoded.actorAdminId).toBe("admin-1");
+        expect(decoded.subjectUserId).toBe("user-1");
+        expect(decoded.id).toBe("user-1");
+        expect(decoded.ticketId).toBe("SUP-1234");
+        expect(decoded.jti).toBeTruthy();
+    });
+
+    test("refuses to impersonate admin subjects", async () => {
+        db.query.mockResolvedValueOnce([[{
+            id: "admin-2",
+            email: "other@example.com",
+            name: "Other Admin",
+            role: "admin",
+            is_active: 1,
+            deleted_at: null
+        }]]);
+
+        await expect(
+            impersonationService.mintImpersonationToken({
+                actorAdmin: { id: "admin-1" },
+                subjectUserId: "admin-2",
+                reason: "Should not be allowed here",
+                ticketId: "SUP-9"
+            })
+        ).rejects.toMatchObject({ code: "ADMIN_SUBJECT_FORBIDDEN" });
+    });
+});
+
+describe("revokeImpersonationGrant", () => {
+    test("marks grant revoked and audits", async () => {
+        db.query
+            .mockResolvedValueOnce([[{
+                id: "grant-1",
+                actor_admin_id: "admin-1",
+                subject_user_id: "user-1",
+                jti: "jti-1",
+                revoked_at: null
+            }]])
+            .mockResolvedValueOnce([{ affectedRows: 1 }])
+            .mockResolvedValueOnce([{ affectedRows: 1 }]);
+
+        const result = await impersonationService.revokeImpersonationGrant({
+            grantId: "grant-1",
+            revokedBy: { id: "admin-1" }
+        });
+
+        expect(result.alreadyRevoked).toBe(false);
+        expect(db.query).toHaveBeenCalledWith(
+            expect.stringMatching(/SET revoked_at = NOW()/i),
+            expect.any(Array)
+        );
+    });
+});
+
+describe("impersonationMiddleware", () => {
+    test("no-ops for normal sessions", async () => {
+        const req = { user: { id: "user-1", role: "customer" } };
+        const res = mockRes();
+        const next = jest.fn();
+        await impersonationMiddleware(req, res, next);
+        expect(next).toHaveBeenCalled();
+        expect(res.headers["x-impersonating"]).toBeUndefined();
+    });
+
+    test("watermarks response and audits requests for valid grants", async () => {
+        const grant = {
+            id: "grant-1",
+            actor_admin_id: "admin-1",
+            subject_user_id: "user-1",
+            reason: "Support ticket investigation",
+            ticket_id: "SUP-1",
+            jti: "jti-1",
+            expires_at: new Date(Date.now() + 60_000),
+            revoked_at: null
+        };
+
+        db.query
+            .mockResolvedValueOnce([[grant]]) // validate by jti
+            .mockResolvedValueOnce([{ affectedRows: 1 }]); // audit on finish
+
+        const req = {
+            method: "GET",
+            originalUrl: "/api/orders/my-orders",
+            ip: "127.0.0.1",
+            headers: { "user-agent": "jest" },
+            user: {
+                id: "user-1",
+                impersonation: true,
+                actorAdminId: "admin-1",
+                subjectUserId: "user-1",
+                grantId: "grant-1",
+                jti: "jti-1",
+                ticketId: "SUP-1"
+            }
+        };
+        const res = mockRes();
+        const next = jest.fn();
+
+        await impersonationMiddleware(req, res, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.headers["x-impersonating"]).toBe("user-1");
+        expect(res.headers["x-impersonation-actor"]).toBe("admin-1");
+        expect(req.impersonation.actorAdminId).toBe("admin-1");
+        expect(req.actorAdminId).toBe("admin-1");
+
+        res.statusCode = 200;
+        res.finish();
+        // allow async audit
+        await new Promise((r) => setImmediate(r));
+        expect(db.query).toHaveBeenCalledWith(
+            expect.stringMatching(/INSERT INTO admin_impersonation_audit/i),
+            expect.arrayContaining(["grant-1", "admin-1", "user-1", "request"])
+        );
+    });
+
+    test("rejects revoked grants", async () => {
+        db.query
+            .mockResolvedValueOnce([[{
+                id: "grant-1",
+                actor_admin_id: "admin-1",
+                subject_user_id: "user-1",
+                jti: "jti-1",
+                expires_at: new Date(Date.now() + 60_000),
+                revoked_at: new Date()
+            }]])
+            .mockResolvedValueOnce([{ affectedRows: 1 }]);
+
+        const req = {
+            method: "GET",
+            url: "/api/cart",
+            headers: {},
+            user: {
+                id: "user-1",
+                impersonation: true,
+                actorAdminId: "admin-1",
+                subjectUserId: "user-1",
+                grantId: "grant-1",
+                jti: "jti-1"
+            }
+        };
+        const res = mockRes();
+        const next = jest.fn();
+
+        await impersonationMiddleware(req, res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(401);
+        expect(res.body.code).toBe("IMPERSONATION_REVOKED");
+    });
+});

--- a/backend/tests/queryBudget.test.js
+++ b/backend/tests/queryBudget.test.js
@@ -1,0 +1,206 @@
+/**
+ * SQL query budget & slow-query circuit breaker tests (#1391).
+ */
+
+process.env.QUERY_BUDGET_ENABLED = "true";
+process.env.QUERY_BUDGET_MAX = "5";
+process.env.QUERY_SLOW_MS = "50";
+process.env.QUERY_CIRCUIT_RETRY_AFTER_SEC = "15";
+process.env.QUERY_CIRCUIT_TRIP_THRESHOLD = "3";
+process.env.QUERY_CIRCUIT_WINDOW_MS = "60000";
+process.env.QUERY_BUDGET_BYPASS = "false";
+
+// Re-require after env so CONFIG picks up test values — module caches CONFIG at load.
+jest.resetModules();
+
+const { sanitizeSql, logSlowQuery } = require("../utils/slowQueryLogger");
+
+describe("slowQueryLogger (#1391)", () => {
+    test("sanitizeSql redacts string literals and long numbers", () => {
+        const sql =
+            "SELECT * FROM users WHERE email = 'alice@example.com' AND id = 1234567890";
+        const cleaned = sanitizeSql(sql);
+        expect(cleaned).not.toContain("alice@example.com");
+        expect(cleaned).toContain("'?'");
+        expect(cleaned).not.toContain("1234567890");
+    });
+
+    test("logSlowQuery returns sanitized payload with route attribution", () => {
+        const payload = logSlowQuery({
+            sql: "UPDATE products SET name = 'Secret' WHERE id = 1",
+            durationMs: 1200,
+            route: "/api/products",
+            method: "GET",
+            requestId: "corr_test"
+        });
+        expect(payload.type).toBe("slow_query");
+        expect(payload.route).toBe("/api/products");
+        expect(payload.method).toBe("GET");
+        expect(payload.sql).not.toContain("Secret");
+        expect(payload.durationMs).toBe(1200);
+    });
+});
+
+describe("queryBudgetMiddleware (#1391)", () => {
+    let qb;
+
+    beforeEach(() => {
+        jest.resetModules();
+        process.env.QUERY_BUDGET_ENABLED = "true";
+        process.env.QUERY_BUDGET_MAX = "5";
+        process.env.QUERY_SLOW_MS = "50";
+        process.env.QUERY_CIRCUIT_RETRY_AFTER_SEC = "15";
+        process.env.QUERY_CIRCUIT_TRIP_THRESHOLD = "3";
+        process.env.QUERY_BUDGET_BYPASS = "false";
+        qb = require("../middleware/queryBudgetMiddleware");
+        qb.resetQueryBudgetState();
+        // Override CONFIG for deterministic tests (module already read env)
+        qb.CONFIG.maxQueries = 5;
+        qb.CONFIG.slowMs = 50;
+        qb.CONFIG.enabled = true;
+        qb.CONFIG.globalBypass = false;
+        qb.CONFIG.tripThreshold = 3;
+        qb.CONFIG.retryAfterSec = 15;
+    });
+
+    test("counts queries inside a request context and trips at budget", () => {
+        qb.runWithQueryBudget({ route: "/api/loop", routeKey: "GET /api/loop" }, () => {
+            for (let i = 0; i < 5; i++) {
+                qb.recordQueryExecution({
+                    phase: "begin",
+                    sql: `SELECT ${i}`
+                });
+                qb.recordQueryExecution({
+                    phase: "finish",
+                    sql: `SELECT ${i}`,
+                    durationMs: 1
+                });
+            }
+
+            expect(() =>
+                qb.recordQueryExecution({
+                    phase: "begin",
+                    sql: "SELECT too_many"
+                })
+            ).toThrow(qb.QueryBudgetError);
+
+            try {
+                qb.recordQueryExecution({
+                    phase: "begin",
+                    sql: "SELECT too_many"
+                });
+            } catch (err) {
+                expect(err.code).toBe("QUERY_BUDGET_EXCEEDED");
+                expect(err.status).toBe(503);
+                expect(err.retryAfter).toBe(15);
+            }
+        });
+    });
+
+    test("bypass skips budget for migrations/jobs", () => {
+        qb.runWithQueryBudgetBypass(() => {
+            for (let i = 0; i < 20; i++) {
+                const result = qb.recordQueryExecution({
+                    phase: "begin",
+                    sql: `SELECT bypass_${i}`
+                });
+                expect(result.counted).toBe(false);
+            }
+        });
+    });
+
+    test("no ALS context is treated as bypass (background work)", () => {
+        const result = qb.recordQueryExecution({
+            phase: "begin",
+            sql: "SELECT 1"
+        });
+        expect(result.counted).toBe(false);
+    });
+
+    test("slow queries are attributed on finish", () => {
+        qb.runWithQueryBudget({ route: "/api/slow", routeKey: "GET /api/slow" }, () => {
+            qb.recordQueryExecution({ phase: "begin", sql: "SELECT sleep" });
+            qb.recordQueryExecution({
+                phase: "finish",
+                sql: "SELECT sleep",
+                durationMs: 200
+            });
+            const ctx = qb.getActiveBudgetContext();
+            expect(ctx.slowCount).toBe(1);
+        });
+    });
+
+    test("middleware returns 503 with Retry-After when route circuit is open", () => {
+        const key = "GET /api/hot";
+        // Force-open the circuit
+        qb._routeCircuits.set(key, {
+            openUntil: Date.now() + 15_000,
+            trips: []
+        });
+
+        const req = {
+            method: "GET",
+            originalUrl: "/api/hot",
+            path: "/api/hot"
+        };
+        const headers = {};
+        const res = {
+            setHeader: (k, v) => {
+                headers[k] = v;
+            },
+            status: jest.fn(function (code) {
+                this.statusCode = code;
+                return this;
+            }),
+            json: jest.fn(function (body) {
+                this.body = body;
+                return this;
+            })
+        };
+        const next = jest.fn();
+
+        qb.queryBudgetMiddleware(req, res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(503);
+        expect(headers["Retry-After"]).toBeDefined();
+        expect(res.body.code).toBe("QUERY_CIRCUIT_OPEN");
+    });
+
+    test("middleware opens ALS and calls next when circuit closed", () => {
+        const req = {
+            method: "GET",
+            originalUrl: "/api/products",
+            path: "/api/products",
+            correlationId: "corr_1"
+        };
+        const res = {
+            setHeader: jest.fn(),
+            on: jest.fn()
+        };
+        const next = jest.fn();
+
+        qb.queryBudgetMiddleware(req, res, next);
+        expect(next).toHaveBeenCalled();
+        expect(res.on).toHaveBeenCalledWith("finish", expect.any(Function));
+    });
+
+    test("getQueryBudgetMetrics returns config and offender lists", () => {
+        qb.runWithQueryBudget({ route: "/api/a", routeKey: "GET /api/a" }, () => {
+            for (let i = 0; i < 5; i++) {
+                qb.recordQueryExecution({ phase: "begin", sql: "SELECT x" });
+            }
+            try {
+                qb.recordQueryExecution({ phase: "begin", sql: "SELECT y" });
+            } catch (_) {
+                /* expected budget trip */
+            }
+        });
+
+        const metrics = qb.getQueryBudgetMetrics(10);
+        expect(metrics.config.maxQueries).toBe(5);
+        expect(Array.isArray(metrics.topOffenders)).toBe(true);
+        expect(Array.isArray(metrics.openCircuits)).toBe(true);
+        expect(metrics.topOffenders.some((o) => o.budgetTrips >= 1)).toBe(true);
+    });
+});

--- a/backend/tests/wishlistNotify.test.js
+++ b/backend/tests/wishlistNotify.test.js
@@ -1,0 +1,239 @@
+/**
+ * Wishlist price-drop notification worker tests (#1394).
+ */
+
+jest.mock("../config/db", () => ({
+    query: jest.fn()
+}));
+
+jest.mock("../services/notificationBrokerService", () => ({
+    NOTIFICATION_TYPES: {
+        WISHLIST_PRICE_DROP: "wishlist.price_drop"
+    },
+    notificationBroker: {
+        publish: jest.fn(async () => ({ id: "n1" }))
+    }
+}));
+
+const db = require("../config/db");
+const { notificationBroker } = require("../services/notificationBrokerService");
+const service = require("../services/wishlistNotifyService");
+const {
+    runPriceDropJob,
+    startPriceDropJob,
+    PRICE_DROP_CRON
+} = require("../jobs/priceDropJob");
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe("wishlistNotifyService preferences", () => {
+    test("getPreferences creates defaults when missing", async () => {
+        db.query
+            .mockResolvedValueOnce([[]]) // select missing
+            .mockResolvedValueOnce([{ affectedRows: 1 }]) // insert
+            .mockResolvedValueOnce([[{
+                user_id: "u1",
+                price_drop_email: 1,
+                price_drop_in_app: 1,
+                unsubscribed_all: 0,
+                unsubscribe_token_hash: "abc",
+                updated_at: new Date()
+            }]]);
+
+        const prefs = await service.getPreferences("u1");
+        expect(prefs.priceDropEmail).toBe(true);
+        expect(prefs.priceDropInApp).toBe(true);
+        expect(prefs.unsubscribeToken).toBeTruthy();
+        expect(prefs.unsubscribeUrl).toMatch(/unsubscribe=/);
+    });
+
+    test("updatePreferences writes channel flags", async () => {
+        db.query
+            .mockResolvedValueOnce([[{
+                user_id: "u1",
+                price_drop_email: 1,
+                price_drop_in_app: 1,
+                unsubscribed_all: 0,
+                unsubscribe_token_hash: "h",
+                updated_at: new Date()
+            }]])
+            .mockResolvedValueOnce([{ affectedRows: 1 }])
+            .mockResolvedValueOnce([[{
+                user_id: "u1",
+                price_drop_email: 0,
+                price_drop_in_app: 1,
+                unsubscribed_all: 0,
+                unsubscribe_token_hash: "h",
+                updated_at: new Date()
+            }]]);
+
+        // ensurePreferences select + update + getPreferences select
+        // getPreferences will hit ensure again
+        db.query
+            .mockReset()
+            .mockResolvedValueOnce([[{
+                user_id: "u1",
+                price_drop_email: 1,
+                price_drop_in_app: 1,
+                unsubscribed_all: 0,
+                unsubscribe_token_hash: "h",
+                updated_at: new Date()
+            }]])
+            .mockResolvedValueOnce([{ affectedRows: 1 }])
+            .mockResolvedValueOnce([[{
+                user_id: "u1",
+                price_drop_email: 0,
+                price_drop_in_app: 1,
+                unsubscribed_all: 0,
+                unsubscribe_token_hash: "h",
+                updated_at: new Date()
+            }]]);
+
+        const prefs = await service.updatePreferences("u1", {
+            priceDropEmail: false,
+            priceDropInApp: true
+        });
+        expect(prefs.priceDropEmail).toBe(false);
+        expect(prefs.priceDropInApp).toBe(true);
+    });
+
+    test("stable unsubscribe token opts the user out", async () => {
+        const token = service.buildStableUnsubscribeToken("user-42");
+        db.query
+            .mockResolvedValueOnce([[{
+                user_id: "user-42",
+                price_drop_email: 1,
+                price_drop_in_app: 1,
+                unsubscribed_all: 0,
+                unsubscribe_token_hash: "x"
+            }]])
+            .mockResolvedValueOnce([{ affectedRows: 1 }]);
+
+        const result = await service.unsubscribeWithToken(token);
+        expect(result.unsubscribedAll).toBe(true);
+        expect(result.userId).toBe("user-42");
+    });
+
+    test("channelsForPrefs returns empty when unsubscribed_all", () => {
+        expect(
+            service.channelsForPrefs({
+                price_drop_email: 1,
+                price_drop_in_app: 1,
+                unsubscribed_all: 1
+            })
+        ).toEqual([]);
+    });
+});
+
+describe("wishlistNotifyService scan", () => {
+    test("runPriceDropScan notifies once and respects daily dedupe", async () => {
+        // syncBaselinesFromWishlist
+        db.query
+            .mockResolvedValueOnce([[{
+                user_id: "u1",
+                product_id: "p1",
+                price: 80
+            }]])
+            .mockResolvedValueOnce([{ affectedRows: 1 }]) // upsert baseline
+            // candidates
+            .mockResolvedValueOnce([[{
+                user_id: "u1",
+                product_id: "p1",
+                baseline_price: 100,
+                last_seen_price: 100,
+                last_notified_price: null,
+                last_notified_at: null,
+                current_price: 80,
+                product_name: "Tee",
+                user_email: "u@example.com",
+                user_name: "U",
+                price_drop_email: 1,
+                price_drop_in_app: 1,
+                unsubscribed_all: 0,
+                unsubscribe_token_hash: "h"
+            }]])
+            // ensurePreferences select
+            .mockResolvedValueOnce([[{
+                user_id: "u1",
+                price_drop_email: 1,
+                price_drop_in_app: 1,
+                unsubscribed_all: 0,
+                unsubscribe_token_hash: "h"
+            }]])
+            // alreadyNotifiedToday
+            .mockResolvedValueOnce([[]])
+            // recordNotificationLog insert
+            .mockResolvedValueOnce([{ affectedRows: 1 }])
+            // update baseline after notify
+            .mockResolvedValueOnce([{ affectedRows: 1 }])
+            // refresh last_seen bulk update
+            .mockResolvedValueOnce([{ affectedRows: 1 }]);
+
+        const result = await service.runPriceDropScan();
+        expect(result.notified).toBe(1);
+        expect(notificationBroker.publish).toHaveBeenCalledWith(
+            "wishlist.price_drop",
+            expect.objectContaining({
+                userId: "u1",
+                productId: "p1",
+                oldPrice: 100,
+                newPrice: 80
+            }),
+            { channels: ["in_app", "email"] }
+        );
+    });
+
+    test("skips when already deduped today", async () => {
+        db.query
+            .mockResolvedValueOnce([[]]) // sync wishlist empty
+            .mockResolvedValueOnce([[{
+                user_id: "u1",
+                product_id: "p1",
+                baseline_price: 100,
+                last_seen_price: 100,
+                last_notified_price: null,
+                current_price: 70,
+                product_name: "Tee",
+                user_email: "u@example.com",
+                price_drop_email: 1,
+                price_drop_in_app: 1,
+                unsubscribed_all: 0
+            }]])
+            .mockResolvedValueOnce([[{
+                user_id: "u1",
+                price_drop_email: 1,
+                price_drop_in_app: 1,
+                unsubscribed_all: 0,
+                unsubscribe_token_hash: "h"
+            }]])
+            .mockResolvedValueOnce([[{ id: 9 }]]) // already notified
+            .mockResolvedValueOnce([{ affectedRows: 1 }]); // bulk last_seen
+
+        const result = await service.runPriceDropScan();
+        expect(result.notified).toBe(0);
+        expect(result.skipped).toBeGreaterThanOrEqual(1);
+        expect(notificationBroker.publish).not.toHaveBeenCalled();
+    });
+});
+
+describe("priceDropJob", () => {
+    test("exports a cron expression", () => {
+        expect(PRICE_DROP_CRON).toMatch(/\S+/);
+    });
+
+    test("startPriceDropJob is a no-op under test", () => {
+        process.env.NODE_ENV = "test";
+        expect(startPriceDropJob()).toBeNull();
+    });
+
+    test("runPriceDropJob returns scan summary", async () => {
+        const spy = jest
+            .spyOn(service, "runPriceDropScan")
+            .mockResolvedValue({ candidates: 0, notified: 0, skipped: 0 });
+        const result = await runPriceDropJob();
+        expect(result).toEqual({ candidates: 0, notified: 0, skipped: 0 });
+        spy.mockRestore();
+    });
+});

--- a/backend/utils/slowQueryLogger.js
+++ b/backend/utils/slowQueryLogger.js
@@ -1,0 +1,73 @@
+/**
+ * Slow-query logging with sanitized SQL and route attribution (#1391).
+ */
+
+"use strict";
+
+const logger = require("./logger");
+
+/**
+ * Strip literals / long digit runs so logs never leak PII from VALUES (...).
+ */
+function sanitizeSql(sql) {
+    if (sql == null) {
+        return "unknown";
+    }
+    let text = String(sql);
+    // Quoted strings (single / double)
+    text = text.replace(/'(?:''|[^'])*'/g, "'?'");
+    text = text.replace(/"(?:\\"|[^"])*"/g, '"?"');
+    // Hex / binary blobs
+    text = text.replace(/\b0x[0-9a-fA-F]+\b/g, "0x?");
+    // Long numeric literals (keep short ones like LIMIT 10)
+    text = text.replace(/\b\d{6,}\b/g, "?");
+    // Collapse whitespace
+    text = text.replace(/\s+/g, " ").trim();
+    if (text.length > 400) {
+        text = `${text.slice(0, 400)}…`;
+    }
+    return text;
+}
+
+/**
+ * @param {object} info
+ * @param {string} info.sql
+ * @param {number} info.durationMs
+ * @param {string} [info.route]
+ * @param {string} [info.method]
+ * @param {string} [info.requestId]
+ * @param {string} [info.correlationId]
+ * @param {*} [info.params]
+ */
+function logSlowQuery(info = {}) {
+    const sanitized = sanitizeSql(info.sql);
+    const durationMs = Number(info.durationMs) || 0;
+    const route = info.route || "background";
+    const method = info.method || "-";
+    const requestId = info.requestId || info.correlationId || "-";
+
+    const payload = {
+        type: "slow_query",
+        durationMs,
+        route,
+        method,
+        requestId,
+        sql: sanitized,
+        paramCount: Array.isArray(info.params) ? info.params.length : 0
+    };
+
+    logger.warn(
+        `Slow query (${durationMs}ms) ${method} ${route} [${requestId}]: ${sanitized}`
+    );
+
+    if (process.env.NODE_ENV === "development") {
+        logger.debug(`Slow query detail: ${JSON.stringify(payload)}`);
+    }
+
+    return payload;
+}
+
+module.exports = {
+    sanitizeSql,
+    logSlowQuery
+};

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -287,6 +287,64 @@
 
                 </h2>
 
+                <section
+                    class="price-drop-preferences"
+                    id="price-drop-preferences"
+                    aria-labelledby="price-drop-pref-heading"
+                >
+                    <h3 id="price-drop-pref-heading">
+                        Price-drop alerts
+                    </h3>
+                    <p class="price-drop-pref-help">
+                        Get notified when wishlisted items get cheaper. You can unsubscribe anytime from email links.
+                    </p>
+                    <div class="price-drop-pref-controls">
+                        <label>
+                            <input
+                                type="checkbox"
+                                id="pref-price-drop-email"
+                            >
+                            Email alerts
+                        </label>
+                        <label>
+                            <input
+                                type="checkbox"
+                                id="pref-price-drop-in-app"
+                            >
+                            In-app alerts
+                        </label>
+                        <label>
+                            <input
+                                type="checkbox"
+                                id="pref-price-drop-unsub-all"
+                            >
+                            Pause all price-drop notifications
+                        </label>
+                    </div>
+                    <div class="price-drop-pref-actions">
+                        <button
+                            type="button"
+                            id="save-price-drop-prefs"
+                            class="normal"
+                        >
+                            Save preferences
+                        </button>
+                        <button
+                            type="button"
+                            id="sync-price-drop-baselines"
+                            class="normal"
+                        >
+                            Sync wishlist baselines
+                        </button>
+                    </div>
+                    <p
+                        id="price-drop-pref-status"
+                        class="price-drop-pref-status"
+                        role="status"
+                        aria-live="polite"
+                    ></p>
+                </section>
+
                 <div id="wishlist-items"></div>
 
             </div>

--- a/frontend/scripts/checkout.js
+++ b/frontend/scripts/checkout.js
@@ -8,6 +8,9 @@ const appliedCoupon =
         ""
     );
 
+// Mid-session FX lock (#1392) — token from last quote; cleared on currency switch
+let activeFxLock = null;
+
 // require authentication
 const currentUser =
     AppUtils.requireAuth();
@@ -364,6 +367,44 @@ async function refreshSummary() {
     const totals =
         await calculateTotals();
 
+    if (totals && totals.fxLock && totals.fxLock.token) {
+        activeFxLock = totals.fxLock;
+        // Keep currency switcher conversion aligned with the locked mid-session rate
+        const code = totals.fxLock.displayCurrency;
+        if (
+            code
+            && AppUtils.CONFIG.SUPPORTED_CURRENCIES
+            && AppUtils.CONFIG.SUPPORTED_CURRENCIES[code]
+            && typeof totals.fxLock.rate === "number"
+        ) {
+            AppUtils.CONFIG.SUPPORTED_CURRENCIES[code].RATE = totals.fxLock.rate;
+        }
+    } else if (
+        totals
+        && totals.displayCurrency
+        && totals.displayCurrency !== (AppUtils.CONFIG.CURRENCY_INFO && AppUtils.CONFIG.CURRENCY_INFO.CODE)
+        && totals.displayCurrency !== "INR"
+    ) {
+        // Quote may have omitted lock; mint one explicitly so checkout can proceed
+        try {
+            const locked = await AppUtils.apiRequest("/checkout/fx/lock", {
+                method: "POST",
+                body: JSON.stringify({
+                    currency: totals.displayCurrency || AppUtils.getSelectedCurrency(),
+                    baseTotal: totals.total
+                })
+            });
+            if (locked && locked.success && locked.fxLock) {
+                activeFxLock = locked.fxLock;
+                totals.fxLock = locked.fxLock;
+            }
+        } catch (err) {
+            console.warn("FX lock refresh failed:", err);
+        }
+    } else {
+        activeFxLock = null;
+    }
+
     renderTotals(
         totals
     );
@@ -664,7 +705,15 @@ async function createOrderPayload() {
                     size:
                         item.size || ""
                 })
-            )
+            ),
+
+        // Mid-session FX lock (#1392)
+        currency:
+            (totals.displayCurrency
+                || AppUtils.getSelectedCurrency()),
+
+        fxLockToken:
+            (activeFxLock && activeFxLock.token) || null
     };
 }
 
@@ -694,6 +743,18 @@ function orderFailure(
             response
             &&
             response.code === TOTAL_MISMATCH_CODE
+        );
+
+    failure.isFxLockExpired =
+        Boolean(
+            response
+            &&
+            (
+                response.code === "FX_LOCK_EXPIRED"
+                || response.code === "FX_LOCK_MISSING"
+                || response.code === "FX_LOCK_CURRENCY_MISMATCH"
+                || response.code === "FX_LOCK_TOTAL_MISMATCH"
+            )
         );
 
     failure.requiresChallenge =
@@ -1029,6 +1090,18 @@ if (
                         "error"
                     );
 
+                } else if (
+                    error.isFxLockExpired
+                ) {
+
+                    activeFxLock = null;
+                    await refreshSummary();
+
+                    AppUtils.notify(
+                        `${error.message} A fresh FX rate has been locked — please review the total and try again.`,
+                        "error"
+                    );
+
                 } else {
 
                     AppUtils.notify(
@@ -1059,6 +1132,8 @@ if (
 }
 
 window.addEventListener("currencyUpdated", () => {
+    // Currency switcher sync (#1392): drop stale lock and re-quote
+    activeFxLock = null;
     if (typeof renderCheckout === "function") {
         renderCheckout();
     }

--- a/frontend/scripts/dashboard-wishlist.js
+++ b/frontend/scripts/dashboard-wishlist.js
@@ -1,10 +1,38 @@
-// dashboard wishlist elements
+// dashboard wishlist elements + price-drop preference center (#1394)
 const getDashboardElements = () => ({
     wishlistContainer: document.getElementById("wishlist-items"),
     wishlistCount: document.getElementById("wishlist-count"),
     cartContainer: document.getElementById("saved-cart-items"),
-    cartCount: document.getElementById("cart-count-dashboard")
+    cartCount: document.getElementById("cart-count-dashboard"),
+    prefEmail: document.getElementById("pref-price-drop-email"),
+    prefInApp: document.getElementById("pref-price-drop-in-app"),
+    prefUnsubAll: document.getElementById("pref-price-drop-unsub-all"),
+    savePrefsBtn: document.getElementById("save-price-drop-prefs"),
+    syncBaselinesBtn: document.getElementById("sync-price-drop-baselines"),
+    prefStatus: document.getElementById("price-drop-pref-status")
 });
+
+function setPrefStatus(message, type) {
+    const elements = getDashboardElements();
+    if (!elements.prefStatus) return;
+    elements.prefStatus.textContent = message || "";
+    elements.prefStatus.dataset.type = type || "";
+}
+
+function paintPreferenceForm(preferences) {
+    const elements = getDashboardElements();
+    if (!preferences) return;
+
+    if (elements.prefEmail) {
+        elements.prefEmail.checked = Boolean(preferences.priceDropEmail);
+    }
+    if (elements.prefInApp) {
+        elements.prefInApp.checked = Boolean(preferences.priceDropInApp);
+    }
+    if (elements.prefUnsubAll) {
+        elements.prefUnsubAll.checked = Boolean(preferences.unsubscribedAll);
+    }
+}
 
 // paint wishlist from whatever is currently stored
 function paintDashboardWishlist() {
@@ -33,6 +61,7 @@ function paintDashboardWishlist() {
         if (!item) return;
         const card = document.createElement("div");
         card.className = "dashboard-item-card";
+        const productId = item.id || item.productId || "";
         card.innerHTML = `
             <img
                 src="${AppUtils.defaultImage(item.image || item.img)}"
@@ -42,10 +71,154 @@ function paintDashboardWishlist() {
                 <h4>${item.name || "Product"}</h4>
                 <p>${item.brand || ""}</p>
                 <strong>${AppUtils.formatPrice(item.price || 0)}</strong>
+                <p class="price-drop-hint">Watching for price drops</p>
             </div>
         `;
+        card.dataset.productId = productId;
         elements.wishlistContainer.appendChild(card);
     });
+}
+
+async function loadPriceDropPreferences() {
+    const token = AppUtils.getToken();
+    if (!token) {
+        setPrefStatus("Sign in to manage price-drop alerts.", "info");
+        return;
+    }
+
+    try {
+        const response = await AppUtils.apiRequest("/wishlist-notify/preferences");
+        if (response && response.success && response.preferences) {
+            paintPreferenceForm(response.preferences);
+            setPrefStatus("Preferences loaded.", "ok");
+        }
+    } catch (error) {
+        console.error("Failed to load price-drop preferences:", error);
+        setPrefStatus("Could not load notification preferences.", "error");
+    }
+}
+
+async function savePriceDropPreferences() {
+    const elements = getDashboardElements();
+    const token = AppUtils.getToken();
+    if (!token) {
+        AppUtils.notify("Please sign in first.", "error");
+        return;
+    }
+
+    const payload = {
+        priceDropEmail: Boolean(elements.prefEmail && elements.prefEmail.checked),
+        priceDropInApp: Boolean(elements.prefInApp && elements.prefInApp.checked),
+        unsubscribedAll: Boolean(elements.prefUnsubAll && elements.prefUnsubAll.checked)
+    };
+
+    try {
+        const response = await AppUtils.apiRequest("/wishlist-notify/preferences", {
+            method: "PUT",
+            body: JSON.stringify(payload)
+        });
+
+        if (!response || !response.success) {
+            throw new Error((response && response.message) || "Save failed");
+        }
+
+        paintPreferenceForm(response.preferences);
+        setPrefStatus("Preferences saved.", "ok");
+        AppUtils.notify("Price-drop preferences updated.", "success");
+    } catch (error) {
+        console.error("Failed to save preferences:", error);
+        setPrefStatus(error.message || "Could not save preferences.", "error");
+        AppUtils.notify(error.message || "Could not save preferences.", "error");
+    }
+}
+
+async function syncPriceDropBaselines() {
+    const token = AppUtils.getToken();
+    if (!token) {
+        AppUtils.notify("Please sign in first.", "error");
+        return;
+    }
+
+    setPrefStatus("Syncing wishlist price baselines…", "info");
+    try {
+        const response = await AppUtils.apiRequest("/wishlist-notify/baselines/sync", {
+            method: "POST",
+            body: JSON.stringify({})
+        });
+        if (!response || !response.success) {
+            throw new Error((response && response.message) || "Sync failed");
+        }
+        setPrefStatus(
+            `Baselines synced (${response.synced || 0}/${response.total || 0}).`,
+            "ok"
+        );
+        AppUtils.notify("Wishlist baselines synced for price-drop alerts.", "success");
+    } catch (error) {
+        console.error("Baseline sync failed:", error);
+        setPrefStatus(error.message || "Baseline sync failed.", "error");
+        AppUtils.notify(error.message || "Baseline sync failed.", "error");
+    }
+}
+
+async function handleUnsubscribeQueryParam() {
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get("unsubscribe");
+    if (!token) return;
+
+    try {
+        const response = await AppUtils.apiRequest("/wishlist-notify/unsubscribe", {
+            method: "POST",
+            body: JSON.stringify({ token })
+        });
+
+        if (response && response.success) {
+            AppUtils.notify(
+                "You are unsubscribed from price-drop emails.",
+                "success"
+            );
+            setPrefStatus("Unsubscribed via email link.", "ok");
+            await loadPriceDropPreferences();
+        } else {
+            AppUtils.notify(
+                (response && response.message) || "Unsubscribe link invalid.",
+                "error"
+            );
+        }
+    } catch (error) {
+        console.error("Unsubscribe failed:", error);
+        AppUtils.notify("Unsubscribe failed.", "error");
+    }
+
+    // Clean the token out of the address bar without reloading.
+    params.delete("unsubscribe");
+    const next = `${window.location.pathname}${params.toString() ? `?${params}` : ""}${window.location.hash || ""}`;
+    window.history.replaceState({}, "", next);
+}
+
+function bindPriceDropPreferenceControls() {
+    const elements = getDashboardElements();
+
+    if (elements.savePrefsBtn) {
+        elements.savePrefsBtn.addEventListener("click", (event) => {
+            event.preventDefault();
+            savePriceDropPreferences();
+        });
+    }
+
+    if (elements.syncBaselinesBtn) {
+        elements.syncBaselinesBtn.addEventListener("click", (event) => {
+            event.preventDefault();
+            syncPriceDropBaselines();
+        });
+    }
+
+    if (elements.prefUnsubAll) {
+        elements.prefUnsubAll.addEventListener("change", () => {
+            if (!elements.prefUnsubAll.checked) return;
+            if (elements.prefEmail) elements.prefEmail.checked = false;
+            if (elements.prefInApp) elements.prefInApp.checked = false;
+        });
+    }
 }
 
 // render wishlist (paint local first, then sync from backend)
@@ -70,6 +243,8 @@ async function renderDashboardWishlist() {
     } catch (error) {
         console.error("Failed to fetch wishlist in dashboard:", error);
     }
+
+    await loadPriceDropPreferences();
 }
 
 // render cart
@@ -114,7 +289,12 @@ function renderDashboardCart() {
     });
 }
 
+bindPriceDropPreferenceControls();
+handleUnsubscribeQueryParam();
+
 // expose globally
 window.renderDashboardWishlist = renderDashboardWishlist;
 window.paintDashboardWishlist = paintDashboardWishlist;
 window.renderDashboardCart = renderDashboardCart;
+window.loadPriceDropPreferences = loadPriceDropPreferences;
+window.savePriceDropPreferences = savePriceDropPreferences;

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -1903,12 +1903,17 @@ const fetchCartQuote = async (
         })
     );
 
+    const displayCurrency = getSelectedCurrency();
+
     try {
         const response = await apiRequest("/checkout/quote", {
             method: "POST",
             body: JSON.stringify({
                 items,
-                promoCode: couponCode || null
+                promoCode: couponCode || null,
+                // Mid-session FX lock (#1392): lock display rate with the quote
+                currency: displayCurrency,
+                lockFx: true
             })
         });
 
@@ -1921,7 +1926,10 @@ const fetchCartQuote = async (
         return {
             ...response.breakdown,
             promoMessage: response.promoMessage || null,
-            isServerQuote: true
+            isServerQuote: true,
+            displayCurrency: response.displayCurrency || displayCurrency,
+            fx: response.fx || null,
+            fxLock: response.fxLock || null
         };
     } catch (error) {
         console.error("CART QUOTE ERROR:", error);
@@ -1930,7 +1938,10 @@ const fetchCartQuote = async (
 
         return {
             ...fallback,
-            isServerQuote: false
+            isServerQuote: false,
+            displayCurrency,
+            fx: null,
+            fxLock: null
         };
     }
 };
@@ -1994,6 +2005,10 @@ window.AppUtils = {
     $,
     $$,
     formatPrice,
+    getSelectedCurrency,
+    getCurrencyInfo,
+    setSelectedCurrency,
+    initCurrencySelector,
     defaultImage,
     safeArray,
     safeNumber,

--- a/frontend/styles/dashboard.css
+++ b/frontend/styles/dashboard.css
@@ -218,6 +218,77 @@
     cursor: pointer;
 }
 
+/* Price-drop preference center (#1394) */
+.price-drop-preferences{
+    margin: 0 0 24px;
+    padding: 18px 20px;
+    background: #f7fafa;
+    border: 1px solid #d9e8e6;
+    border-radius: 8px;
+}
+
+.price-drop-preferences h3{
+    margin: 0 0 8px;
+    color: #088178;
+}
+
+.price-drop-pref-help{
+    margin: 0 0 14px;
+    color: #465b52;
+    font-size: 14px;
+}
+
+.price-drop-pref-controls{
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px 22px;
+    margin-bottom: 14px;
+}
+
+.price-drop-pref-controls label{
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    color: #1a1a1a;
+}
+
+.price-drop-pref-actions{
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.price-drop-pref-actions button{
+    background: #088178;
+    color: #fff;
+    border: none;
+    padding: 10px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.price-drop-pref-status{
+    margin: 10px 0 0;
+    min-height: 1.2em;
+    font-size: 13px;
+    color: #465b52;
+}
+
+.price-drop-pref-status[data-type="error"]{
+    color: #a11;
+}
+
+.price-drop-pref-status[data-type="ok"]{
+    color: #088178;
+}
+
+.price-drop-hint{
+    margin: 6px 0 0;
+    font-size: 12px;
+    color: #088178;
+}
+
 @media (max-width: 1024px){
 
     #dashboard{

--- a/migrations/0027_price_drop_baselines.sql
+++ b/migrations/0027_price_drop_baselines.sql
@@ -1,0 +1,51 @@
+-- Wishlist price-drop baselines & preference center (#1394)
+-- Folded from backend/sql/price_drop_baselines.sql
+
+CREATE TABLE IF NOT EXISTS price_drop_baselines (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id CHAR(36) NOT NULL,
+    product_id CHAR(36) NOT NULL,
+    baseline_price DECIMAL(10,2) NOT NULL,
+    last_seen_price DECIMAL(10,2) NOT NULL,
+    last_notified_at DATETIME NULL,
+    last_notified_price DECIMAL(10,2) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_price_drop_user_product (user_id, product_id),
+    INDEX idx_pdb_product (product_id),
+    INDEX idx_pdb_notified (last_notified_at),
+
+    CONSTRAINT fk_pdb_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_pdb_product FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS notification_preferences (
+    user_id CHAR(36) PRIMARY KEY,
+    price_drop_email TINYINT(1) NOT NULL DEFAULT 1,
+    price_drop_in_app TINYINT(1) NOT NULL DEFAULT 1,
+    unsubscribed_all TINYINT(1) NOT NULL DEFAULT 0,
+    unsubscribe_token_hash CHAR(64) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_notif_pref_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS price_drop_notification_log (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id CHAR(36) NOT NULL,
+    product_id CHAR(36) NOT NULL,
+    old_price DECIMAL(10,2) NOT NULL,
+    new_price DECIMAL(10,2) NOT NULL,
+    channels_json JSON NULL,
+    dedupe_key VARCHAR(128) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_price_drop_dedupe (dedupe_key),
+    INDEX idx_pdnl_user (user_id),
+    INDEX idx_pdnl_created (created_at),
+
+    CONSTRAINT fk_pdnl_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_pdnl_product FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/migrations/0028_admin_impersonation_audit.sql
+++ b/migrations/0028_admin_impersonation_audit.sql
@@ -1,0 +1,46 @@
+-- Admin impersonation grants & immutable audit trail (#1393)
+-- Folded from backend/sql/admin_impersonation_audit.sql
+
+CREATE TABLE IF NOT EXISTS admin_impersonation_grants (
+    id CHAR(36) PRIMARY KEY,
+    actor_admin_id CHAR(36) NOT NULL,
+    subject_user_id CHAR(36) NOT NULL,
+    reason VARCHAR(500) NOT NULL,
+    ticket_id VARCHAR(100) NOT NULL,
+    jti CHAR(36) NOT NULL,
+    expires_at DATETIME NOT NULL,
+    revoked_at DATETIME NULL,
+    revoked_by CHAR(36) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_impersonation_jti (jti),
+    INDEX idx_imp_grant_actor (actor_admin_id),
+    INDEX idx_imp_grant_subject (subject_user_id),
+    INDEX idx_imp_grant_expires (expires_at),
+
+    CONSTRAINT fk_imp_grant_actor FOREIGN KEY (actor_admin_id)
+        REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_imp_grant_subject FOREIGN KEY (subject_user_id)
+        REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS admin_impersonation_audit (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    grant_id CHAR(36) NOT NULL,
+    actor_admin_id CHAR(36) NOT NULL,
+    subject_user_id CHAR(36) NOT NULL,
+    action VARCHAR(32) NOT NULL,
+    method VARCHAR(16) NULL,
+    path VARCHAR(512) NULL,
+    status_code INT NULL,
+    ip VARCHAR(45) NULL,
+    user_agent VARCHAR(512) NULL,
+    meta_json JSON NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    INDEX idx_imp_audit_grant (grant_id),
+    INDEX idx_imp_audit_actor (actor_admin_id),
+    INDEX idx_imp_audit_subject (subject_user_id),
+    INDEX idx_imp_audit_created (created_at),
+    INDEX idx_imp_audit_action (action)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
# #1391 issue resolved

## Description

This PR wraps the MySQL pool with a per-request query budget so N+1 / loop storms cannot exhaust the connection pool. Slow queries are logged with sanitized SQL and route attribution; budget trips return 503 with Retry-After.

## Features

- Per-request SQL query budget via AsyncLocalStorage
- Slow-query threshold logging with sanitized SQL
- Circuit open → 503 with Retry-After
- Admin metrics for top offending routes (`/api/admin/query-budget`)
- Bypass for migrations/jobs (no request context or `QUERY_BUDGET_BYPASS`)