### PR TITLE
Make cart abandonment a real state

### DIFF
--- a/backend/config/cartConfig.js
+++ b/backend/config/cartConfig.js
@@ -1,0 +1,32 @@
+// backend/config/cartConfig.js
+//
+// The cart lifecycle's one judgement call, and the limits the sweep that
+// applies it runs under.
+//
+// "How long until a basket counts as abandoned" is a merchandising decision,
+// not an implementation detail: it moves with campaigns, and it is the single
+// number every abandonment figure in reporting depends on. It is named and
+// overridable here so changing it is a configuration change rather than a
+// patch to the job.
+
+const MINUTES_PER_DAY = 24 * 60;
+
+const CART_CONFIG = Object.freeze({
+    // A cart untouched for this long is abandoned. A day is long enough that a
+    // shopper comparing prices over an evening is not written off, and short
+    // enough that the figure still describes this week's trading.
+    ABANDON_AFTER_MINUTES:
+        Number(process.env.CART_ABANDON_AFTER_MINUTES) || MINUTES_PER_DAY,
+
+    // Rows per statement. The sweep works in batches so a backlog cannot turn
+    // into one enormous UPDATE holding locks across the whole table while
+    // shoppers are trying to check out.
+    SWEEP_BATCH_SIZE: Number(process.env.CART_SWEEP_BATCH_SIZE) || 500,
+
+    // Ceiling on batches in a single run, so a large backlog is drained over
+    // several scheduled runs instead of one that never ends. At the defaults a
+    // run transitions at most 10,000 carts.
+    SWEEP_MAX_BATCHES: Number(process.env.CART_SWEEP_MAX_BATCHES) || 20
+});
+
+module.exports = CART_CONFIG;

--- a/backend/services/cartLifecycleService.js
+++ b/backend/services/cartLifecycleService.js
@@ -12,6 +12,17 @@
 // shopper did something, which is the clock abandonment is later measured
 // against.
 //
+// A cart has exactly two exits, and both live here:
+//
+//   active -> converted, at the moment an order is created from it, inside the
+//             order's own transaction so a cart is never recorded as converted
+//             against an order that rolled back;
+//   active -> abandoned, once it has gone untouched for longer than the
+//             configured threshold, applied by the scheduled sweep.
+//
+// Both are terminal. Nothing moves a cart back to active; the shopper's next
+// action resolves a new one.
+//
 // Guest carts: `carts.user_id` is nullable so a pre-sign-in basket can be
 // persisted later, but nothing creates one yet -- every cart endpoint is behind
 // authentication. Resolving a cart therefore requires an account, and says so
@@ -19,7 +30,9 @@
 
 const crypto = require('crypto');
 const db = require('../config/db');
