### PR TITLE
Attribute orders that arrive through a recovery link

### DIFF
--- a/backend/config/cartRecoveryConfig.js
+++ b/backend/config/cartRecoveryConfig.js
@@ -84,6 +84,15 @@ const CART_RECOVERY_CONFIG = Object.freeze({
     // not indefinitely valuable to whoever else ends up reading it.
     RESTORE_LINK_TTL_MINUTES:
         Number(process.env.CART_RECOVERY_RESTORE_LINK_TTL_MINUTES) ||
+        3 * MINUTES_PER_DAY,
+
+    // How long after spending a link an order still counts as recovered by it.
+    // Someone who restores a basket, sleeps on it and buys the next morning was
+    // recovered; someone whose browser kept the reference for a fortnight and
+    // then bought something unrelated was not. Matching the link's own lifetime
+    // keeps the two windows from having to be reasoned about separately.
+    ATTRIBUTION_WINDOW_MINUTES:
+        Number(process.env.CART_RECOVERY_ATTRIBUTION_WINDOW_MINUTES) ||
         3 * MINUTES_PER_DAY
 });
 

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -31,6 +31,8 @@ const addressService = require("../services/addressService");
 // Order status history (#1351). Every status change records who, when, from
 // what, and why -- inside the same transaction as the change itself.
 const orderStatusHistoryService = require("../services/orderStatusHistoryService");
+// Abandoned-cart recovery attribution (#1429).
+const cartRecoveryAttribution = require("../services/cartRecoveryAttributionService");
 
 // create order
 const createOrder =
@@ -51,7 +53,13 @@ const createOrder =
                 promoCode,
                 // Saved address book (#1347). A signed-in shopper can send an
                 // id instead of retyping the whole address.
-                addressId
+                addressId,
+                // Abandoned-cart recovery (#1429). Present when this basket
+                // came back through a restore link. Unvalidated here: the
+                // order service decides whether it attributes anything, and a
+                // reference it does not recognise is not a reason to refuse an
+                // order.
+                recoveryRef
             } = req.body;
 
             // Resolve a saved address into the same flat shape the manual form
@@ -203,7 +211,8 @@ const createOrder =
                         payment_method: sanitizeString(paymentMethod).toLowerCase(),
                         total: safeNumber(total),
                         items,
-                        promo_code: promoCode ? sanitizeString(promoCode) : null
+                        promo_code: promoCode ? sanitizeString(promoCode) : null,
+                        recovery_ref: recoveryRef ? sanitizeString(recoveryRef) : null
                     }
                 );
             
