### PR TITLE
Send recovery messages for abandoned carts

### DIFF
--- a/backend/config/cartRecoveryConfig.js
+++ b/backend/config/cartRecoveryConfig.js
@@ -1,0 +1,82 @@
+// backend/config/cartRecoveryConfig.js
+//
+// The suppression policy for abandoned-cart recovery, written down in one
+// place.
+//
+// Every value here is the difference between a recovery programme and a
+// complaint, and every one of them is a merchandising decision rather than an
+// implementation detail: how soon after walking away it is reasonable to say
+// something, how many times, how long a basket stays worth chasing. Buried as
+// literals in the sender they would be changed by patching the job, at which
+// point nobody can say what the policy currently is without reading it.
+//
+// The rules the schema enforces -- one message per basket per step, the
+// preference flags -- are not repeated here. This file is only the numbers.
+
+const MINUTES_PER_HOUR = 60;
+const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR;
+
+// A first nudge an hour after the basket is written off, then one more the
+// following day. Measured from `abandoned_at`, which is already a day of
+// silence after the last shopper action, so the first message lands roughly a
+// day after the shopper actually left.
+const DEFAULT_STAGE_DELAYS_MINUTES = [MINUTES_PER_HOUR, MINUTES_PER_DAY];
+
+/**
+ * Read a recovery sequence from a comma-separated environment value.
+ *
+ * Sorted and de-duplicated rather than taken as written: the sender treats
+ * position in this list as the stage number, so an unordered or repeated entry
+ * would silently mean "send the third message before the second".
+ *
+ * @param {string} [raw]
+ * @returns {number[]} Delays in minutes, ascending, or the default sequence.
+ */
+function parseStageDelays(raw) {
+    if (!raw) return DEFAULT_STAGE_DELAYS_MINUTES;
+
+    const delays = String(raw)
+        .split(',')
+        .map((part) => Number(part.trim()))
+        .filter((minutes) => Number.isFinite(minutes) && minutes >= 0);
+
+    if (!delays.length) return DEFAULT_STAGE_DELAYS_MINUTES;
+
+    return [...new Set(delays)].sort((a, b) => a - b);
+}
+
+const CART_RECOVERY_CONFIG = Object.freeze({
+    // How long after abandonment each message in the sequence is due. The
+    // length of this list is the length of the sequence: emptying it to a
+    // single entry turns the programme into one reminder and nothing else.
+    STAGE_DELAYS_MINUTES: Object.freeze(
+        parseStageDelays(process.env.CART_RECOVERY_STAGE_DELAYS_MINUTES)
+    ),
+
+    // Per-person ceiling, counted across every basket they have left behind.
+    // The per-basket rule alone does not bound this: a shopper who abandons
+    // three baskets in an afternoon would otherwise get three messages for it.
+    FREQUENCY_CAP_MESSAGES:
+        Number(process.env.CART_RECOVERY_FREQUENCY_CAP_MESSAGES) || 2,
+    FREQUENCY_CAP_HOURS:
+        Number(process.env.CART_RECOVERY_FREQUENCY_CAP_HOURS) || 24,
+
+    // Past this, the basket is history rather than a sale in progress and we
+    // stop asking about it. Without a stop the sequence would reach back over
+    // every abandoned cart ever recorded the first time it runs.
+    GIVE_UP_AFTER_MINUTES:
+        Number(process.env.CART_RECOVERY_GIVE_UP_AFTER_MINUTES) ||
+        7 * MINUTES_PER_DAY,
+
+    // Candidates examined per run. A backlog is drained across scheduled runs
+    // rather than in one pass that holds a long read while shoppers check out,
+    // matching how the abandonment sweep is bounded.
+    SCAN_BATCH_SIZE: Number(process.env.CART_RECOVERY_SCAN_BATCH_SIZE) || 200,
+
+    // Lines quoted in the message. A basket of thirty items does not need
+    // thirty lines of email to be recognisable.
+    MAX_ITEMS_IN_MESSAGE:
+        Number(process.env.CART_RECOVERY_MAX_ITEMS_IN_MESSAGE) || 5
+});
+
+module.exports = CART_RECOVERY_CONFIG;

--- a/backend/jobs/cartRecoveryJob.js
+++ b/backend/jobs/cartRecoveryJob.js
@@ -1,0 +1,71 @@
+/**
+ * Abandoned-cart recovery cron worker (#1429).
+ *
+ * Runs the recovery sweep on a schedule: which baskets are due a message, and
+ * which are suppressed, is decided entirely by cartRecoveryService. This is the
+ * clock and nothing else.
+ */
+
+'use strict';
+
+const cron = require('node-cron');
+const logger = require('../utils/logger');
+const cartRecoveryService = require('../services/cartRecoveryService');
+
+// Every twenty minutes. The stage delays are measured in hours, so the run
+// interval only decides how late a due message can be, and a tighter schedule
+// buys punctuality nobody would notice at the cost of a scan nobody needs.
+const CART_RECOVERY_CRON = process.env.CART_RECOVERY_CRON || '*/20 * * * *';
+
+let scheduledTask = null;
+
+async function runCartRecoveryJob() {
+    logger.info('Cart recovery job: starting sweep…');
+
+    try {
+        const result = await cartRecoveryService.runRecoverySweep();
+
+        logger.info(
+            `Cart recovery job: candidates=${result.candidates} sent=${result.sent}`
+        );
+
+        return result;
+    } catch (error) {
+        logger.error(`Cart recovery job failed: ${error.message}`);
+        throw error;
+    }
+}
+
+function startCartRecoveryJob() {
+    if (process.env.NODE_ENV === 'test') {
+        return null;
+    }
+    if (process.env.CART_RECOVERY_JOB_ENABLED === 'false') {
+        logger.info('Cart recovery job disabled via CART_RECOVERY_JOB_ENABLED=false');
+        return null;
+    }
+    if (scheduledTask) {
+        return scheduledTask;
+    }
+
+    scheduledTask = cron.schedule(CART_RECOVERY_CRON, () => {
+        runCartRecoveryJob().catch(() => {});
+    });
+    logger.info(`Cart recovery job scheduled (${CART_RECOVERY_CRON})`);
+
+    return scheduledTask;
+}
+
+function stopCartRecoveryJob() {
+    if (scheduledTask) {
+        scheduledTask.stop();
+        scheduledTask = null;
+    }
+}
+
+module.exports = {
+    runCartRecoveryJob,
+    startCartRecoveryJob,
+    stopCartRecoveryJob,
+    CART_RECOVERY_CRON
+};

