### PR TITLE
Make variant stock the authoritative counter where variants exist

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -13,6 +13,7 @@ const paymentService = require("../services/payment.service");
 const CURRENCY = require("../config/currency");
 const { generateInvoicePdf } = require("../services/invoice.service");
 const inventoryReservationService = require("../services/inventoryReservationService");
+const stockCounter = require("../services/stockCounterService");
 
 const {
     safeNumber,
@@ -522,19 +523,22 @@ const getOrderStatus = async (req, res) => {
  * for.
  */
 const performOrderStatusUpdate = async (connection, id, currentStatus, newStatus, context = {}) => {
-    // if cancelling a previously un-cancelled order, restore stock
+    // If cancelling a previously un-cancelled order, put the units back on the
+    // counter the sale took them from. Crediting only the product total would
+    // leave the size the shopper actually cancelled permanently short.
     if (newStatus === "cancelled" && currentStatus !== "cancelled") {
         const [items] = await connection.query(
-            "SELECT product_id, qty FROM order_items WHERE order_id = ?",
+            "SELECT product_id, variant_id, qty FROM order_items WHERE order_id = ?",
             [id]
         );
 
         for (const item of safeArray(items)) {
             if (item.product_id) {
-                await connection.query(
-                    "UPDATE products SET stock = stock + ? WHERE id = ?",
-                    [item.qty, item.product_id]
-                );
+                await stockCounter.restoreStock(connection, {
+                    productId: item.product_id,
+                    variantId: item.variant_id,
+                    quantity: item.qty
+                });
             }
         }
     }

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -1,5 +1,6 @@
 const db = require("../config/db");
 const productService = require("../services/productService");
+const stockCounter = require("../services/stockCounterService");
 
 // helper functions
 const {
@@ -596,6 +597,35 @@ const updateProduct = async (req, res) => {
     try {
         const categoryId = category !== undefined ? await getOrCreateCategoryId(category, db) : undefined;
 
+        // For a product with variants, `products.stock` is a roll-up of the
+        // variants a shopper can pick, not a figure of its own. Refuse an edit
+        // to it rather than accept a number and quietly discard it at the next
+        // sale -- the quantity has to be set on the variant that holds it. A
+        // submission that already agrees with the roll-up is not an edit and
+        // passes, so an administrator renaming a product does not have to fight
+        // the stock field.
+        const rollup = await stockCounter.getVariantRollup(db, id);
+        const hasVariants = rollup.variantCount > 0;
+
+        if (hasVariants && stock !== undefined && Math.max(0, safeInteger(stock)) !== rollup.stock) {
+            return res.status(400).json({
+                success: false,
+                message:
+                    "This product's stock is held on its variants. Update the variant quantities instead."
+            });
+        }
+
+        // Recomputed by the statement rather than written from the figure read
+        // a moment ago, so a sale landing in between is not undone here.
+        const stockAssignment = hasVariants
+            ? `stock = COALESCE((
+                    SELECT SUM(v.stock) FROM product_variants v
+                    WHERE v.product_id = products.id
+                      AND v.is_active = 1
+                      AND v.deleted_at IS NULL
+                ), stock)`
+            : "stock = ?";
+
         const query = `
             UPDATE products
             SET
@@ -604,7 +634,7 @@ const updateProduct = async (req, res) => {
                 price = ?,
                 image = ?,
                 category_id = COALESCE(?, category_id),
-                stock = ?,
+                ${stockAssignment},
                 featured = ?
             WHERE id = ? AND deleted_at IS NULL
         `;
@@ -617,10 +647,7 @@ const updateProduct = async (req, res) => {
                 safeNumber(price),
                 sanitizeString(image),
                 categoryId,
-                Math.max(
-                    0,
-                    safeInteger(stock)
-                ),
+                ...(hasVariants ? [] : [Math.max(0, safeInteger(stock))]),
                 featured === true
                     || featured === 1
                     || featured === "1"

--- a/backend/controllers/refundController.js
+++ b/backend/controllers/refundController.js
@@ -1,5 +1,6 @@
 const db = require("../config/db");
 const RefundRequest = require("../models/RefundRequest");
+const stockCounter = require("../services/stockCounterService");
 const {
     safeArray,
     safeInteger,
@@ -264,8 +265,9 @@ const approveRequest = async (req, res) => {
             });
         }
 
-        // The order item may reference a variant; restock both the base
-        // product and the specific variant so inventory stays consistent.
+        // Credit the counter the sale drew down. The order item records which
+        // variant was bought; an item placed before that was recorded has none,
+        // and the return can only be credited to the product total.
         let variantId = null;
 
         if (request.orderItemId) {
@@ -277,19 +279,11 @@ const approveRequest = async (req, res) => {
             variantId = safeArray(items)[0]?.variant_id ?? null;
         }
 
-        if (request.productId) {
-            await connection.query(
-                "UPDATE products SET stock = stock + ? WHERE id = ?",
-                [request.quantity, request.productId]
-            );
-        }
-
-        if (variantId) {
-            await connection.query(
-                "UPDATE product_variants SET stock = stock + ? WHERE id = ?",
-                [request.quantity, variantId]
-            );
-        }
+        await stockCounter.restoreStock(connection, {
+            productId: request.productId,
+            variantId,
+            quantity: request.quantity
+        });
 
         await RefundRequest.updateStatus(
             requestId,

--- a/backend/services/inventoryReservationService.js
+++ b/backend/services/inventoryReservationService.js
@@ -2,6 +2,7 @@ const promisePool = require("../config/db");
 const { safeArray, safeInteger, safeNumber, sanitizeString } = require("../utils/helpers");
 const { NO_VARIANT_ID } = require("./cart.service");
 const { cacheService } = require("./cacheService");
+const stockCounter = require("./stockCounterService");
 
 // Atomic reservation TTL — 10 minutes (#1260)
 const LOCK_TTL_MS = parseInt(process.env.INVENTORY_LOCK_TTL_MS, 10) || 10 * 60 * 1000;
@@ -64,53 +65,16 @@ function hasVariantChoice(line) {
     return line.variantId > NO_VARIANT_ID || Boolean(line.color) || Boolean(line.size);
 }
 
+// Reservation resolves a line to a variant exactly the way the sale does, by
+// calling the same resolver. Two implementations of "which variant is this"
+// would eventually disagree, and the counter that was reserved would not be the
+// counter that gets decremented.
 async function resolveLockVariant(conn, productId, line) {
     if (!hasVariantChoice(line)) {
         return null;
     }
 
-    try {
-        if (line.variantId > NO_VARIANT_ID) {
-            const [rows] = await conn.query(
-                `SELECT id, stock FROM product_variants
-                 WHERE id = ? AND product_id = ? AND is_active = 1
-                 LIMIT 1 FOR UPDATE`,
-                [line.variantId, productId]
-            );
-
-            return safeArray(rows)[0] || null;
-        }
-
-        const conditions = [];
-        const params = [productId];
-
-        if (line.color) {
-            conditions.push(
-                "LOWER(JSON_UNQUOTE(JSON_EXTRACT(attributes, '$.color'))) = LOWER(?)"
-            );
-            params.push(line.color);
-        }
-
-        if (line.size) {
-            conditions.push(
-                "LOWER(JSON_UNQUOTE(JSON_EXTRACT(attributes, '$.size'))) = LOWER(?)"
-            );
-            params.push(line.size);
-        }
-
-        const [rows] = await conn.query(
-            `SELECT id, stock FROM product_variants
-             WHERE product_id = ? AND is_active = 1
-             AND ${conditions.join(" AND ")}
-             LIMIT 2 FOR UPDATE`,
-            params
-        );
-
-        const matches = safeArray(rows);
-        return matches.length === 1 ? matches[0] : null;
-    } catch {
-        return null;
-    }
+    return stockCounter.resolveVariant(conn, productId, line);
 }
 
 /**
@@ -139,15 +103,17 @@ async function reserveStockInTransaction(conn, userId, productId, quantity, now,
     let totalStock = safeNumber(products[0].stock);
     const productName = products[0].name;
 
+    // Where the line names a variant, the variant's own quantity is what has to
+    // cover the reservation, because it is what the sale will draw down. This
+    // machinery was keyed per variant from the start; comparing against the
+    // product total was what made it guard a number that was not the variant's.
     const variant = await resolveLockVariant(conn, productId, line);
-    const hasVariantStock =
-        Boolean(variant) && variant.stock !== null && variant.stock !== undefined;
 
-    if (hasVariantStock) {
+    if (variant) {
         totalStock = safeNumber(variant.stock);
     }
 
-    const [locks] = hasVariantStock
+    const [locks] = variant
         ? await conn.query(
             "SELECT SUM(quantity) as locked_qty FROM inventory_locks WHERE product_id = ? AND variant_id = ? AND color = ? AND size = ? AND expires_at > ?",
             [productId, line.variantId, line.color, line.size, now]
@@ -337,15 +303,23 @@ const inventoryReservationService = {
             const requested = safeInteger(item.quantity ?? item.qty, 0);
 
             if (requested > lockedQty) {
-                // Also report live available stock under FOR UPDATE when possible
+                // Report the live figure from whichever counter governs this
+                // line, so the number in the 409 is the number the shopper is
+                // actually being held to.
                 let availableStock = lockedQty;
                 try {
-                    const [products] = await pool.query(
-                        "SELECT stock FROM products WHERE id = ? FOR UPDATE",
-                        [line.productId]
-                    );
-                    if (products[0]) {
-                        availableStock = Math.max(0, safeNumber(products[0].stock));
+                    const variant = await resolveLockVariant(pool, line.productId, line);
+
+                    if (variant) {
+                        availableStock = Math.max(0, safeNumber(variant.stock));
+                    } else {
+                        const [products] = await pool.query(
+                            "SELECT stock FROM products WHERE id = ? FOR UPDATE",
+                            [line.productId]
+                        );
+                        if (products[0]) {
+                            availableStock = Math.max(0, safeNumber(products[0].stock));
+                        }
                     }
                 } catch (_) { /* ignore */ }
 
@@ -404,16 +378,19 @@ const inventoryReservationService = {
     },
 
     /**
-     * Deduct stock under the same connection after FOR UPDATE (used at checkout).
+     * Deduct stock under the same connection after FOR UPDATE, from whichever
+     * counter is authoritative for the line. `line` is optional so a caller
+     * with no variant choice keeps the product-level behaviour.
      */
-    deductStockAtomic: async (connection, productId, quantity) => {
-        const [result] = await connection.query(
-            `UPDATE products SET stock = stock - ?
-             WHERE id = ? AND stock >= ?`,
-            [quantity, productId, quantity]
-        );
+    deductStockAtomic: async (connection, productId, quantity, line = {}) => {
+        const movement = await stockCounter.deductStock(connection, {
+            productId,
+            variantId: lockLine({ ...line, productId }).variantId,
+            quantity
+        });
+
         return {
-            ok: result.affectedRows > 0,
+            ok: movement.ok,
             productId,
             requested: quantity
         };

--- a/backend/services/order.service.js
+++ b/backend/services/order.service.js
@@ -10,6 +10,9 @@ const logger = require("../utils/logger");
 const { validatePromo } = require("./promo.service");
 const pricing = require("./pricing.service");
 const cartLifecycle = require("./cartLifecycleService");
+const stockCounter = require("./stockCounterService");
+
+const { NO_VARIANT_ID } = stockCounter;
 
 // Marks the one failure the client can act on, so controllers can answer with
 // the specific figures instead of a generic server error.
@@ -90,75 +93,6 @@ const validateOrderData = (orderData) => {
     };
 };
 
-// Create order service with enhanced validations
-// Resolve the priced product variant for an order item, if any. A variant is
-// matched either by an explicit `variantId`/`variant_id` on the item, or —
-// since the current cart payload only carries color/size — by matching those
-// against the variant's `attributes` JSON. Only an unambiguous, active match
-// is honored. The lookup is deliberately defensive: deployments without a
-// `product_variants` table simply fall back to base product pricing.
-//
-// `lockRows` is off for read-only pricing (a quote holds no rows); order
-// creation keeps it on so the price cannot move under the transaction.
-const resolveItemVariant = async (connection, productId, item, lockRows = true) => {
-    const explicitVariantId = safeInteger(item.variantId ?? item.variant_id, 0);
-    const rowLock = lockRows ? " FOR UPDATE" : "";
-
-    try {
-        if (explicitVariantId > 0) {
-            const [rows] = await connection.query(
-                `SELECT id, price, stock FROM product_variants
-                 WHERE id = ? AND product_id = ? AND is_active = 1
-                 LIMIT 1${rowLock}`,
-                [explicitVariantId, productId],
-            );
-            return safeArray(rows)[0] || null;
-        }
-
-        const color = sanitizeString(item.color);
-        const size = sanitizeString(item.size);
-
-        if (!color && !size) {
-            return null;
-        }
-
-        const conditions = [];
-        const params = [productId];
-
-        if (color) {
-            conditions.push(
-                "LOWER(JSON_UNQUOTE(JSON_EXTRACT(attributes, '$.color'))) = LOWER(?)",
-            );
-            params.push(color);
-        }
-
-        if (size) {
-            conditions.push(
-                "LOWER(JSON_UNQUOTE(JSON_EXTRACT(attributes, '$.size'))) = LOWER(?)",
-            );
-            params.push(size);
-        }
-
-        const [rows] = await connection.query(
-            `SELECT id, price, stock FROM product_variants
-             WHERE product_id = ? AND is_active = 1
-             AND ${conditions.join(" AND ")}
-             LIMIT 2${rowLock}`,
-            params,
-        );
-
-        const matches = safeArray(rows);
-
-        // Ambiguous attribute matches are ignored so we never guess a price.
-        return matches.length === 1 ? matches[0] : null;
-    } catch (error) {
-        logger.warn(
-            `Variant lookup skipped for product ${productId}: ${error.message}`,
-        );
-        return null;
-    }
-};
-
 /**
  * Turn a client-supplied basket into priced lines using the database's own
  * prices. Client-supplied prices are never read — the only fields taken from
@@ -167,6 +101,9 @@ const resolveItemVariant = async (connection, productId, item, lockRows = true) 
  * Order creation runs this inside its transaction with row locks and stock
  * enforcement; the quote endpoint runs it read-only, where an out-of-stock
  * item should still be priced rather than rejected.
+ *
+ * Each line carries the variant it resolved to, so the sale, the order record
+ * and any later return all name the same counter.
  *
  * @param {Object} connection - pool or transactional connection
  * @param {Array<Object>} items
@@ -199,7 +136,24 @@ const resolveOrderLines = async (connection, items, options = {}) => {
         const product = safeResults[0];
         const qty = Math.max(1, safeInteger(item.qty, 1));
 
-        if (enforceStock && safeInteger(product.stock) < qty) {
+        // `lockRows` is off for read-only pricing (a quote holds no rows);
+        // order creation keeps it on so neither the price nor the quantity can
+        // move under the transaction.
+        const variant = await stockCounter.resolveVariant(
+            connection,
+            productId,
+            item,
+            { lockRows },
+        );
+
+        // The order has to be covered by the quantity it will actually draw
+        // down. Checking the product total for a line that names a variant is
+        // what let a size with two left go out ten at a time on the strength of
+        // its siblings.
+        const { stock: availableStock, variantId } =
+            stockCounter.resolveAvailableStock(product, variant);
+
+        if (enforceStock && availableStock < qty) {
             throw new Error(
                 `Insufficient stock for ${sanitizeString(product.name)}`,
             );
@@ -209,13 +163,6 @@ const resolveOrderLines = async (connection, items, options = {}) => {
         // product price is only a fallback. This keeps order totals correct
         // for variants that are priced differently from their parent.
         let realPrice = safeNumber(product.price);
-
-        const variant = await resolveItemVariant(
-            connection,
-            productId,
-            item,
-            lockRows,
-        );
 
         if (variant && variant.price !== null && variant.price !== undefined) {
             const variantPrice = safeNumber(variant.price);
@@ -227,6 +174,7 @@ const resolveOrderLines = async (connection, items, options = {}) => {
 
         resolvedLines.push({
             id: safeUUID(product.id),
+            variantId,
             name: sanitizeString(product.name),
             image: sanitizeString(product.image),
             price: realPrice,
@@ -378,22 +326,30 @@ const createOrderService = async (connection, orderData) => {
         ]);
 
         // insert into order_items
+        //
+        // The variant is recorded on the line, not merely implied by the colour
+        // and size text. A return has to credit the counter the sale drew down,
+        // and re-deriving that months later from free-text attributes is a
+        // guess. Sentinel zero becomes NULL: the column is a foreign key, and
+        // no variant has id 0.
         for (const item of validatedItems) {
             const itemQuery = `
                 INSERT INTO order_items (
                     order_id,
                     product_id,
+                    variant_id,
                     name,
                     price,
                     qty,
                     color,
                     size,
                     total
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             `;
             await connection.query(itemQuery, [
                 orderId,
                 item.id,
+                item.variantId > NO_VARIANT_ID ? item.variantId : null,
                 item.name,
                 item.price,
                 item.qty,
@@ -403,21 +359,19 @@ const createOrderService = async (connection, orderData) => {
             ]);
         }
 
-        // reduce stock safely
+        // Reduce the same counter the availability check was made against, on
+        // this connection so the movement shares the order's fate. The
+        // sufficiency test lives in the UPDATE's WHERE clause rather than in a
+        // read before it, so two checkouts racing for the last unit cannot both
+        // pass: the loser changes no rows and is refused here.
         for (const item of validatedItems) {
-            const stockQuery = `UPDATE products SET stock = stock - ? WHERE id = ? 
-            AND stock >= ? `;
+            const movement = await stockCounter.deductStock(connection, {
+                productId: item.id,
+                variantId: item.variantId,
+                quantity: item.qty,
+            });
 
-            const [result] = await connection.query(
-                stockQuery,
-                [
-                    item.qty,
-                    item.id,
-                    item.qty
-                ]
-            );
-
-            if (result.affectedRows === 0) {
+            if (!movement.ok) {
                 throw new Error(
                     `Insufficient stock for ${item.name}`
                 );

--- a/backend/services/stockCounterService.js
+++ b/backend/services/stockCounterService.js
@@ -1,0 +1,257 @@
+// Which quantity column is authoritative for an order line, and the only place
+// that moves it.
+//
+// A shopper buys a variant, not a product -- a medium in blue is what leaves
+// the warehouse. So where a line resolves to a variant, `product_variants.stock`
+// is the counter that is checked, decremented on sale and credited back on
+// return. A line with no variant keeps `products.stock` as its counter and
+// behaves exactly as it always has.
+//
+// `products.stock` is still maintained for a product that has variants, but as
+// a roll-up rather than an authority. Availability filters, recommendation
+// queries, product feeds, restock alerts and merchandising all read the product
+// column; teaching every one of them to sum variants would be a far larger and
+// riskier change than the one that closes the oversell. Keeping the roll-up in
+// step inside the same transaction keeps all of them honest without making any
+// of them the arbiter.
+
+const { NO_VARIANT_ID } = require("./cart.service");
+const { safeArray, safeInteger, sanitizeString } = require("../utils/helpers");
+const logger = require("../utils/logger");
+
+const normalizeVariantId = (value) =>
+    Math.max(NO_VARIANT_ID, safeInteger(value, NO_VARIANT_ID));
+
+/**
+ * Find the active variant a line refers to: by explicit id when the client sent
+ * one, otherwise by the colour/size choice matched against the variant's
+ * attributes.
+ *
+ * Everything that needs to know which counter a line touches comes through
+ * here. Reservation, pricing and the sale each resolving a line their own way
+ * is how the quantity that was checked and the quantity that was decremented
+ * came to be two different numbers.
+ *
+ * An ambiguous attribute match resolves to nothing rather than a guess: putting
+ * the deduction on the wrong variant is worse than falling back to the product.
+ * The lookup is deliberately defensive for the same reason it always was -- a
+ * deployment with no `product_variants` table still has to be able to sell.
+ *
+ * @param {Object} connection - pool or transactional connection
+ * @param {string} productId
+ * @param {Object} item - anything carrying variantId/variant_id, color, size
+ * @param {{ lockRows?: boolean }} [options]
+ * @returns {Promise<Object|null>} the variant row, or null
+ */
+const resolveVariant = async (connection, productId, item, options = {}) => {
+    const { lockRows = true } = options;
+    const rowLock = lockRows ? " FOR UPDATE" : "";
+    const explicitVariantId = normalizeVariantId(item?.variantId ?? item?.variant_id);
+
+    try {
+        if (explicitVariantId > NO_VARIANT_ID) {
+            const [rows] = await connection.query(
+                `SELECT id, price, stock FROM product_variants
+                 WHERE id = ? AND product_id = ? AND is_active = 1
+                 LIMIT 1${rowLock}`,
+                [explicitVariantId, productId],
+            );
+
+            return safeArray(rows)[0] || null;
+        }
+
+        const color = sanitizeString(item?.color);
+        const size = sanitizeString(item?.size);
+
+        if (!color && !size) {
+            return null;
+        }
+
+        const conditions = [];
+        const params = [productId];
+
+        if (color) {
+            conditions.push(
+                "LOWER(JSON_UNQUOTE(JSON_EXTRACT(attributes, '$.color'))) = LOWER(?)",
+            );
+            params.push(color);
+        }
+
+        if (size) {
+            conditions.push(
+                "LOWER(JSON_UNQUOTE(JSON_EXTRACT(attributes, '$.size'))) = LOWER(?)",
+            );
+            params.push(size);
+        }
+
+        const [rows] = await connection.query(
+            `SELECT id, price, stock FROM product_variants
+             WHERE product_id = ? AND is_active = 1
+             AND ${conditions.join(" AND ")}
+             LIMIT 2${rowLock}`,
+            params,
+        );
+
+        const matches = safeArray(rows);
+
+        return matches.length === 1 ? matches[0] : null;
+    } catch (error) {
+        logger.warn(
+            `Variant lookup skipped for product ${productId}: ${error.message}`,
+        );
+        return null;
+    }
+};
+
+/**
+ * How many units a line can draw on, and which counter that figure came from.
+ *
+ * @returns {{ stock: number, variantId: number }}
+ */
+const resolveAvailableStock = (product, variant) => {
+    if (variant) {
+        return {
+            stock: safeInteger(variant.stock),
+            variantId: normalizeVariantId(variant.id),
+        };
+    }
+
+    return {
+        stock: safeInteger(product?.stock),
+        variantId: NO_VARIANT_ID,
+    };
+};
+
+/**
+ * The sellable total across a product's variants, and how many there are.
+ *
+ * Only variants a shopper can actually select are counted. An inactive or
+ * soft-deleted row may still carry a figure, but nothing can put it in a
+ * basket, so including it would overstate what is on the shelf.
+ *
+ * @returns {Promise<{ variantCount: number, stock: number }>}
+ */
+const getVariantRollup = async (connection, productId) => {
+    try {
+        const [rows] = await connection.query(
+            `SELECT COUNT(*) AS variant_count, COALESCE(SUM(stock), 0) AS variant_stock
+             FROM product_variants
+             WHERE product_id = ? AND is_active = 1 AND deleted_at IS NULL`,
+            [productId],
+        );
+
+        const rollup = safeArray(rows)[0];
+
+        return {
+            variantCount: safeInteger(rollup?.variant_count),
+            stock: safeInteger(rollup?.variant_stock),
+        };
+    } catch (error) {
+        logger.warn(
+            `Variant roll-up skipped for product ${productId}: ${error.message}`,
+        );
+        return { variantCount: 0, stock: 0 };
+    }
+};
+
+/**
+ * Take `quantity` off the authoritative counter for a line.
+ *
+ * The decrement is conditional on the counter still holding enough, so two
+ * checkouts racing for the last unit cannot both win: the loser changes no rows
+ * and gets `ok: false`. Reading a balance and writing back the difference would
+ * put that race straight back.
+ *
+ * Returns rather than throws so the caller can name the line in the message the
+ * shopper sees. Must be given the connection the order is running on: a stock
+ * movement on a second connection commits independently of the order it belongs
+ * to.
+ *
+ * @param {Object} connection - transactional connection
+ * @param {{ productId: string, variantId?: number, quantity: number }} movement
+ * @returns {Promise<{ ok: boolean, productId: string, variantId: number, quantity: number }>}
+ */
+const deductStock = async (connection, movement) => {
+    const productId = movement?.productId;
+    const variantId = normalizeVariantId(movement?.variantId);
+    const quantity = Math.max(0, safeInteger(movement?.quantity));
+
+    if (!productId || quantity === 0) {
+        return { ok: true, productId, variantId, quantity };
+    }
+
+    if (variantId === NO_VARIANT_ID) {
+        const [result] = await connection.query(
+            `UPDATE products SET stock = stock - ?
+             WHERE id = ? AND stock >= ?`,
+            [quantity, productId, quantity],
+        );
+
+        return { ok: result.affectedRows > 0, productId, variantId, quantity };
+    }
+
+    const [result] = await connection.query(
+        `UPDATE product_variants SET stock = stock - ?
+         WHERE id = ? AND product_id = ? AND stock >= ?`,
+        [quantity, variantId, productId, quantity],
+    );
+
+    if (result.affectedRows === 0) {
+        return { ok: false, productId, variantId, quantity };
+    }
+
+    // The roll-up follows a sale the variant has already authorised, so it
+    // clamps instead of refusing. An administrator can still write
+    // `products.stock` directly, and a total that has drifted below the sum of
+    // its variants must not veto a sale the authoritative counter allowed --
+    // nor drive the column negative and fail the whole order on its CHECK.
+    await connection.query(
+        "UPDATE products SET stock = GREATEST(stock - ?, 0) WHERE id = ?",
+        [quantity, productId],
+    );
+
+    return { ok: true, productId, variantId, quantity };
+};
+
+/**
+ * Put `quantity` back on the counter the sale took it from -- cancellation and
+ * approved returns. Unconditional: goods coming back are not a request that can
+ * be refused.
+ *
+ * @param {Object} connection - transactional connection
+ * @param {{ productId: string, variantId?: number, quantity: number }} movement
+ */
+const restoreStock = async (connection, movement) => {
+    const productId = movement?.productId;
+    const variantId = normalizeVariantId(movement?.variantId);
+    const quantity = Math.max(0, safeInteger(movement?.quantity));
+
+    if (quantity === 0) {
+        return { ok: true, productId, variantId, quantity };
+    }
+
+    if (variantId > NO_VARIANT_ID) {
+        await connection.query(
+            "UPDATE product_variants SET stock = stock + ? WHERE id = ?",
+            [quantity, variantId],
+        );
+    }
+
+    if (productId) {
+        await connection.query(
+            "UPDATE products SET stock = stock + ? WHERE id = ?",
+            [quantity, productId],
+        );
+    }
+
+    return { ok: true, productId, variantId, quantity };
+};
+
+module.exports = {
+    NO_VARIANT_ID,
+    resolveVariant,
+    resolveAvailableStock,
+    getVariantRollup,
+    deductStock,
+    restoreStock,
+};

--- a/backend/tests/variantStock.test.js
+++ b/backend/tests/variantStock.test.js
@@ -1,0 +1,268 @@
+// Tests for variant-authoritative stock (#1428).
+//
+// The point of the change is that one counter is checked, decremented and
+// credited back, so these assert which table each movement lands on and that
+// the sufficiency test stays inside the UPDATE's WHERE clause. A read followed
+// by a write would pass every functional test here and still oversell under
+// concurrency, so the shape of the statement is asserted, not only its effect.
+
+jest.mock("../config/db", () => {
+    const query = jest.fn();
+    return { query, getConnection: jest.fn() };
+});
+
+jest.mock("../utils/logger", () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+jest.mock("../services/promo.service", () => ({
+    validatePromo: jest.fn()
+}));
+
+jest.mock("../services/cartLifecycleService", () => ({
+    markCartConverted: jest.fn(async () => ({ cartId: null, converted: false }))
+}));
+
+const stockCounter = require("../services/stockCounterService");
+const { resolveOrderLines } = require("../services/order.service");
+
+const PRODUCT_ID = "3f1a2b4c-5d6e-4f70-8a9b-0c1d2e3f4a5b";
+
+function makeConnection(responder) {
+    const calls = [];
+    const query = jest.fn(async (sql, params = []) => {
+        calls.push({ sql, params });
+        return responder(sql, params);
+    });
+    return { query, calls };
+}
+
+function sqlsMatching(calls, regex) {
+    return calls.filter(({ sql }) => regex.test(sql));
+}
+
+describe("deductStock", () => {
+    test("a line with a variant draws down the variant, guarded on the variant's own balance", async () => {
+        const { query, calls } = makeConnection(() => [{ affectedRows: 1 }]);
+
+        const movement = await stockCounter.deductStock(
+            { query },
+            { productId: PRODUCT_ID, variantId: 42, quantity: 3 }
+        );
+
+        expect(movement.ok).toBe(true);
+
+        const variantUpdates = sqlsMatching(calls, /UPDATE product_variants SET stock = stock - \?/i);
+        expect(variantUpdates).toHaveLength(1);
+
+        // The whole concurrency property: the balance test is a predicate on the
+        // write, not a separate read, so a losing racer changes no rows.
+        expect(variantUpdates[0].sql).toMatch(/WHERE id = \? AND product_id = \? AND stock >= \?/i);
+        expect(variantUpdates[0].params).toEqual([3, 42, PRODUCT_ID, 3]);
+
+        // Nothing gates on the product total for a variant line.
+        expect(sqlsMatching(calls, /UPDATE products SET stock = stock - \?/i)).toHaveLength(0);
+    });
+
+    test("the product total follows the variant sale as a clamped roll-up", async () => {
+        const { calls, query } = makeConnection(() => [{ affectedRows: 1 }]);
+
+        await stockCounter.deductStock(
+            { query },
+            { productId: PRODUCT_ID, variantId: 42, quantity: 2 }
+        );
+
+        const rollups = sqlsMatching(calls, /UPDATE products SET stock = GREATEST\(stock - \?, 0\)/i);
+        expect(rollups).toHaveLength(1);
+        expect(rollups[0].params).toEqual([2, PRODUCT_ID]);
+    });
+
+    test("a variant that cannot cover the line is refused and the product total is left alone", async () => {
+        const { query, calls } = makeConnection((sql) => {
+            if (/UPDATE product_variants SET stock = stock - \?/i.test(sql)) {
+                return [{ affectedRows: 0 }];
+            }
+            return [{ affectedRows: 1 }];
+        });
+
+        const movement = await stockCounter.deductStock(
+            { query },
+            { productId: PRODUCT_ID, variantId: 42, quantity: 5 }
+        );
+
+        expect(movement.ok).toBe(false);
+        expect(sqlsMatching(calls, /UPDATE products/i)).toHaveLength(0);
+    });
+
+    test("a line with no variant keeps the product-level conditional decrement", async () => {
+        const { query, calls } = makeConnection(() => [{ affectedRows: 1 }]);
+
+        const movement = await stockCounter.deductStock(
+            { query },
+            { productId: PRODUCT_ID, quantity: 4 }
+        );
+
+        expect(movement.ok).toBe(true);
+        expect(sqlsMatching(calls, /UPDATE product_variants/i)).toHaveLength(0);
+
+        const productUpdates = sqlsMatching(calls, /UPDATE products SET stock = stock - \?/i);
+        expect(productUpdates).toHaveLength(1);
+        expect(productUpdates[0].sql).toMatch(/WHERE id = \? AND stock >= \?/i);
+        expect(productUpdates[0].params).toEqual([4, PRODUCT_ID, 4]);
+    });
+
+    test("a product that cannot cover the line is refused", async () => {
+        const { query } = makeConnection(() => [{ affectedRows: 0 }]);
+
+        const movement = await stockCounter.deductStock(
+            { query },
+            { productId: PRODUCT_ID, quantity: 4 }
+        );
+
+        expect(movement.ok).toBe(false);
+    });
+});
+
+describe("restoreStock", () => {
+    test("credits the variant the sale drew down, and the roll-up with it", async () => {
+        const { query, calls } = makeConnection(() => [{ affectedRows: 1 }]);
+
+        await stockCounter.restoreStock(
+            { query },
+            { productId: PRODUCT_ID, variantId: 42, quantity: 2 }
+        );
+
+        const variantCredits = sqlsMatching(calls, /UPDATE product_variants SET stock = stock \+ \?/i);
+        expect(variantCredits).toHaveLength(1);
+        expect(variantCredits[0].params).toEqual([2, 42]);
+
+        const productCredits = sqlsMatching(calls, /UPDATE products SET stock = stock \+ \?/i);
+        expect(productCredits).toHaveLength(1);
+        expect(productCredits[0].params).toEqual([2, PRODUCT_ID]);
+    });
+
+    test("an item with no variant recorded credits the product total only", async () => {
+        const { query, calls } = makeConnection(() => [{ affectedRows: 1 }]);
+
+        await stockCounter.restoreStock(
+            { query },
+            { productId: PRODUCT_ID, variantId: null, quantity: 2 }
+        );
+
+        expect(sqlsMatching(calls, /UPDATE product_variants/i)).toHaveLength(0);
+        expect(sqlsMatching(calls, /UPDATE products SET stock = stock \+ \?/i)).toHaveLength(1);
+    });
+});
+
+describe("resolveVariant", () => {
+    test("an ambiguous colour and size match resolves to nothing rather than a guess", async () => {
+        const { query } = makeConnection(() => [[{ id: 1, price: 10, stock: 5 }, { id: 2, price: 10, stock: 5 }]]);
+
+        const variant = await stockCounter.resolveVariant(
+            { query },
+            PRODUCT_ID,
+            { color: "blue", size: "m" }
+        );
+
+        expect(variant).toBeNull();
+    });
+
+    test("an explicit variant id is looked up under a row lock when the caller is in a transaction", async () => {
+        const { query, calls } = makeConnection(() => [[{ id: 42, price: 10, stock: 5 }]]);
+
+        const variant = await stockCounter.resolveVariant({ query }, PRODUCT_ID, { variantId: 42 });
+
+        expect(variant).toMatchObject({ id: 42 });
+        expect(calls[0].sql).toMatch(/FOR UPDATE/i);
+        expect(calls[0].sql).toMatch(/is_active = 1/i);
+    });
+});
+
+describe("getVariantRollup", () => {
+    test("totals only the variants a shopper can select", async () => {
+        const { query, calls } = makeConnection(() => [[{ variant_count: 3, variant_stock: 11 }]]);
+
+        const rollup = await stockCounter.getVariantRollup({ query }, PRODUCT_ID);
+
+        expect(rollup).toEqual({ variantCount: 3, stock: 11 });
+        expect(calls[0].sql).toMatch(/is_active = 1 AND deleted_at IS NULL/i);
+    });
+
+    test("a deployment without the variants table falls back to product-level behaviour", async () => {
+        const query = jest.fn(async () => {
+            throw new Error("Table 'product_variants' doesn't exist");
+        });
+
+        await expect(stockCounter.getVariantRollup({ query }, PRODUCT_ID)).resolves.toEqual({
+            variantCount: 0,
+            stock: 0
+        });
+    });
+});
+
+describe("resolveOrderLines", () => {
+    test("refuses a variant the variant cannot cover even when the product total could", async () => {
+        const { query } = makeConnection((sql) => {
+            if (/FROM products WHERE id = \?/i.test(sql)) {
+                return [[{ id: PRODUCT_ID, name: "Tee", price: 20, stock: 100, image: "" }]];
+            }
+            if (/FROM product_variants/i.test(sql)) {
+                return [[{ id: 42, price: 20, stock: 2 }]];
+            }
+            return [{ affectedRows: 1 }];
+        });
+
+        await expect(
+            resolveOrderLines({ query }, [{ id: PRODUCT_ID, variantId: 42, qty: 10 }])
+        ).rejects.toThrow(/Insufficient stock for Tee/);
+    });
+
+    test("still enforces against the product total when the line has no variant", async () => {
+        const { query } = makeConnection((sql) => {
+            if (/FROM products WHERE id = \?/i.test(sql)) {
+                return [[{ id: PRODUCT_ID, name: "Tee", price: 20, stock: 1, image: "" }]];
+            }
+            return [{ affectedRows: 1 }];
+        });
+
+        await expect(
+            resolveOrderLines({ query }, [{ id: PRODUCT_ID, qty: 3 }])
+        ).rejects.toThrow(/Insufficient stock for Tee/);
+    });
+
+    test("carries the resolved variant onto the line so the sale and any return name the same counter", async () => {
+        const { query } = makeConnection((sql) => {
+            if (/FROM products WHERE id = \?/i.test(sql)) {
+                return [[{ id: PRODUCT_ID, name: "Tee", price: 20, stock: 100, image: "" }]];
+            }
+            if (/FROM product_variants/i.test(sql)) {
+                return [[{ id: 42, price: 25, stock: 9 }]];
+            }
+            return [{ affectedRows: 1 }];
+        });
+
+        const lines = await resolveOrderLines({ query }, [
+            { id: PRODUCT_ID, variantId: 42, qty: 2 }
+        ]);
+
+        expect(lines).toHaveLength(1);
+        expect(lines[0].variantId).toBe(42);
+        expect(lines[0].price).toBe(25);
+    });
+
+    test("a line with no variant carries the sentinel, so nothing later mistakes it for one", async () => {
+        const { query } = makeConnection((sql) => {
+            if (/FROM products WHERE id = \?/i.test(sql)) {
+                return [[{ id: PRODUCT_ID, name: "Tee", price: 20, stock: 100, image: "" }]];
+            }
+            return [{ affectedRows: 1 }];
+        });
+
+        const lines = await resolveOrderLines({ query }, [{ id: PRODUCT_ID, qty: 2 }]);
+
+        expect(lines[0].variantId).toBe(stockCounter.NO_VARIANT_ID);
+    });
+});

--- a/migrations/0032_variant_stock_authority.sql
+++ b/migrations/0032_variant_stock_authority.sql
@@ -1,0 +1,160 @@
+-- ============================================
+-- VARIANT STOCK BECOMES THE AUTHORITATIVE COUNTER
+-- ============================================
+--
+-- `product_variants.stock` has been in the schema since the baseline and has
+-- never once been decremented. Its only writer credited it back on an approved
+-- return, so it has risen monotonically since the table was created while
+-- `products.stock` absorbed every sale. Reservations were keyed per variant all
+-- along, but the quantity they compared against was the product total, so a
+-- size with two left could go out ten at a time on the strength of its
+-- siblings.
+--
+-- From here the variant holds the quantity for any product that has one, and
+-- `products.stock` is a roll-up of that product's sellable variants rather than
+-- an authority in its own right. Products with no variants are touched by
+-- nothing below: their total stays authoritative and their behaviour does not
+-- change.
+
+-- ============================================
+-- A VARIANT ALWAYS HAS A QUANTITY
+-- ============================================
+--
+-- The column was nullable, and the code deciding whether a variant was
+-- authoritative read NULL as "ask the product instead". That fork is exactly
+-- what this change exists to remove, so NULL normalizes to zero and the column
+-- becomes NOT NULL.
+--
+-- Negatives are clamped in the same statement. None should exist -- nothing has
+-- ever subtracted from this column -- but the CHECK added below would fail the
+-- whole migration on one stray row, and refusing to start is a worse answer
+-- than starting from zero on a figure that is about to be rebased anyway.
+
+UPDATE product_variants
+SET stock = 0
+WHERE stock IS NULL OR stock < 0;
+
+DELIMITER //
+
+CREATE PROCEDURE EnforceVariantStockCounter()
+BEGIN
+    IF EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'product_variants'
+        AND COLUMN_NAME = 'stock'
+        AND IS_NULLABLE = 'YES'
+    ) THEN
+        ALTER TABLE product_variants
+        MODIFY COLUMN stock INT NOT NULL DEFAULT 0;
+    END IF;
+
+    -- The counterpart of chk_stock on products. The application already refuses
+    -- to decrement past zero; this is the backstop for anything that writes the
+    -- column without going through it.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'product_variants'
+        AND CONSTRAINT_NAME = 'chk_variant_stock'
+    ) THEN
+        ALTER TABLE product_variants
+        ADD CONSTRAINT chk_variant_stock CHECK (stock >= 0);
+    END IF;
+
+    -- Both the roll-up recompute below and the availability read at runtime
+    -- group a product's variants by what a shopper can actually select. The
+    -- existing index on product_id alone leaves the is_active and deleted_at
+    -- tests to a row visit each.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'product_variants'
+        AND INDEX_NAME = 'idx_product_variants_sellable'
+    ) THEN
+        CREATE INDEX idx_product_variants_sellable
+        ON product_variants (product_id, is_active, deleted_at);
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL EnforceVariantStockCounter();
+DROP PROCEDURE EnforceVariantStockCounter;
+
+-- ============================================
+-- RECONCILIATION -- AND WHAT IT ASSUMES
+-- ============================================
+--
+-- Stated plainly rather than buried, because the numbers below are a decision
+-- and not a derivation.
+--
+-- The figure currently in `product_variants.stock` is not an opening balance.
+-- It is whatever the row was seeded with plus every unit ever credited back by
+-- an approved return, with no sale ever taken off it. Adopting it as the new
+-- authoritative quantity would hand the counter a number that is wrong in the
+-- one direction that matters -- upwards -- and the first thing this fix did
+-- would be to license the overselling it exists to stop.
+--
+-- `products.stock` is the only quantity in the database that has actually been
+-- maintained: every sale, cancellation and approved return has moved it. It is
+-- therefore taken as the product's true total, and reconciliation reduces to
+-- one question: how does that total split across the variants?
+--
+-- Nothing in the schema records the split. It is ASSUMED to follow the existing
+-- variant figures in proportion, on the grounds that their relative sizes still
+-- carry some signal about which colours and sizes were stocked deepest even
+-- though their absolute values carry none. Where a product's variants sum to
+-- zero the total is divided evenly, which is a guess and is meant to look like
+-- one.
+--
+-- The division floors and the product total is then set to the sum of what was
+-- actually allocated, so a remainder of a few units is dropped rather than
+-- handed to an arbitrary variant. Dropping understates availability by less
+-- than one unit per variant. The alternative overstates it, which is the bug.
+--
+-- Only variants a shopper can select take part. An inactive or soft-deleted
+-- variant keeps whatever figure it had and is excluded from the product's
+-- total, because nothing can put it in a basket -- which also means its figure
+-- is still an inflated one if it is ever reactivated.
+--
+-- None of this is a stock count. It is a defensible starting position that is
+-- internally consistent from the first sale onwards. Only a warehouse count
+-- makes these numbers true, and one should follow.
+--
+-- Re-running changes nothing. After the second statement a product's total
+-- equals the sum of its variants, so the proportional split resolves to the
+-- figures already there.
+
+UPDATE product_variants v
+JOIN products p
+  ON p.id = v.product_id
+JOIN (
+    SELECT
+        product_id,
+        SUM(stock) AS weight_total,
+        COUNT(*)   AS sellable_variants
+    FROM product_variants
+    WHERE is_active = 1 AND deleted_at IS NULL
+    GROUP BY product_id
+) agg ON agg.product_id = v.product_id
+SET v.stock = CASE
+        WHEN agg.weight_total > 0
+            THEN FLOOR(GREATEST(COALESCE(p.stock, 0), 0) * v.stock / agg.weight_total)
+        ELSE FLOOR(GREATEST(COALESCE(p.stock, 0), 0) / agg.sellable_variants)
+    END
+WHERE v.is_active = 1
+  AND v.deleted_at IS NULL;
+
+-- Bring the product total back to what was actually allocated, so the roll-up
+-- the application maintains from here starts in step with the variants it is
+-- summarising.
+
+UPDATE products p
+JOIN (
+    SELECT product_id, SUM(stock) AS sellable_stock
+    FROM product_variants
+    WHERE is_active = 1 AND deleted_at IS NULL
+    GROUP BY product_id
+) v ON v.product_id = p.id
+SET p.stock = v.sellable_stock;


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

> Not split. Enforcement, restocking and reconciliation cannot be separated without leaving an interval in which both counters are live and disagree, which is the defect itself.

Stock was tracked in two places that never agreed. Reservations were keyed per product, variant, colour and size, but the quantity they were compared against — and the quantity a sale reduced — was the product total. The variant column was only ever credited, by an approved return, so it rose monotonically while the product column absorbed every sale. A variant could therefore be oversold: a size with two left went out ten at a time as long as the product as a whole had ten.

**The variant is the counter now.** Where a line resolves to a variant, that variant's quantity is what availability is checked against, what the sale decrements, and what a cancellation or an approved return credits back. One number, moved in one place. A line with no variant is untouched — the product total stays authoritative and nothing about those products changes.

**Every path resolves a line the same way.** Reservation, pricing and the sale each had their own answer to "which variant is this", and that is how the number that was checked and the number that was reduced came apart in the first place. They share one resolver now. An ambiguous colour-and-size match still resolves to nothing rather than a guess: putting a deduction on the wrong variant is worse than falling back to the product.

**The sale still cannot oversell under concurrency.** The sufficiency test stays inside the update's `WHERE` clause rather than moving to a read that precedes it, so two checkouts racing for the last unit cannot both pass — the loser changes no rows and is refused. That property was won at the product level in earlier work and is carried across intact rather than re-derived. The movement runs on the order's own connection inside its transaction, so an order that rolls back cannot leave a stock change behind it.

**The variant that was sold is recorded on the order line.** It previously was not, which left a return with nothing to credit but the product total even when the buyer had plainly bought one specific size. Re-deriving that months later from free-text colour and size is a guess, so it is written at the point of sale instead.

**The product total survives as a roll-up.** Availability filters, recommendations, product feeds, restock alerts and merchandising all read the product column; teaching each of them to sum variants would be a far larger and riskier change than the one that closes the oversell. It is maintained alongside the variant in the same transaction, as a summary rather than an authority — which also means it is no longer a figure an administrator can set by hand on a product that has variants. That edit is refused with an explanation rather than accepted and then silently discarded by the next sale.

---

## 🔗 Related Issue

Closes #1428

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [ ] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Not applicable — this is a backend and schema change with no visual surface.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**What the reconciliation assumes.** The existing variant figures are not an opening balance. They are whatever the row was seeded with plus every unit ever credited back by a return, with no sale ever taken off, so adopting them would hand the new authoritative counter a number inflated in precisely the direction that causes overselling. The product total is the only quantity that has actually been maintained, so it is taken as true and the migration's job reduces to splitting it across the variants. Nothing in the schema records that split. It is assumed to follow the existing variant figures in proportion, on the grounds that their relative sizes still say something about which colours and sizes were stocked deepest even though their absolute values say nothing; where those figures sum to zero the total is divided evenly, which is a guess and is written to look like one. The split floors, and the product total is then set to what was actually allocated, so a remainder of a few units is dropped rather than handed to an arbitrary variant — understating by under a unit per variant is the safe direction and overstating is the bug. Only variants a shopper can select take part; an inactive or soft-deleted row keeps its old figure and is left out of the total. Re-running it changes nothing.

**What an operator should check before running it.** This is not a stock count and does not pretend to be one. Take a backup, run it against a copy, and compare the resulting per-variant figures against what the warehouse actually believes — particularly for products with a heavy returns history, since those are the rows whose variant figures are most inflated and whose proportions therefore carry the least signal. Products whose total is small relative to their variant count will floor to zero on some variants and read as out of stock immediately; that is the correct answer for an unknown quantity, but it is visible to shoppers, so it is worth knowing which products they are before the deploy rather than after. A physical count should follow. Until it does, these numbers are a defensible starting position rather than the truth, and inactive variants in particular keep their inflated figure and will need setting by hand if they are ever reactivated.

**Orders placed before this.** Their lines carry no variant, so an approved return against one credits the product total only. There is nothing in the data to recover the variant from, and inferring it from the colour and size text would be the same guess this change refuses to make everywhere else.

**Two reservations can still name one variant.** A shopper sending an explicit variant id and another sending the equivalent colour and size produce different reservation keys that resolve to the same variant, so their holds are counted separately and the second one looks available when it is not. The sale itself is safe — it is refused at checkout rather than oversold — but the shopper finds out later than they should. Normalizing the key where it is created is a separate change.

**Note on CI.** Two frontend scripts do not parse on `main`, which fails the syntax gate for every branch regardless of its contents and causes the test and boot jobs to skip. Neither file is touched here; reported in #1416.
