### PR TITLE
Offer delivery options at checkout and price them on the server

### DIFF
--- a/backend/config/shippingConfig.js
+++ b/backend/config/shippingConfig.js
@@ -1,0 +1,39 @@
+// Declarative source of truth for how delivery options are resolved.
+//
+// The options themselves live in `shipping_methods`, because adding one is an
+// operational decision rather than a deployment. What lives here is the
+// handful of settings the resolution *code* needs: which code is the fallback
+// when the table cannot be read, and how long a read of it may be reused.
+//
+// The fallback matters more than it looks. Checkout must not fail because a
+// reference table is briefly unavailable or because a deployment has not run
+// the migration yet, and the shape it falls back to has to charge exactly what
+// this store charged before delivery options existed -- otherwise an outage
+// silently changes what people pay.
+
+const PRICING_CONFIG = require("./pricingConfig");
+
+const SHIPPING_CONFIG = Object.freeze({
+    // The option a checkout gets when it does not choose one, and the option
+    // whose rate a free-shipping entitlement covers.
+    DEFAULT_METHOD_CODE: "standard",
+
+    // Delivery options change on the scale of campaigns, not requests, so they
+    // are read once and reused. Short enough that an operator changing a rate
+    // sees it take effect without a restart.
+    CACHE_TTL_MS: Number(process.env.SHIPPING_METHOD_CACHE_TTL_MS) || 60_000,
+
+    // Used only when `shipping_methods` cannot be read. The rate is the flat
+    // rate the pricing engine has always applied, so a store running on the
+    // fallback charges what it charged before this existed.
+    FALLBACK_METHOD: Object.freeze({
+        code: "standard",
+        label: "Standard delivery",
+        description: "Arrives in three to six days.",
+        rate: PRICING_CONFIG.SHIPPING_FLAT_RATE,
+        isDefault: true,
+        sortOrder: 10,
+    }),
+});
+
+module.exports = SHIPPING_CONFIG;

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -31,6 +31,9 @@ const addressService = require("../services/addressService");
 // Order status history (#1351). Every status change records who, when, from
 // what, and why -- inside the same transaction as the change itself.
 const orderStatusHistoryService = require("../services/orderStatusHistoryService");
+// Delivery options (#1430). Required here only for the error code, so an
+// unrecognised option answers 400 rather than 500.
+const shippingService = require("../services/shipping.service");
 
 // create order
 const createOrder =
@@ -51,7 +54,10 @@ const createOrder =
                 promoCode,
                 // Saved address book (#1347). A signed-in shopper can send an
                 // id instead of retyping the whole address.
-                addressId
+                addressId,
+                // Delivery options (#1430). A code naming one of the offered
+                // methods; the server looks up what it costs.
+                shippingMethod
             } = req.body;
 
             // Resolve a saved address into the same flat shape the manual form
@@ -203,7 +209,10 @@ const createOrder =
                         payment_method: sanitizeString(paymentMethod).toLowerCase(),
                         total: safeNumber(total),
                         items,
-                        promo_code: promoCode ? sanitizeString(promoCode) : null
+                        promo_code: promoCode ? sanitizeString(promoCode) : null,
+                        shipping_method: shippingMethod
+                            ? sanitizeString(shippingMethod)
+                            : null
                     }
                 );
             
@@ -284,6 +293,16 @@ const createOrder =
                     productId: error.productId,
                     availableStock: error.availableStock ?? null,
                     requested: error.requested ?? null
+                });
+            }
+
+            // A delivery option that names nothing is a bad request, not a
+            // server fault, and the message lists what is on offer.
+            if (error.code === shippingService.UNKNOWN_METHOD_CODE) {
+                return res.status(400).json({
+                    success: false,
+                    code: shippingService.UNKNOWN_METHOD_CODE,
+                    message: error.message
                 });
             }
 
@@ -780,7 +799,7 @@ const createPaymentIntent = async (req, res) => {
     try {
         connection = await db.getConnection();
 
-        const { customer, address, items, total, promoCode } = req.body;
+        const { customer, address, items, total, promoCode, shippingMethod } = req.body;
 
         if (!customer || !customer.name || !customer.email) {
             return res.status(400).json({ success: false, message: "Customer information required" });
@@ -827,7 +846,8 @@ const createPaymentIntent = async (req, res) => {
             payment_method: 'card',
             total: safeNumber(total),
             items,
-            promo_code: promoCode ? sanitizeString(promoCode) : null
+            promo_code: promoCode ? sanitizeString(promoCode) : null,
+            shipping_method: shippingMethod ? sanitizeString(shippingMethod) : null
         });
 
         await inventoryReservationService.consumeLocks(req.user.id, items, connection);
@@ -902,6 +922,14 @@ const createPaymentIntent = async (req, res) => {
                 productId: error.productId,
                 availableStock: error.availableStock ?? null,
                 requested: error.requested ?? null
+            });
+        }
+
+        if (error.code === shippingService.UNKNOWN_METHOD_CODE) {
+            return res.status(400).json({
+                success: false,
+                code: shippingService.UNKNOWN_METHOD_CODE,
+                message: error.message
             });
         }
 

--- a/backend/openapi/ecommerce.openapi.yaml
+++ b/backend/openapi/ecommerce.openapi.yaml
@@ -851,6 +851,34 @@ components:
           nullable: true
         currency:
           type: string
+        shippingMethod:
+          description: The delivery option the charge was computed for.
+          nullable: true
+          type: object
+          properties:
+            code:
+              type: string
+            label:
+              type: string
+
+    ShippingOption:
+      type: object
+      required: [code, label, cost]
+      properties:
+        code:
+          type: string
+        label:
+          type: string
+        description:
+          type: string
+          nullable: true
+        cost:
+          description: Server-computed charge for this option on this basket.
+          type: number
+        isDefault:
+          type: boolean
+        isSelected:
+          type: boolean
 
     CheckoutQuoteRequest:
       type: object
@@ -861,6 +889,10 @@ components:
             $ref: "#/components/schemas/CartLineInput"
         promoCode:
           type: string
+        shippingMethod:
+          description: Code naming a delivery option. Omitted, the default applies.
+          type: string
+          nullable: true
 
     CheckoutQuoteSuccess:
       type: object
@@ -871,6 +903,10 @@ components:
           const: true
         breakdown:
           $ref: "#/components/schemas/PriceBreakdown"
