### PR TITLE
Report cart conversion and abandonment from real cart state

### DIFF
--- a/backend/config/cartConfig.js
+++ b/backend/config/cartConfig.js
@@ -1,0 +1,32 @@
+// backend/config/cartConfig.js
+//
+// The cart lifecycle's one judgement call, and the limits the sweep that
+// applies it runs under.
+//
+// "How long until a basket counts as abandoned" is a merchandising decision,
+// not an implementation detail: it moves with campaigns, and it is the single
+// number every abandonment figure in reporting depends on. It is named and
+// overridable here so changing it is a configuration change rather than a
+// patch to the job.
+
+const MINUTES_PER_DAY = 24 * 60;
+
+const CART_CONFIG = Object.freeze({
+    // A cart untouched for this long is abandoned. A day is long enough that a
+    // shopper comparing prices over an evening is not written off, and short
+    // enough that the figure still describes this week's trading.
+    ABANDON_AFTER_MINUTES:
+        Number(process.env.CART_ABANDON_AFTER_MINUTES) || MINUTES_PER_DAY,
+
+    // Rows per statement. The sweep works in batches so a backlog cannot turn
+    // into one enormous UPDATE holding locks across the whole table while
+    // shoppers are trying to check out.
+    SWEEP_BATCH_SIZE: Number(process.env.CART_SWEEP_BATCH_SIZE) || 500,
+
+    // Ceiling on batches in a single run, so a large backlog is drained over
+    // several scheduled runs instead of one that never ends. At the defaults a
+    // run transitions at most 10,000 carts.
+    SWEEP_MAX_BATCHES: Number(process.env.CART_SWEEP_MAX_BATCHES) || 20
+});
+
+module.exports = CART_CONFIG;

--- a/backend/controllers/promo.controller.js
+++ b/backend/controllers/promo.controller.js
@@ -1,5 +1,6 @@
 
 const { validatePromo, calculateDiscount, getPromoByCode, applyPromoTransaction } = require("../services/promo.service");
+const cartLifecycle = require("../services/cartLifecycleService");
 const { safeNumber, sanitizeString } = require("../utils/helpers");
 const NodeCache = require('node-cache');
 const crypto = require('crypto');
@@ -526,15 +527,19 @@ const applyMultiplePromos = async (req, res) => {
                 });
             }
 