--- a/backend/routes/wishlistNotifyRoutes.js
+++ b/backend/routes/wishlistNotifyRoutes.js
@@ -30,13 +30,16 @@ router.get("/preferences", authMiddleware, async (req, res) => {
 
 /**
  * PUT /api/wishlist-notify/preferences
- * Body: { priceDropEmail?, priceDropInApp?, unsubscribedAll? }
+ * Body: { priceDropEmail?, priceDropInApp?, cartRecoveryEmail?,
+ *         cartRecoveryInApp?, unsubscribedAll? }
  */
 router.put("/preferences", authMiddleware, async (req, res) => {
     try {
         const preferences = await wishlistNotifyService.updatePreferences(req.user.id, {
             priceDropEmail: req.body?.priceDropEmail,
             priceDropInApp: req.body?.priceDropInApp,
+            cartRecoveryEmail: req.body?.cartRecoveryEmail,
+            cartRecoveryInApp: req.body?.cartRecoveryInApp,
             unsubscribedAll: req.body?.unsubscribedAll
         });
         return res.status(200).json({

--- a/backend/server.js
+++ b/backend/server.js
@@ -519,6 +519,15 @@ async function bootstrap() {
         } catch (err) {
             console.error("Warning: Failed to start wishlist price-drop job:", err.message);
         }
+
+        // Abandoned-cart recovery (#1429). The lifecycle sweep decides what is
+        // abandoned; this decides what to say about it, and to whom.
+        try {
+            const { startCartRecoveryJob } = require("./jobs/cartRecoveryJob");
+            startCartRecoveryJob();
+        } catch (err) {
+            console.error("Warning: Failed to start cart recovery job:", err.message);
+        }
     }
 
     // Start HTTP listening only after services finish initializations

--- a/backend/services/cartRecoveryService.js
+++ b/backend/services/cartRecoveryService.js
@@ -1,0 +1,499 @@
+// backend/services/cartRecoveryService.js
+//
+// Acting on an abandoned cart (#1429).
+//
+// The lifecycle from #1364 detects the moment a basket is walked away from and
+// then discards it: `abandoned_at` is stamped and nothing reads it. This module
+// is what reads it.
+//
+// Almost none of this is new machinery. The preference centre, the broker and
+// the record-then-send idiom all arrived with the price-drop worker (#1394) and
+// are reused here; what is genuinely new is the policy, and the policy is most
+// of the work. Sending mail to somebody who left a basket behind is easy. Not
+// sending it to somebody who already bought, or who said no, or who heard from
+// us twice this morning already, is the part that decides whether this is a
+// recovery programme or a complaint.
+//
+// So the suppression rules are named, counted and reported rather than being
+// implied by the shape of a query:
+//
+//   * the basket is empty        -- there is nothing left to come back to;
+//   * the shopper has bought     -- the sequence stops at the sale, whether or
+//                                   not the sale came from this basket;
+//   * the shopper opted out      -- preferences, including the global one;
+//   * the sequence is finished   -- a basket is chased a fixed number of times;
+//   * the next message is not due yet;
+//   * the frequency cap is spent -- across every basket, not just this one;
+//   * something was already sent for this basket at this step.
+//
+// The last of those is also a unique key, so it holds when two instances run at
+// once. The log row is written *before* the message goes out for exactly that
+// reason: a crash between the two loses one message, which is the failure worth
+// having.
+
+'use strict';
+
+const crypto = require('crypto');
+const db = require('../config/db');
+const cartRecoveryConfig = require('../config/cartRecoveryConfig');
+const logger = require('../utils/logger');
+const { safeInteger, safeUUID } = require('../utils/helpers');
+const { sendNotificationEmail } = require('./notificationEmailService');
+const {
+    notificationBroker,
+    NOTIFICATION_TYPES
+} = require('./notificationBrokerService');
+const {
+    buildStableUnsubscribeToken,
+    buildUnsubscribeUrl
+} = require('./wishlistNotifyService');
+
+const CART_STATUS_ABANDONED = 'abandoned';
+
+// mysql2's code for a unique-key collision.
+const DUPLICATE_ENTRY = 'ER_DUP_ENTRY';
+
+/**
+ * Why a candidate basket was passed over.
+ *
+ * Reported per run so the log says which rule is doing the work. "Sent
+ * nothing" for the right reason and "sent nothing" because the query is wrong
+ * look identical otherwise, and this programme is one where the quiet failure
+ * is the expensive one.
+ */
+const SUPPRESSION = Object.freeze({
+    BASKET_EMPTIED: 'basket-emptied',
+    ALREADY_BOUGHT: 'already-bought',
+    OPTED_OUT: 'opted-out',
+    NO_ADDRESS: 'no-address',
+    SEQUENCE_COMPLETE: 'sequence-complete',
+    NOT_DUE: 'not-due',
+    FREQUENCY_CAP: 'frequency-cap',
+    ALREADY_SENT: 'already-sent'
+});
+
+/**
+ * `cartId:stage` -- one message per basket per step of the sequence.
+ *
+ * @param {string} cartId
+ * @param {number} stage
+ * @returns {string}
+ */
+function dedupeKey(cartId, stage) {
+    return `${cartId}:${stage}`;
+}
+
+/**
+ * A shopper with no preferences row has never expressed one, so the column
+ * default is what they would have. Only an explicit zero is a "no".
+ *
+ * @param {*} flag
+ * @returns {boolean}
+ */
+function isChannelEnabled(flag) {
+    return flag === null || flag === undefined ? true : Boolean(Number(flag));
+}
+
+/**
+ * The channels a shopper is willing to hear about an abandoned basket on.
+ *
+ * @param {object} preferences - A `notification_preferences` row, possibly
+ *   absent, joined onto the candidate.
+ * @returns {string[]}
+ */
+function recoveryChannels(preferences = {}) {
+    if (Number(preferences.unsubscribed_all)) return [];
+
+    const channels = [];
+
+    if (isChannelEnabled(preferences.cart_recovery_in_app)) channels.push('in_app');
+    if (isChannelEnabled(preferences.cart_recovery_email)) channels.push('email');
+
+    return channels;
+}
+
+/**
+ * The step of the sequence this basket is owed, or null when it is owed none.
+ *
+ * Position in the configured delay list *is* the stage number, which is why
+ * the configuration sorts it: the count of messages already sent for a basket
+ * is what says where in the sequence it has got to.
+ *
+ * @param {number} messagesSent
+ * @param {number} minutesSinceAbandoned
+ * @param {number[]} stageDelays
+ * @returns {number|null}
+ */
+function dueStage(messagesSent, minutesSinceAbandoned, stageDelays) {
+    const stage = Math.max(0, safeInteger(messagesSent, 0));
+
+    if (stage >= stageDelays.length) return null;
+
+    return minutesSinceAbandoned >= stageDelays[stage] ? stage : null;
+}
+
+/**
+ * Abandoned baskets worth looking at, with everything the suppression rules
+ * need to judge them.
+ *
+ * The counts are subqueries rather than joins on purpose: a basket is
+ * suppressed by the *existence* of an order or an earlier message, and joining
+ * would multiply candidate rows by their own history before anything had
+ * decided whether to send.
+ *
+ * @param {object} [options]
+ * @param {number} [options.frequencyCapHours]
+ * @param {number} [options.giveUpAfterMinutes]
+ * @param {number} [options.batchSize]
+ * @returns {Promise<object[]>}
+ */
+async function findRecoveryCandidates(options = {}) {
+    const frequencyCapHours = Math.max(
+        1,
+        safeInteger(options.frequencyCapHours, cartRecoveryConfig.FREQUENCY_CAP_HOURS)
+    );
+    const giveUpAfterMinutes = Math.max(
+        1,
+        safeInteger(options.giveUpAfterMinutes, cartRecoveryConfig.GIVE_UP_AFTER_MINUTES)
+    );
+    const batchSize = Math.max(
+        1,
+        safeInteger(options.batchSize, cartRecoveryConfig.SCAN_BATCH_SIZE)
+    );
+
+    const [rows] = await db.query(
+        `SELECT
+             c.id AS cart_id,
+             c.user_id,
+             c.abandoned_at,
+             u.email AS user_email,
+             u.name AS user_name,
+             pref.unsubscribed_all,
+             pref.cart_recovery_email,
+             pref.cart_recovery_in_app,
+             TIMESTAMPDIFF(MINUTE, c.abandoned_at, NOW()) AS minutes_since_abandoned,
+             (SELECT COUNT(*) FROM cart_items ci
+               WHERE ci.cart_id = c.id) AS line_count,
+             (SELECT COUNT(*) FROM cart_recovery_log l
+               WHERE l.cart_id = c.id) AS messages_for_cart,
+             (SELECT COUNT(*) FROM cart_recovery_log l
+               WHERE l.user_id = c.user_id
+                 AND l.sent_at > DATE_SUB(NOW(), INTERVAL ? HOUR)) AS messages_in_window,
+             (SELECT COUNT(*) FROM orders o
+               WHERE o.user_id = c.user_id
+                 AND o.deleted_at IS NULL
+                 AND o.created_at >= c.abandoned_at) AS orders_since_abandoned
+         FROM carts c
+         JOIN users u ON u.id = c.user_id
+         LEFT JOIN notification_preferences pref ON pref.user_id = c.user_id
+         WHERE c.status = ?
+           AND c.abandoned_at IS NOT NULL
+           AND c.abandoned_at > DATE_SUB(NOW(), INTERVAL ? MINUTE)
+         ORDER BY c.abandoned_at ASC
+         LIMIT ?`,
+        [frequencyCapHours, CART_STATUS_ABANDONED, giveUpAfterMinutes, batchSize]
+    );
+
+    return rows;
+}
+
+/**
+ * The lines to quote back at the shopper, longest-standing first.
+ *
+ * @param {string} cartId
+ * @param {number} limit
+ * @returns {Promise<Array<{name: string, price: number, quantity: number}>>}
+ */
+async function loadBasketPreview(cartId, limit) {
+    const [rows] = await db.query(
+        `SELECT p.name, p.price, ci.quantity, ci.color, ci.size
+         FROM cart_items ci
+         JOIN products p ON p.id = ci.product_id
+         WHERE ci.cart_id = ?
+         ORDER BY ci.created_at ASC
+         LIMIT ?`,
+        [cartId, Math.max(1, safeInteger(limit, 5))]
+    );
+
+    return rows;
+}
+
+/**
+ * Claim the right to send, before sending.
+ *
+ * Returns false rather than throwing when the key is taken: another instance,
+ * or an earlier run of this one, has this basket at this stage, and that is an
+ * ordinary outcome rather than a fault.
+ *
+ * @param {object} send
+ * @param {string} send.cartId
+ * @param {string} send.userId
+ * @param {number} send.stage
+ * @param {string[]} send.channels
+ * @returns {Promise<string|null>} The log row id, or null when suppressed.
+ */
+async function recordRecoverySend({ cartId, userId, stage, channels }) {
+    const id = crypto.randomUUID();
+
+    try {
+        await db.query(
+            `INSERT INTO cart_recovery_log
+                (id, cart_id, user_id, stage, channels_json, dedupe_key)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+            [id, cartId, userId, stage, JSON.stringify(channels), dedupeKey(cartId, stage)]
+        );
+
+        return id;
+    } catch (error) {
+        if (error && error.code === DUPLICATE_ENTRY) return null;
+
+        throw error;
+    }
+}
+
+/**
+ * The message itself.
+ *
+ * @param {object} context
+ * @param {string} context.userName
+ * @param {Array} context.items
+ * @param {number} context.lineCount
+ * @param {string} [context.preferencesUrl]
+ * @returns {{subject: string, text: string}}
+ */
+function buildRecoveryMessage({ userName, items, lineCount, preferencesUrl }) {
+    const lines = items.map(
+        (item) => `  - ${item.name}${item.quantity > 1 ? ` x${item.quantity}` : ''}`
+    );
+
+    const remaining = lineCount - items.length;
+
+    if (remaining > 0) {
+        lines.push(`  - and ${remaining} more`);
+    }
+
+    const greeting = userName ? `Hi ${userName},` : 'Hi,';
+
+    return {
+        subject: 'You left something in your basket',
+        text:
+            `${greeting}\n\n` +
+            'Your basket is still here:\n\n' +
+            `${lines.join('\n')}\n\n` +
+            (preferencesUrl
+                ? `Manage preferences / unsubscribe: ${preferencesUrl}\n`
+                : '')
+    };
+}
+
+/**
+ * Send whatever recovery messages are due, and nothing else.
+ *
+ * @param {object} [options] - Overrides for the configured policy, used by the
+ *   job's manual trigger and by tests.
+ * @returns {Promise<{candidates: number, sent: number, suppressed: object}>}
+ */
+async function runRecoverySweep(options = {}) {
+    const stageDelays = options.stageDelaysMinutes || cartRecoveryConfig.STAGE_DELAYS_MINUTES;
+    const frequencyCapMessages = Math.max(
+        1,
+        safeInteger(options.frequencyCapMessages, cartRecoveryConfig.FREQUENCY_CAP_MESSAGES)
+    );
+    const maxItemsInMessage = Math.max(
+        1,
+        safeInteger(options.maxItemsInMessage, cartRecoveryConfig.MAX_ITEMS_IN_MESSAGE)
+    );
+
+    const candidates = await findRecoveryCandidates(options);
+
+    const suppressed = Object.fromEntries(
+        Object.values(SUPPRESSION).map((reason) => [reason, 0])
+    );
+
+    // The cap is read per candidate, so several baskets belonging to one
+    // shopper would each see the same pre-run figure. What this run has
+    // already spent has to be carried forward, or the cap only bites between
+    // runs and not within one.
+    const spentThisRun = new Map();
+
+    let sent = 0;
+
+    for (const candidate of candidates) {
+        const cartId = safeUUID(candidate.cart_id);
+        const userId = safeUUID(candidate.user_id);
+
+        if (!cartId || !userId) continue;
+
+        if (safeInteger(candidate.line_count, 0) === 0) {
+            suppressed[SUPPRESSION.BASKET_EMPTIED] += 1;
+            continue;
+        }
+
+        // Buying stops the sequence. Deliberately "any order since the basket
+        // was abandoned" rather than "an order from this basket": a shopper who
+        // bought the same thing in a fresh basket has still bought it, and
+        // being chased about it afterwards is the worst version of this feature.
+        if (safeInteger(candidate.orders_since_abandoned, 0) > 0) {
+            suppressed[SUPPRESSION.ALREADY_BOUGHT] += 1;
+            continue;
+        }
+
+        const channels = recoveryChannels(candidate);
+
+        if (!channels.length) {
+            suppressed[SUPPRESSION.OPTED_OUT] += 1;
+            continue;
+        }
+
+        const deliverable = candidate.user_email
+            ? channels
+            : channels.filter((channel) => channel !== 'email');
+
+        if (!deliverable.length) {
+            suppressed[SUPPRESSION.NO_ADDRESS] += 1;
+            continue;
+        }
+
+        const messagesForCart = safeInteger(candidate.messages_for_cart, 0);
+
+        if (messagesForCart >= stageDelays.length) {
+            suppressed[SUPPRESSION.SEQUENCE_COMPLETE] += 1;
+            continue;
+        }
+
+        const stage = dueStage(
+            messagesForCart,
+            safeInteger(candidate.minutes_since_abandoned, 0),
+            stageDelays
+        );
+
+        if (stage === null) {
+            suppressed[SUPPRESSION.NOT_DUE] += 1;
+            continue;
+        }
+
+        const alreadySpent =
+            safeInteger(candidate.messages_in_window, 0) + (spentThisRun.get(userId) || 0);
+
+        if (alreadySpent >= frequencyCapMessages) {
+            suppressed[SUPPRESSION.FREQUENCY_CAP] += 1;
+            continue;
+        }
+
+        const logId = await recordRecoverySend({
+            cartId,
+            userId,
+            stage,
+            channels: deliverable
+        });
+
+        if (!logId) {
+            suppressed[SUPPRESSION.ALREADY_SENT] += 1;
+            continue;
+        }
+
+        spentThisRun.set(userId, (spentThisRun.get(userId) || 0) + 1);
+
+        try {
+            await deliverRecoveryMessage({
+                logId,
+                candidate,
+                cartId,
+                userId,
+                stage,
+                channels: deliverable,
+                maxItemsInMessage
+            });
+
+            sent += 1;
+        } catch (error) {
+            // The log row stays. Rolling it back to allow a retry would mean a
+            // transport that fails halfway through delivery gets to send the
+            // same message again on the next run, which is the one outcome the
+            // send log exists to prevent.
+            logger.error(
+                `Cart recovery delivery failed for cart ${cartId} at stage ${stage}: ${error.message}`
+            );
+        }
+    }
+
+    logger.info(
+        `Cart recovery: ${sent} message(s) sent from ${candidates.length} candidate(s); ` +
+        `suppressed ${describeSuppression(suppressed)}`
+    );
+
+    return { candidates: candidates.length, sent, suppressed };
+}
+
+/**
+ * Publish the message on every channel the shopper allows.
+ *
+ * Separate from the policy above so that what gets sent can change without the
+ * rules about whether to send it moving with it.
+ */
+async function deliverRecoveryMessage({
+    logId,
+    candidate,
+    cartId,
+    userId,
+    stage,
+    channels,
+    maxItemsInMessage
+}) {
+    const lineCount = safeInteger(candidate.line_count, 0);
+    const items = await loadBasketPreview(cartId, maxItemsInMessage);
+
+    await notificationBroker.publish(
+        NOTIFICATION_TYPES.CART_RECOVERY,
+        {
+            userId,
+            cartId,
+            stage,
+            itemCount: lineCount,
+            items: items.map((item) => ({
+                name: item.name,
+                price: item.price,
+                quantity: item.quantity
+            }))
+        },
+        { channels, metadata: { recoveryLogId: logId } }
+    );
+
+    if (channels.includes('email')) {
+        const preferencesUrl = buildUnsubscribeUrl(buildStableUnsubscribeToken(userId));
+
+        const { subject, text } = buildRecoveryMessage({
+            userName: candidate.user_name,
+            items,
+            lineCount,
+            preferencesUrl
+        });
+
+        await sendNotificationEmail({ to: candidate.user_email, subject, text });
+    }
+}
+
+/**
+ * Render the suppression counts, omitting the rules that did nothing.
+ *
+ * @param {object} suppressed
+ * @returns {string}
+ */
+function describeSuppression(suppressed) {
+    const active = Object.entries(suppressed)
+        .filter(([, count]) => count > 0)
+        .map(([reason, count]) => `${reason}=${count}`);
+
+    return active.length ? active.join(', ') : 'nothing';
+}
+
+module.exports = {
+    SUPPRESSION,
+    dedupeKey,
+    recoveryChannels,
+    dueStage,
+    findRecoveryCandidates,
+    recordRecoverySend,
+    buildRecoveryMessage,
+    runRecoverySweep
+};

--- a/backend/services/notificationBrokerService.js
+++ b/backend/services/notificationBrokerService.js
@@ -12,6 +12,7 @@ const NOTIFICATION_TYPES = {
     ORDER_DELIVERED: 'order.delivered',
     COUPON_EXPIRED: 'coupon.expired',
     WISHLIST_PRICE_DROP: 'wishlist.price_drop',
+    CART_RECOVERY: 'cart.recovery',
     PAYMENT_CONFIRMED: 'payment.confirmed',
     ORDER_SHIPPED: 'order.shipped',
     ORDER_CANCELLED: 'order.cancelled',

--- a/backend/services/notificationEmailService.js
+++ b/backend/services/notificationEmailService.js
@@ -1,0 +1,62 @@
+// backend/services/notificationEmailService.js
+//
+// One way out of the building for notification mail.
+//
+// The price-drop worker (#1394) carried its own copy of "configure a
+// transport, send, and fall back to a log line when SMTP is not set up". A
+// second notification programme copying the same block is how deployments end
+// up with two senders that disagree about which environment variables matter
+// and whether a missing transport is an error or a no-op.
+//
+// Delivery is deliberately best-effort. A store with no SMTP credentials --
+// every local checkout, and CI -- still has to be able to run the workers, so
+// an unconfigured transport writes the message where a developer can see it
+// and reports honestly that nothing was delivered. What is *not* best-effort
+// is the send log: callers record the send first, so a transport failure loses
+// one message rather than freeing the sender to try again forever.
+
+'use strict';
+
+/**
+ * Send a plain-text notification email, or log it when SMTP is unconfigured.
+ *
+ * @param {object} message
+ * @param {string} message.to
+ * @param {string} message.subject
+ * @param {string} message.text
+ * @returns {Promise<{delivered: boolean, channel: 'smtp'|'log'}>}
+ */
+async function sendNotificationEmail({ to, subject, text }) {
+    const host = process.env.SMTP_HOST;
+    const user = process.env.SMTP_USER;
+    const pass = process.env.SMTP_PASS;
+
+    if (host && user && pass) {
+        try {
+            const nodemailer = require('nodemailer');
+            const transporter = nodemailer.createTransport({
+                host,
+                port: Number(process.env.SMTP_PORT) || 587,
+                secure: false,
+                auth: { user, pass }
+            });
+
+            await transporter.sendMail({
+                from: process.env.SMTP_FROM || user,
+                to,
+                subject,
+                text
+            });
+
+            return { delivered: true, channel: 'smtp' };
+        } catch (error) {
+            console.error('Notification email failed:', error.message);
+        }
+    }
+
+    console.info('[notification] email (SMTP not configured):', { to, subject });
+
+    return { delivered: false, channel: 'log' };
+}
+
+module.exports = { sendNotificationEmail };

--- a/backend/services/wishlistNotifyService.js
+++ b/backend/services/wishlistNotifyService.js
@@ -16,6 +16,7 @@ const {
     notificationBroker,
     NOTIFICATION_TYPES
 } = require("./notificationBrokerService");
+const { sendNotificationEmail } = require("./notificationEmailService");
 
 const UNSUBSCRIBE_SECRET =
     process.env.PRICE_DROP_UNSUB_SECRET ||
@@ -105,6 +106,10 @@ async function getPreferences(userId) {
         userId,
         priceDropEmail: Boolean(prefs.price_drop_email),
         priceDropInApp: Boolean(prefs.price_drop_in_app),
+        // Abandoned-cart recovery (#1429) shares this preference centre rather
+        // than growing a second one, so a shopper has one place to say no.
+        cartRecoveryEmail: Boolean(prefs.cart_recovery_email),
+        cartRecoveryInApp: Boolean(prefs.cart_recovery_in_app),
         unsubscribedAll: Boolean(prefs.unsubscribed_all),
         // Fresh token when prefs were just created; otherwise a stable signed link.
         unsubscribeToken:
@@ -135,15 +140,25 @@ async function updatePreferences(userId, patch = {}) {
         patch.unsubscribedAll === undefined
             ? null
             : patch.unsubscribedAll ? 1 : 0;
+    const recoveryEmail =
+        patch.cartRecoveryEmail === undefined
+            ? null
+            : patch.cartRecoveryEmail ? 1 : 0;
+    const recoveryInApp =
+        patch.cartRecoveryInApp === undefined
+            ? null
+            : patch.cartRecoveryInApp ? 1 : 0;
 
     await db.query(
         `UPDATE notification_preferences SET
             price_drop_email = COALESCE(?, price_drop_email),
             price_drop_in_app = COALESCE(?, price_drop_in_app),
+            cart_recovery_email = COALESCE(?, cart_recovery_email),
+            cart_recovery_in_app = COALESCE(?, cart_recovery_in_app),
             unsubscribed_all = COALESCE(?, unsubscribed_all),
             updated_at = NOW()
          WHERE user_id = ?`,
-        [email, inApp, unsubAll, userId]
+        [email, inApp, recoveryEmail, recoveryInApp, unsubAll, userId]
     );
 
     return getPreferences(userId);
@@ -220,11 +235,16 @@ async function unsubscribeWithToken(token) {
     }
 
     await ensurePreferences(userId);
+    // Every channel, not just the one the link came from. A shopper who clicks
+    // "unsubscribe" and then hears from a different programme has not been
+    // unsubscribed from anything they would recognise.
     await db.query(
         `UPDATE notification_preferences
          SET unsubscribed_all = 1,
              price_drop_email = 0,
              price_drop_in_app = 0,
+             cart_recovery_email = 0,
+             cart_recovery_in_app = 0,
              updated_at = NOW()
          WHERE user_id = ?`,
         [userId]
@@ -332,9 +352,6 @@ async function recordNotificationLog({
 }
 
 async function sendPriceDropEmail({ to, productName, oldPrice, newPrice, unsubscribeUrl }) {
-    const host = process.env.SMTP_HOST;
-    const user = process.env.SMTP_USER;
-    const pass = process.env.SMTP_PASS;
     const subject = `Price drop: ${productName}`;
     const text =
         `${productName} dropped from ${oldPrice} to ${newPrice}.\n\n` +
@@ -342,34 +359,7 @@ async function sendPriceDropEmail({ to, productName, oldPrice, newPrice, unsubsc
             ? `Manage preferences / unsubscribe: ${unsubscribeUrl}\n`
             : "");
 
-    if (host && user && pass) {
-        try {
-            const nodemailer = require("nodemailer");
-            const transporter = nodemailer.createTransport({
-                host,
-                port: Number(process.env.SMTP_PORT) || 587,
-                secure: false,
-                auth: { user, pass }
-            });
-            await transporter.sendMail({
-                from: process.env.SMTP_FROM || user,
-                to,
-                subject,
-                text
-            });
-            return { delivered: true, channel: "smtp" };
-        } catch (err) {
-            console.error("Price-drop email failed:", err.message);
-        }
-    }
-
-    console.info("[price-drop] email (SMTP not configured):", {
-        to,
-        subject,
-        oldPrice,
-        newPrice
-    });
-    return { delivered: false, channel: "log" };
+    return sendNotificationEmail({ to, subject, text });
 }
 
 /**

--- a/backend/tests/cartRecovery.test.js
+++ b/backend/tests/cartRecovery.test.js
@@ -1,0 +1,367 @@
+// backend/tests/cartRecovery.test.js
+//
+// Abandoned-cart recovery (#1429).
+//
+// The database is mocked at the module boundary, as the rest of this suite
+// does. What is pinned here is the suppression policy rather than SQL text,
+// because the policy is the feature: a run that sends the right message is
+// unremarkable, and a run that sends one it should have withheld is the
+// failure that reaches a shopper's inbox.
+
+jest.mock('../config/db', () => {
+    const query = jest.fn();
+    const pool = { query, getConnection: jest.fn() };
+    // notificationBrokerService reaches the pool through `.promise`.
+    pool.promise = pool;
+    return pool;
+});
+
+jest.mock('../utils/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+jest.mock('../services/notificationBrokerService', () => ({
+    NOTIFICATION_TYPES: { CART_RECOVERY: 'cart.recovery' },
+    notificationBroker: { publish: jest.fn(async () => ({ id: 'n1' })) }
+}));
+
+jest.mock('../services/notificationEmailService', () => ({
+    sendNotificationEmail: jest.fn(async () => ({ delivered: false, channel: 'log' }))
+}));
+
+const db = require('../config/db');
+const logger = require('../utils/logger');
+const { notificationBroker } = require('../services/notificationBrokerService');
+const { sendNotificationEmail } = require('../services/notificationEmailService');
+const cartRecovery = require('../services/cartRecoveryService');
+const cartRecoveryConfig = require('../config/cartRecoveryConfig');
+const {
+    runCartRecoveryJob,
+    startCartRecoveryJob,
+    CART_RECOVERY_CRON
+} = require('../jobs/cartRecoveryJob');
+
+const USER = '11111111-1111-4111-8111-111111111111';
+const CART = '33333333-3333-4333-8333-333333333333';
+const SECOND_CART = '44444444-4444-4444-8444-444444444444';
+
+const { SUPPRESSION } = cartRecovery;
+
+/**
+ * A candidate row shaped as findRecoveryCandidates returns it: eligible in
+ * every respect, so each test can spoil exactly one thing.
+ */
+function candidate(overrides = {}) {
+    return {
+        cart_id: CART,
+        user_id: USER,
+        abandoned_at: '2026-01-01 10:00:00',
+        user_email: 'shopper@example.com',
+        user_name: 'Sam',
+        unsubscribed_all: 0,
+        cart_recovery_email: 1,
+        cart_recovery_in_app: 1,
+        minutes_since_abandoned: 100000,
+        line_count: 2,
+        messages_for_cart: 0,
+        messages_in_window: 0,
+        orders_since_abandoned: 0,
+        ...overrides
+    };
+}
+
+/**
+ * Answer the sweep's three query shapes: the candidate scan, the send-log
+ * insert, and the basket preview.
+ */
+function mockSweep(candidates, { insertFails = false } = {}) {
+    db.query.mockImplementation(async (sql) => {
+        if (/FROM carts c/i.test(sql)) return [candidates];
+
+        if (/INSERT INTO cart_recovery_log/i.test(sql)) {
+            if (insertFails) {
+                const duplicate = new Error('Duplicate entry for key uq_cart_recovery_dedupe');
+                duplicate.code = 'ER_DUP_ENTRY';
+                throw duplicate;
+            }
+            return [{ affectedRows: 1 }];
+        }
+
+        if (/FROM cart_items ci/i.test(sql)) {
+            return [[{ name: 'Tee', price: 20, quantity: 1, color: '', size: '' }]];
+        }
+
+        return [{ affectedRows: 1 }];
+    });
+}
+
+afterEach(() => {
+    jest.clearAllMocks();
+    db.query.mockReset();
+});
+
+describe('the recovery sequence', () => {
+    test('position in the configured delays is the stage number', () => {
+        const delays = [60, 1440];
+
+        expect(cartRecovery.dueStage(0, 60, delays)).toBe(0);
+        expect(cartRecovery.dueStage(1, 1440, delays)).toBe(1);
+    });
+
+    test('a stage that is not due yet is owed nothing', () => {
+        expect(cartRecovery.dueStage(0, 59, [60, 1440])).toBeNull();
+        expect(cartRecovery.dueStage(1, 100, [60, 1440])).toBeNull();
+    });
+
+    test('the sequence ends rather than repeating its last step forever', () => {
+        expect(cartRecovery.dueStage(2, 99999, [60, 1440])).toBeNull();
+    });
+
+    test('the delays are configuration, and ordered', () => {
+        const delays = cartRecoveryConfig.STAGE_DELAYS_MINUTES;
+
+        expect(delays.length).toBeGreaterThan(0);
+        expect([...delays]).toEqual([...delays].sort((a, b) => a - b));
+    });
+
+    test('one basket at one step has one key, whatever else is going on', () => {
+        expect(cartRecovery.dedupeKey(CART, 0)).toBe(`${CART}:0`);
+        expect(cartRecovery.dedupeKey(CART, 1)).not.toBe(cartRecovery.dedupeKey(CART, 0));
+    });
+});
+
+describe('preferences decide the channels', () => {
+    test('the global opt-out silences everything', () => {
+        expect(
+            cartRecovery.recoveryChannels({
+                unsubscribed_all: 1,
+                cart_recovery_email: 1,
+                cart_recovery_in_app: 1
+            })
+        ).toEqual([]);
+    });
+
+    test('a channel turned off is not used', () => {
+        expect(
+            cartRecovery.recoveryChannels({
+                unsubscribed_all: 0,
+                cart_recovery_email: 0,
+                cart_recovery_in_app: 1
+            })
+        ).toEqual(['in_app']);
+    });
+
+    // A shopper who has never opened the preference centre has no row at all,
+    // and the LEFT JOIN hands the sender nulls rather than the column defaults.
+    test('never having expressed a preference is not the same as refusing', () => {
+        expect(cartRecovery.recoveryChannels({})).toEqual(['in_app', 'email']);
+    });
+});
+
+describe('a due basket', () => {
+    test('is recorded before it is sent, and sent on the allowed channels', async () => {
+        mockSweep([candidate()]);
+
+        const summary = await cartRecovery.runRecoverySweep();
+
+        expect(summary.sent).toBe(1);
+
+        const statements = db.query.mock.calls.map(([sql]) => sql);
+        const insertAt = statements.findIndex((sql) => /INSERT INTO cart_recovery_log/i.test(sql));
+
+        expect(insertAt).toBeGreaterThanOrEqual(0);
+        expect(notificationBroker.publish).toHaveBeenCalledWith(
+            'cart.recovery',
+            expect.objectContaining({ userId: USER, cartId: CART, stage: 0 }),
+            expect.objectContaining({ channels: ['in_app', 'email'] })
+        );
+        expect(sendNotificationEmail).toHaveBeenCalledWith(
+            expect.objectContaining({ to: 'shopper@example.com' })
+        );
+    });
+
+    test('claims its dedupe key before the message leaves', async () => {
+        mockSweep([candidate()]);
+
+        await cartRecovery.runRecoverySweep();
+
+        const [, params] = db.query.mock.calls
+            .find(([sql]) => /INSERT INTO cart_recovery_log/i.test(sql));
+
+        // id, cart, user, stage, channels, dedupe key.
+        expect(params[1]).toBe(CART);
+        expect(params[2]).toBe(USER);
+        expect(params[3]).toBe(0);
+        expect(params[5]).toBe(`${CART}:0`);
+    });
+});
+
+describe('suppression', () => {
+    /**
+     * Run one candidate and report which rule, if any, withheld the message.
+     */
+    async function sweepOne(overrides, options = {}) {
+        mockSweep([candidate(overrides)], options);
+
+        const summary = await cartRecovery.runRecoverySweep(options.sweep);
+        const [reason] =
+            Object.entries(summary.suppressed).find(([, count]) => count > 0) || [null];
+
+        return { summary, reason };
+    }
+
+    test('an emptied basket is nothing to come back to', async () => {
+        const { summary, reason } = await sweepOne({ line_count: 0 });
+
+        expect(summary.sent).toBe(0);
+        expect(reason).toBe(SUPPRESSION.BASKET_EMPTIED);
+    });
+
+    test('buying stops the sequence', async () => {
+        const { summary, reason } = await sweepOne({ orders_since_abandoned: 1 });
+
+        expect(summary.sent).toBe(0);
+        expect(reason).toBe(SUPPRESSION.ALREADY_BOUGHT);
+        expect(notificationBroker.publish).not.toHaveBeenCalled();
+    });
+
+    test('a shopper who opted out hears nothing', async () => {
+        const { summary, reason } = await sweepOne({ unsubscribed_all: 1 });
+
+        expect(summary.sent).toBe(0);
+        expect(reason).toBe(SUPPRESSION.OPTED_OUT);
+    });
+
+    test('email-only preferences with no address on file send nothing', async () => {
+        const { reason } = await sweepOne({
+            user_email: null,
+            cart_recovery_in_app: 0
+        });
+
+        expect(reason).toBe(SUPPRESSION.NO_ADDRESS);
+    });
+
+    test('a basket that has had every message in the sequence gets no more', async () => {
+        const { reason } = await sweepOne({
+            messages_for_cart: cartRecoveryConfig.STAGE_DELAYS_MINUTES.length
+        });
+
+        expect(reason).toBe(SUPPRESSION.SEQUENCE_COMPLETE);
+    });
+
+    test('a basket abandoned moments ago waits for its first stage', async () => {
+        const { reason } = await sweepOne({ minutes_since_abandoned: 0 });
+
+        expect(reason).toBe(SUPPRESSION.NOT_DUE);
+    });
+
+    test('the frequency cap counts messages to the person, not to the basket', async () => {
+        const { reason } = await sweepOne(
+            { messages_in_window: cartRecoveryConfig.FREQUENCY_CAP_MESSAGES },
+            { sweep: {} }
+        );
+
+        expect(reason).toBe(SUPPRESSION.FREQUENCY_CAP);
+    });
+
+    // Two instances sweeping at once select the same basket; the unique key on
+    // the send log is what decides which of them gets to send.
+    test('losing the race for the send log is an outcome, not a fault', async () => {
+        const { summary, reason } = await sweepOne({}, { insertFails: true });
+
+        expect(summary.sent).toBe(0);
+        expect(reason).toBe(SUPPRESSION.ALREADY_SENT);
+        expect(notificationBroker.publish).not.toHaveBeenCalled();
+    });
+
+    test('a cap spent earlier in the same run still binds later in it', async () => {
+        // Two baskets, one shopper, a cap of one. The pre-run count is zero for
+        // both rows, so only carrying the spend forward stops the second send.
+        mockSweep([candidate(), candidate({ cart_id: SECOND_CART })]);
+
+        const summary = await cartRecovery.runRecoverySweep({ frequencyCapMessages: 1 });
+
+        expect(summary.candidates).toBe(2);
+        expect(summary.sent).toBe(1);
+        expect(summary.suppressed[SUPPRESSION.FREQUENCY_CAP]).toBe(1);
+    });
+
+    test('the run says which rule did the work', async () => {
+        await sweepOne({ orders_since_abandoned: 1 });
+
+        expect(logger.info).toHaveBeenCalledWith(
+            expect.stringContaining(SUPPRESSION.ALREADY_BOUGHT)
+        );
+    });
+});
+
+describe('delivery failure', () => {
+    test('keeps the send log, so a broken transport cannot resend forever', async () => {
+        mockSweep([candidate()]);
+        notificationBroker.publish.mockRejectedValueOnce(new Error('broker down'));
+
+        const summary = await cartRecovery.runRecoverySweep();
+
+        expect(summary.sent).toBe(0);
+        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('delivery failed'));
+
+        const deletes = db.query.mock.calls
+            .filter(([sql]) => /DELETE FROM cart_recovery_log/i.test(sql));
+        expect(deletes).toHaveLength(0);
+    });
+});
+
+describe('the candidate scan', () => {
+    test('looks only at abandoned baskets inside the give-up window', async () => {
+        mockSweep([]);
+
+        await cartRecovery.runRecoverySweep();
+
+        const [sql, params] = db.query.mock.calls[0];
+
+        expect(sql).toMatch(/c\.status = \?/i);
+        expect(sql).toMatch(/c\.abandoned_at > DATE_SUB\(NOW\(\), INTERVAL \? MINUTE\)/i);
+        expect(params).toContain('abandoned');
+        expect(params).toContain(cartRecoveryConfig.GIVE_UP_AFTER_MINUTES);
+        expect(params[params.length - 1]).toBe(cartRecoveryConfig.SCAN_BATCH_SIZE);
+    });
+
+    test('is bounded, so a backlog drains across runs', async () => {
+        mockSweep([]);
+
+        await cartRecovery.runRecoverySweep({ batchSize: 25 });
+
+        const [sql, params] = db.query.mock.calls[0];
+
+        expect(sql).toMatch(/LIMIT \?/i);
+        expect(params[params.length - 1]).toBe(25);
+    });
+});
+
+describe('cartRecoveryJob', () => {
+    test('exports a cron expression', () => {
+        expect(CART_RECOVERY_CRON).toMatch(/\S+/);
+    });
+
+    test('is a no-op under test', () => {
+        process.env.NODE_ENV = 'test';
+        expect(startCartRecoveryJob()).toBeNull();
+    });
+
+    test('returns the sweep summary', async () => {
+        const spy = jest
+            .spyOn(cartRecovery, 'runRecoverySweep')
+            .mockResolvedValue({ candidates: 0, sent: 0, suppressed: {} });
+
+        await expect(runCartRecoveryJob()).resolves.toEqual({
+            candidates: 0,
+            sent: 0,
+            suppressed: {}
+        });
+
+        spy.mockRestore();
+    });
+});

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -293,10 +293,10 @@
                     aria-labelledby="price-drop-pref-heading"
                 >
                     <h3 id="price-drop-pref-heading">
-                        Price-drop alerts
+                        Notifications
                     </h3>
                     <p class="price-drop-pref-help">
-                        Get notified when wishlisted items get cheaper. You can unsubscribe anytime from email links.
+                        Get notified when wishlisted items get cheaper, and when you leave something in your basket. You can unsubscribe anytime from email links.
                     </p>
                     <div class="price-drop-pref-controls">
                         <label>
@@ -304,21 +304,35 @@
                                 type="checkbox"
                                 id="pref-price-drop-email"
                             >
-                            Email alerts
+                            Price-drop email alerts
                         </label>
                         <label>
                             <input
                                 type="checkbox"
                                 id="pref-price-drop-in-app"
                             >
-                            In-app alerts
+                            Price-drop in-app alerts
+                        </label>
+                        <label>
+                            <input
+                                type="checkbox"
+                                id="pref-cart-recovery-email"
+                            >
+                            Basket reminder emails
+                        </label>
+                        <label>
+                            <input
+                                type="checkbox"
+                                id="pref-cart-recovery-in-app"
+                            >
+                            Basket reminders in-app
                         </label>
                         <label>
                             <input
                                 type="checkbox"
                                 id="pref-price-drop-unsub-all"
                             >
-                            Pause all price-drop notifications
+                            Pause all notifications
                         </label>
                     </div>
                     <div class="price-drop-pref-actions">

--- a/frontend/scripts/dashboard-wishlist.js
+++ b/frontend/scripts/dashboard-wishlist.js
@@ -1,4 +1,4 @@
-// dashboard wishlist elements + price-drop preference center (#1394)
+// dashboard wishlist elements + notification preference center (#1394, #1429)
 const getDashboardElements = () => ({
     wishlistContainer: document.getElementById("wishlist-items"),
     wishlistCount: document.getElementById("wishlist-count"),
@@ -6,6 +6,8 @@ const getDashboardElements = () => ({
     cartCount: document.getElementById("cart-count-dashboard"),
     prefEmail: document.getElementById("pref-price-drop-email"),
     prefInApp: document.getElementById("pref-price-drop-in-app"),
+    prefRecoveryEmail: document.getElementById("pref-cart-recovery-email"),
+    prefRecoveryInApp: document.getElementById("pref-cart-recovery-in-app"),
     prefUnsubAll: document.getElementById("pref-price-drop-unsub-all"),
     savePrefsBtn: document.getElementById("save-price-drop-prefs"),
     syncBaselinesBtn: document.getElementById("sync-price-drop-baselines"),
@@ -28,6 +30,12 @@ function paintPreferenceForm(preferences) {
     }
     if (elements.prefInApp) {
         elements.prefInApp.checked = Boolean(preferences.priceDropInApp);
+    }
+    if (elements.prefRecoveryEmail) {
+        elements.prefRecoveryEmail.checked = Boolean(preferences.cartRecoveryEmail);
+    }
+    if (elements.prefRecoveryInApp) {
+        elements.prefRecoveryInApp.checked = Boolean(preferences.cartRecoveryInApp);
     }
     if (elements.prefUnsubAll) {
         elements.prefUnsubAll.checked = Boolean(preferences.unsubscribedAll);
@@ -109,6 +117,12 @@ async function savePriceDropPreferences() {
     const payload = {
         priceDropEmail: Boolean(elements.prefEmail && elements.prefEmail.checked),
         priceDropInApp: Boolean(elements.prefInApp && elements.prefInApp.checked),
+        cartRecoveryEmail: Boolean(
+            elements.prefRecoveryEmail && elements.prefRecoveryEmail.checked
+        ),
+        cartRecoveryInApp: Boolean(
+            elements.prefRecoveryInApp && elements.prefRecoveryInApp.checked
+        ),
         unsubscribedAll: Boolean(elements.prefUnsubAll && elements.prefUnsubAll.checked)
     };
 
@@ -124,7 +138,7 @@ async function savePriceDropPreferences() {
 
         paintPreferenceForm(response.preferences);
         setPrefStatus("Preferences saved.", "ok");
-        AppUtils.notify("Price-drop preferences updated.", "success");
+        AppUtils.notify("Notification preferences updated.", "success");
     } catch (error) {
         console.error("Failed to save preferences:", error);
         setPrefStatus(error.message || "Could not save preferences.", "error");

--- a/migrations/0033_cart_recovery.sql
+++ b/migrations/0033_cart_recovery.sql
@@ -1,0 +1,133 @@
+-- ============================================
+-- ABANDONED-CART RECOVERY
+-- ============================================
+--
+-- Migration 0027 gave a cart somewhere to go when it is walked away from, and
+-- nothing has acted on that since: the sweep stamps `abandoned_at` and the
+-- basket is never mentioned again. This adds the two things needed before a
+-- recovery message can be sent safely -- a record of what was already sent, and
+-- somewhere for the shopper to say they would rather not hear about it.
+--
+-- The preference centre from #1394 is extended rather than replaced. A second
+-- table of opt-outs would mean a shopper who unsubscribed from one kind of mail
+-- still hearing from us through the other, which is the complaint the
+-- preference centre exists to prevent.
+
+-- ============================================
+-- SEND LOG
+-- ============================================
+--
+-- The suppression rules are enforced here rather than in application code alone.
+-- A recovery run can be retried, can overlap with another instance, and can be
+-- restarted mid-batch; in all three cases the thing that must not happen is a
+-- second message about a basket the shopper has already been reminded of.
+-- `dedupe_key` is written before the message goes out, so the database refuses
+-- the duplicate instead of the sender having to notice it.
+
+CREATE TABLE IF NOT EXISTS cart_recovery_log (
+    -- CHAR(36) to match carts.id and users.id, both referenced below. A
+    -- CHAR(36)/INT mismatch is how a foreign key in this schema has failed
+    -- before.
+    id CHAR(36) PRIMARY KEY,
+
+    cart_id CHAR(36) NOT NULL,
+    user_id CHAR(36) NOT NULL,
+
+    -- Which message in the sequence this was, counted from zero. Stored rather
+    -- than derived: the delays behind the sequence are configuration and move
+    -- with campaigns, so "the second message" has to stay identifiable after
+    -- the schedule that produced it has changed.
+    stage TINYINT UNSIGNED NOT NULL,
+
+    channels_json JSON NULL,
+
+    -- `cartId:stage`. One row per basket per step of the sequence, which is
+    -- what makes "nobody is contacted twice for the same basket" a constraint
+    -- rather than a convention.
+    dedupe_key VARCHAR(128) NOT NULL,
+
+    sent_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_cart_recovery_dedupe (dedupe_key),
+
+    INDEX idx_cart_recovery_cart (cart_id),
+    -- The frequency cap's access path: how much this person has heard from us
+    -- lately, across every basket they have left behind.
+    INDEX idx_cart_recovery_user_sent (user_id, sent_at),
+
+    CONSTRAINT fk_cart_recovery_cart
+        FOREIGN KEY (cart_id) REFERENCES carts(id) ON DELETE CASCADE,
+    CONSTRAINT fk_cart_recovery_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================
+-- PREFERENCES AND ACCESS PATHS
+-- ============================================
+--
+-- Recovery mail gets its own two flags rather than riding on the price-drop
+-- ones: a shopper who does not want to be told about discounts may still want
+-- to be told they left a basket behind, and conflating the two makes the only
+-- available answer "all or nothing". `unsubscribed_all` still overrides both.
+--
+-- Defaulting to 1 matches the price-drop columns and keeps existing accounts
+-- in the same position they are in today for every other notification. The
+-- suppression rules in the recovery service, not this default, are what stop
+-- the programme becoming a nuisance.
+
+DELIMITER //
+
+CREATE PROCEDURE AddCartRecoveryPreferences()
+BEGIN
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'notification_preferences'
+        AND COLUMN_NAME = 'cart_recovery_email'
+    ) THEN
+        ALTER TABLE notification_preferences
+        ADD COLUMN cart_recovery_email TINYINT(1) NOT NULL DEFAULT 1
+        AFTER price_drop_in_app;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'notification_preferences'
+        AND COLUMN_NAME = 'cart_recovery_in_app'
+    ) THEN
+        ALTER TABLE notification_preferences
+        ADD COLUMN cart_recovery_in_app TINYINT(1) NOT NULL DEFAULT 1
+        AFTER cart_recovery_email;
+    END IF;
+
+    -- The recovery scan reads oldest-abandoned-first, which none of the
+    -- indexes from 0027 serve: they are keyed on last_activity_at and
+    -- created_at, neither of which moves when the sweep abandons a cart.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'carts'
+        AND INDEX_NAME = 'idx_carts_status_abandoned'
+    ) THEN
+        CREATE INDEX idx_carts_status_abandoned ON carts (status, abandoned_at);
+    END IF;
+
+    -- "Has this person bought since they walked away" is asked once per
+    -- candidate basket, and answering it by user alone means scanning every
+    -- order that account has ever placed.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'orders'
+        AND INDEX_NAME = 'idx_orders_user_created'
+    ) THEN
+        CREATE INDEX idx_orders_user_created ON orders (user_id, created_at);
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL AddCartRecoveryPreferences();
+DROP PROCEDURE AddCartRecoveryPreferences;


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

> First of three. Builds directly on `main` and depends on nothing outstanding.

The cart lifecycle detects abandonment and then throws the moment away. A sweep moves an untouched basket to `abandoned`, stamps `abandoned_at`, and nothing reads it again. This makes something happen next.

**An abandoned basket now produces a recovery message, on a schedule.** The delays are a configured sequence rather than a single hard-coded wait: a first nudge shortly after the basket is written off, another the following day, and the length of the list is the length of the sequence. Position in that list is the stage number, which is what lets a basket be chased a bounded number of times and lets the schedule be changed without the sender having to know it changed.

**Almost none of this is new machinery, and that is deliberate.** The price-drop work brought a notification broker, a preference table and the record-then-send idiom for deduplication; all three are reused rather than reimplemented. Recovery mail gets its own preference flags alongside the price-drop ones — a shopper who does not want to hear about discounts may still want to be told they left something behind, and conflating the two makes the only available answer "all or nothing" — but they live in the same preference centre, so there is one place to say no and the global opt-out still means all of it. The SMTP-or-log send that the price-drop worker carried privately is now shared, because two notification programmes disagreeing about which environment variables matter is a support ticket waiting to be written.

**The suppression rules are the feature.** Sending mail to someone who left a basket behind is easy; not sending it to someone who already bought, or who said no, or who heard from us twice this morning, is what decides whether this is a recovery programme or a complaint. So the rules are named, configurable and counted rather than implied by the shape of a query: the basket is empty, the shopper has bought, the shopper opted out, the sequence is finished, the next message is not due, the frequency cap is spent, something was already sent for this basket at this step. Every run reports which rule did the work, because "sent nothing" for the right reason and "sent nothing" because the query is wrong otherwise look identical.

**Buying stops the sequence,** and deliberately on "any order since the basket was abandoned" rather than "an order from this basket". Someone who bought the same thing in a fresh basket has still bought it, and being chased about it afterwards is the worst version of this feature.

**Nobody is contacted twice for the same basket, and the database is what guarantees it.** The send log row is written *before* the message goes out, keyed on the basket and the step, under a unique constraint. Two workers sweeping at once select the same basket and only one of them gets to send; a crash between the write and the delivery loses one message, which is the failure worth having. A delivery that fails does not release the key — a broken transport that got to retry would send the same reminder on every run until somebody noticed.

**The per-person cap is counted across baskets, not within one.** A shopper who abandons three baskets in an afternoon is one person having one afternoon. The cap also holds within a single run, not just between runs, so several baskets belonging to the same shopper cannot each spend it.

---

## 🔗 Related Issue

Part of #1429

---

## 🛠️ Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [ ] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Mostly a backend change. The only visible surface is the notification section of the dashboard, which now offers basket reminders alongside price-drop alerts and describes the pause control as covering all notifications rather than just one kind.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**First run after deploy.** The give-up window bounds what the sender will look at, so the historical backlog of abandoned carts does not all become mail on the first tick. Anything older than the window is history rather than a sale in progress and is never picked up at all.

**Defaults are opt-in, the way every other notification here is.** That is a policy choice worth reviewing on its own terms, and it is one line of schema to change. The argument for it is that the suppression rules, not a defaulted-off column, are what stop this becoming a nuisance — and a channel nobody is enrolled in cannot be measured or tuned.

**Left as it is.** The job queue already carries a `cart_cleanup` handler that nothing schedules; this ships as its own cron worker beside the price-drop job rather than adopting that queue, because reconciling the two schedulers is a larger change than this one and would bury the policy inside it.

**Note on CI.** Two frontend scripts do not parse on `main`, which fails the syntax gate for every branch regardless of its contents and causes the test and boot jobs to skip. Neither file is touched here; reported in #1416.