@@ -780,7 +789,7 @@ const createPaymentIntent = async (req, res) => {
     try {
         connection = await db.getConnection();
 
-        const { customer, address, items, total, promoCode } = req.body;
+        const { customer, address, items, total, promoCode, recoveryRef } = req.body;
 
         if (!customer || !customer.name || !customer.email) {
             return res.status(400).json({ success: false, message: "Customer information required" });
@@ -827,7 +836,8 @@ const createPaymentIntent = async (req, res) => {
             payment_method: 'card',
             total: safeNumber(total),
             items,
-            promo_code: promoCode ? sanitizeString(promoCode) : null
+            promo_code: promoCode ? sanitizeString(promoCode) : null,
+            recovery_ref: recoveryRef ? sanitizeString(recoveryRef) : null
         });
 
         await inventoryReservationService.consumeLocks(req.user.id, items, connection);
@@ -1052,6 +1062,32 @@ const getFulfilmentReport = async (req, res) => {
     }
 };
 
+// What the recovery programme brought back, and which message brought it
+// (#1429). Read straight off the orders that recorded it, so the figure does
+// not move when the reporting code does.
+const getRecoveryReport = async (req, res) => {
+    try {
+        const days = safeInteger(req.query.days, 30);
+
+        const [revenue, byStage] = await Promise.all([
+            cartRecoveryAttribution.getRecoveredRevenue({ days }),
+            cartRecoveryAttribution.getRecoveryByStage({ days })
+        ]);
+
+        return res.status(200).json({
+            success: true,
+            data: { ...revenue, byStage }
+        });
+    } catch (error) {
+        console.error("GET RECOVERY REPORT ERROR:", error);
+
+        return res.status(500).json({
+            success: false,
+            message: "Failed to build the recovery report"
+        });
+    }
+};
+
 module.exports = {
     createOrder,
     getAllOrders,
@@ -1059,6 +1095,7 @@ module.exports = {
     getOrderById,
     getOrderTimeline,
     getFulfilmentReport,
+    getRecoveryReport,
     getOrderStatus,
     updateOrderStatus,
     cancelUserOrder,

--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -356,6 +356,15 @@ router.get(
     orderController.getFulfilmentReport
 );
 
+// What the abandoned-cart recovery programme earned (#1429). Answerable at all
+// only because orders record the link they arrived through.
+router.get(
+    "/reports/recovery",
+    authMiddleware,
+    authorizeRoles(ROLES.ADMIN),
+    orderController.getRecoveryReport
+);
+
 // The order's progress ladder plus the recorded history behind it. Scoped to
 // the order's owner; admins additionally see the actor and internal notes.
 router.get("/:id/timeline", authMiddleware, ownsOrder, orderController.getOrderTimeline);

--- a/backend/services/cartRecoveryAttributionService.js
+++ b/backend/services/cartRecoveryAttributionService.js
@@ -1,0 +1,198 @@
+// backend/services/cartRecoveryAttributionService.js
+//
+// What the recovery programme actually recovered (#1429).
+//
+// A programme that cannot say what it earned cannot be tuned, defended or
+// turned off, and the tempting way to answer the question is to infer it
+// afterwards: orders from people we mailed, placed within some window of the
+// message. That number is worthless. It counts everyone who would have come
+// back regardless, it moves whenever somebody adjusts the window, and it stops
+// being computable at all once the send log is pruned.
+//
+// So attribution is a fact recorded when it is known. The restore endpoint
+// hands back a reference to the link that was spent; the browser carries it to
+// checkout; the order stores it. Afterwards, reporting is a filter on a column
+// rather than a reconstruction, and the figure does not change when the
+// reporting code does.
+//
+// The reference is not a credential and grants nothing -- it buys a row in a
+// report, not a discount or an entitlement -- but it still may not be used to
+// claim somebody else's recovery, so a signed-in order has to match the account
+// the link was issued to. A guest order is accepted, because checking out
+// without signing in is the case the whole link exists to serve.
+
+'use strict';
+
+const db = require('../config/db');
+const cartRecoveryConfig = require('../config/cartRecoveryConfig');
+const logger = require('../utils/logger');
+const { safeInteger, safeUUID } = require('../utils/helpers');
+
+const NO_ATTRIBUTION = Object.freeze({ recoveryTokenId: null, recoveredCartId: null });
+
+/**
+ * Run against the caller's transaction when there is one, the pool otherwise.
+ *
+ * Attribution is resolved inside the order's transaction so the claim that an
+ * order was recovered can never outlive an order that rolled back.
+ */
+function runner(connection) {
+    return connection || db;
+}
+
+/**
+ * Turn a restore reference from the browser into an attribution, or nothing.
+ *
+ * Refusals are silent by design. An unrecognised, stale or mismatched
+ * reference means the order is simply not attributed; failing checkout over a
+ * reporting field would be trading revenue for a statistic.
+ *
+ * @param {object} params
+ * @param {string} [params.recoveryRef] - The token id handed back at restore.
+ * @param {string} [params.userId] - The ordering account, if any.
+ * @param {object} [params.connection]
+ * @param {number} [params.windowMinutes]
+ * @returns {Promise<{recoveryTokenId: string|null, recoveredCartId: string|null}>}
+ */
+async function resolveAttribution({ recoveryRef, userId, connection, windowMinutes } = {}) {
+    const reference = safeUUID(recoveryRef);
+
+    if (!reference) return NO_ATTRIBUTION;
+
+    const window = Math.max(
+        1,
+        safeInteger(windowMinutes, cartRecoveryConfig.ATTRIBUTION_WINDOW_MINUTES)
+    );
+
+    const [rows] = await runner(connection).query(
+        `SELECT id, cart_id, user_id
+         FROM cart_restore_tokens
+         WHERE id = ?
+           AND redeemed_at IS NOT NULL
+           AND redeemed_at > DATE_SUB(NOW(), INTERVAL ? MINUTE)
+         LIMIT 1`,
+        [reference, window]
+    );
+
+    const token = rows[0];
+
+    if (!token) return NO_ATTRIBUTION;
+
+    const buyer = safeUUID(userId);
+
+    // A signed-in shopper may only claim their own recovery. A guest order
+    // carries no account to compare against and is taken at face value: the
+    // reference is only obtainable by having spent the link, and the credit it
+    // buys is a line in a report.
+    if (buyer && safeUUID(token.user_id) !== buyer) {
+        logger.warn(
+            `Recovery reference ${reference} presented by a different account; not attributed`
+        );
+        return NO_ATTRIBUTION;
+    }
+
+    return { recoveryTokenId: token.id, recoveredCartId: token.cart_id };
+}
+
+/**
+ * Recovered revenue over a trading window, beside the total it came out of.
+ *
+ * The denominator is deliberately included. "We recovered £12,000" is not a
+ * figure anybody can act on without knowing what was taken overall in the same
+ * period, and computing the two separately is how the two end up covering
+ * different windows.
+ *
+ * @param {object} [options]
+ * @param {number} [options.days]
+ * @returns {Promise<object>}
+ */
+async function getRecoveredRevenue({ days = 30 } = {}) {
+    const window = Math.min(365, Math.max(1, safeInteger(days, 30)));
+
+    const [rows] = await db.query(
+        `SELECT
+             COUNT(*) AS total_orders,
+             COALESCE(SUM(o.total), 0) AS total_revenue,
+             SUM(CASE WHEN o.recovered_cart_id IS NOT NULL THEN 1 ELSE 0 END)
+                 AS recovered_orders,
+             COALESCE(
+                 SUM(CASE WHEN o.recovered_cart_id IS NOT NULL THEN o.total ELSE 0 END),
+                 0
+             ) AS recovered_revenue
+         FROM orders o
+         WHERE o.deleted_at IS NULL
+           AND o.status <> 'cancelled'
+           AND o.created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)`,
+        [window]
+    );
+
+    const summary = rows[0] || {};
+
+    const totalOrders = Number(summary.total_orders) || 0;
+    const totalRevenue = Number(summary.total_revenue) || 0;
+    const recoveredOrders = Number(summary.recovered_orders) || 0;
+    const recoveredRevenue = Number(summary.recovered_revenue) || 0;
+
+    return {
+        windowDays: window,
+        totalOrders,
+        totalRevenue,
+        recoveredOrders,
+        recoveredRevenue,
+        // Reported as a share of revenue rather than of order count: a
+        // recovery programme that brings back small baskets and one that
+        // brings back large ones are worth different amounts, and only this
+        // ratio can tell them apart.
+        recoveredRevenueShare: totalRevenue > 0
+            ? Number(((recoveredRevenue / totalRevenue) * 100).toFixed(2))
+            : 0
+    };
+}
+
+/**
+ * The same figures broken down by which message in the sequence earned them.
+ *
+ * This is what the stage delays are tuned against: a second reminder that
+ * recovers nothing is a second reminder that should not be sent.
+ *
+ * @param {object} [options]
+ * @param {number} [options.days]
+ * @returns {Promise<Array<{stage: number, orders: number, revenue: number}>>}
+ */
+async function getRecoveryByStage({ days = 30 } = {}) {
+    const window = Math.min(365, Math.max(1, safeInteger(days, 30)));
+
+    // Joined through the link rather than through the basket. A basket can be
+    // asked about more than once, so matching orders to messages by cart and
+    // timing would credit the same order to every reminder that preceded it;
+    // the link is minted per send, and the order recorded which link it used.
+    const [rows] = await db.query(
+        `SELECT l.stage,
+                COUNT(DISTINCT l.id) AS messages,
+                COUNT(DISTINCT o.id) AS orders,
+                COALESCE(SUM(o.total), 0) AS revenue
+         FROM cart_recovery_log l
+         LEFT JOIN cart_restore_tokens t ON t.recovery_log_id = l.id
+         LEFT JOIN orders o
+                ON o.recovery_token_id = t.id
+               AND o.deleted_at IS NULL
+               AND o.status <> 'cancelled'
+         WHERE l.sent_at >= DATE_SUB(NOW(), INTERVAL ? DAY)
+         GROUP BY l.stage
+         ORDER BY l.stage ASC`,
+        [window]
+    );
+
+    return rows.map((row) => ({
+        stage: Number(row.stage),
+        messages: Number(row.messages) || 0,
+        orders: Number(row.orders) || 0,
+        revenue: Number(row.revenue) || 0
+    }));
+}
+
+module.exports = {
+    resolveAttribution,
+    getRecoveredRevenue,
+    getRecoveryByStage
+};

--- a/backend/services/cartRecoveryService.js
+++ b/backend/services/cartRecoveryService.js
@@ -448,8 +448,10 @@ async function deliverRecoveryMessage({
 
     // One link per message, minted here rather than reused across the sequence.
     // Issuing supersedes the basket's previous link, so a shopper never has two
-    // live credentials for one cart just because we asked twice.
-    const { token } = await issueRestoreToken({ cartId, userId });
+    // live credentials for one cart just because we asked twice. The link
+    // remembers which send it belongs to, which is what lets an order be
+    // credited to a particular message rather than to the programme (#1429).
+    const { token } = await issueRestoreToken({ cartId, userId, recoveryLogId: logId });
     const restoreUrl = buildRestoreUrl(token);
 
     await notificationBroker.publish(

--- a/backend/services/cartRestoreService.js
+++ b/backend/services/cartRestoreService.js
@@ -81,10 +81,13 @@ function sha256(value) {
  * @param {object} params
  * @param {string} params.cartId
  * @param {string} params.userId
+ * @param {string} [params.recoveryLogId] - The send this link was minted for,
+ *   so an order arriving through it can be credited to the message that earned
+ *   it rather than to the programme in general (#1429).
  * @param {number} [params.ttlMinutes]
  * @returns {Promise<{token: string, tokenId: string, expiresInMinutes: number}>}
  */
-async function issueRestoreToken({ cartId, userId, ttlMinutes }) {
+async function issueRestoreToken({ cartId, userId, recoveryLogId, ttlMinutes }) {
     const cart = safeUUID(cartId);
     const owner = safeUUID(userId);
 
@@ -109,9 +112,9 @@ async function issueRestoreToken({ cartId, userId, ttlMinutes }) {
 
     await db.query(
         `INSERT INTO cart_restore_tokens
-            (id, token_hash, cart_id, user_id, expires_at)
-         VALUES (?, ?, ?, ?, DATE_ADD(NOW(), INTERVAL ? MINUTE))`,
-        [tokenId, sha256(token), cart, owner, ttl]
+            (id, token_hash, cart_id, user_id, recovery_log_id, expires_at)
+         VALUES (?, ?, ?, ?, ?, DATE_ADD(NOW(), INTERVAL ? MINUTE))`,
+        [tokenId, sha256(token), cart, owner, safeUUID(recoveryLogId), ttl]
     );
 
     return { token, tokenId, expiresInMinutes: ttl };
@@ -136,8 +139,13 @@ function buildRestoreUrl(token) {
 /**
  * Spend a restore link and hand back the basket it covers.
  *
+ * The `recoveryRef` in the reply is the identifier of the link that was just
+ * spent, so an order placed from the restored basket can say which link earned
+ * it (#1429). It is not a second credential: the link it names is already
+ * spent, and presenting the reference buys nothing but a line in a report.
+ *
  * @param {string} rawToken
- * @returns {Promise<{items: Array, itemCount: number}>}
+ * @returns {Promise<{items: Array, itemCount: number, recoveryRef: string}>}
  * @throws {Error} With `status` and `code` set, for every refusal.
  */
 async function redeemRestoreToken(rawToken) {
@@ -200,7 +208,7 @@ async function redeemRestoreToken(rawToken) {
         );
     }
 
-    return { items, itemCount: items.length };
+    return { items, itemCount: items.length, recoveryRef: record.id };
 }
 
 /**

--- a/backend/services/order.service.js
+++ b/backend/services/order.service.js
@@ -10,6 +10,7 @@ const logger = require("../utils/logger");
 const { validatePromo } = require("./promo.service");
 const pricing = require("./pricing.service");
 const cartLifecycle = require("./cartLifecycleService");
+const cartRecoveryAttribution = require("./cartRecoveryAttributionService");
 
 // Marks the one failure the client can act on, so controllers can answer with
 // the specific figures instead of a generic server error.
@@ -267,6 +268,9 @@ const createOrderService = async (connection, orderData) => {
             // deletes the saved address -- and this only records *which* saved
             // address the order came from.
             address_id,
+            // Abandoned-cart recovery (#1429). The reference to the restore
+            // link this basket came back through, if it came back through one.
+            recovery_ref,
         } = orderData;
 
         // validate empty cart
@@ -321,6 +325,17 @@ const createOrderService = async (connection, orderData) => {
         const crypto = require("crypto");
         const orderId = crypto.randomUUID();
 
+        // Resolved on this connection, inside the caller's transaction: an
+        // order that rolls back must not leave a claim that it was recovered.
+        // A reference that does not check out costs the order nothing -- it is
+        // simply not attributed.
+        const { recoveryTokenId, recoveredCartId } =
+            await cartRecoveryAttribution.resolveAttribution({
+                recoveryRef: recovery_ref,
+                userId: user_id,
+                connection,
+            });
+
         // create order
         const orderQuery = `
             INSERT INTO orders (
@@ -344,12 +359,14 @@ const createOrderService = async (connection, orderData) => {
                 discount,
                 discount_code,
                 promo_code,
+                recovery_token_id,
+                recovered_cart_id,
                 discount_amount,
                 final_amount,
                 created_at,
                 updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
         `;
 
         const [orderResult] = await connection.query(orderQuery, [
@@ -373,6 +390,8 @@ const createOrderService = async (connection, orderData) => {
             discountAmount,
             appliedPromoCode,
             appliedPromoCode,
+            recoveryTokenId,
+            recoveredCartId,
             discountAmount,
             breakdown.total,
         ]);
@@ -476,6 +495,10 @@ const createOrderService = async (connection, orderData) => {
                 );
                 logger.info(`Recorded promo usage for user ${user_id} and promo ${appliedPromoId}`);
             }
+        }
+
+        if (recoveredCartId) {
+            logger.info(`Order ${orderId} recovered cart ${recoveredCartId}`);
         }
 
         logger.info(`Order created successfully: ${orderId} by user ${user_id || 'guest'}`);

--- a/backend/tests/cartRecoveryAttribution.test.js
+++ b/backend/tests/cartRecoveryAttribution.test.js
@@ -1,0 +1,250 @@
+// backend/tests/cartRecoveryAttribution.test.js
+//
+// Recovery attribution (#1429).
+//
+// Two properties matter here and they pull against each other. Attribution has
+// to be a recorded fact rather than a reconstruction, so the resolution rules
+// are pinned; and it must never be able to cost a shopper their order, so the
+// refusals are pinned as silent.
+
+jest.mock('../config/db', () => {
+    const query = jest.fn();
+    const pool = { query, getConnection: jest.fn() };
+    pool.promise = pool;
+    return pool;
+});
+
+jest.mock('../utils/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+const db = require('../config/db');
+const attribution = require('../services/cartRecoveryAttributionService');
+const cartRecoveryConfig = require('../config/cartRecoveryConfig');
+
+const REF = '55555555-5555-4555-8555-555555555555';
+const CART = '33333333-3333-4333-8333-333333333333';
+const OWNER = '11111111-1111-4111-8111-111111111111';
+const STRANGER = '22222222-2222-4222-8222-222222222222';
+
+/** A connection double that records every statement and answers by pattern. */
+function fakeConnection(responder) {
+    const calls = [];
+
+    return {
+        calls,
+        query: jest.fn(async (sql, params = []) => {
+            calls.push({ sql, params });
+            return responder(sql, params);
+        })
+    };
+}
+
+const tokenRow = (overrides = {}) => ({
+    id: REF,
+    cart_id: CART,
+    user_id: OWNER,
+    ...overrides
+});
+
+afterEach(() => {
+    db.query.mockReset();
+});
+
+describe('resolving a reference', () => {
+    test('names the link and the basket it brought back', async () => {
+        const connection = fakeConnection(() => [[tokenRow()]]);
+
+        await expect(
+            attribution.resolveAttribution({ recoveryRef: REF, userId: OWNER, connection })
+        ).resolves.toEqual({ recoveryTokenId: REF, recoveredCartId: CART });
+    });
+
+    // A claim that an order was recovered must not survive an order that did
+    // not happen.
+    test('reads on the order\'s connection, never on the pool', async () => {
+        const connection = fakeConnection(() => [[tokenRow()]]);
+
+        await attribution.resolveAttribution({ recoveryRef: REF, userId: OWNER, connection });
+
+        expect(connection.query).toHaveBeenCalled();
+        expect(db.query).not.toHaveBeenCalled();
+    });
+
+    test('only counts a link that was actually spent, and spent recently', async () => {
+        const connection = fakeConnection(() => [[tokenRow()]]);
+
+        await attribution.resolveAttribution({ recoveryRef: REF, userId: OWNER, connection });
+
+        const [{ sql, params }] = connection.calls;
+
+        expect(sql).toMatch(/redeemed_at IS NOT NULL/i);
+        expect(sql).toMatch(/redeemed_at > DATE_SUB\(NOW\(\), INTERVAL \? MINUTE\)/i);
+        expect(params).toEqual([REF, cartRecoveryConfig.ATTRIBUTION_WINDOW_MINUTES]);
+    });
+
+    test('a stale reference attributes nothing', async () => {
+        // Out of window, so the guarded select returns no row at all.
+        const connection = fakeConnection(() => [[]]);
+
+        await expect(
+            attribution.resolveAttribution({ recoveryRef: REF, userId: OWNER, connection })
+        ).resolves.toEqual({ recoveryTokenId: null, recoveredCartId: null });
+    });
+
+    test('a signed-in shopper cannot claim another account\'s recovery', async () => {
+        const connection = fakeConnection(() => [[tokenRow()]]);
+
+        await expect(
+            attribution.resolveAttribution({ recoveryRef: REF, userId: STRANGER, connection })
+        ).resolves.toEqual({ recoveryTokenId: null, recoveredCartId: null });
+    });
+
+    // Checking out without signing in is the case the restore link exists to
+    // serve, so a guest order has no account to compare and is taken as given.
+    test('a guest order is attributed', async () => {
+        const connection = fakeConnection(() => [[tokenRow()]]);
+
+        await expect(
+            attribution.resolveAttribution({ recoveryRef: REF, userId: null, connection })
+        ).resolves.toEqual({ recoveryTokenId: REF, recoveredCartId: CART });
+    });
+
+    test.each([
+        ['absent', undefined],
+        ['empty', ''],
+        ['not a reference at all', 'or 1=1']
+    ])('a reference that is %s costs no query', async (_name, recoveryRef) => {
+        const connection = fakeConnection(() => [[]]);
+
+        await expect(
+            attribution.resolveAttribution({ recoveryRef, userId: OWNER, connection })
+        ).resolves.toEqual({ recoveryTokenId: null, recoveredCartId: null });
+
+        expect(connection.query).not.toHaveBeenCalled();
+    });
+
+    // Checkout calls this inside its own transaction. Anything thrown here
+    // would roll the order back, which is trading revenue for a statistic.
+    test('never throws over a reference it does not like', async () => {
+        const connection = fakeConnection(() => [[tokenRow({ user_id: STRANGER })]]);
+
+        await expect(
+            attribution.resolveAttribution({ recoveryRef: REF, userId: OWNER, connection })
+        ).resolves.toEqual({ recoveryTokenId: null, recoveredCartId: null });
+
+        await expect(attribution.resolveAttribution()).resolves.toEqual({
+            recoveryTokenId: null,
+            recoveredCartId: null
+        });
+    });
+});
+
+describe('recovered revenue', () => {
+    test('reports the recovered figures beside the total they came from', async () => {
+        db.query.mockResolvedValue([[{
+            total_orders: 20,
+            total_revenue: 10000,
+            recovered_orders: 3,
+            recovered_revenue: 1500
+        }]]);
+
+        const report = await attribution.getRecoveredRevenue({ days: 30 });
+
+        expect(report).toMatchObject({
+            windowDays: 30,
+            totalOrders: 20,
+            totalRevenue: 10000,
+            recoveredOrders: 3,
+            recoveredRevenue: 1500,
+            recoveredRevenueShare: 15
+        });
+    });
+
+    test('counts recovery from the column, not from timing', async () => {
+        db.query.mockResolvedValue([[{}]]);
+
+        await attribution.getRecoveredRevenue({ days: 7 });
+
+        const [sql] = db.query.mock.calls[0];
+
+        expect(sql).toMatch(/o\.recovered_cart_id IS NOT NULL/i);
+        // Nothing here reconstructs attribution from when a message was sent.
+        expect(sql).not.toMatch(/cart_recovery_log/i);
+    });
+
+    test('leaves out cancelled and deleted orders', async () => {
+        db.query.mockResolvedValue([[{}]]);
+
+        await attribution.getRecoveredRevenue({});
+
+        const [sql] = db.query.mock.calls[0];
+
+        expect(sql).toMatch(/o\.deleted_at IS NULL/i);
+        expect(sql).toMatch(/o\.status <> 'cancelled'/i);
+    });
+
+    test('a period with no trade reads as zero rather than NaN', async () => {
+        db.query.mockResolvedValue([[]]);
+
+        await expect(attribution.getRecoveredRevenue({})).resolves.toMatchObject({
+            totalRevenue: 0,
+            recoveredRevenue: 0,
+            recoveredRevenueShare: 0
+        });
+    });
+
+    test('the window is clamped, so a report cannot ask for all of history', async () => {
+        db.query.mockResolvedValue([[{}]]);
+
+        const report = await attribution.getRecoveredRevenue({ days: 100000 });
+
+        expect(report.windowDays).toBe(365);
+    });
+});
+
+describe('recovery by stage', () => {
+    test('says which message in the sequence earned what', async () => {
+        db.query.mockResolvedValue([[
+            { stage: 0, messages: 10, orders: 3, revenue: 900 },
+            { stage: 1, messages: 7, orders: 0, revenue: 0 }
+        ]]);
+
+        const byStage = await attribution.getRecoveryByStage({ days: 30 });
+
+        expect(byStage).toEqual([
+            { stage: 0, messages: 10, orders: 3, revenue: 900 },
+            { stage: 1, messages: 7, orders: 0, revenue: 0 }
+        ]);
+    });
+
+    test('a stage that sent messages and earned nothing still appears', async () => {
+        db.query.mockResolvedValue([[{ stage: 1, messages: 7, orders: 0, revenue: null }]]);
+
+        const byStage = await attribution.getRecoveryByStage({});
+
+        expect(byStage).toEqual([{ stage: 1, messages: 7, orders: 0, revenue: 0 }]);
+
+        // A LEFT JOIN is what keeps the unproductive stage in the report, and
+        // an unproductive stage is the one worth seeing.
+        const [sql] = db.query.mock.calls[0];
+        expect(sql).toMatch(/LEFT JOIN orders o/i);
+    });
+
+    // A basket is asked about more than once. Matching orders to messages by
+    // cart and timing would credit one order to every reminder before it.
+    test('credits the message that was actually clicked', async () => {
+        db.query.mockResolvedValue([[]]);
+
+        await attribution.getRecoveryByStage({});
+
+        const [sql] = db.query.mock.calls[0];
+
+        expect(sql).toMatch(/t\.recovery_log_id = l\.id/i);
+        expect(sql).toMatch(/o\.recovery_token_id = t\.id/i);
+        expect(sql).not.toMatch(/o\.created_at >= l\.sent_at/i);
+    });
+});

--- a/backend/tests/cartRestore.test.js
+++ b/backend/tests/cartRestore.test.js
@@ -151,6 +151,19 @@ describe('spending a link', () => {
         expect(result).not.toHaveProperty('token');
     });
 
+    // The reference names the link that was just spent, so an order out of the
+    // restored basket can record what brought it (#1429). It is not a second
+    // credential: the link it names is already spent.
+    test('hands back a reference to the link, not a second one', async () => {
+        mockRedemption({ record: liveRecord(), lines: [productLine()] });
+
+        const token = wellFormedToken();
+        const result = await cartRestoreService.redeemRestoreToken(token);
+
+        expect(result.recoveryRef).toBe(TOKEN_ID);
+        expect(result.recoveryRef).not.toBe(token);
+    });
+
     test('looks the token up by hash, never by its plain text', async () => {
         mockRedemption({ record: liveRecord(), lines: [productLine()] });
 

--- a/frontend/scripts/cart-restore.js
+++ b/frontend/scripts/cart-restore.js
@@ -101,6 +101,10 @@ const restoreCartFromLink = async () => {
     // be signed in.
     AppUtils.saveCart(merged);
 
+    // Carried to checkout so an order out of this basket is recorded as
+    // recovered rather than inferred to be (#1429).
+    AppUtils.rememberRecoveryRef(response.recoveryRef);
+
     AppUtils.notify("Your basket is back.", "success");
 };
 

--- a/frontend/scripts/checkout.js
+++ b/frontend/scripts/checkout.js
@@ -642,6 +642,12 @@ async function createOrderPayload() {
         promoCode:
             appliedCoupon || null,
 
+        // Set when this basket came back through a recovery link (#1429). The
+        // backend decides whether it attributes anything; sending one it does
+        // not recognise costs the order nothing.
+        recoveryRef:
+            AppUtils.getRecoveryRef(),
+
         items:
             AppUtils.safeArray(
                 cart
@@ -980,6 +986,10 @@ if (
                 // clear cart
                 AppUtils.clearCart();
                 AppUtils.removeStorage("appliedCoupon");
+
+                // The recovery is spent on the order that just used it. Left
+                // in place it would go on to claim the next order too.
+                AppUtils.clearRecoveryRef();
 
                 // update ui
                 if (

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -1739,6 +1739,43 @@ const mergeGuestCartIntoAccount = async () => {
     return accepted ? merged : getCart();
 };
 
+// ---------- Recovery attribution (#1429) ----------
+// A basket restored from a recovery link hands back a reference to the link it
+// came through. Checkout sends it on, so the order can record that it was
+// recovered instead of the figure being guessed from timestamps afterwards.
+//
+// It lives here rather than with the restore landing page because the two ends
+// are on different pages: the reference is written on the cart page and read on
+// the checkout page, and only utils is loaded by both.
+
+const RECOVERY_REF_KEY = "cart_recovery_ref";
+
+// Housekeeping, not enforcement. The server has its own attribution window and
+// is the only thing that decides what counts; this just stops a reference from
+// a fortnight ago riding along on every order in the meantime.
+const RECOVERY_REF_TTL_MS = 3 * 24 * 60 * 60 * 1000;
+
+const rememberRecoveryRef = (reference) => {
+    if (!reference) return;
+
+    setJSON(RECOVERY_REF_KEY, { ref: String(reference), storedAt: Date.now() });
+};
+
+const getRecoveryRef = () => {
+    const stored = getJSON(RECOVERY_REF_KEY, null);
+
+    if (!stored || !stored.ref) return null;
+
+    if (Date.now() - safeNumber(stored.storedAt, 0) > RECOVERY_REF_TTL_MS) {
+        removeStorage(RECOVERY_REF_KEY);
+        return null;
+    }
+
+    return stored.ref;
+};
+
+const clearRecoveryRef = () => removeStorage(RECOVERY_REF_KEY);
+
 const getCartCount = (
     cart = getCart()
 ) => {
@@ -2017,6 +2054,9 @@ window.AppUtils = {
     mergeCartLines,
     hydrateCartFromServer,
     mergeGuestCartIntoAccount,
+    rememberRecoveryRef,
+    getRecoveryRef,
+    clearRecoveryRef,
     validateCoupon,
     calculateCartTotals,
     fetchCartQuote,

--- a/migrations/0035_order_recovery_attribution.sql
+++ b/migrations/0035_order_recovery_attribution.sql
@@ -1,0 +1,128 @@
+-- ============================================
+-- RECOVERY ATTRIBUTION
+-- ============================================
+--
+-- The recovery programme can now send a message and rebuild a basket from it,
+-- and cannot say what either of those is worth. Anything reconstructed later --
+-- "an order from someone we mailed, placed soon enough afterwards" -- is a
+-- guess dressed as a figure: it counts shoppers who would have come back
+-- anyway, it changes whenever somebody adjusts the window, and it cannot
+-- survive the send log being pruned.
+--
+-- So attribution is recorded at the moment it is known, on the order, as a
+-- fact. An order either arrived through a link or it did not, and the row says
+-- which.
+
+DELIMITER //
+
+CREATE PROCEDURE AddOrderRecoveryAttribution()
+BEGIN
+    -- Which message minted the link. A link is issued per send, so this is what
+    -- makes "the second reminder earns nothing" an exact statement rather than
+    -- a guess from timestamps -- and the stage delays are configuration nobody
+    -- can tune without it.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'cart_restore_tokens'
+        AND COLUMN_NAME = 'recovery_log_id'
+    ) THEN
+        ALTER TABLE cart_restore_tokens
+        ADD COLUMN recovery_log_id CHAR(36) NULL AFTER user_id;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'cart_restore_tokens'
+        AND INDEX_NAME = 'idx_cart_restore_recovery_log'
+    ) THEN
+        CREATE INDEX idx_cart_restore_recovery_log
+            ON cart_restore_tokens (recovery_log_id);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'cart_restore_tokens'
+        AND CONSTRAINT_NAME = 'fk_cart_restore_recovery_log'
+    ) THEN
+        ALTER TABLE cart_restore_tokens
+        ADD CONSTRAINT fk_cart_restore_recovery_log
+        FOREIGN KEY (recovery_log_id)
+            REFERENCES cart_recovery_log(id) ON DELETE SET NULL;
+    END IF;
+
+    -- The link that was actually spent. Precise enough to answer which message
+    -- in the sequence earned the order, since the token is minted per send.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'orders'
+        AND COLUMN_NAME = 'recovery_token_id'
+    ) THEN
+        ALTER TABLE orders
+        ADD COLUMN recovery_token_id CHAR(36) NULL AFTER promo_code;
+    END IF;
+
+    -- The basket that was recovered. Derivable from the token today, and stored
+    -- anyway: restore tokens are short-lived rows that a housekeeping job will
+    -- eventually clear out, and losing them must not silently turn recovered
+    -- revenue back into ordinary revenue.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'orders'
+        AND COLUMN_NAME = 'recovered_cart_id'
+    ) THEN
+        ALTER TABLE orders
+        ADD COLUMN recovered_cart_id CHAR(36) NULL AFTER recovery_token_id;
+    END IF;
+
+    -- The reporting access path: recovered orders in a trading window. Leading
+    -- with the cart id keeps the index selective -- almost every order has NULL
+    -- there, and NULLs are not stored in a way that makes this index grow with
+    -- ordinary trade.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'orders'
+        AND INDEX_NAME = 'idx_orders_recovered_cart'
+    ) THEN
+        CREATE INDEX idx_orders_recovered_cart
+            ON orders (recovered_cart_id, created_at);
+    END IF;
+
+    -- ON DELETE SET NULL, not CASCADE, on both. Deleting a spent link or an old
+    -- cart must never delete the order that came out of it; the worst it may do
+    -- is cost the attribution, and the denormalised pair above means it takes
+    -- both deletions to do even that.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'orders'
+        AND CONSTRAINT_NAME = 'fk_orders_recovery_token'
+    ) THEN
+        ALTER TABLE orders
+        ADD CONSTRAINT fk_orders_recovery_token
+        FOREIGN KEY (recovery_token_id)
+            REFERENCES cart_restore_tokens(id) ON DELETE SET NULL;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'orders'
+        AND CONSTRAINT_NAME = 'fk_orders_recovered_cart'
+    ) THEN
+        ALTER TABLE orders
+        ADD CONSTRAINT fk_orders_recovered_cart
+        FOREIGN KEY (recovered_cart_id)
+            REFERENCES carts(id) ON DELETE SET NULL;
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL AddOrderRecoveryAttribution();
+DROP PROCEDURE AddOrderRecoveryAttribution;


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

> Builds on `feat/1429-cart-recovery-restore`, which is not yet merged. Review that first; this branch contains it and the branch beneath it.

The programme can now send a message and rebuild a basket from it, and cannot say what either of those is worth. That is not a reporting gap so much as a governance one: a recovery programme that cannot state what it recovered cannot be tuned, defended, or turned off.

**Attribution is recorded, not reconstructed.** The tempting alternative is to infer it afterwards — orders from people we mailed, placed within some window of the message — and that number is worthless. It counts everyone who would have come back regardless, it moves whenever somebody adjusts the window, and it stops being computable at all once the send log is pruned. Instead the restore endpoint hands back a reference to the link that was just spent, the browser carries it to checkout, and the order stores it. Afterwards, reporting is a filter on a column rather than a reconstruction, and the figure does not change when the reporting code does.

**The reference is not a second credential.** The link it names is already spent, and presenting it buys nothing but a line in a report. It is still not usable to claim somebody else's recovery: a signed-in order has to match the account the link was issued to. A guest order is accepted, because checking out without signing in is the case the link exists to serve, and refusing it would leave the headline scenario unmeasured.

**Attribution can never cost a shopper their order.** It is resolved inside the order's own transaction, so a claim that an order was recovered cannot outlive an order that rolled back — but every refusal is silent. An unrecognised, stale or mismatched reference means the order is simply not attributed. Failing checkout over a reporting field would be trading revenue for a statistic.

**The stage is answerable, which is what makes the schedule tunable.** A link is minted per send, so the link remembers which message it belongs to and the order remembers which link it used. The report joins through that rather than matching orders to messages by basket and timing, which would credit a single order to every reminder that happened to precede it. A second reminder that recovers nothing is a second reminder that should not be sent, and that is now a statement about the data rather than a suspicion.

**Recovered revenue is reported beside the total it came out of.** A recovered figure on its own is not something anyone can act on without knowing what was taken overall in the same period, and computing the two separately is how the two end up covering different windows. The share is expressed against revenue rather than order count, because a programme that brings back small baskets and one that brings back large ones are worth different amounts and only that ratio tells them apart.

---

## 🔗 Related Issue

Part of #1429

---

## 🛠️ Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [ ] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Not applicable. The shopper-facing change is invisible by design: a reference travels from the restored basket to checkout and is cleared once the order that used it is placed. The figures come out of an admin-only report endpoint alongside the existing fulfilment one.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Why the basket is stored on the order as well as the link.** Restore links are short-lived rows that a housekeeping sweep will eventually clear out, and losing them must not quietly turn recovered revenue back into ordinary revenue. Both references are `ON DELETE SET NULL`, never cascade — deleting a spent link or an old cart may at worst cost the attribution, and with the pair recorded it takes both deletions to do even that.

**The attribution window is configuration.** Someone who restores a basket, sleeps on it and buys the next morning was recovered; someone whose browser kept the reference for a fortnight and then bought something unrelated was not. It defaults to the link's own lifetime so the two do not have to be reasoned about separately, and the browser expires its copy on the same clock as housekeeping rather than as enforcement — the server is the only thing that decides what counts.

**Cancelled and deleted orders are excluded from both figures.** Revenue that was refunded away was not recovered.

**Note on CI.** Two frontend scripts do not parse on `main`, which fails the syntax gate for every branch regardless of its contents and causes the test and boot jobs to skip. Neither file is touched here; reported in #1416.