-const { safeUUID } = require('../utils/helpers');
+const cartConfig = require('../config/cartConfig');
+const logger = require('../utils/logger');
+const { safeInteger, safeUUID } = require('../utils/helpers');
 
 const CART_STATUS = Object.freeze({
     ACTIVE: 'active',
@@ -133,9 +146,155 @@ async function touchCart(cartId, connection) {
     );
 }
 
+/**
+ * active -> converted, for the account that just placed an order.
+ *
+ * Call inside the order's transaction: if the order rolls back, so must the
+ * claim that a cart became it. The status guard makes the write idempotent --
+ * a retry finds the cart already converted and reports that it changed
+ * nothing, rather than overwriting the first order id with the second.
+ *
+ * A guest checkout has no cart to convert, and that is not an error.
+ *
+ * @param {string} userId
+ * @param {string} orderId
+ * @param {object} [connection]
+ * @returns {Promise<{cartId: string|null, converted: boolean}>}
+ */
+async function markCartConverted(userId, orderId, connection) {
+    const owner = safeUUID(userId);
+    const order = safeUUID(orderId);
+
+    if (!owner || !order) {
+        return { cartId: null, converted: false };
+    }
+
+    const cartId = await findActiveCartId(owner, connection);
+
+    if (!cartId) {
+        return { cartId: null, converted: false };
+    }
+
+    const [result] = await runner(connection).query(
+        `UPDATE carts
+         SET status = ?, converted_order_id = ?, converted_at = NOW()
+         WHERE id = ? AND status = ?`,
+        [CART_STATUS.CONVERTED, order, cartId, CART_STATUS.ACTIVE]
+    );
+
+    return { cartId, converted: result.affectedRows > 0 };
+}
+
+/**
+ * active -> abandoned, for carts left untouched past the threshold.
+ *
+ * Three properties matter more than throughput here:
+ *
+ *   * bounded -- work is done in batches of `batchSize`, capped at
+ *     `maxBatches` per run, so a backlog is drained over several runs rather
+ *     than in one statement that locks the table;
+ *   * idempotent -- the transition is guarded on `status = 'active'`, so a
+ *     second run over the same carts changes nothing and reports zero;
+ *   * safe to run twice at once -- two instances may select the same ids, but
+ *     the same guard means only one of them actually transitions a given cart,
+ *     and each reports only what it changed. No cart is counted twice.
+ *
+ * Empty carts are skipped. A cart with no lines in it is a session that never
+ * became a basket, and counting those as abandoned would put a floor under the
+ * abandonment rate that has nothing to do with shopping.
+ *
+ * @param {object} [options]
+ * @param {number} [options.inactivityMinutes]
+ * @param {number} [options.batchSize]
+ * @param {number} [options.maxBatches]
+ * @param {object} [options.connection]
+ * @returns {Promise<{abandoned: number, batches: number, scanned: number,
+ *   inactivityMinutes: number, batchSize: number, exhausted: boolean}>}
+ */
+async function sweepAbandonedCarts(options = {}) {
+    const inactivityMinutes = Math.max(
+        1,
+        safeInteger(options.inactivityMinutes, cartConfig.ABANDON_AFTER_MINUTES)
+    );
+    const batchSize = Math.max(
+        1,
+        safeInteger(options.batchSize, cartConfig.SWEEP_BATCH_SIZE)
+    );
+    const maxBatches = Math.max(
+        1,
+        safeInteger(options.maxBatches, cartConfig.SWEEP_MAX_BATCHES)
+    );
+
+    const client = runner(options.connection);
+
+    let abandoned = 0;
+    let scanned = 0;
+    let batches = 0;
+    let exhausted = false;
+
+    while (batches < maxBatches) {
+        const [candidates] = await client.query(
+            `SELECT c.id
+             FROM carts c
+             WHERE c.status = ?
+               AND c.last_activity_at < DATE_SUB(NOW(), INTERVAL ? MINUTE)
+               AND EXISTS (
+                   SELECT 1 FROM cart_items ci WHERE ci.cart_id = c.id
+               )
+             ORDER BY c.last_activity_at ASC
+             LIMIT ?`,
+            [CART_STATUS.ACTIVE, inactivityMinutes, batchSize]
+        );
+
+        batches += 1;
+
+        if (!candidates.length) {
+            exhausted = true;
+            break;
+        }
+
+        const ids = candidates.map((row) => row.id);
+        scanned += ids.length;
+
+        const [result] = await client.query(
+            `UPDATE carts
+             SET status = ?, abandoned_at = NOW()
+             WHERE id IN (${ids.map(() => '?').join(',')}) AND status = ?`,
+            [CART_STATUS.ABANDONED, ...ids, CART_STATUS.ACTIVE]
+        );
+
+        abandoned += result.affectedRows;
+
+        if (ids.length < batchSize) {
+            exhausted = true;
+            break;
+        }
+    }
+
+    // Logged unconditionally, and with the figure rather than a verb: a run
+    // that found nothing to do has to be distinguishable from a run that did
+    // nothing, which is exactly what the previous no-op handler could not say.
+    logger.info(
+        `Abandoned-cart sweep: ${abandoned} cart(s) transitioned from ${scanned} candidate(s) ` +
+        `in ${batches} batch(es); threshold ${inactivityMinutes} minute(s)` +
+        `${exhausted ? '' : '; batch ceiling reached, backlog remains'}`
+    );
+
+    return {
+        abandoned,
+        batches,
+        scanned,
+        inactivityMinutes,
+        batchSize,
+        exhausted
+    };
+}
+
 module.exports = {
     CART_STATUS,
     findActiveCartId,
     resolveActiveCart,
-    touchCart
+    touchCart,
+    markCartConverted,
+    sweepAbandonedCarts
 };

--- a/backend/services/jobQueueService.js
+++ b/backend/services/jobQueueService.js
@@ -2,6 +2,7 @@
 const EventEmitter = require('events');
 const db = require('../config/db').promise;
 const crypto = require('crypto');
+const cartLifecycleService = require('./cartLifecycleService');
 
 // ============================================
 // JOB QUEUE CONFIGURATION
@@ -566,10 +567,23 @@ const jobHandlers = {
         return { processed: true, date: data.date };
     },
 
-    [JOB_TYPES.CART_CLEANUP]: async (data) => {
-        console.log('🧹 Cleaning up abandoned carts');
-        await new Promise(resolve => setTimeout(resolve, 2000));
-        return { cleaned: true, count: data.count || 0 };
+    // Moves carts that have gone quiet from active to abandoned (#1364). The
+    // job payload may narrow the threshold or the batch limits for a one-off
+    // run; left alone it uses the configured defaults.
+    [JOB_TYPES.CART_CLEANUP]: async (data = {}) => {
+        const summary = await cartLifecycleService.sweepAbandonedCarts({
+            inactivityMinutes: data.inactivityMinutes,
+            batchSize: data.batchSize,
+            maxBatches: data.maxBatches
+        });
+
+        console.log(
+            `🧹 Abandoned carts: ${summary.abandoned} transitioned in ` +
+            `${summary.batches} batch(es), threshold ${summary.inactivityMinutes}m` +
+            `${summary.exhausted ? '' : ', backlog remains'}`
+        );
+
+        return { cleaned: true, count: summary.abandoned, ...summary };
     },
 
     [JOB_TYPES.INVENTORY_SYNC]: async (data) => {

--- a/backend/services/order.service.js
+++ b/backend/services/order.service.js
@@ -9,6 +9,7 @@ const {
 const logger = require("../utils/logger");
 const { validatePromo } = require("./promo.service");
 const pricing = require("./pricing.service");
+const cartLifecycle = require("./cartLifecycleService");
 
 // Marks the one failure the client can act on, so controllers can answer with
 // the specific figures instead of a generic server error.
@@ -438,8 +439,20 @@ const createOrderService = async (connection, orderData) => {
             }
         }
 
-        // Clear authenticated user's cart
+        // Close the cart and clear it. Both happen on this connection, inside
+        // the caller's transaction: a cart must never be recorded as converted
+        // against an order that then rolls back.
         if (user_id) {
+            const { cartId, converted } = await cartLifecycle.markCartConverted(
+                user_id,
+                orderId,
+                connection,
+            );
+
+            if (converted) {
+                logger.info(`Cart ${cartId} converted into order ${orderId}`);
+            }
+
             await connection.query(
                 "DELETE FROM cart_items WHERE user_id = ?",
                 [user_id]


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

> Follows #1369, which has merged. This builds directly on `main` and depends on nothing outstanding.

A cart now exists as a record, but only ever in one state. This gives it its two exits.

**active → converted**, when an order is created from the cart. Written on the order's own connection, inside its transaction: a cart must never be recorded as converted against an order that then rolls back. The write is guarded on the current status, so a retry finds the cart already converted and reports that it changed nothing rather than re-pointing it at a second order.

**active → abandoned**, once the cart has gone untouched for longer than the threshold. Both transitions are terminal; the shopper's next action resolves a new cart.

**The threshold is configuration, not a literal.** The inactivity window, the batch size and the per-run batch ceiling are named settings with environment overrides, alongside the other configuration modules here. How long until a basket counts as abandoned moves with campaigns, and it is the single number every abandonment figure depends on, so it does not belong buried in the job.

**The cleanup job does something now.** It previously logged that it was cleaning up abandoned carts, slept, and returned success. It now performs the transition, and does so in bounded batches so a backlog drains across scheduled runs rather than in one statement holding locks over the whole table while shoppers are checking out. It is idempotent, because the transition is guarded on the current status, so a second run over the same carts changes nothing and reports zero. It is safe on more than one instance: two sweeps may select the same carts, but only one transitions any given cart, and each reports only what it actually changed, so nothing is double-counted. And it logs the count, the candidates seen, the batches used and whether a backlog remains, so "nothing to do" finally reads differently from "did nothing".

Empty carts are skipped. A basket with nothing in it is a session that never became a basket, and counting those would put a floor under the abandonment rate that has nothing to do with shopping.

---

## 🔗 Related Issue

Part of #1364

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [ ] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Not applicable — this is a backend change with no visual surface.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**First sweep after deploy.** Backfilled carts are dated from their lines rather than from migration time. That is deliberate — otherwise a year-old basket would look brand new and hide from the sweep — but it does mean the first run after deploy sees the entire historical backlog at once. The per-run batch ceiling bounds it, and the log says plainly that a backlog remains.

**Left as it is.** Converted carts still have their lines deleted at checkout, preserving today's behaviour. Retaining line-level history for a converted cart is worth doing but is a separate decision.

**Note on CI.** Two frontend scripts do not parse on `main`, which fails the syntax gate for every branch regardless of its contents and causes the test and boot jobs to skip. Neither file is touched here; reported in #1416.