+        shippingOptions:
+          type: array
+          items:
+            $ref: "#/components/schemas/ShippingOption"
         promoMessage:
           type: string
           nullable: true
@@ -946,6 +982,10 @@ components:
         paymentMethod:
           type: string
           enum: [cod, card, upi, paypal]
+        shippingMethod:
+          description: Code naming a delivery option. Omitted, the default applies.
+          type: string
+          nullable: true
         promoCode:
           type: string
         idempotencyKey:

--- a/backend/routes/checkoutRoutes.js
+++ b/backend/routes/checkoutRoutes.js
@@ -4,6 +4,7 @@ const db = require('../config/db');
 const { resolveOrderLines } = require('../services/order.service');
 const { validatePromo } = require('../services/promo.service');
 const pricing = require('../services/pricing.service');
+const shipping = require('../services/shipping.service');
 const { safeArray, sanitizeString } = require('../utils/helpers');
 const authMiddleware = require('../middleware/authMiddleware');
 const powChallengeService = require('../services/powChallengeService');
@@ -12,9 +13,11 @@ const powChallengeService = require('../services/powChallengeService');
 // resolves prices under lock, enforces stock and consumes inventory holds.
 router.post('/quote', async (req, res) => {
     try {
-        const { items, promoCode } = req.body;
+        const { items, promoCode, shippingMethod } = req.body;
         const requestedItems = safeArray(items);
 
+        // Nothing to price and nothing to deliver, so no options are offered
+        // either: on an empty basket every one of them would read as free.
         if (!requestedItems.length) {
             return res.status(200).json({
                 success: true,
@@ -45,15 +48,29 @@ router.post('/quote', async (req, res) => {
             }
         }
 
+        // Every option is priced alongside the chosen one, so the shopper can
+        // compare them without the browser doing any arithmetic and without a
+        // second round trip per option.
+        const { subtotal } = pricing.priceLineItems(lines);
+        const discount = pricing.applyDiscount(promo, subtotal);
+
+        const delivery = await shipping.quoteOptions({
+            postDiscountSubtotal: subtotal - discount.amount,
+            isShippingWaived: discount.isShippingWaived,
+            selectedCode: shippingMethod
+        });
+
         const breakdown = pricing.quote({
             items: lines,
             promo,
-            promoCode: promo ? promo.code : null
+            promoCode: promo ? promo.code : null,
+            shippingMethod: delivery.selected
         });
 
         return res.status(200).json({
             success: true,
             breakdown,
+            shippingOptions: delivery.options,
             promoMessage
         });
     } catch (error) {

--- a/backend/services/checkoutService.js
+++ b/backend/services/checkoutService.js
@@ -1,13 +1,14 @@
 const db = require("../config/db");
 const pricing = require("./pricing.service");
+const shipping = require("./shipping.service");
 
 // These two used to return a hardcoded zero, which is how this checkout path
 // came to disagree with both the storefront and the order path. They now
 // forward to the pricing engine, so there is nothing left that can drift.
 //
-// The parameter is the post-discount subtotal, not the shipping address: the
-// shipping rule is a function of basket value, and the address never entered
-// into it even when this returned zero.
+// The first parameter is the post-discount subtotal, not the shipping address.
+// Which delivery option was chosen now travels in `options`, resolved to a rate
+// server-side before it gets here.
 function calculateShipping(postDiscountSubtotal, options = {}) {
     return pricing.calculateShipping(postDiscountSubtotal, options);
 }
@@ -26,10 +27,21 @@ function calculateTax(taxableBase) {
  * @param {Array<Object>} input.items
  * @param {number} [input.discountAmount]
  * @param {string|null} [input.promoCode]
- * @returns {Object} breakdown
+ * @param {string|null} [input.shippingMethod] - code naming a delivery option
+ * @returns {Promise<Object>} breakdown
  */
-function quoteOrder({ items = [], discountAmount = 0, promoCode = null } = {}) {
+async function quoteOrder({
+    items = [],
+    discountAmount = 0,
+    promoCode = null,
+    shippingMethod = null
+} = {}) {
     const discount = Number(discountAmount) || 0;
+
+    const [selected, fallback] = await Promise.all([
+        shipping.resolveMethod(shippingMethod),
+        shipping.getDefaultMethod()
+    ]);
 
     return pricing.quote({
         items,
@@ -37,7 +49,8 @@ function quoteOrder({ items = [], discountAmount = 0, promoCode = null } = {}) {
             discount > 0
                 ? { discount_type: "fixed", discount_value: discount }
                 : null,
-        promoCode
+        promoCode,
+        shippingMethod: shipping.toPricingDescriptor(selected, fallback)
     });
 }
 
@@ -47,10 +60,11 @@ async function processOrder(orderData) {
         items,
         shippingAddress,
         breakdown,
+        shippingMethod = null,
         appliedRules = []
     } = orderData;
 
-    const priced = breakdown || quoteOrder({ items });
+    const priced = breakdown || (await quoteOrder({ items, shippingMethod }));
 
     const crypto = require("crypto");
     const orderId = crypto.randomUUID();
@@ -65,6 +79,7 @@ async function processOrder(orderData) {
             subtotal,
             discount_amount,
             tax,
+            shipping_method,
             shipping_cost,
             total,
             total_amount,
@@ -74,7 +89,7 @@ async function processOrder(orderData) {
             status,
             created_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', NOW())
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', NOW())
         `,
         [
             orderId,
@@ -84,6 +99,7 @@ async function processOrder(orderData) {
             priced.subtotal,
             priced.discount,
             priced.tax,
+            priced.shippingMethod ? priced.shippingMethod.code : null,
             priced.shipping,
             priced.total,
             priced.total,

--- a/backend/services/order.service.js
+++ b/backend/services/order.service.js
@@ -10,6 +10,7 @@ const logger = require("../utils/logger");
 const { validatePromo } = require("./promo.service");
 const pricing = require("./pricing.service");
 const cartLifecycle = require("./cartLifecycleService");
+const shipping = require("./shipping.service");
 
 // Marks the one failure the client can act on, so controllers can answer with
 // the specific figures instead of a generic server error.
@@ -261,6 +262,12 @@ const createOrderService = async (connection, orderData) => {
             items,
             promo_code,
             total: claimedTotal,
+            // The delivery option the shopper chose (#1430). A code, never a
+            // rate: what it costs is looked up and priced here, so a client
+            // cannot influence its own delivery charge. Absent, the default
+            // option applies and the basket prices exactly as it did before
+            // checkout offered a choice.
+            shipping_method,
             // Optional link back to the saved address book (#1347). The
             // flattened columns above stay authoritative for what was actually
             // shipped -- they must not change when the shopper later edits or
@@ -294,10 +301,19 @@ const createOrderService = async (connection, orderData) => {
             appliedPromo = promoValidation.promo;
         }
 
+        const [selectedMethod, defaultMethod] = await Promise.all([
+            shipping.resolveMethod(shipping_method),
+            shipping.getDefaultMethod(),
+        ]);
+
         const breakdown = pricing.quote({
             items: validatedItems,
             promo: appliedPromo,
             promoCode: appliedPromo ? appliedPromo.code : null,
+            shippingMethod: shipping.toPricingDescriptor(
+                selectedMethod,
+                defaultMethod,
+            ),
         });
 
         const verification = pricing.verifyClaimedTotal(
@@ -340,6 +356,7 @@ const createOrderService = async (connection, orderData) => {
                 status,
                 subtotal,
                 tax,
+                shipping_method,
                 shipping_cost,
                 discount,
                 discount_code,
@@ -349,7 +366,7 @@ const createOrderService = async (connection, orderData) => {
                 created_at,
                 updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
         `;
 
         const [orderResult] = await connection.query(orderQuery, [
@@ -369,6 +386,7 @@ const createOrderService = async (connection, orderData) => {
             "pending",
             breakdown.subtotal,
             breakdown.tax,
+            selectedMethod.code,
             breakdown.shipping,
             discountAmount,
             appliedPromoCode,
@@ -519,6 +537,7 @@ const getOrderSummaryById = async (connection, orderId) => {
                 o.status,
                 o.subtotal,
                 o.tax,
+                o.shipping_method,
                 o.shipping_cost,
                 o.discount_amount,
                 o.final_amount,
@@ -842,6 +861,9 @@ const generateOrderSummaryService = async (orderId) => {
             discountAmount: order.discount_amount || 0,
             tax: order.tax || 0,
             shipping: order.shipping_cost || 0,
+            // Null on orders placed before checkout offered a choice. Nothing
+            // recorded how those were sent, so nothing claims to know.
+            shippingMethod: order.shipping_method || null,
             total: order.final_amount || order.total,
             timeline: await getOrderTimeline(orderId)
         };

--- a/backend/services/pricing.service.js
+++ b/backend/services/pricing.service.js
@@ -140,23 +140,57 @@ const calculateTax = (taxableBase) =>
     roundMoney(Math.max(0, roundMoney(taxableBase)) * PRICING_CONFIG.TAX_RATE);
 
 /**
- * Shipping due on a post-discount subtotal. An empty basket never attracts a
- * shipping charge, and a `free_shipping` promo waives it outright.
+ * Shipping due on a post-discount subtotal for a chosen delivery method.
+ *
+ * The charge is the method's own rate. A waiver — the free-shipping threshold,
+ * or a `free_shipping` promo — covers `waiverRate` of it and no more, which is
+ * what "free shipping" has always meant here: the store absorbs the standard
+ * cost of delivery. A shopper who has earned it and then upgrades to a faster
+ * option pays the difference rather than nothing at all.
+ *
+ * With no method supplied both rates fall back to the flat rate, which
+ * reproduces the pre-#1430 figure exactly: nothing below the threshold, free
+ * at or above it. That is what lets a caller that does not offer a choice keep
+ * pricing baskets the way it always has.
+ *
+ * An empty basket never attracts a shipping charge.
  *
  * @param {number} postDiscountSubtotal
- * @param {{ isShippingWaived?: boolean }} [options]
+ * @param {{ isShippingWaived?: boolean, methodRate?: number, waiverRate?: number }} [options]
  * @returns {number}
  */
 const calculateShipping = (postDiscountSubtotal, options = {}) => {
     const base = Math.max(0, roundMoney(postDiscountSubtotal));
 
-    if (options.isShippingWaived || base <= 0) {
+    if (base <= 0) {
         return 0;
     }
 
-    return base >= PRICING_CONFIG.FREE_SHIPPING_THRESHOLD
-        ? 0
-        : roundMoney(PRICING_CONFIG.SHIPPING_FLAT_RATE);
+    const rate = Math.max(
+        0,
+        roundMoney(
+            options.methodRate === undefined || options.methodRate === null
+                ? PRICING_CONFIG.SHIPPING_FLAT_RATE
+                : options.methodRate,
+        ),
+    );
+
+    const isEarned = base >= PRICING_CONFIG.FREE_SHIPPING_THRESHOLD;
+
+    if (!options.isShippingWaived && !isEarned) {
+        return rate;
+    }
+
+    const waiver = Math.max(
+        0,
+        roundMoney(
+            options.waiverRate === undefined || options.waiverRate === null
+                ? PRICING_CONFIG.SHIPPING_FLAT_RATE
+                : options.waiverRate,
+        ),
+    );
+
+    return roundMoney(Math.max(0, rate - waiver));
 };
 
 /**
@@ -169,9 +203,18 @@ const calculateShipping = (postDiscountSubtotal, options = {}) => {
  * @param {Array<Object>} input.items
  * @param {Object|null} [input.promo] - validated promo descriptor, if any
  * @param {string|null} [input.promoCode] - code to echo back on the breakdown
+ * @param {Object|null} [input.shippingMethod] - resolved delivery method,
+ *        carrying its own `rate` and the `waiverRate` free shipping covers.
+ *        Omitted, the flat rate applies, which is what every caller got before
+ *        there was a choice of delivery.
  * @returns {Object} breakdown
  */
-const quote = ({ items = [], promo = null, promoCode = null } = {}) => {
+const quote = ({
+    items = [],
+    promo = null,
+    promoCode = null,
+    shippingMethod = null,
+} = {}) => {
     const { lines, subtotal } = priceLineItems(items);
 
     const discount = applyDiscount(promo, subtotal);
@@ -179,6 +222,8 @@ const quote = ({ items = [], promo = null, promoCode = null } = {}) => {
     const tax = calculateTax(taxableBase);
     const shipping = calculateShipping(taxableBase, {
         isShippingWaived: discount.isShippingWaived,
+        methodRate: shippingMethod?.rate,
+        waiverRate: shippingMethod?.waiverRate,
     });
 
     return {
@@ -192,6 +237,12 @@ const quote = ({ items = [], promo = null, promoCode = null } = {}) => {
         taxableBase,
         tax,
         shipping,
+        // What was charged for, alongside what it cost. An order that records
+        // a figure without recording which option produced it cannot be
+        // reconciled against fulfilment.
+        shippingMethod: shippingMethod
+            ? { code: shippingMethod.code, label: shippingMethod.label }
+            : null,
         total: roundMoney(taxableBase + tax + shipping),
     };
 };

--- a/backend/services/shipping.service.js
+++ b/backend/services/shipping.service.js
@@ -1,0 +1,222 @@
+// Delivery options: what may be offered, and what each one costs (#1430).
+//
+// This is the only place that reads `shipping_methods`, and the only place
+// that turns a code the client sent into a rate. The pricing engine does the
+// arithmetic and knows nothing about the database; this module does the
+// lookup and knows nothing about the arithmetic. That split is what keeps the
+// charge server-computed: a request body can name a method, and nothing else.
+//
+// Every read is defensive in the same way `order.service.resolveItemVariant`
+// is: a deployment that has not applied the migration, or a reference table
+// that is briefly unreadable, must not take checkout down. It falls back to
+// the configured default, which prices exactly as this store did before
+// delivery options existed.
+
+const db = require("../config/db");
+const logger = require("../utils/logger");
+const { safeArray, safeInteger, safeNumber, sanitizeString } = require("../utils/helpers");
+const pricing = require("./pricing.service");
+const SHIPPING_CONFIG = require("../config/shippingConfig");
+
+// Marks a code the client sent that names no active method, so controllers can
+// answer with a 400 naming the options rather than a generic server error.
+const UNKNOWN_METHOD_CODE = "SHIPPING_METHOD_UNKNOWN";
+
+let cache = null;
+
+const toMethod = (row) => ({
+    code: sanitizeString(row.code),
+    label: sanitizeString(row.label),
+    description: sanitizeString(row.description) || null,
+    rate: safeNumber(row.base_rate),
+    isDefault: Boolean(row.is_default),
+    sortOrder: safeInteger(row.sort_order, 0),
+});
+
+const readMethods = async () => {
+    let methods;
+
+    try {
+        const [rows] = await db.query(
+            `SELECT code, label, description, base_rate, is_default, sort_order
+               FROM shipping_methods
+              WHERE is_active = 1
+              ORDER BY sort_order ASC, code ASC`,
+        );
+
+        methods = safeArray(rows).map(toMethod);
+    } catch (error) {
+        logger.warn(`Delivery options could not be read: ${error.message}`);
+        methods = [];
+    }
+
+    // An empty list is treated the same as an unreadable one. Offering no way
+    // to have an order delivered is never the intended configuration, and a
+    // checkout with no options is a checkout nobody can complete.
+    return methods.length > 0 ? methods : [SHIPPING_CONFIG.FALLBACK_METHOD];
+};
+
+/**
+ * The active delivery options, in the order they should be offered.
+ *
+ * The in-flight read is what is cached, not just its result: pricing one
+ * basket asks for the options several times over, and caching only the
+ * settled value would send every one of those to the database while the first
+ * was still running.
+ *
+ * @returns {Promise<Array<Object>>}
+ */
+const listMethods = () => {
+    if (cache && Date.now() < cache.expiresAt) {
+        return cache.methods;
+    }
+
+    const methods = readMethods();
+
+    cache = {
+        methods,
+        expiresAt: Date.now() + SHIPPING_CONFIG.CACHE_TTL_MS,
+    };
+
+    return methods;
+};
+
+/**
+ * The option a checkout gets when it does not choose one.
+ *
+ * The configured code wins over the table's own flag so that the method whose
+ * rate a free-shipping entitlement covers is a stated decision rather than
+ * whichever row happens to carry the marker. Falling through to the first
+ * offered option keeps a misconfigured table from leaving checkout with no
+ * default at all.
+ *
+ * @returns {Promise<Object>}
+ */
+const getDefaultMethod = async () => {
+    const methods = await listMethods();
+
+    return (
+        methods.find((method) => method.code === SHIPPING_CONFIG.DEFAULT_METHOD_CODE) ||
+        methods.find((method) => method.isDefault) ||
+        methods[0]
+    );
+};
+
+/**
+ * Turn a requested code into the method it names.
+ *
+ * An absent code is the backwards-compatible case and resolves to the default,
+ * which is what keeps a checkout path that does not offer a choice working
+ * unchanged. A code that is present but names nothing is rejected rather than
+ * quietly defaulted: silently substituting an option would charge a shopper
+ * for delivery they did not pick.
+ *
+ * @param {any} requestedCode
+ * @returns {Promise<Object>}
+ */
+const resolveMethod = async (requestedCode) => {
+    const code = sanitizeString(requestedCode);
+
+    if (!code) {
+        return getDefaultMethod();
+    }
+
+    const methods = await listMethods();
+    const match = methods.find((method) => method.code === code);
+
+    if (!match) {
+        const error = new Error(
+            `Unknown delivery option "${code}". Available: ` +
+                `${methods.map((method) => method.code).join(", ")}.`,
+        );
+        error.code = UNKNOWN_METHOD_CODE;
+        throw error;
+    }
+
+    return match;
+};
+
+/**
+ * The descriptor the pricing engine takes.
+ *
+ * `waiverRate` is how much of this method's rate a free-shipping entitlement
+ * covers, and it is the *default* method's rate for every option. Free
+ * shipping means the store absorbs the standard cost of delivery, so a shopper
+ * who has earned it and then upgrades pays the difference rather than nothing.
+ *
+ * @param {Object} method
+ * @param {Object} defaultMethod
+ * @returns {Object}
+ */
+const toPricingDescriptor = (method, defaultMethod) => ({
+    code: method.code,
+    label: method.label,
+    rate: method.rate,
+    waiverRate: defaultMethod ? defaultMethod.rate : method.rate,
+});
+
+/**
+ * Price every option for one basket.
+ *
+ * Each option is priced by the engine rather than by adding rates up here, so
+ * what a shopper is shown next to each option is the figure that option would
+ * actually be charged -- including the case where a waiver makes two options
+ * cost the same.
+ *
+ * @param {Object} input
+ * @param {number} input.postDiscountSubtotal
+ * @param {boolean} [input.isShippingWaived] a free_shipping promo is applied
+ * @param {any} [input.selectedCode] the option the shopper picked, if any
+ * @returns {Promise<{ selected: Object, options: Array<Object> }>}
+ */
+const quoteOptions = async ({
+    postDiscountSubtotal,
+    isShippingWaived = false,
+    selectedCode = null,
+} = {}) => {
+    const [methods, defaultMethod, selected] = await Promise.all([
+        listMethods(),
+        getDefaultMethod(),
+        resolveMethod(selectedCode),
+    ]);
+
+    const options = methods.map((method) => {
+        const descriptor = toPricingDescriptor(method, defaultMethod);
+
+        return {
+            code: method.code,
+            label: method.label,
+            description: method.description,
+            isDefault: method.code === defaultMethod.code,
+            isSelected: method.code === selected.code,
+            cost: pricing.calculateShipping(postDiscountSubtotal, {
+                isShippingWaived,
+                methodRate: descriptor.rate,
+                waiverRate: descriptor.waiverRate,
+            }),
+        };
+    });
+
+    return {
+        selected: toPricingDescriptor(selected, defaultMethod),
+        options,
+    };
+};
+
+/**
+ * Drop the cached options. Used by tests, and by anything that changes a rate
+ * and needs the change to be visible immediately.
+ */
+const clearCache = () => {
+    cache = null;
+};
+
+module.exports = {
+    UNKNOWN_METHOD_CODE,
+    listMethods,
+    getDefaultMethod,
+    resolveMethod,
+    toPricingDescriptor,
+    quoteOptions,
+    clearCache,
+};

--- a/backend/tests/shipping.service.test.js
+++ b/backend/tests/shipping.service.test.js
@@ -1,0 +1,221 @@
+// backend/tests/shipping.service.test.js
+//
+// Delivery options (#1430).
+//
+// The properties worth pinning are the ones whose absence would cost money:
+//
+//   * a checkout that chooses nothing prices exactly as it did before there
+//     were options at all;
+//   * an option the client names but the store does not offer is rejected
+//     rather than quietly substituted;
+//   * free shipping covers the standard rate and no more, so upgrading on top
+//     of an earned waiver still costs the difference;
+//   * nothing on the request side of the boundary carries a rate.
+
+jest.mock('../config/db', () => ({
+    query: jest.fn()
+}));
+
+jest.mock('../utils/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+const db = require('../config/db');
+const PRICING_CONFIG = require('../config/pricingConfig');
+const SHIPPING_CONFIG = require('../config/shippingConfig');
+const pricing = require('../services/pricing.service');
+const shipping = require('../services/shipping.service');
+
+const STANDARD = {
+    code: 'standard',
+    label: 'Standard delivery',
+    description: 'Arrives in three to six days.',
+    base_rate: '49.00',
+    is_default: 1,
+    sort_order: 10
+};
+
+const EXPRESS = {
+    code: 'express',
+    label: 'Express delivery',
+    description: 'Arrives in one to two days.',
+    base_rate: '149.00',
+    is_default: 0,
+    sort_order: 20
+};
+
+// Comfortably under the free-shipping threshold, so a charge actually applies.
+const SMALL_BASKET = 500;
+const LARGE_BASKET = PRICING_CONFIG.FREE_SHIPPING_THRESHOLD + 1;
+
+function offering(rows) {
+    db.query.mockResolvedValue([rows]);
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    shipping.clearCache();
+    offering([STANDARD, EXPRESS]);
+});
+
+describe('resolving a requested option', () => {
+    it('falls back to the default when nothing was chosen', async () => {
+        await expect(shipping.resolveMethod(null)).resolves.toMatchObject({
+            code: 'standard'
+        });
+        await expect(shipping.resolveMethod('')).resolves.toMatchObject({
+            code: 'standard'
+        });
+    });
+
+    it('rejects an option the store does not offer rather than substituting one', async () => {
+        // Silently defaulting would charge a shopper for delivery they did not
+        // pick, and would hide a client sending a code that no longer exists.
+        await expect(shipping.resolveMethod('teleport')).rejects.toMatchObject({
+            code: shipping.UNKNOWN_METHOD_CODE
+        });
+    });
+
+    it('names what is on offer when it rejects one', async () => {
+        await expect(shipping.resolveMethod('teleport')).rejects.toThrow(/standard, express/);
+    });
+
+    it('keeps checkout working when the options cannot be read', async () => {
+        db.query.mockRejectedValue(new Error('Table shipping_methods does not exist'));
+        shipping.clearCache();
+
+        const method = await shipping.getDefaultMethod();
+
+        expect(method.code).toBe(SHIPPING_CONFIG.FALLBACK_METHOD.code);
+        expect(method.rate).toBe(PRICING_CONFIG.SHIPPING_FLAT_RATE);
+    });
+
+    it('treats an empty table the same as an unreadable one', async () => {
+        offering([]);
+        shipping.clearCache();
+
+        await expect(shipping.listMethods()).resolves.toEqual([
+            SHIPPING_CONFIG.FALLBACK_METHOD
+        ]);
+    });
+
+    it('reads the options once and reuses them', async () => {
+        await shipping.listMethods();
+        await shipping.listMethods();
+
+        expect(db.query).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('what a waiver covers', () => {
+    it('waives the default option outright once the threshold is met', async () => {
+        const { options } = await shipping.quoteOptions({
+            postDiscountSubtotal: LARGE_BASKET
+        });
+
+        expect(options.find((option) => option.code === 'standard').cost).toBe(0);
+    });
+
+    it('charges the difference when an earned waiver is spent on an upgrade', async () => {
+        // Free shipping means the store absorbs the standard cost of delivery.
+        // Making it absorb an express upgrade as well would give away the whole
+        // premium to every basket that crossed the threshold.
+        const { options } = await shipping.quoteOptions({
+            postDiscountSubtotal: LARGE_BASKET
+        });
+
+        expect(options.find((option) => option.code === 'express').cost).toBe(100);
+    });
+
+    it('charges each option in full below the threshold', async () => {
+        const { options } = await shipping.quoteOptions({
+            postDiscountSubtotal: SMALL_BASKET
+        });
+
+        expect(options.map((option) => option.cost)).toEqual([49, 149]);
+    });
+
+    it('treats a free_shipping promo the same as the threshold', async () => {
+        const { options } = await shipping.quoteOptions({
+            postDiscountSubtotal: SMALL_BASKET,
+            isShippingWaived: true
+        });
+
+        expect(options.map((option) => option.cost)).toEqual([0, 100]);
+    });
+});
+
+describe('backwards compatibility with the flat rate', () => {
+    it('prices a basket that names no option exactly as the engine always did', async () => {
+        const { selected } = await shipping.quoteOptions({
+            postDiscountSubtotal: SMALL_BASKET
+        });
+
+        const withMethod = pricing.calculateShipping(SMALL_BASKET, {
+            methodRate: selected.rate,
+            waiverRate: selected.waiverRate
+        });
+
+        expect(withMethod).toBe(pricing.calculateShipping(SMALL_BASKET));
+        expect(withMethod).toBe(PRICING_CONFIG.SHIPPING_FLAT_RATE);
+    });
+
+    it('still charges nothing above the threshold when no option is named', () => {
+        expect(pricing.calculateShipping(LARGE_BASKET)).toBe(0);
+    });
+
+    it('leaves the breakdown reconciling when a paid option is chosen', async () => {
+        const { selected } = await shipping.quoteOptions({
+            postDiscountSubtotal: SMALL_BASKET,
+            selectedCode: 'express'
+        });
+
+        const breakdown = pricing.quote({
+            items: [{ id: 'a', price: SMALL_BASKET, qty: 1 }],
+            shippingMethod: selected
+        });
+
+        expect(breakdown.shippingMethod).toEqual({
+            code: 'express',
+            label: 'Express delivery'
+        });
+        expect(breakdown.shipping).toBe(149);
+        expect(
+            pricing.roundMoney(
+                breakdown.subtotal -
+                    breakdown.discount +
+                    breakdown.tax +
+                    breakdown.shipping
+            )
+        ).toBe(breakdown.total);
+    });
+});
+
+describe('the pricing descriptor handed across the boundary', () => {
+    it('carries a rate the caller looked up, never one the caller supplied', async () => {
+        const { selected } = await shipping.quoteOptions({
+            postDiscountSubtotal: SMALL_BASKET,
+            selectedCode: 'express'
+        });
+
+        expect(selected).toEqual({
+            code: 'express',
+            label: 'Express delivery',
+            rate: 149,
+            waiverRate: 49
+        });
+    });
+
+    it('marks the chosen option so the shopper sees what they picked', async () => {
+        const { options } = await shipping.quoteOptions({
+            postDiscountSubtotal: SMALL_BASKET,
+            selectedCode: 'express'
+        });
+
+        expect(options.map((option) => option.isSelected)).toEqual([false, true]);
+        expect(options.map((option) => option.isDefault)).toEqual([true, false]);
+    });
+});

--- a/frontend/checkout.html
+++ b/frontend/checkout.html
@@ -233,6 +233,35 @@
                     <small class="field-error" id="address-error"></small>
                 </div>
 
+                <!-- Delivery -->
+
+                <h3>
+
+                    Delivery Option
+
+                </h3>
+
+                <!--
+                    Options and their prices are rendered from the server's
+                    quote. The markup carries no rates: what each option costs
+                    is priced server-side for this basket, and the browser only
+                    ever sends back which one was picked.
+                -->
+                <div
+                    class="delivery-options"
+                    id="delivery-options"
+                    role="radiogroup"
+                    aria-label="Delivery option"
+                >
+
+                    <p class="delivery-options-loading" id="delivery-options-loading">
+
+                        Loading delivery options…
+
+                    </p>
+
+                </div>
+
                 <!-- Payment -->
 
                 <h3>
@@ -356,7 +385,7 @@
 
                 <span>
 
-                    Shipping
+                    Shipping <small id="checkout-shipping-method" class="summary-note"></small>
 
                 </span>
 

--- a/frontend/scripts/checkout.js
+++ b/frontend/scripts/checkout.js
@@ -70,6 +70,16 @@ const elements = {
             "checkout-shipping"
         ),
 
+    shippingMethodNote:
+        document.getElementById(
+            "checkout-shipping-method"
+        ),
+
+    deliveryOptions:
+        document.getElementById(
+            "delivery-options"
+        ),
+
     discount:
         document.getElementById(
             "checkout-discount"
@@ -270,13 +280,132 @@ function safeQty(
         );
 }
 
+// DELIVERY OPTION
+//
+// Which option the shopper picked, and nothing else. What it costs is never
+// held here: the server prices the selection and the summary renders whatever
+// comes back, so there is no figure on this page the browser could send.
+let selectedShippingMethod =
+    null;
+
 // CALCULATE TOTALS
 async function calculateTotals() {
 
     return AppUtils.fetchCartQuote(
         cart,
-        appliedCoupon
+        appliedCoupon,
+        selectedShippingMethod
     );
+}
+
+function renderDeliveryOptions(
+    options,
+    currency
+) {
+
+    if (
+        !elements.deliveryOptions
+    ) {
+        return;
+    }
+
+    const available =
+        AppUtils.safeArray(
+            options
+        );
+
+    if (
+        !available.length
+    ) {
+
+        // The quote could not be reached, or this basket has nothing to
+        // deliver. Saying so is better than an empty box, and leaving the
+        // selection untouched means the order still goes out on the default.
+        elements.deliveryOptions.innerHTML =
+            '<p class="delivery-options-loading">Delivery options are unavailable right now — your order will be sent by our standard service.</p>';
+
+        return;
+    }
+
+    elements.deliveryOptions.innerHTML =
+        available
+            .map(
+                (
+                    option
+                ) => `
+                    <label class="delivery-option${option.isSelected ? " is-selected" : ""}">
+
+                        <input
+                            type="radio"
+                            name="delivery"
+                            value="${escapeHTML(option.code)}"
+                            ${option.isSelected ? "checked" : ""}
+                        >
+
+                        <span class="delivery-option-body">
+
+                            <span class="delivery-option-label">
+                                ${escapeHTML(option.label)}
+                            </span>
+
+                            <small class="delivery-option-description">
+                                ${escapeHTML(option.description || "")}
+                            </small>
+
+                        </span>
+
+                        <span class="delivery-option-cost">
+                            ${
+                                option.cost === 0
+                                    ? "Free"
+                                    : AppUtils.formatPrice(
+                                        option.cost,
+                                        currency
+                                    )
+                            }
+                        </span>
+
+                    </label>
+                `
+            )
+            .join("");
+
+    const selected =
+        available.find(
+            (
+                option
+            ) => option.isSelected
+        );
+
+    selectedShippingMethod =
+        selected
+            ? selected.code
+            : null;
+
+    elements.deliveryOptions
+        .querySelectorAll(
+            'input[name="delivery"]'
+        )
+        .forEach(
+            (
+                input
+            ) => {
+
+                input.addEventListener(
+                    "change",
+                    async () => {
+
+                        selectedShippingMethod =
+                            input.value;
+
+                        // Re-price rather than adjust the total locally. The
+                        // charge for an option is the server's to state, and
+                        // the two must not be able to disagree.
+                        await refreshSummary();
+                    }
+                );
+            }
+        );
 }
 
 function renderTotals(
@@ -323,6 +452,18 @@ function renderTotals(
                 );
     }
 
+    if (
+        elements.shippingMethodNote
+    ) {
+
+        // Naming the option next to the charge is what makes the line
+        // reconcilable — "Shipping ₹149" alone does not say what was bought.
+        elements.shippingMethodNote.innerText =
+            totals.shippingMethod
+                ? `(${totals.shippingMethod.label})`
+                : "";
+    }
+
     const discount =
         Number(totals.discount) || 0;
 
@@ -366,6 +507,11 @@ async function refreshSummary() {
 
     renderTotals(
         totals
+    );
+
+    renderDeliveryOptions(
+        totals.shippingOptions,
+        totals.currency
     );
 
     return totals;
@@ -633,6 +779,11 @@ async function createOrderPayload() {
         paymentMethod:
             selectedPayment.value
                 .toLowerCase(),
+
+        // The code only. The server looks up what it costs, so nothing about
+        // the delivery charge travels in this payload.
+        shippingMethod:
+            selectedShippingMethod,
 
         total:
             totals.total,

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -1891,7 +1891,8 @@ const calculateCartTotals = async (
 // `isServerQuote` tells callers which of the two they are looking at.
 const fetchCartQuote = async (
     cart = getCart(),
-    couponCode = ""
+    couponCode = "",
+    shippingMethod = null
 ) => {
     const items = safeArray(cart).map(
         (item) => ({
@@ -1908,7 +1909,10 @@ const fetchCartQuote = async (
             method: "POST",
             body: JSON.stringify({
                 items,
-                promoCode: couponCode || null
+                promoCode: couponCode || null,
+                // A code naming a delivery option, never a rate. The server
+                // decides what it costs.
+                shippingMethod: shippingMethod || null
             })
         });
 
@@ -1920,6 +1924,7 @@ const fetchCartQuote = async (
 
         return {
             ...response.breakdown,
+            shippingOptions: safeArray(response.shippingOptions),
             promoMessage: response.promoMessage || null,
             isServerQuote: true
         };
@@ -1930,6 +1935,10 @@ const fetchCartQuote = async (
 
         return {
             ...fallback,
+            // Deliberately empty: the local fallback cannot price a delivery
+            // option, and offering a choice it could not cost would show the
+            // shopper a figure the server never agreed to.
+            shippingOptions: [],
             isServerQuote: false
         };
     }

--- a/migrations/0036_shipping_methods.sql
+++ b/migrations/0036_shipping_methods.sql
@@ -1,0 +1,149 @@
+-- ============================================
+-- SHIPPING METHODS (#1430)
+-- ============================================
+--
+-- `orders.shipping_method VARCHAR(50)` and `orders.shipping_cost DECIMAL(10,2)`
+-- have been in the schema since the baseline. `shipping_cost` acquired a writer
+-- when the pricing engine landed; `shipping_method` never did, because there
+-- was nothing to record -- checkout offered no choice of delivery, so every
+-- order was shipped by an unnamed method at a flat rate.
+--
+-- This declares the methods that may be offered. `shipments.shipping_method`
+-- is the same vocabulary, one step further downstream: fulfilment reads what
+-- checkout sold. It is deliberately not a second list, and it is not an ENUM
+-- on either table -- adding a delivery option is a row, not a schema change.
+--
+-- Safe to re-run.
+
+CREATE TABLE IF NOT EXISTS shipping_methods (
+    -- The code is the primary key rather than a surrogate id, because it is
+    -- what `orders.shipping_method` has always stored and what fulfilment,
+    -- accounting and the courier integrations all speak. VARCHAR(50) matches
+    -- that column exactly so the two can be joined and constrained.
+    code VARCHAR(50) PRIMARY KEY,
+
+    label VARCHAR(100) NOT NULL,
+    description VARCHAR(255),
+
+    -- What this method costs before any waiver. Rates are DECIMAL and are read
+    -- by the server only: a delivery charge the client can send is a discount
+    -- the client can grant itself.
+    base_rate DECIMAL(10,2) NOT NULL DEFAULT 0,
+
+    -- Exactly one method is the default, enforced by the database rather than
+    -- by application code alone. MySQL has no partial indexes, so only the
+    -- default row stores a marker and every other row stores NULL; NULLs do
+    -- not collide in a UNIQUE index. The generated column keeps the marker in
+    -- lockstep with the flag with no way for code to get the two out of step.
+    is_default TINYINT(1) NOT NULL DEFAULT 0,
+    default_marker TINYINT(1)
+        GENERATED ALWAYS AS (
+            CASE WHEN is_default = 1 THEN 1 ELSE NULL END
+        ) STORED,
+
+    -- Retiring a method deactivates it. Deleting it would orphan every order
+    -- that recorded it, which is why the foreign key below restricts deletes.
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+
+    -- Display order at checkout. Cheapest-first is not always the order a
+    -- shopper should see, so it is a stated value rather than a sort on rate.
+    sort_order INT NOT NULL DEFAULT 0,
+
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    CONSTRAINT chk_shipping_methods_base_rate CHECK (base_rate >= 0),
+
+    UNIQUE KEY uq_shipping_methods_default (default_marker),
+
+    -- The checkout access path: the active options, in the order they show.
+    INDEX idx_shipping_methods_active_sort (is_active, sort_order)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================
+-- THE OPTIONS ON OFFER
+-- ============================================
+--
+-- `standard` reproduces exactly what every order has been charged until now:
+-- the flat rate the pricing engine has always applied, waived above the
+-- free-shipping threshold. That is what makes it a safe default -- a checkout
+-- that chooses nothing prices identically to before this migration.
+--
+-- Guarded on the code so re-running does not overwrite rates an operator has
+-- since changed. Rates are business configuration; this seed only establishes
+-- that the options exist.
+
+INSERT INTO shipping_methods (
+    code, label, description, base_rate, is_default, is_active, sort_order
+)
+SELECT
+    'standard', 'Standard delivery', 'Arrives in three to six days.',
+    49.00, 1, 1, 10
+FROM DUAL
+WHERE NOT EXISTS (
+    SELECT 1 FROM shipping_methods WHERE code = 'standard'
+);
+
+INSERT INTO shipping_methods (
+    code, label, description, base_rate, is_default, is_active, sort_order
+)
+SELECT
+    'express', 'Express delivery', 'Arrives in one to two days.',
+    149.00, 0, 1, 20
+FROM DUAL
+WHERE NOT EXISTS (
+    SELECT 1 FROM shipping_methods WHERE code = 'express'
+);
+
+-- ============================================
+-- TIE ORDERS TO THE VOCABULARY
+-- ============================================
+--
+-- The index exists before the foreign key so InnoDB adopts it rather than
+-- building a second one for the constraint.
+--
+-- Historical orders keep a NULL `shipping_method`, which the constraint
+-- permits. Backfilling them to 'standard' would assert something nobody
+-- recorded: what those orders were shipped by is not known, and the pricing
+-- breakdown work established that figures which were never captured are left
+-- absent rather than invented. NULL reads as "not recorded" everywhere it is
+-- displayed.
+--
+-- The column has never had a writer, so every existing value is NULL and the
+-- constraint builds. A deployment where the column was populated by hand will
+-- fail here rather than quietly dropping the constraint -- an unrecognised
+-- method on an order is a real inconsistency and worth stopping for.
+
+DELIMITER //
+
+CREATE PROCEDURE LinkOrdersToShippingMethods()
+BEGIN
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'orders'
+        AND INDEX_NAME = 'idx_orders_shipping_method'
+    ) THEN
+        CREATE INDEX idx_orders_shipping_method ON orders (shipping_method);
+    END IF;
+
+    -- ON DELETE RESTRICT is the point of the constraint: a method that has
+    -- been sold cannot be deleted out from under the orders that recorded it,
+    -- and renaming one has to carry those orders with it.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'orders'
+        AND CONSTRAINT_NAME = 'fk_orders_shipping_method'
+    ) THEN
+        ALTER TABLE orders
+        ADD CONSTRAINT fk_orders_shipping_method
+        FOREIGN KEY (shipping_method) REFERENCES shipping_methods(code)
+        ON DELETE RESTRICT ON UPDATE CASCADE;
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL LinkOrdersToShippingMethods();
+DROP PROCEDURE LinkOrdersToShippingMethods;


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

Every order has been placed with no record of how it was to be sent, and until the pricing engine landed, with no charge for sending it either. `orders.shipping_method` has been in the schema since the baseline and has never had a writer. This gives checkout a delivery choice, prices the choice on the server, and records both the method and the charge on the order.

**The options are rows, not code.** A delivery method is a code, a label, a rate and a display position, and adding one is an operational decision rather than a deployment. The code is the primary key, because it is what `orders.shipping_method` has always stored and what `shipments.shipping_method` speaks one step further downstream — fulfilment reads what checkout sold, and a second vocabulary for the same thing is how those two stop agreeing. Orders are constrained to it, and a method that has been sold cannot be deleted out from under the orders that recorded it.

**The charge is never a number the client sends.** A request body names an option and nothing more; the rate is looked up server-side and priced by the same engine that owns the rest of the total, which then verifies the total the client claims against the one it computed. That is the footing the order pricing work established, and shipping had to land on it from the outset — a delivery charge the client can influence is a discount the client can grant itself. An option the store does not offer is rejected rather than quietly substituted, because silently swapping in a different service charges somebody for delivery they did not pick.

**The default keeps everything that does not choose working exactly as it did.** Its rate is the flat rate the engine has always applied, and a basket that names no option prices to the figure it priced to before this branch — including the free-shipping threshold, which still waives it. Checkout paths that do not offer a choice, and callers that price a basket without one, are unaffected.

**Free delivery covers the standard cost of delivery, not whatever was picked.** A shopper who has earned free shipping and then upgrades pays the difference rather than nothing. Treating a waiver as "this order ships for nothing" would give the whole premium away to every basket over the threshold, and this is the reading that generalises when rates stop being flat.

Historical orders keep a null method. Nothing recorded how they were sent, and backfilling them to the default would assert something nobody knows; it reads as "not recorded" everywhere it is displayed.

---

## 🔗 Related Issue

Part of #1430

---

## 🛠️ Type of Change

- [ ] Bug fix
- [x] New feature
- [x] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

No image. On the checkout page a reviewer sees a new **Delivery Option** block above the payment methods, listing each option with its description and its price for the basket in hand — "Free" where a waiver covers it. Choosing one re-prices the order summary from the server, and the Shipping line names the chosen option next to the charge.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**If the options cannot be read.** A deployment that has not applied the migration, or a reference table that is briefly unavailable, falls back to a configured default whose rate is the flat rate. Checkout stays up and charges what it charged before, rather than failing or, worse, shipping for free.

**Rates are seeded, not decided here.** The migration establishes that two options exist and gives the default the rate already in force. What a store actually charges is a row an operator edits.

**Left as it is.** `shipments.shipping_method` is still unwritten — fulfilment records are created elsewhere and reading the order's method into them belongs with that code, not here. Its column is wider than the orders one, so the two are not constrained to each other yet.

**Noticed while reading.** `courierWebhookService.js` calls `orderStatusHistory.recordTransition` without importing it, so mirroring a courier event onto an order throws a `ReferenceError` and is swallowed by the surrounding catch. Untouched here; it is not on this path.

**Note on CI.** Two frontend scripts do not parse on `main`, which fails the syntax gate for every branch regardless of its contents and causes the test and boot jobs to skip. Neither file is touched here; reported in #1416.