-            // Update cart in database with atomic transaction
-            await db.query(
-                `UPDATE carts 
-                 SET promo_codes = ?, 
-                     discount_total = ?, 
-                     final_total = ?,
-                     updated_at = NOW()
-                 WHERE user_id = ? AND session_id = ?`,
-                [JSON.stringify(appliedPromos), totalDiscount, remainingTotal, userId, sessionId]
+            // Applying a promo is shopper activity on the cart, so the cart's
+            // clock moves.
+            //
+            // What this replaced was a write to a `carts` table that did not
+            // exist, through a `db` binding this module never imported, on
+            // columns (promo_codes, discount_total, final_total, session_id)
+            // that are not part of the cart. The discount is not persisted
+            // here on purpose: the figures below are returned to the caller and
+            // re-derived from the submitted code at checkout, which is where
+            // `orders.promo_code` and `promo_usage` record what was actually
+            // granted. A second copy on the cart could only drift from it.
+            await cartLifecycle.touchCart(
+                await cartLifecycle.findActiveCartId(userId)
             );
 
             return {

--- a/backend/services/cartLifecycleService.js
+++ b/backend/services/cartLifecycleService.js
@@ -12,6 +12,17 @@
 // shopper did something, which is the clock abandonment is later measured
 // against.
 //
+// A cart has exactly two exits, and both live here:
+//
+//   active -> converted, at the moment an order is created from it, inside the
+//             order's own transaction so a cart is never recorded as converted
+//             against an order that rolled back;
+//   active -> abandoned, once it has gone untouched for longer than the
+//             configured threshold, applied by the scheduled sweep.
+//
+// Both are terminal. Nothing moves a cart back to active; the shopper's next
+// action resolves a new one.
+//
 // Guest carts: `carts.user_id` is nullable so a pre-sign-in basket can be
 // persisted later, but nothing creates one yet -- every cart endpoint is behind
 // authentication. Resolving a cart therefore requires an account, and says so
@@ -19,7 +30,9 @@
 
 const crypto = require('crypto');
 const db = require('../config/db');
-const { safeUUID } = require('../utils/helpers');
+const cartConfig = require('../config/cartConfig');
+const logger = require('../utils/logger');
+const { safeInteger, safeUUID } = require('../utils/helpers');
 
 const CART_STATUS = Object.freeze({
     ACTIVE: 'active',
@@ -133,9 +146,155 @@ async function touchCart(cartId, connection) {
     );
 }
 
+/**
+ * active -> converted, for the account that just placed an order.
+ *
+ * Call inside the order's transaction: if the order rolls back, so must the
+ * claim that a cart became it. The status guard makes the write idempotent --
+ * a retry finds the cart already converted and reports that it changed
+ * nothing, rather than overwriting the first order id with the second.
+ *
+ * A guest checkout has no cart to convert, and that is not an error.
+ *
+ * @param {string} userId
+ * @param {string} orderId
+ * @param {object} [connection]
+ * @returns {Promise<{cartId: string|null, converted: boolean}>}
+ */
+async function markCartConverted(userId, orderId, connection) {
+    const owner = safeUUID(userId);
+    const order = safeUUID(orderId);
+
+    if (!owner || !order) {
+        return { cartId: null, converted: false };
+    }
+
+    const cartId = await findActiveCartId(owner, connection);
+
+    if (!cartId) {
+        return { cartId: null, converted: false };
+    }
+
+    const [result] = await runner(connection).query(
+        `UPDATE carts
+         SET status = ?, converted_order_id = ?, converted_at = NOW()
+         WHERE id = ? AND status = ?`,
+        [CART_STATUS.CONVERTED, order, cartId, CART_STATUS.ACTIVE]
+    );
+
+    return { cartId, converted: result.affectedRows > 0 };
+}
+
+/**
+ * active -> abandoned, for carts left untouched past the threshold.
+ *
+ * Three properties matter more than throughput here:
+ *
+ *   * bounded -- work is done in batches of `batchSize`, capped at
+ *     `maxBatches` per run, so a backlog is drained over several runs rather
+ *     than in one statement that locks the table;
+ *   * idempotent -- the transition is guarded on `status = 'active'`, so a
+ *     second run over the same carts changes nothing and reports zero;
+ *   * safe to run twice at once -- two instances may select the same ids, but
+ *     the same guard means only one of them actually transitions a given cart,
+ *     and each reports only what it changed. No cart is counted twice.
+ *
+ * Empty carts are skipped. A cart with no lines in it is a session that never
+ * became a basket, and counting those as abandoned would put a floor under the
+ * abandonment rate that has nothing to do with shopping.
+ *
+ * @param {object} [options]
+ * @param {number} [options.inactivityMinutes]
+ * @param {number} [options.batchSize]
+ * @param {number} [options.maxBatches]
+ * @param {object} [options.connection]
+ * @returns {Promise<{abandoned: number, batches: number, scanned: number,
+ *   inactivityMinutes: number, batchSize: number, exhausted: boolean}>}
+ */
+async function sweepAbandonedCarts(options = {}) {
+    const inactivityMinutes = Math.max(
+        1,
+        safeInteger(options.inactivityMinutes, cartConfig.ABANDON_AFTER_MINUTES)
+    );
+    const batchSize = Math.max(
+        1,
+        safeInteger(options.batchSize, cartConfig.SWEEP_BATCH_SIZE)
+    );
+    const maxBatches = Math.max(
+        1,
+        safeInteger(options.maxBatches, cartConfig.SWEEP_MAX_BATCHES)
+    );
+
+    const client = runner(options.connection);
+
+    let abandoned = 0;
+    let scanned = 0;
+    let batches = 0;
+    let exhausted = false;
+
+    while (batches < maxBatches) {
+        const [candidates] = await client.query(
+            `SELECT c.id
+             FROM carts c
+             WHERE c.status = ?
+               AND c.last_activity_at < DATE_SUB(NOW(), INTERVAL ? MINUTE)
+               AND EXISTS (
+                   SELECT 1 FROM cart_items ci WHERE ci.cart_id = c.id
+               )
+             ORDER BY c.last_activity_at ASC
+             LIMIT ?`,
+            [CART_STATUS.ACTIVE, inactivityMinutes, batchSize]
+        );
+
+        batches += 1;
+
+        if (!candidates.length) {
+            exhausted = true;
+            break;
+        }
+
+        const ids = candidates.map((row) => row.id);
+        scanned += ids.length;
+
+        const [result] = await client.query(
+            `UPDATE carts
+             SET status = ?, abandoned_at = NOW()
+             WHERE id IN (${ids.map(() => '?').join(',')}) AND status = ?`,
+            [CART_STATUS.ABANDONED, ...ids, CART_STATUS.ACTIVE]
+        );
+
+        abandoned += result.affectedRows;
+
+        if (ids.length < batchSize) {
+            exhausted = true;
+            break;
+        }
+    }
+
+    // Logged unconditionally, and with the figure rather than a verb: a run
+    // that found nothing to do has to be distinguishable from a run that did
+    // nothing, which is exactly what the previous no-op handler could not say.
+    logger.info(
+        `Abandoned-cart sweep: ${abandoned} cart(s) transitioned from ${scanned} candidate(s) ` +
+        `in ${batches} batch(es); threshold ${inactivityMinutes} minute(s)` +
+        `${exhausted ? '' : '; batch ceiling reached, backlog remains'}`
+    );
+
+    return {
+        abandoned,
+        batches,
+        scanned,
+        inactivityMinutes,
+        batchSize,
+        exhausted
+    };
+}
+
 module.exports = {
     CART_STATUS,
     findActiveCartId,
     resolveActiveCart,
-    touchCart
+    touchCart,
+    markCartConverted,
+    sweepAbandonedCarts
 };

--- a/backend/services/jobQueueService.js
+++ b/backend/services/jobQueueService.js
@@ -2,6 +2,7 @@
 const EventEmitter = require('events');
 const db = require('../config/db').promise;
 const crypto = require('crypto');
+const cartLifecycleService = require('./cartLifecycleService');
 
 // ============================================
 // JOB QUEUE CONFIGURATION
@@ -566,10 +567,23 @@ const jobHandlers = {
         return { processed: true, date: data.date };
     },
 
-    [JOB_TYPES.CART_CLEANUP]: async (data) => {
-        console.log('🧹 Cleaning up abandoned carts');
-        await new Promise(resolve => setTimeout(resolve, 2000));
-        return { cleaned: true, count: data.count || 0 };
+    // Moves carts that have gone quiet from active to abandoned (#1364). The
+    // job payload may narrow the threshold or the batch limits for a one-off
+    // run; left alone it uses the configured defaults.
+    [JOB_TYPES.CART_CLEANUP]: async (data = {}) => {
+        const summary = await cartLifecycleService.sweepAbandonedCarts({
+            inactivityMinutes: data.inactivityMinutes,
+            batchSize: data.batchSize,
+            maxBatches: data.maxBatches
+        });
+
+        console.log(
+            `🧹 Abandoned carts: ${summary.abandoned} transitioned in ` +
+            `${summary.batches} batch(es), threshold ${summary.inactivityMinutes}m` +
+            `${summary.exhausted ? '' : ', backlog remains'}`
+        );
+
+        return { cleaned: true, count: summary.abandoned, ...summary };
     },
 
     [JOB_TYPES.INVENTORY_SYNC]: async (data) => {

--- a/backend/services/metricsAggregationService.js
+++ b/backend/services/metricsAggregationService.js
@@ -69,24 +69,31 @@ class MetricsAggregationService extends EventEmitter {
         const dateRange = this.getDateRange(period);
         const params = [dateRange.start, dateRange.end];
 
+        // Conversion is a property of the cart's own state (#1364), not of a
+        // join to an order: `orders` has no cart_id, and the cart is what knows
+        // which order it became. Carts are counted in the window they started
+        // in, so a cohort's rate does not move as its carts convert later.
         let query = `
-            SELECT 
-                COUNT(DISTINCT o.id) as orders,
-                COUNT(DISTINCT c.id) as carts,
-                (COUNT(DISTINCT o.id) / NULLIF(COUNT(DISTINCT c.id), 0)) * 100 as conversion_rate
+            SELECT
+                COUNT(*) as carts,
+                SUM(CASE WHEN c.status = 'converted' THEN 1 ELSE 0 END) as orders,
+                (SUM(CASE WHEN c.status = 'converted' THEN 1 ELSE 0 END)
+                    / NULLIF(COUNT(*), 0)) * 100 as conversion_rate
             FROM carts c
-            LEFT JOIN orders o ON o.cart_id = c.id AND o.status = 'completed'
             WHERE c.created_at BETWEEN ? AND ?
         `;
 
+        // A cart has no category of its own; the category of what is in it is
+        // the question actually being asked.
         if (filters.category) {
-            query += ' AND c.category = ?';
+            query += `
+                AND EXISTS (
+                    SELECT 1 FROM cart_items ci
+                    JOIN products p ON p.id = ci.product_id
+                    WHERE ci.cart_id = c.id AND p.category_id = ?
+                )
+            `;
             params.push(filters.category);
-        }
-
-        if (filters.userSegment) {
-            query += ' AND c.user_segment = ?';
-            params.push(filters.userSegment);
         }
 
         const [rows] = await db.query(query, params);
@@ -161,24 +168,40 @@ class MetricsAggregationService extends EventEmitter {
         const dateRange = this.getDateRange(period);
         const params = [dateRange.start, dateRange.end];
 
+        // The denominator is every cart in the window, not only the abandoned
+        // ones -- the previous filter made the rate 100% by construction. A
+        // cart carries no stored total either, so what was left behind is
+        // priced from its lines.
         let query = `
-            SELECT 
+            SELECT
                 COUNT(*) as total_carts,
-                SUM(CASE WHEN abandoned = 1 THEN 1 ELSE 0 END) as abandoned_carts,
-                (SUM(CASE WHEN abandoned = 1 THEN 1 ELSE 0 END) / COUNT(*)) * 100 as abandoned_rate,
-                SUM(total_value) as lost_revenue
-            FROM carts
-            WHERE created_at BETWEEN ? AND ?
-            AND status = 'abandoned'
+                SUM(CASE WHEN c.status = 'abandoned' THEN 1 ELSE 0 END) as abandoned_carts,
+                (SUM(CASE WHEN c.status = 'abandoned' THEN 1 ELSE 0 END)
+                    / NULLIF(COUNT(*), 0)) * 100 as abandoned_rate,
+                SUM(CASE WHEN c.status = 'abandoned' THEN COALESCE(v.cart_value, 0) ELSE 0 END) as lost_revenue
+            FROM carts c
+            LEFT JOIN (
+                SELECT ci.cart_id, SUM(ci.quantity * p.price) as cart_value
+                FROM cart_items ci
+                JOIN products p ON p.id = ci.product_id
+                GROUP BY ci.cart_id
+            ) v ON v.cart_id = c.id
+            WHERE c.created_at BETWEEN ? AND ?
         `;
 
         if (filters.category) {
-            query += ' AND category = ?';
+            query += `
+                AND EXISTS (
+                    SELECT 1 FROM cart_items ci
+                    JOIN products p ON p.id = ci.product_id
+                    WHERE ci.cart_id = c.id AND p.category_id = ?
+                )
+            `;
             params.push(filters.category);
         }
 
         if (filters.minValue) {
-            query += ' AND total_value >= ?';
+            query += ' AND COALESCE(v.cart_value, 0) >= ?';
             params.push(filters.minValue);
         }
 

--- a/backend/services/order.service.js
+++ b/backend/services/order.service.js
@@ -9,6 +9,7 @@ const {
 const logger = require("../utils/logger");
 const { validatePromo } = require("./promo.service");
 const pricing = require("./pricing.service");
+const cartLifecycle = require("./cartLifecycleService");
 
 // Marks the one failure the client can act on, so controllers can answer with
 // the specific figures instead of a generic server error.
@@ -438,8 +439,20 @@ const createOrderService = async (connection, orderData) => {
             }
         }
 
-        // Clear authenticated user's cart
+        // Close the cart and clear it. Both happen on this connection, inside
+        // the caller's transaction: a cart must never be recorded as converted
+        // against an order that then rolls back.
         if (user_id) {
+            const { cartId, converted } = await cartLifecycle.markCartConverted(
+                user_id,
+                orderId,
+                connection,
+            );
+
+            if (converted) {
+                logger.info(`Cart ${cartId} converted into order ${orderId}`);
+            }
+
             await connection.query(
                 "DELETE FROM cart_items WHERE user_id = ?",
                 [user_id]

--- a/backend/tests/cartLifecycle.test.js
+++ b/backend/tests/cartLifecycle.test.js
@@ -1,0 +1,377 @@
+// backend/tests/cartLifecycle.test.js
+//
+// Cart lifecycle (#1364).
+//
+// The database is mocked at the module boundary, as every healthy suite in this
+// repo does. What is worth pinning here is not SQL text but the properties the
+// lifecycle has to hold whatever the SQL looks like:
+//
+//   * an account has one active cart, and a race for it yields one, not two;
+//   * a cart converts exactly once, against the order it actually became;
+//   * the abandonment sweep is bounded, idempotent, and safe to run twice at
+//     the same time;
+//   * the reporting queries read cart state instead of columns and joins that
+//     never existed.
+
+jest.mock('../config/db', () => {
+    const query = jest.fn();
+    const pool = { query, getConnection: jest.fn() };
+    // metricsAggregationService reaches the pool through `.promise`.
+    pool.promise = pool;
+    return pool;
+});
+
+jest.mock('../utils/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+const db = require('../config/db');
+const logger = require('../utils/logger');
+const cartLifecycle = require('../services/cartLifecycleService');
+const cartConfig = require('../config/cartConfig');
+const { MetricsAggregationService } = require('../services/metricsAggregationService');
+
+const USER = '11111111-1111-4111-8111-111111111111';
+const ORDER = '22222222-2222-4222-8222-222222222222';
+const CART = '33333333-3333-4333-8333-333333333333';
+
+/** A connection double that records every statement and answers by pattern. */
+function fakeConnection(responder) {
+    const calls = [];
+
+    const connection = {
+        calls,
+        query: jest.fn(async (sql, params = []) => {
+            calls.push({ sql, params });
+            return responder(sql, params);
+        })
+    };
+
+    return connection;
+}
+
+function callsMatching(calls, regex) {
+    return calls.filter(({ sql }) => regex.test(sql));
+}
+
+/** `count` cart id rows, as the sweep's candidate select returns them. */
+function candidateRows(count, offset = 0) {
+    return Array.from({ length: count }, (_, i) => ({ id: `cart-${offset + i}` }));
+}
+
+afterEach(() => {
+    db.query.mockReset();
+    logger.info.mockClear();
+});
+
+describe('resolving the active cart', () => {
+    test('reuses the account\'s active cart rather than opening another', async () => {
+        const connection = fakeConnection((sql) => {
+            if (/SELECT id FROM carts/i.test(sql)) return [[{ id: CART }]];
+            return [{ affectedRows: 1 }];
+        });
+
+        await expect(cartLifecycle.resolveActiveCart(USER, connection)).resolves.toBe(CART);
+        expect(callsMatching(connection.calls, /INSERT INTO carts/i)).toHaveLength(0);
+    });
+
+    test('creates one when the account has none', async () => {
+        const connection = fakeConnection((sql) => {
+            if (/SELECT id FROM carts/i.test(sql)) return [[]];
+            return [{ affectedRows: 1 }];
+        });
+
+        const cartId = await cartLifecycle.resolveActiveCart(USER, connection);
+
+        const inserts = callsMatching(connection.calls, /INSERT INTO carts/i);
+        expect(inserts).toHaveLength(1);
+        expect(inserts[0].params).toEqual([cartId, USER, 'active']);
+        expect(cartId).toMatch(/^[0-9a-f-]{36}$/i);
+    });
+
+    test('adopts the winner\'s cart when it loses the race for the single active slot', async () => {
+        // Two concurrent add-to-cart requests: the unique key on carts rejects
+        // the loser, which must end up on the winner's cart and not throw.
+        let selects = 0;
+
+        const connection = fakeConnection((sql) => {
+            if (/SELECT id FROM carts/i.test(sql)) {
+                selects += 1;
+                return selects === 1 ? [[]] : [[{ id: CART }]];
+            }
+            if (/INSERT INTO carts/i.test(sql)) {
+                const duplicate = new Error('Duplicate entry for key uq_carts_one_active');
+                duplicate.code = 'ER_DUP_ENTRY';
+                throw duplicate;
+            }
+            return [{ affectedRows: 1 }];
+        });
+
+        await expect(cartLifecycle.resolveActiveCart(USER, connection)).resolves.toBe(CART);
+
+        // The recovery read has to be a locking one: under REPEATABLE READ the
+        // transaction's own snapshot would not contain the winner's row.
+        const recovery = callsMatching(connection.calls, /SELECT id FROM carts/i).pop();
+        expect(recovery.sql).toMatch(/FOR UPDATE/i);
+    });
+
+    test('refuses to invent an ownerless cart', async () => {
+        await expect(cartLifecycle.resolveActiveCart(null)).rejects.toThrow(/signed-in account/i);
+        expect(db.query).not.toHaveBeenCalled();
+    });
+
+    test('touching a cart moves only its activity clock, and only while active', async () => {
+        db.query.mockResolvedValue([{ affectedRows: 1 }]);
+
+        await cartLifecycle.touchCart(CART);
+
+        const [sql, params] = db.query.mock.calls[0];
+        expect(sql).toMatch(/UPDATE carts SET last_activity_at = NOW\(\)/i);
+        expect(sql).toMatch(/status = \?/i);
+        expect(params).toEqual([CART, 'active']);
+    });
+
+    test('touching nothing is a no-op, so an account with no cart costs no query', async () => {
+        await cartLifecycle.touchCart(null);
+        expect(db.query).not.toHaveBeenCalled();
+    });
+});
+
+describe('active -> converted', () => {
+    test('records the order the cart became, on the caller\'s connection', async () => {
+        const connection = fakeConnection((sql) => {
+            if (/SELECT id FROM carts/i.test(sql)) return [[{ id: CART }]];
+            return [{ affectedRows: 1 }];
+        });
+
+        await expect(cartLifecycle.markCartConverted(USER, ORDER, connection))
+            .resolves.toEqual({ cartId: CART, converted: true });
+
+        const [update] = callsMatching(connection.calls, /UPDATE carts/i);
+        expect(update.sql).toMatch(/converted_order_id = \?/i);
+        expect(update.sql).toMatch(/converted_at = NOW\(\)/i);
+        expect(update.params).toEqual(['converted', ORDER, CART, 'active']);
+
+        // Never on the pool: the conversion belongs to the order's transaction.
+        expect(db.query).not.toHaveBeenCalled();
+    });
+
+    test('is idempotent -- a cart already converted is not re-pointed at a second order', async () => {
+        const connection = fakeConnection((sql) => {
+            if (/SELECT id FROM carts/i.test(sql)) return [[{ id: CART }]];
+            return [{ affectedRows: 0 }];
+        });
+
+        await expect(cartLifecycle.markCartConverted(USER, ORDER, connection))
+            .resolves.toEqual({ cartId: CART, converted: false });
+    });
+
+    test('a guest checkout has no cart to convert, and that is not an error', async () => {
+        const connection = fakeConnection(() => [[]]);
+
+        await expect(cartLifecycle.markCartConverted(null, ORDER, connection))
+            .resolves.toEqual({ cartId: null, converted: false });
+        expect(connection.query).not.toHaveBeenCalled();
+    });
+});
+
+describe('active -> abandoned (the sweep)', () => {
+    test('works in bounded batches instead of one statement over the table', async () => {
+        const batchSize = 2;
+        let selects = 0;
+
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT c\.id/i.test(sql)) {
+                selects += 1;
+                // Two full batches, then a short one, which ends the run.
+                if (selects <= 2) return [candidateRows(batchSize, selects * 10)];
+                return [candidateRows(1, 99)];
+            }
+            return [{ affectedRows: 2 }];
+        });
+
+        const summary = await cartLifecycle.sweepAbandonedCarts({ batchSize, maxBatches: 10 });
+
+        expect(summary.batches).toBe(3);
+        expect(summary.scanned).toBe(5);
+        expect(summary.exhausted).toBe(true);
+
+        const candidateSelects = db.query.mock.calls.filter(([sql]) => /SELECT c\.id/i.test(sql));
+        expect(candidateSelects).toHaveLength(3);
+        for (const [sql, params] of candidateSelects) {
+            expect(sql).toMatch(/LIMIT \?/i);
+            expect(params[params.length - 1]).toBe(batchSize);
+        }
+    });
+
+    test('stops at the batch ceiling and says the backlog is not drained', async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT c\.id/i.test(sql)) return [candidateRows(2)];
+            return [{ affectedRows: 2 }];
+        });
+
+        const summary = await cartLifecycle.sweepAbandonedCarts({ batchSize: 2, maxBatches: 3 });
+
+        expect(summary.batches).toBe(3);
+        expect(summary.abandoned).toBe(6);
+        expect(summary.exhausted).toBe(false);
+        expect(logger.info).toHaveBeenCalledWith(expect.stringMatching(/backlog remains/i));
+    });
+
+    test('a second run over the same carts transitions nothing', async () => {
+        // The guard is `status = 'active'`: the first run flipped them, so the
+        // candidate select finds none the second time round.
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT c\.id/i.test(sql)) return [[]];
+            return [{ affectedRows: 0 }];
+        });
+
+        const summary = await cartLifecycle.sweepAbandonedCarts();
+
+        expect(summary).toMatchObject({ abandoned: 0, scanned: 0, exhausted: true });
+        expect(db.query.mock.calls.filter(([sql]) => /UPDATE carts/i.test(sql))).toHaveLength(0);
+    });
+
+    test('counts only what it changed, so two instances running at once cannot double-count', async () => {
+        // Three candidates selected, one of which another instance transitioned
+        // between the select and the update.
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT c\.id/i.test(sql)) return [candidateRows(3)];
+            return [{ affectedRows: 2 }];
+        });
+
+        const summary = await cartLifecycle.sweepAbandonedCarts({ batchSize: 3, maxBatches: 1 });
+
+        expect(summary.scanned).toBe(3);
+        expect(summary.abandoned).toBe(2);
+
+        const [updateSql, updateParams] = db.query.mock.calls
+            .find(([sql]) => /UPDATE carts/i.test(sql));
+        expect(updateSql).toMatch(/status = \?\s*$|AND status = \?/i);
+        expect(updateParams[0]).toBe('abandoned');
+        expect(updateParams[updateParams.length - 1]).toBe('active');
+    });
+
+    test('leaves empty carts alone -- a basket with nothing in it was never abandoned', async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT c\.id/i.test(sql)) return [[]];
+            return [{ affectedRows: 0 }];
+        });
+
+        await cartLifecycle.sweepAbandonedCarts();
+
+        const [sql] = db.query.mock.calls[0];
+        expect(sql).toMatch(/EXISTS\s*\(\s*SELECT 1 FROM cart_items/i);
+    });
+
+    test('measures inactivity against the configured threshold', async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT c\.id/i.test(sql)) return [[]];
+            return [{ affectedRows: 0 }];
+        });
+
+        const summary = await cartLifecycle.sweepAbandonedCarts();
+
+        expect(summary.inactivityMinutes).toBe(cartConfig.ABANDON_AFTER_MINUTES);
+
+        const [sql, params] = db.query.mock.calls[0];
+        expect(sql).toMatch(/DATE_SUB\(NOW\(\), INTERVAL \? MINUTE\)/i);
+        expect(params).toContain(cartConfig.ABANDON_AFTER_MINUTES);
+    });
+
+    test('reports the figure, so "nothing to do" reads differently from "did nothing"', async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT c\.id/i.test(sql)) return [candidateRows(1)];
+            return [{ affectedRows: 1 }];
+        });
+
+        await cartLifecycle.sweepAbandonedCarts({ batchSize: 5 });
+
+        expect(logger.info).toHaveBeenCalledWith(
+            expect.stringMatching(/1 cart\(s\) transitioned from 1 candidate\(s\)/i)
+        );
+    });
+});
+
+describe('reporting reads cart state', () => {
+    let metrics;
+
+    beforeEach(() => {
+        // A fresh instance per test: the service memoizes results for five
+        // minutes, which would otherwise answer the next test from cache.
+        metrics = new MetricsAggregationService();
+    });
+
+    test('conversion is counted from the cart\'s own status', async () => {
+        db.query.mockResolvedValue([[{ carts: 10, orders: 4, conversion_rate: 40 }]]);
+
+        const result = await metrics.getConversionRate('week');
+
+        const [sql] = db.query.mock.calls[0];
+        expect(sql).toMatch(/FROM carts c/i);
+        expect(sql).toMatch(/status = 'converted'/i);
+        // `orders` has no cart_id -- the cart is what knows which order it became.
+        expect(sql).not.toMatch(/o\.cart_id/i);
+
+        expect(result).toMatchObject({ metric: 'conversion_rate', carts: 10, orders: 4, value: 40 });
+    });
+
+    test('the abandonment denominator is every cart in the window, not the abandoned ones', async () => {
+        db.query.mockResolvedValue([[{
+            total_carts: 8,
+            abandoned_carts: 2,
+            abandoned_rate: 25,
+            lost_revenue: 1500
+        }]]);
+
+        const result = await metrics.getAbandonedCartRate('week');
+
+        const [sql] = db.query.mock.calls[0];
+        // The old query filtered the whole population to `status = 'abandoned'`,
+        // which made the rate 100% by construction.
+        expect(sql).not.toMatch(/WHERE[\s\S]*status = 'abandoned'/i);
+        expect(sql).toMatch(/SUM\(CASE WHEN c\.status = 'abandoned'/i);
+
+        expect(result).toMatchObject({
+            metric: 'abandoned_cart',
+            totalCarts: 8,
+            abandonedCarts: 2,
+            value: 25,
+            lostRevenue: 1500
+        });
+    });
+
+    test('what a cart was worth is priced from its lines, since a cart stores no total', async () => {
+        db.query.mockResolvedValue([[{}]]);
+
+        await metrics.getAbandonedCartRate('month');
+
+        const [sql] = db.query.mock.calls[0];
+        expect(sql).toMatch(/SUM\(ci\.quantity \* p\.price\)/i);
+        expect(sql).not.toMatch(/total_value/i);
+    });
+
+    test('a category filter asks what is in the cart', async () => {
+        db.query.mockResolvedValue([[{}]]);
+
+        await metrics.getConversionRate('week', { category: 7 });
+
+        const [sql, params] = db.query.mock.calls[0];
+        expect(sql).toMatch(/EXISTS\s*\(\s*SELECT 1 FROM cart_items ci/i);
+        expect(sql).toMatch(/p\.category_id = \?/i);
+        expect(params[params.length - 1]).toBe(7);
+    });
+
+    test('an empty result set reads as zero rather than NaN', async () => {
+        db.query.mockResolvedValue([[]]);
+
+        const conversion = await metrics.getConversionRate('today');
+        const abandoned = await metrics.getAbandonedCartRate('today');
+
+        expect(conversion).toMatchObject({ value: 0, carts: 0, orders: 0 });
+        expect(abandoned).toMatchObject({ value: 0, totalCarts: 0, abandonedCarts: 0 });
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

> Stacked on top of #1422. Review that one first — this diff shrinks to the reporting and promo fixes plus the tests once it merges.

Conversion and abandonment were being measured against a table that did not exist. Now that it does, the queries can be pointed at it — and several of them turn out to have been wrong in ways the missing table was hiding.

**Conversion** is counted from the cart's own status. The previous query joined orders on a cart reference that `orders` does not have; the cart is the thing that knows which order it became. Carts are counted in the window they started in, so a cohort's rate does not drift as its carts convert later.

**Abandonment** now uses every cart in the window as its denominator. It previously filtered the whole population down to abandoned carts, which made the rate 100% whenever it returned anything at all.

**Lost revenue** is priced from the cart's lines. A cart stores no total, and the column the old query summed was never defined anywhere.

**Filters.** A category filter now asks what is actually in the cart, which is the question it was always meant to answer. The user-segment filter is dropped: there is no segment model to filter on, and a predicate against a column that does not exist is not a filter, it is an error.

**Promo application.** The endpoint wrote promo totals to `carts` on columns the cart does not have, through a `db` binding the module never imported — two independent reasons the request could only ever fail. Applying a promo now records activity on the shopper's active cart. The discount is deliberately not persisted there: the figures are returned to the caller and re-derived from the submitted code at checkout, which is where the order and the usage record capture what was actually granted, and a second copy on the cart could only drift from it. The session predicate is dropped too — it was a per-request lock key with a random default and never identified a stored cart.

---

## 🔗 Related Issue

Closes #1364

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Not applicable — this is a backend change with no visual surface.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Coverage.** Lifecycle transitions including the race for an account's single active cart, conversion idempotency and its confinement to the order's connection, the sweep's batching, batch ceiling, idempotency and concurrent-run safety, and the shape of the reporting queries. The database is mocked at the module boundary, in line with the rest of the suite, so nothing here needs a live server. No dependencies added.

**Adjacent but out of scope.** `getAverageOrderValue` filters on order columns that do not exist either. It is broken in the same way, but it is not a cart aggregate, so it belongs in its own change rather than being folded in here.

**Note on CI.** Two frontend scripts do not parse on `main`, which fails the syntax gate for every branch regardless of its contents and causes the test and boot jobs to skip. Neither file is touched here; reported in #1416.
