### PR TITLE
Derive delivery rates from rules over destination, weight and value

### DIFF
--- a/backend/config/pricingConfig.js
+++ b/backend/config/pricingConfig.js
@@ -37,7 +37,11 @@ const PRICING_CONFIG = Object.freeze({
 
     TAX_RATE: 0.18,
     SHIPPING_FLAT_RATE: 49,
-    // At or above this post-discount subtotal shipping is free.
+    // At or above this post-discount subtotal shipping is free, for any caller
+    // that prices without rate rules to hand. The store's actual threshold is
+    // a waiver rule and can be moved, scoped or withdrawn; this is what the
+    // engine falls back to on its own, and it is the figure migration 0037
+    // seeds that rule with so the two start out saying the same thing.
     FREE_SHIPPING_THRESHOLD: 999,
 
     // Both the tax and the shipping rule read the subtotal *after* the

--- a/backend/config/shippingConfig.js
+++ b/backend/config/shippingConfig.js
@@ -18,10 +18,16 @@ const SHIPPING_CONFIG = Object.freeze({
     // whose rate a free-shipping entitlement covers.
     DEFAULT_METHOD_CODE: "standard",
 
-    // Delivery options change on the scale of campaigns, not requests, so they
-    // are read once and reused. Short enough that an operator changing a rate
-    // sees it take effect without a restart.
+    // Delivery options and rate rules change on the scale of campaigns, not
+    // requests, so they are read once and reused. Short enough that an operator
+    // changing a rate sees it take effect without a restart.
     CACHE_TTL_MS: Number(process.env.SHIPPING_METHOD_CACHE_TTL_MS) || 60_000,
+
+    // Assumed weight of a product that has none recorded. Most of the catalogue
+    // is in that state, and treating those as weightless would put every such
+    // basket in the lightest band of every weight rule.
+    DEFAULT_ITEM_WEIGHT_KG:
+        Number(process.env.SHIPPING_DEFAULT_ITEM_WEIGHT_KG) || 0.5,
 
     // Used only when `shipping_methods` cannot be read. The rate is the flat
     // rate the pricing engine has always applied, so a store running on the

--- a/backend/openapi/ecommerce.openapi.yaml
+++ b/backend/openapi/ecommerce.openapi.yaml
@@ -893,6 +893,32 @@ components:
           description: Code naming a delivery option. Omitted, the default applies.
           type: string
           nullable: true
+        destination:
+          description: >
+            Where the parcel would go, so destination rules can apply. Optional:
+            the cart has no address yet. Re-resolved from the order when one is
+            placed, so it cannot be used to buy a cheaper rate.
+          nullable: true
+          type: object
+          properties:
+            pincode:
+              type: string
+            city:
+              type: string
+            state:
+              type: string
+
+    FreeShippingProgress:
+      description: Progress toward the nearest free-delivery threshold.
+      type: object
+      required: [threshold, remaining, qualified]
+      properties:
+        threshold:
+          type: number
+        remaining:
+          type: number
+        qualified:
+          type: boolean
 
     CheckoutQuoteSuccess:
       type: object
@@ -907,6 +933,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ShippingOption"
+        freeShipping:
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/FreeShippingProgress"
         promoMessage:
           type: string
           nullable: true

--- a/backend/routes/checkoutRoutes.js
+++ b/backend/routes/checkoutRoutes.js
@@ -13,7 +13,7 @@ const powChallengeService = require('../services/powChallengeService');
 // resolves prices under lock, enforces stock and consumes inventory holds.
 router.post('/quote', async (req, res) => {
     try {
-        const { items, promoCode, shippingMethod } = req.body;
+        const { items, promoCode, shippingMethod, destination } = req.body;
         const requestedItems = safeArray(items);
 
         // Nothing to price and nothing to deliver, so no options are offered
@@ -57,7 +57,12 @@ router.post('/quote', async (req, res) => {
         const delivery = await shipping.quoteOptions({
             postDiscountSubtotal: subtotal - discount.amount,
             isShippingWaived: discount.isShippingWaived,
-            selectedCode: shippingMethod
+            selectedCode: shippingMethod,
+            // A destination is optional: the cart page has no address yet, and
+            // a basket still has to be priced there. Rules scoped to a place
+            // simply do not match until one is known.
+            destination: destination || null,
+            weightKg: shipping.basketWeightKg(lines)
         });
 
         const breakdown = pricing.quote({
@@ -71,6 +76,7 @@ router.post('/quote', async (req, res) => {
             success: true,
             breakdown,
             shippingOptions: delivery.options,
+            freeShipping: delivery.freeShipping,
             promoMessage
         });
     } catch (error) {

--- a/backend/services/checkoutService.js
+++ b/backend/services/checkoutService.js
@@ -28,20 +28,25 @@ function calculateTax(taxableBase) {
  * @param {number} [input.discountAmount]
  * @param {string|null} [input.promoCode]
  * @param {string|null} [input.shippingMethod] - code naming a delivery option
+ * @param {Object|null} [input.destination] - where the parcel is going
  * @returns {Promise<Object>} breakdown
  */
 async function quoteOrder({
     items = [],
     discountAmount = 0,
     promoCode = null,
-    shippingMethod = null
+    shippingMethod = null,
+    destination = null
 } = {}) {
     const discount = Number(discountAmount) || 0;
+    const { subtotal } = pricing.priceLineItems(items);
 
-    const [selected, fallback] = await Promise.all([
-        shipping.resolveMethod(shippingMethod),
-        shipping.getDefaultMethod()
-    ]);
+    const delivery = await shipping.quoteOptions({
+        postDiscountSubtotal: subtotal - Math.min(discount, subtotal),
+        selectedCode: shippingMethod,
+        destination,
+        weightKg: shipping.basketWeightKg(items)
+    });
 
     return pricing.quote({
         items,
@@ -50,7 +55,7 @@ async function quoteOrder({
                 ? { discount_type: "fixed", discount_value: discount }
                 : null,
         promoCode,
-        shippingMethod: shipping.toPricingDescriptor(selected, fallback)
+        shippingMethod: delivery.selected
     });
 }
 
@@ -64,7 +69,13 @@ async function processOrder(orderData) {
         appliedRules = []
     } = orderData;
 
-    const priced = breakdown || (await quoteOrder({ items, shippingMethod }));
+    const priced =
+        breakdown ||
+        (await quoteOrder({
+            items,
+            shippingMethod,
+            destination: shippingAddress
+        }));
 
     const crypto = require("crypto");
     const orderId = crypto.randomUUID();

--- a/backend/services/order.service.js
+++ b/backend/services/order.service.js
@@ -108,7 +108,7 @@ const resolveItemVariant = async (connection, productId, item, lockRows = true) 
     try {
         if (explicitVariantId > 0) {
             const [rows] = await connection.query(
-                `SELECT id, price, stock FROM product_variants
+                `SELECT id, price, stock, weight FROM product_variants
                  WHERE id = ? AND product_id = ? AND is_active = 1
                  LIMIT 1${rowLock}`,
                 [explicitVariantId, productId],
@@ -141,7 +141,7 @@ const resolveItemVariant = async (connection, productId, item, lockRows = true) 
         }
 
         const [rows] = await connection.query(
-            `SELECT id, price, stock FROM product_variants
+            `SELECT id, price, stock, weight FROM product_variants
              WHERE product_id = ? AND is_active = 1
              AND ${conditions.join(" AND ")}
              LIMIT 2${rowLock}`,
@@ -187,7 +187,7 @@ const resolveOrderLines = async (connection, items, options = {}) => {
         }
 
         const [productResults] = await connection.query(
-            `SELECT id, name, price, stock, image FROM products WHERE id = ?
+            `SELECT id, name, price, stock, image, weight FROM products WHERE id = ?
              LIMIT 1${rowLock}`,
             [productId],
         );
@@ -210,6 +210,11 @@ const resolveOrderLines = async (connection, items, options = {}) => {
         // product price is only a fallback. This keeps order totals correct
         // for variants that are priced differently from their parent.
         let realPrice = safeNumber(product.price);
+        // Carried through so shipping rules can be written over how heavy a
+        // basket is. Null when nothing has recorded a weight, which is most of
+        // the catalogue; the shipping service decides what to assume rather
+        // than a zero being invented here.
+        let realWeight = product.weight === null ? null : safeNumber(product.weight);
 
         const variant = await resolveItemVariant(
             connection,
@@ -226,11 +231,20 @@ const resolveOrderLines = async (connection, items, options = {}) => {
             }
         }
 
+        if (variant && variant.weight !== null && variant.weight !== undefined) {
+            const variantWeight = safeNumber(variant.weight);
+
+            if (variantWeight > 0) {
+                realWeight = variantWeight;
+            }
+        }
+
         resolvedLines.push({
             id: safeUUID(product.id),
             name: sanitizeString(product.name),
             image: sanitizeString(product.image),
             price: realPrice,
+            weight: realWeight,
             qty,
             color: sanitizeString(item.color),
             size: sanitizeString(item.size),
@@ -301,19 +315,29 @@ const createOrderService = async (connection, orderData) => {
             appliedPromo = promoValidation.promo;
         }
 
-        const [selectedMethod, defaultMethod] = await Promise.all([
-            shipping.resolveMethod(shipping_method),
-            shipping.getDefaultMethod(),
-        ]);
+        // Priced against the address the parcel is actually going to, not
+        // against whatever destination the browser used to fetch its quote. A
+        // client that quotes a cheap destination and ships to an expensive one
+        // is caught here, as a total that does not match.
+        const { subtotal: preDiscountSubtotal } =
+            pricing.priceLineItems(validatedItems);
+        const promoValue = appliedPromo
+            ? pricing.applyDiscount(appliedPromo, preDiscountSubtotal)
+            : { amount: 0, isShippingWaived: false };
+
+        const delivery = await shipping.quoteOptions({
+            postDiscountSubtotal: preDiscountSubtotal - promoValue.amount,
+            isShippingWaived: promoValue.isShippingWaived,
+            selectedCode: shipping_method,
+            destination: { pincode: zip, city, state },
+            weightKg: shipping.basketWeightKg(validatedItems),
+        });
 
         const breakdown = pricing.quote({
             items: validatedItems,
             promo: appliedPromo,
             promoCode: appliedPromo ? appliedPromo.code : null,
-            shippingMethod: shipping.toPricingDescriptor(
-                selectedMethod,
-                defaultMethod,
-            ),
+            shippingMethod: delivery.selected,
         });
 
         const verification = pricing.verifyClaimedTotal(
@@ -386,7 +410,7 @@ const createOrderService = async (connection, orderData) => {
             "pending",
             breakdown.subtotal,
             breakdown.tax,
-            selectedMethod.code,
+            delivery.selected.code,
             breakdown.shipping,
             discountAmount,
             appliedPromoCode,

--- a/backend/services/pricing.service.js
+++ b/backend/services/pricing.service.js
@@ -142,21 +142,24 @@ const calculateTax = (taxableBase) =>
 /**
  * Shipping due on a post-discount subtotal for a chosen delivery method.
  *
- * The charge is the method's own rate. A waiver — the free-shipping threshold,
- * or a `free_shipping` promo — covers `waiverRate` of it and no more, which is
- * what "free shipping" has always meant here: the store absorbs the standard
- * cost of delivery. A shopper who has earned it and then upgrades to a faster
- * option pays the difference rather than nothing at all.
+ * The charge is the rate the caller resolved for the chosen option. A waiver —
+ * a rule the basket satisfies, or a `free_shipping` promo — covers
+ * `waiverRate` of it and no more, which is what "free shipping" has always
+ * meant here: the store absorbs the standard cost of delivery. A shopper who
+ * has earned it and then upgrades to a faster option pays the difference
+ * rather than nothing at all.
  *
- * With no method supplied both rates fall back to the flat rate, which
- * reproduces the pre-#1430 figure exactly: nothing below the threshold, free
- * at or above it. That is what lets a caller that does not offer a choice keep
- * pricing baskets the way it always has.
+ * Whether a waiver has been earned is the caller's to decide, because since
+ * the rate rules landed the free-shipping threshold is a rule like any other
+ * and can depend on more than basket value. A caller that expresses no opinion
+ * gets the configured threshold instead, which reproduces the pre-#1430
+ * figure exactly: nothing below it, free at or above it. That is what lets a
+ * caller with no rules to hand keep pricing baskets the way it always has.
  *
  * An empty basket never attracts a shipping charge.
  *
  * @param {number} postDiscountSubtotal
- * @param {{ isShippingWaived?: boolean, methodRate?: number, waiverRate?: number }} [options]
+ * @param {{ isShippingWaived?: boolean, isWaiverEarned?: boolean, methodRate?: number, waiverRate?: number }} [options]
  * @returns {number}
  */
 const calculateShipping = (postDiscountSubtotal, options = {}) => {
@@ -175,7 +178,10 @@ const calculateShipping = (postDiscountSubtotal, options = {}) => {
         ),
     );
 
-    const isEarned = base >= PRICING_CONFIG.FREE_SHIPPING_THRESHOLD;
+    const isEarned =
+        options.isWaiverEarned === undefined
+            ? base >= PRICING_CONFIG.FREE_SHIPPING_THRESHOLD
+            : Boolean(options.isWaiverEarned);
 
     if (!options.isShippingWaived && !isEarned) {
         return rate;
@@ -204,8 +210,9 @@ const calculateShipping = (postDiscountSubtotal, options = {}) => {
  * @param {Object|null} [input.promo] - validated promo descriptor, if any
  * @param {string|null} [input.promoCode] - code to echo back on the breakdown
  * @param {Object|null} [input.shippingMethod] - resolved delivery method,
- *        carrying its own `rate` and the `waiverRate` free shipping covers.
- *        Omitted, the flat rate applies, which is what every caller got before
+ *        carrying the `rate` the rules produced for it, how much of that a
+ *        waiver covers, and whether one was earned. Omitted, the flat rate and
+ *        the configured threshold apply, which is what every caller got before
  *        there was a choice of delivery.
  * @returns {Object} breakdown
  */
@@ -222,6 +229,7 @@ const quote = ({
     const tax = calculateTax(taxableBase);
     const shipping = calculateShipping(taxableBase, {
         isShippingWaived: discount.isShippingWaived,
+        isWaiverEarned: shippingMethod?.isWaiverEarned,
         methodRate: shippingMethod?.rate,
         waiverRate: shippingMethod?.waiverRate,
     });

--- a/backend/services/shipping.service.js
+++ b/backend/services/shipping.service.js
@@ -1,10 +1,12 @@
 // Delivery options: what may be offered, and what each one costs (#1430).
 //
-// This is the only place that reads `shipping_methods`, and the only place
-// that turns a code the client sent into a rate. The pricing engine does the
-// arithmetic and knows nothing about the database; this module does the
-// lookup and knows nothing about the arithmetic. That split is what keeps the
-// charge server-computed: a request body can name a method, and nothing else.
+// This is the only place that reads `shipping_methods` and `shipping_rate_
+// rules`, and the only place that turns a code the client sent into a rate.
+// Three modules meet here and none of them overlaps: shippingRates.service
+// matches rules and knows no SQL, pricing.service does the money arithmetic
+// and knows neither, and this module does the lookups. That split is what
+// keeps the charge server-computed — a request body can name a method and a
+// destination, and nothing else.
 //
 // Every read is defensive in the same way `order.service.resolveItemVariant`
 // is: a deployment that has not applied the migration, or a reference table
@@ -16,6 +18,8 @@ const db = require("../config/db");
 const logger = require("../utils/logger");
 const { safeArray, safeInteger, safeNumber, sanitizeString } = require("../utils/helpers");
 const pricing = require("./pricing.service");
+const rates = require("./shippingRates.service");
+const Pincode = require("../models/Pincode");
 const SHIPPING_CONFIG = require("../config/shippingConfig");
 
 // Marks a code the client sent that names no active method, so controllers can
@@ -23,6 +27,7 @@ const SHIPPING_CONFIG = require("../config/shippingConfig");
 const UNKNOWN_METHOD_CODE = "SHIPPING_METHOD_UNKNOWN";
 
 let cache = null;
+let rulesCache = null;
 
 const toMethod = (row) => ({
     code: sanitizeString(row.code),
@@ -81,6 +86,106 @@ const listMethods = () => {
     return methods;
 };
 
+const readRules = async () => {
+    try {
+        const [rows] = await db.query(
+            `SELECT id, name, method_code, destination_scope, destination_value,
+                    min_weight_kg, max_weight_kg, min_order_value, max_order_value,
+                    effect, amount, priority
+               FROM shipping_rate_rules
+              WHERE is_active = 1
+              ORDER BY priority ASC, id ASC`,
+        );
+
+        return safeArray(rows).map(rates.toRule);
+    } catch (error) {
+        // No rules is a valid configuration — it means every option costs its
+        // own rate — so an unreadable table degrades to flat pricing rather
+        // than to a failed checkout.
+        logger.warn(`Shipping rate rules could not be read: ${error.message}`);
+        return [];
+    }
+};
+
+/**
+ * The active rate rules. Cached on the same terms as the options themselves.
+ *
+ * @returns {Promise<Array<Object>>}
+ */
+const listRules = () => {
+    if (rulesCache && Date.now() < rulesCache.expiresAt) {
+        return rulesCache.rules;
+    }
+
+    const rules = readRules();
+
+    rulesCache = {
+        rules,
+        expiresAt: Date.now() + SHIPPING_CONFIG.CACHE_TTL_MS,
+    };
+
+    return rules;
+};
+
+/**
+ * Fill in the city and state a pincode resolves to.
+ *
+ * Destination rules are written against what `serviceable_pincodes` already
+ * knows, so this is the one translation between "the shopper typed six digits"
+ * and "the rule says Maharashtra". A pincode the store does not serve resolves
+ * to nothing, and rules scoped to a place then simply do not match.
+ *
+ * @param {{ pincode?: string, city?: string, state?: string }} [destination]
+ * @returns {Promise<{ pincode: string|null, city: string|null, state: string|null }>}
+ */
+const resolveDestination = async (destination = {}) => {
+    const pincode = sanitizeString(destination.pincode || destination.zip);
+    const resolved = {
+        pincode: pincode || null,
+        city: sanitizeString(destination.city) || null,
+        state: sanitizeString(destination.state) || null,
+    };
+
+    if (!pincode || (resolved.city && resolved.state)) {
+        return resolved;
+    }
+
+    try {
+        const [row] = safeArray(await Pincode.findByCode(pincode));
+
+        if (row) {
+            // The serviceability record wins over anything the client typed:
+            // a rule that says "Maharashtra" must not be dodged by claiming a
+            // Mumbai pincode is somewhere else.
+            resolved.city = sanitizeString(row.city) || resolved.city;
+            resolved.state = sanitizeString(row.state) || resolved.state;
+        }
+    } catch (error) {
+        logger.warn(`Destination ${pincode} could not be resolved: ${error.message}`);
+    }
+
+    return resolved;
+};
+
+/**
+ * How heavy a basket is, in kilograms.
+ *
+ * Products carry a weight and most of them have never had one set. A missing
+ * weight becomes the configured per-unit default rather than zero, because a
+ * weightless parcel would fall in the lightest band of every weight rule and
+ * quietly under-charge the whole catalogue.
+ *
+ * @param {Array<Object>} lines - priced lines carrying `weight` and `qty`
+ * @returns {number}
+ */
+const basketWeightKg = (lines) =>
+    safeArray(lines).reduce((total, line) => {
+        const unit = safeNumber(line?.weight, 0) || SHIPPING_CONFIG.DEFAULT_ITEM_WEIGHT_KG;
+        const qty = Math.max(1, safeInteger(line?.qty, 1));
+
+        return total + unit * qty;
+    }, 0);
+
 /**
  * The option a checkout gets when it does not choose one.
  *
@@ -137,23 +242,52 @@ const resolveMethod = async (requestedCode) => {
 };
 
 /**
- * The descriptor the pricing engine takes.
+ * The descriptor the pricing engine takes, for one option and one basket.
  *
- * `waiverRate` is how much of this method's rate a free-shipping entitlement
- * covers, and it is the *default* method's rate for every option. Free
- * shipping means the store absorbs the standard cost of delivery, so a shopper
- * who has earned it and then upgrades pays the difference rather than nothing.
+ * `rate` is what the rules made of the option's own rate. `waiverRate` is how
+ * much of that a waiver covers, and it is the better of two entitlements: what
+ * a matching waive rule states, and — when a `free_shipping` promo is in play —
+ * the *default* option's rate. Free shipping means the store absorbs the
+ * standard cost of delivery, so a shopper who has earned it and then upgrades
+ * pays the difference rather than nothing.
  *
- * @param {Object} method
- * @param {Object} defaultMethod
+ * @param {Object} input
+ * @param {Object} input.method
+ * @param {Object} input.defaultMethod
+ * @param {Array<Object>} input.rules
+ * @param {Object} input.context - the basket, as `shippingRates.matches` takes it
+ * @param {boolean} [input.isShippingWaived]
  * @returns {Object}
  */
-const toPricingDescriptor = (method, defaultMethod) => ({
-    code: method.code,
-    label: method.label,
-    rate: method.rate,
-    waiverRate: defaultMethod ? defaultMethod.rate : method.rate,
-});
+const toPricingDescriptor = ({
+    method,
+    defaultMethod,
+    rules = [],
+    context = {},
+    isShippingWaived = false,
+} = {}) => {
+    const defaultRate = defaultMethod ? defaultMethod.rate : method.rate;
+
+    const applied = rates.applyRules({
+        rules,
+        baseRate: method.rate,
+        defaultRate,
+        context: { ...context, methodCode: method.code },
+    });
+
+    const waiverRate = Math.max(
+        applied.isWaiverEarned ? applied.waiverAmount : 0,
+        isShippingWaived ? defaultRate : 0,
+    );
+
+    return {
+        code: method.code,
+        label: method.label,
+        rate: applied.rate,
+        waiverRate,
+        isWaiverEarned: waiverRate > 0,
+    };
+};
 
 /**
  * Price every option for one basket.
@@ -163,25 +297,51 @@ const toPricingDescriptor = (method, defaultMethod) => ({
  * actually be charged -- including the case where a waiver makes two options
  * cost the same.
  *
+ * The destination is taken on trust for a quote and re-resolved from the order
+ * itself when the order is placed, so a client that names a cheaper pincode
+ * than it ships to gets a quote that the order path then refuses as a total
+ * mismatch.
+ *
  * @param {Object} input
  * @param {number} input.postDiscountSubtotal
  * @param {boolean} [input.isShippingWaived] a free_shipping promo is applied
  * @param {any} [input.selectedCode] the option the shopper picked, if any
- * @returns {Promise<{ selected: Object, options: Array<Object> }>}
+ * @param {Object} [input.destination] pincode, and city/state if already known
+ * @param {number} [input.weightKg]
+ * @returns {Promise<{ selected: Object, options: Array<Object>, freeShipping: Object|null }>}
  */
 const quoteOptions = async ({
     postDiscountSubtotal,
     isShippingWaived = false,
     selectedCode = null,
+    destination = null,
+    weightKg = 0,
 } = {}) => {
-    const [methods, defaultMethod, selected] = await Promise.all([
+    const [methods, defaultMethod, selected, rules, place] = await Promise.all([
         listMethods(),
         getDefaultMethod(),
         resolveMethod(selectedCode),
+        listRules(),
+        resolveDestination(destination || {}),
     ]);
 
+    const context = {
+        orderValue: safeNumber(postDiscountSubtotal),
+        weightKg: safeNumber(weightKg),
+        destination: place,
+    };
+
+    const describe = (method) =>
+        toPricingDescriptor({
+            method,
+            defaultMethod,
+            rules,
+            context,
+            isShippingWaived,
+        });
+
     const options = methods.map((method) => {
-        const descriptor = toPricingDescriptor(method, defaultMethod);
+        const descriptor = describe(method);
 
         return {
             code: method.code,
@@ -191,31 +351,53 @@ const quoteOptions = async ({
             isSelected: method.code === selected.code,
             cost: pricing.calculateShipping(postDiscountSubtotal, {
                 isShippingWaived,
+                isWaiverEarned: descriptor.isWaiverEarned,
                 methodRate: descriptor.rate,
                 waiverRate: descriptor.waiverRate,
             }),
         };
     });
 
+    // Reported against the default option, because that is the one a threshold
+    // is understood to be about. A shopper is told what free delivery would
+    // cover, not what an upgrade would still cost on top of it.
+    const progress = rates.freeShippingProgress({
+        rules,
+        context: { ...context, methodCode: defaultMethod.code },
+    });
+
     return {
-        selected: toPricingDescriptor(selected, defaultMethod),
+        selected: describe(selected),
         options,
+        // The rule's own name is internal wording for operators and is left
+        // behind here; the shopper is shown the figures.
+        freeShipping: progress
+            ? {
+                  threshold: progress.threshold,
+                  remaining: progress.remaining,
+                  qualified: progress.qualified,
+              }
+            : null,
     };
 };
 
 /**
- * Drop the cached options. Used by tests, and by anything that changes a rate
- * and needs the change to be visible immediately.
+ * Drop the cached options and rules. Used by tests, and by anything that
+ * changes a rate and needs the change to be visible immediately.
  */
 const clearCache = () => {
     cache = null;
+    rulesCache = null;
 };
 
 module.exports = {
     UNKNOWN_METHOD_CODE,
     listMethods,
+    listRules,
     getDefaultMethod,
     resolveMethod,
+    resolveDestination,
+    basketWeightKg,
     toPricingDescriptor,
     quoteOptions,
     clearCache,

--- a/backend/services/shippingRates.service.js
+++ b/backend/services/shippingRates.service.js
@@ -1,0 +1,264 @@
+// How a delivery rate is derived from rules (#1430).
+//
+// Everything here is pure: no database, no logger, no clock. Loading the rules
+// belongs to shipping.service because it needs the database; this module only
+// takes the already-loaded rules and a description of the basket and does the
+// matching and the arithmetic. That split is the same one pricing.service and
+// promo.service already use, and it is what makes the rules testable on their
+// own — rate selection is the part of this that is worth getting wrong loudly.
+//
+// The order of application is fixed and named, because it is the thing every
+// figure depends on and the thing a reader will otherwise have to infer from
+// the order of statements:
+//
+//   1. start at the option's own rate
+//   2. the winning `set_rate` rule replaces it
+//   3. every matching `surcharge` adds to it
+//   4. the largest matching `waive` comes off, floored at zero
+//
+// Surcharges accumulate and waivers do not, deliberately. Two reasons to
+// charge more are two costs; two reasons to charge nothing are still one
+// delivery.
+
+const { safeArray, safeNumber, sanitizeString } = require("../utils/helpers");
+
+const APPLICATION_ORDER = Object.freeze([
+    "set_rate",
+    "surcharge",
+    "waive",
+]);
+
+const EFFECTS = Object.freeze({
+    SET_RATE: "set_rate",
+    SURCHARGE: "surcharge",
+    WAIVE: "waive",
+});
+
+const DESTINATION_SCOPES = Object.freeze({
+    ANY: "any",
+    PINCODE: "pincode",
+    CITY: "city",
+    STATE: "state",
+});
+
+const round = (value) => Math.round((safeNumber(value) + Number.EPSILON) * 100) / 100;
+
+const normalise = (value) => sanitizeString(value).toLowerCase();
+
+/**
+ * Turn a database row into the shape the matcher works with.
+ *
+ * @param {Object} row
+ * @returns {Object}
+ */
+const toRule = (row) => ({
+    id: row.id,
+    name: sanitizeString(row.name),
+    methodCode: row.method_code ? sanitizeString(row.method_code) : null,
+    destinationScope: sanitizeString(row.destination_scope) || DESTINATION_SCOPES.ANY,
+    destinationValue: row.destination_value ? sanitizeString(row.destination_value) : null,
+    minWeightKg: row.min_weight_kg === null ? null : safeNumber(row.min_weight_kg),
+    maxWeightKg: row.max_weight_kg === null ? null : safeNumber(row.max_weight_kg),
+    minOrderValue: row.min_order_value === null ? null : safeNumber(row.min_order_value),
+    maxOrderValue: row.max_order_value === null ? null : safeNumber(row.max_order_value),
+    effect: sanitizeString(row.effect),
+    // NULL is meaningful on a waiver — "cover the standard rate" — so it is
+    // preserved rather than coerced to zero, which would waive nothing.
+    amount: row.amount === null || row.amount === undefined ? null : safeNumber(row.amount),
+    priority: safeNumber(row.priority),
+});
+
+/**
+ * Does a half-open window contain a value? Minimum inclusive, maximum
+ * exclusive, so bands written back to back neither overlap nor leave a gap.
+ */
+const isWithin = (value, min, max) => {
+    if (min !== null && min !== undefined && value < min) return false;
+    if (max !== null && max !== undefined && value >= max) return false;
+    return true;
+};
+
+/**
+ * Does the rule's destination condition hold?
+ *
+ * A rule scoped to a place does not match a basket whose destination is not
+ * yet known, which happens on the cart page before an address is entered. That
+ * is the safe direction for both effects: an unknown destination is quoted
+ * without the surcharge it might attract *and* without the waiver it might
+ * earn, and the order path re-prices against the address the parcel is
+ * actually going to.
+ */
+const matchesDestination = (rule, destination) => {
+    if (rule.destinationScope === DESTINATION_SCOPES.ANY) {
+        return true;
+    }
+
+    const target = normalise(rule.destinationValue);
+
+    if (!target) {
+        return false;
+    }
+
+    const place = destination || {};
+
+    if (rule.destinationScope === DESTINATION_SCOPES.PINCODE) {
+        return normalise(place.pincode) === target;
+    }
+
+    if (rule.destinationScope === DESTINATION_SCOPES.CITY) {
+        return normalise(place.city) === target;
+    }
+
+    return normalise(place.state) === target;
+};
+
+/**
+ * Does the rule apply to this basket, going to this place, by this option?
+ *
+ * @param {Object} rule
+ * @param {Object} context
+ * @param {string} context.methodCode
+ * @param {number} context.orderValue - post-discount subtotal
+ * @param {number} context.weightKg
+ * @param {{ pincode?: string, city?: string, state?: string }} [context.destination]
+ * @returns {boolean}
+ */
+const matches = (rule, context = {}) => {
+    if (rule.methodCode && rule.methodCode !== context.methodCode) {
+        return false;
+    }
+
+    if (!isWithin(safeNumber(context.weightKg), rule.minWeightKg, rule.maxWeightKg)) {
+        return false;
+    }
+
+    if (!isWithin(safeNumber(context.orderValue), rule.minOrderValue, rule.maxOrderValue)) {
+        return false;
+    }
+
+    return matchesDestination(rule, context.destination);
+};
+
+/**
+ * Derive the rate for one delivery option.
+ *
+ * The waiver is reported separately from the rate rather than already
+ * subtracted, because the pricing engine owns the subtraction and a
+ * `free_shipping` promo produces a waiver by another route entirely. Reporting
+ * both lets the two meet in one place.
+ *
+ * @param {Object} input
+ * @param {Array<Object>} input.rules - normalised rules, any order
+ * @param {number} input.baseRate - the option's own rate
+ * @param {number} input.defaultRate - the default option's rate, which is what
+ *        a waiver with no stated amount covers
+ * @param {Object} input.context - see `matches`
+ * @returns {{ rate: number, waiverAmount: number, isWaiverEarned: boolean, appliedRules: Array<Object> }}
+ */
+const applyRules = ({ rules = [], baseRate = 0, defaultRate = 0, context = {} } = {}) => {
+    const applicable = safeArray(rules)
+        .filter((rule) => matches(rule, context))
+        .sort((a, b) => a.priority - b.priority);
+
+    const appliedRules = [];
+
+    let rate = round(baseRate);
+
+    const override = applicable.find((rule) => rule.effect === EFFECTS.SET_RATE);
+
+    if (override) {
+        rate = round(override.amount);
+        appliedRules.push(override);
+    }
+
+    for (const rule of applicable) {
+        if (rule.effect === EFFECTS.SURCHARGE) {
+            rate = round(rate + safeNumber(rule.amount));
+            appliedRules.push(rule);
+        }
+    }
+
+    let waiverAmount = 0;
+    let waiver = null;
+
+    for (const rule of applicable) {
+        if (rule.effect !== EFFECTS.WAIVE) continue;
+
+        const covers = rule.amount === null ? round(defaultRate) : round(rule.amount);
+
+        if (covers > waiverAmount || waiver === null) {
+            waiverAmount = covers;
+            waiver = rule;
+        }
+    }
+
+    if (waiver) {
+        appliedRules.push(waiver);
+    }
+
+    return {
+        rate: Math.max(0, rate),
+        waiverAmount: Math.max(0, waiverAmount),
+        isWaiverEarned: Boolean(waiver),
+        appliedRules,
+    };
+};
+
+/**
+ * How far this basket is from earning free delivery.
+ *
+ * Only value thresholds can be reported this way: "spend 200 more" is
+ * actionable, and "live somewhere else" is not. The nearest unearned threshold
+ * is the one reported, because telling a shopper about a 5000 threshold while
+ * they are 50 short of a 999 one is worse than saying nothing.
+ *
+ * @param {Object} input - as `applyRules`, minus the rates
+ * @returns {{ threshold: number, remaining: number, qualified: boolean, name: string }|null}
+ */
+const freeShippingProgress = ({ rules = [], context = {} } = {}) => {
+    const orderValue = safeNumber(context.orderValue);
+
+    const thresholds = safeArray(rules).filter(
+        (rule) =>
+            rule.effect === EFFECTS.WAIVE &&
+            rule.minOrderValue !== null &&
+            rule.minOrderValue > 0 &&
+            // Matched with the value condition lifted, so a basket that is
+            // short of the threshold still hears about it. Every other
+            // condition still has to hold: a threshold that only applies to
+            // one state must not be dangled in front of the whole country.
+            matches(
+                { ...rule, minOrderValue: null, maxOrderValue: null },
+                context,
+            ),
+    );
+
+    if (thresholds.length === 0) {
+        return null;
+    }
+
+    const unearned = thresholds.filter((rule) => orderValue < rule.minOrderValue);
+
+    const target = unearned.length
+        ? unearned.reduce((a, b) => (a.minOrderValue <= b.minOrderValue ? a : b))
+        : thresholds.reduce((a, b) => (a.minOrderValue >= b.minOrderValue ? a : b));
+
+    const qualified = orderValue >= target.minOrderValue;
+
+    return {
+        name: target.name,
+        threshold: round(target.minOrderValue),
+        remaining: qualified ? 0 : round(target.minOrderValue - orderValue),
+        qualified,
+    };
+};
+
+module.exports = {
+    APPLICATION_ORDER,
+    EFFECTS,
+    DESTINATION_SCOPES,
+    toRule,
+    matches,
+    applyRules,
+    freeShippingProgress,
+};

--- a/backend/tests/shipping.service.test.js
+++ b/backend/tests/shipping.service.test.js
@@ -11,6 +11,10 @@
 //   * free shipping covers the standard rate and no more, so upgrading on top
 //     of an earned waiver still costs the difference;
 //   * nothing on the request side of the boundary carries a rate.
+//
+// The threshold itself is a rate rule now rather than a constant in the
+// engine, so it is seeded into the rules the fixture serves. Its selection is
+// covered on its own in shippingRates.test.js.
 
 jest.mock('../config/db', () => ({
     query: jest.fn()
@@ -47,12 +51,31 @@ const EXPRESS = {
     sort_order: 20
 };
 
+// The threshold as migration 0037 seeds it: a waiver over basket value, with
+// no stated amount, so it covers whatever the default option costs.
+const THRESHOLD_RULE = {
+    id: 1,
+    name: 'Free delivery over 999',
+    method_code: null,
+    destination_scope: 'any',
+    destination_value: null,
+    min_weight_kg: null,
+    max_weight_kg: null,
+    min_order_value: PRICING_CONFIG.FREE_SHIPPING_THRESHOLD,
+    max_order_value: null,
+    effect: 'waive',
+    amount: null,
+    priority: 100
+};
+
 // Comfortably under the free-shipping threshold, so a charge actually applies.
 const SMALL_BASKET = 500;
 const LARGE_BASKET = PRICING_CONFIG.FREE_SHIPPING_THRESHOLD + 1;
 
-function offering(rows) {
-    db.query.mockResolvedValue([rows]);
+function offering(methods, rules = [THRESHOLD_RULE]) {
+    db.query.mockImplementation(async (sql) =>
+        /shipping_rate_rules/.test(sql) ? [rules] : [methods]
+    );
 }
 
 beforeEach(() => {
@@ -205,7 +228,8 @@ describe('the pricing descriptor handed across the boundary', () => {
             code: 'express',
             label: 'Express delivery',
             rate: 149,
-            waiverRate: 49
+            waiverRate: 0,
+            isWaiverEarned: false
         });
     });
 
@@ -217,5 +241,92 @@ describe('the pricing descriptor handed across the boundary', () => {
 
         expect(options.map((option) => option.isSelected)).toEqual([false, true]);
         expect(options.map((option) => option.isDefault)).toEqual([true, false]);
+    });
+});
+
+describe('rules reaching the quote', () => {
+    it('tells the shopper how far short of free delivery they are', async () => {
+        const { freeShipping } = await shipping.quoteOptions({
+            postDiscountSubtotal: 799
+        });
+
+        expect(freeShipping).toEqual({
+            threshold: PRICING_CONFIG.FREE_SHIPPING_THRESHOLD,
+            remaining: 200,
+            qualified: false
+        });
+    });
+
+    it('keeps the rule\'s internal name out of the response', async () => {
+        const { freeShipping } = await shipping.quoteOptions({
+            postDiscountSubtotal: 799
+        });
+
+        expect(freeShipping).not.toHaveProperty('name');
+    });
+
+    it('surcharges by weight when a rule says so', async () => {
+        offering([STANDARD, EXPRESS], [
+            {
+                ...THRESHOLD_RULE,
+                id: 2,
+                name: 'Heavy parcel',
+                min_order_value: null,
+                min_weight_kg: 5,
+                effect: 'surcharge',
+                amount: 60,
+                priority: 50
+            }
+        ]);
+        shipping.clearCache();
+
+        const light = await shipping.quoteOptions({
+            postDiscountSubtotal: SMALL_BASKET,
+            weightKg: 2
+        });
+        const heavy = await shipping.quoteOptions({
+            postDiscountSubtotal: SMALL_BASKET,
+            weightKg: 8
+        });
+
+        expect(light.options[0].cost).toBe(49);
+        expect(heavy.options[0].cost).toBe(109);
+    });
+
+    it('falls back to flat rates when the rules cannot be read', async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/shipping_rate_rules/.test(sql)) {
+                throw new Error('Table shipping_rate_rules does not exist');
+            }
+            return [[STANDARD, EXPRESS]];
+        });
+        shipping.clearCache();
+
+        const { options, freeShipping } = await shipping.quoteOptions({
+            postDiscountSubtotal: LARGE_BASKET
+        });
+
+        // No rules means no waiver: the options cost what they cost. Charging
+        // is the safe direction — the alternative is giving delivery away
+        // because a table could not be read.
+        expect(options.map((option) => option.cost)).toEqual([49, 149]);
+        expect(freeShipping).toBeNull();
+    });
+});
+
+describe('basket weight', () => {
+    it('assumes a weight for products that have none recorded', () => {
+        expect(
+            shipping.basketWeightKg([{ weight: null, qty: 2 }])
+        ).toBe(SHIPPING_CONFIG.DEFAULT_ITEM_WEIGHT_KG * 2);
+    });
+
+    it('counts each unit of a line', () => {
+        expect(shipping.basketWeightKg([{ weight: 1.5, qty: 3 }])).toBe(4.5);
+    });
+
+    it('is zero for an empty basket', () => {
+        expect(shipping.basketWeightKg([])).toBe(0);
+        expect(shipping.basketWeightKg(null)).toBe(0);
     });
 });

--- a/backend/tests/shippingRates.test.js
+++ b/backend/tests/shippingRates.test.js
@@ -1,0 +1,312 @@
+// backend/tests/shippingRates.test.js
+//
+// Shipping rate rules (#1430).
+//
+// Rule selection is the part of delivery pricing that is worth getting wrong
+// loudly: a rule that matches when it should not undercharges every order it
+// touches, and one that fails to match overcharges them. The module is pure,
+// so nothing is mocked here.
+//
+// What these pin:
+//
+//   * an unstated condition matches everything, and a stated one must hold;
+//   * weight and value bands are half-open, so bands written back to back
+//     neither overlap nor leave a gap;
+//   * surcharges accumulate and waivers do not;
+//   * one set_rate wins, by priority, and the rest are ignored;
+//   * a rule scoped to a place does not fire when the place is unknown;
+//   * the free-shipping threshold is reported against the basket, including
+//     how far short of it the shopper is.
+
+const {
+    EFFECTS,
+    toRule,
+    matches,
+    applyRules,
+    freeShippingProgress
+} = require('../services/shippingRates.service');
+
+const STANDARD_RATE = 49;
+const EXPRESS_RATE = 149;
+
+// A row as the database hands it over, so the normaliser is exercised too.
+function rule(overrides = {}) {
+    return toRule({
+        id: 1,
+        name: 'Rule',
+        method_code: null,
+        destination_scope: 'any',
+        destination_value: null,
+        min_weight_kg: null,
+        max_weight_kg: null,
+        min_order_value: null,
+        max_order_value: null,
+        effect: EFFECTS.SURCHARGE,
+        amount: 0,
+        priority: 100,
+        ...overrides
+    });
+}
+
+function context(overrides = {}) {
+    return {
+        methodCode: 'standard',
+        orderValue: 500,
+        weightKg: 1,
+        destination: { pincode: '400001', city: 'Mumbai', state: 'Maharashtra' },
+        ...overrides
+    };
+}
+
+function priceStandard(rules, ctx = context()) {
+    return applyRules({
+        rules,
+        baseRate: STANDARD_RATE,
+        defaultRate: STANDARD_RATE,
+        context: ctx
+    });
+}
+
+describe('matching', () => {
+    it('matches everything a rule does not mention', () => {
+        expect(matches(rule(), context())).toBe(true);
+    });
+
+    it('honours the option a rule is scoped to', () => {
+        const expressOnly = rule({ method_code: 'express' });
+
+        expect(matches(expressOnly, context({ methodCode: 'express' }))).toBe(true);
+        expect(matches(expressOnly, context({ methodCode: 'standard' }))).toBe(false);
+    });
+
+    it('matches a destination by pincode, city or state', () => {
+        expect(
+            matches(
+                rule({ destination_scope: 'pincode', destination_value: '400001' }),
+                context()
+            )
+        ).toBe(true);
+        expect(
+            matches(
+                rule({ destination_scope: 'city', destination_value: 'mumbai' }),
+                context()
+            )
+        ).toBe(true);
+        expect(
+            matches(
+                rule({ destination_scope: 'state', destination_value: 'MAHARASHTRA' }),
+                context()
+            )
+        ).toBe(true);
+    });
+
+    it('does not fire a placed rule when the destination is unknown', () => {
+        // The cart page has no address. Quoting a surcharge that might not
+        // apply, or a waiver that might not be earned, would both be a figure
+        // the order path then contradicts.
+        const scoped = rule({ destination_scope: 'state', destination_value: 'Kerala' });
+
+        expect(matches(scoped, context({ destination: null }))).toBe(false);
+        expect(matches(scoped, context({ destination: {} }))).toBe(false);
+    });
+
+    it('treats weight bands as half-open', () => {
+        const band = rule({ min_weight_kg: 1, max_weight_kg: 5 });
+
+        expect(matches(band, context({ weightKg: 0.999 }))).toBe(false);
+        expect(matches(band, context({ weightKg: 1 }))).toBe(true);
+        expect(matches(band, context({ weightKg: 4.999 }))).toBe(true);
+        // Exclusive at the top, so a 5kg parcel belongs to the next band up and
+        // not to both.
+        expect(matches(band, context({ weightKg: 5 }))).toBe(false);
+    });
+
+    it('treats value bands as half-open', () => {
+        const band = rule({ min_order_value: 999 });
+
+        expect(matches(band, context({ orderValue: 998.99 }))).toBe(false);
+        expect(matches(band, context({ orderValue: 999 }))).toBe(true);
+    });
+
+    it('leaves an unbounded side unbounded', () => {
+        const heavy = rule({ min_weight_kg: 10 });
+
+        expect(matches(heavy, context({ weightKg: 1000 }))).toBe(true);
+    });
+});
+
+describe('applying rules to a rate', () => {
+    it('charges the option\'s own rate when nothing matches', () => {
+        expect(priceStandard([]).rate).toBe(STANDARD_RATE);
+    });
+
+    it('accumulates every matching surcharge', () => {
+        // Two reasons to charge more are two costs. A remote destination does
+        // not become free because the parcel is also heavy.
+        const applied = priceStandard([
+            rule({ id: 1, effect: EFFECTS.SURCHARGE, amount: 30, min_weight_kg: 0.5 }),
+            rule({
+                id: 2,
+                effect: EFFECTS.SURCHARGE,
+                amount: 20,
+                destination_scope: 'state',
+                destination_value: 'Maharashtra'
+            })
+        ]);
+
+        expect(applied.rate).toBe(STANDARD_RATE + 50);
+        expect(applied.appliedRules).toHaveLength(2);
+    });
+
+    it('lets one set_rate replace the rate, lowest priority number winning', () => {
+        const applied = priceStandard([
+            rule({ id: 1, effect: EFFECTS.SET_RATE, amount: 200, priority: 50 }),
+            rule({ id: 2, effect: EFFECTS.SET_RATE, amount: 300, priority: 10 })
+        ]);
+
+        expect(applied.rate).toBe(300);
+        expect(applied.appliedRules.map((r) => r.id)).toEqual([2]);
+    });
+
+    it('applies surcharges on top of a replaced rate', () => {
+        const applied = priceStandard([
+            rule({ id: 1, effect: EFFECTS.SET_RATE, amount: 200, priority: 10 }),
+            rule({ id: 2, effect: EFFECTS.SURCHARGE, amount: 25 })
+        ]);
+
+        expect(applied.rate).toBe(225);
+    });
+
+    it('takes the largest waiver rather than stacking them', () => {
+        // Two reasons to charge nothing are still one delivery. Summing them
+        // would let a store owe money on the shipping line.
+        const applied = priceStandard([
+            rule({ id: 1, effect: EFFECTS.WAIVE, amount: 20, min_order_value: 100 }),
+            rule({ id: 2, effect: EFFECTS.WAIVE, amount: 40, min_order_value: 200 })
+        ]);
+
+        expect(applied.waiverAmount).toBe(40);
+        expect(applied.isWaiverEarned).toBe(true);
+        expect(applied.appliedRules.map((r) => r.id)).toEqual([2]);
+    });
+
+    it('reads a waiver with no stated amount as the standard cost of delivery', () => {
+        // This is the free-shipping threshold. It covers what the default
+        // option costs, which is why an upgrade still costs its difference.
+        const applied = applyRules({
+            rules: [rule({ effect: EFFECTS.WAIVE, amount: null, min_order_value: 100 })],
+            baseRate: EXPRESS_RATE,
+            defaultRate: STANDARD_RATE,
+            context: context({ methodCode: 'express', orderValue: 1000 })
+        });
+
+        expect(applied.rate).toBe(EXPRESS_RATE);
+        expect(applied.waiverAmount).toBe(STANDARD_RATE);
+    });
+
+    it('reports no waiver when the basket has not earned one', () => {
+        const applied = priceStandard(
+            [rule({ effect: EFFECTS.WAIVE, amount: null, min_order_value: 999 })],
+            context({ orderValue: 500 })
+        );
+
+        expect(applied.isWaiverEarned).toBe(false);
+        expect(applied.waiverAmount).toBe(0);
+    });
+
+    it('never returns a negative rate', () => {
+        const applied = priceStandard([
+            rule({ effect: EFFECTS.SET_RATE, amount: 0, priority: 10 })
+        ]);
+
+        expect(applied.rate).toBe(0);
+    });
+});
+
+describe('progress toward free delivery', () => {
+    const threshold = rule({
+        name: 'Free delivery over 999',
+        effect: EFFECTS.WAIVE,
+        amount: null,
+        min_order_value: 999
+    });
+
+    it('reports how much further the basket has to go', () => {
+        expect(
+            freeShippingProgress({
+                rules: [threshold],
+                context: context({ orderValue: 799 })
+            })
+        ).toEqual({
+            name: 'Free delivery over 999',
+            threshold: 999,
+            remaining: 200,
+            qualified: false
+        });
+    });
+
+    it('reports the threshold as met once it is', () => {
+        expect(
+            freeShippingProgress({
+                rules: [threshold],
+                context: context({ orderValue: 1200 })
+            })
+        ).toMatchObject({ remaining: 0, qualified: true });
+    });
+
+    it('reports the nearest unearned threshold, not the largest', () => {
+        // Telling a shopper about a 5000 threshold while they are 50 short of
+        // a 999 one is worse than saying nothing.
+        const progress = freeShippingProgress({
+            rules: [
+                threshold,
+                rule({ id: 2, effect: EFFECTS.WAIVE, amount: null, min_order_value: 5000 })
+            ],
+            context: context({ orderValue: 949 })
+        });
+
+        expect(progress.threshold).toBe(999);
+        expect(progress.remaining).toBe(50);
+    });
+
+    it('says nothing when no threshold applies', () => {
+        expect(
+            freeShippingProgress({ rules: [], context: context() })
+        ).toBeNull();
+
+        // A waiver that is not about basket value is not progress anybody can
+        // make, so it is not reported as such.
+        expect(
+            freeShippingProgress({
+                rules: [
+                    rule({
+                        effect: EFFECTS.WAIVE,
+                        amount: null,
+                        destination_scope: 'state',
+                        destination_value: 'Maharashtra'
+                    })
+                ],
+                context: context()
+            })
+        ).toBeNull();
+    });
+
+    it('does not dangle a threshold the basket could never satisfy', () => {
+        // Scoped to somewhere the parcel is not going: spending more would not
+        // earn it, so promising it would be a lie.
+        expect(
+            freeShippingProgress({
+                rules: [
+                    rule({
+                        effect: EFFECTS.WAIVE,
+                        amount: null,
+                        min_order_value: 999,
+                        destination_scope: 'state',
+                        destination_value: 'Kerala'
+                    })
+                ],
+                context: context({ orderValue: 500 })
+            })
+        ).toBeNull();
+    });
+});

--- a/frontend/cart.html
+++ b/frontend/cart.html
@@ -193,6 +193,16 @@
 
             </div>
 
+            <!--
+                Progress toward free delivery. The figures are the server's;
+                this only holds them.
+            -->
+            <p
+                class="free-shipping-progress"
+                id="free-shipping-progress"
+                aria-live="polite"
+            ></p>
+
             <div class="summary-row discount-row">
 
                 <span>

--- a/frontend/checkout.html
+++ b/frontend/checkout.html
@@ -262,6 +262,12 @@
 
                 </div>
 
+                <p
+                    class="free-shipping-progress"
+                    id="free-shipping-progress"
+                    aria-live="polite"
+                ></p>
+
                 <!-- Payment -->
 
                 <h3>

--- a/frontend/scripts/cart.js
+++ b/frontend/scripts/cart.js
@@ -25,6 +25,7 @@ const elements = {
     taxElement: document.getElementById("tax"),
     totalElement: document.getElementById("total"),
     shippingElement: document.getElementById("shipping"),
+    freeShippingProgress: document.getElementById("free-shipping-progress"),
     discountElement: document.getElementById("discount"),
     checkoutBtn: document.getElementById("checkout-btn"),
     emptyCartBtn: document.getElementById("empty-cart-btn"),
@@ -264,6 +265,12 @@ async function updateCartTotals() {
     }
     if (elements.shippingElement) {
         elements.shippingElement.innerText = totals.shipping === 0 ? "Free" : AppUtils.formatPrice(totals.shipping, currency);
+    }
+    if (elements.freeShippingProgress) {
+        // The cart is where this matters most: it is the last screen where
+        // adding another item is still the obvious thing to do.
+        elements.freeShippingProgress.innerText =
+            AppUtils.formatFreeShippingProgress(totals.freeShipping, currency);
     }
     if (elements.discountElement) {
         elements.discountElement.innerText = `-${AppUtils.formatPrice(totals.discount > 0 ? totals.discount : 0, currency)}`;

--- a/frontend/scripts/checkout.js
+++ b/frontend/scripts/checkout.js
@@ -80,6 +80,11 @@ const elements = {
             "delivery-options"
         ),
 
+    freeShippingProgress:
+        document.getElementById(
+            "free-shipping-progress"
+        ),
+
     discount:
         document.getElementById(
             "checkout-discount"
@@ -288,13 +293,47 @@ function safeQty(
 let selectedShippingMethod =
     null;
 
+// Where the parcel is going, as far as the form knows so far. Rates can depend
+// on it, so it travels with every quote; the order is re-priced against the
+// address it is actually placed with, so this can only ever be an estimate the
+// server has to agree with.
+function currentDestination() {
+
+    const pincode =
+        elements.zip
+            ? elements.zip.value.trim()
+            : "";
+
+    if (
+        !pincode
+    ) {
+        return null;
+    }
+
+    return {
+
+        pincode,
+
+        city:
+            elements.city
+                ? elements.city.value.trim()
+                : "",
+
+        state:
+            elements.state
+                ? elements.state.value.trim()
+                : ""
+    };
+}
+
 // CALCULATE TOTALS
 async function calculateTotals() {
 
     return AppUtils.fetchCartQuote(
         cart,
         appliedCoupon,
-        selectedShippingMethod
+        selectedShippingMethod,
+        currentDestination()
     );
 }
 
@@ -514,7 +553,44 @@ async function refreshSummary() {
         totals.currency
     );
 
+    if (
+        elements.freeShippingProgress
+    ) {
+
+        elements.freeShippingProgress.innerText =
+            AppUtils.formatFreeShippingProgress(
+                totals.freeShipping,
+                totals.currency
+            );
+    }
+
     return totals;
+}
+
+// A rate can depend on where the parcel is going, so the summary follows the
+// address rather than waiting for the order to be placed to reveal the real
+// figure. Debounced, because this fires on every keystroke in a PIN code.
+if (
+    elements.zip
+) {
+
+    elements.zip.addEventListener(
+        "input",
+        AppUtils.debounce(
+            () => {
+
+                if (
+                    /^\d{5,6}$/.test(
+                        elements.zip.value.trim()
+                    )
+                ) {
+
+                    refreshSummary();
+                }
+            },
+            500
+        )
+    );
 }
 
 // RENDER CHECKOUT

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -1892,7 +1892,8 @@ const calculateCartTotals = async (
 const fetchCartQuote = async (
     cart = getCart(),
     couponCode = "",
-    shippingMethod = null
+    shippingMethod = null,
+    destination = null
 ) => {
     const items = safeArray(cart).map(
         (item) => ({
@@ -1912,7 +1913,11 @@ const fetchCartQuote = async (
                 promoCode: couponCode || null,
                 // A code naming a delivery option, never a rate. The server
                 // decides what it costs.
-                shippingMethod: shippingMethod || null
+                shippingMethod: shippingMethod || null,
+                // Where it is going, so destination rules can apply. Null
+                // until an address is known, which is the whole of the cart
+                // page.
+                destination: destination || null
             })
         });
 
@@ -1925,6 +1930,7 @@ const fetchCartQuote = async (
         return {
             ...response.breakdown,
             shippingOptions: safeArray(response.shippingOptions),
+            freeShipping: response.freeShipping || null,
             promoMessage: response.promoMessage || null,
             isServerQuote: true
         };
@@ -1937,11 +1943,35 @@ const fetchCartQuote = async (
             ...fallback,
             // Deliberately empty: the local fallback cannot price a delivery
             // option, and offering a choice it could not cost would show the
-            // shopper a figure the server never agreed to.
+            // shopper a figure the server never agreed to. The same goes for
+            // promising free delivery at a threshold only the server knows.
             shippingOptions: [],
+            freeShipping: null,
             isServerQuote: false
         };
     }
+};
+
+// How the progress toward free delivery reads. The threshold and the shortfall
+// are both the server's figures — the browser knows neither the rule nor the
+// basket value it is measured against — so this only chooses the wording.
+//
+// Returns an empty string when there is no threshold to work toward, which is
+// a perfectly ordinary configuration and should render nothing rather than an
+// empty promise.
+const formatFreeShippingProgress = (freeShipping, currency) => {
+    if (!freeShipping) {
+        return "";
+    }
+
+    if (freeShipping.qualified) {
+        return "Your order qualifies for free delivery.";
+    }
+
+    return (
+        `Add ${formatPrice(freeShipping.remaining, currency)} more to qualify ` +
+        "for free delivery."
+    );
 };
 
 const getWishlist = () => {
@@ -2029,6 +2059,7 @@ window.AppUtils = {
     validateCoupon,
     calculateCartTotals,
     fetchCartQuote,
+    formatFreeShippingProgress,
     getWishlist,
     saveWishlist,
     getSkeletonCardHTML,

--- a/migrations/0037_shipping_rate_rules.sql
+++ b/migrations/0037_shipping_rate_rules.sql
@@ -1,0 +1,129 @@
+-- ============================================
+-- SHIPPING RATE RULES (#1430)
+-- ============================================
+--
+-- A delivery option carries one flat rate. Real delivery pricing is not flat:
+-- it moves with where the parcel is going, how heavy it is and what the basket
+-- is worth. Hardcoding those three would put the store's commercial policy in
+-- a deployment, so they are rows.
+--
+-- The free-shipping threshold is one of these rules rather than a special case
+-- beside them. Before this it was a constant in the pricing engine, which is
+-- why it could not be varied by destination, could not be run as a campaign,
+-- and could not be turned off. Expressing it as a waiver over basket value
+-- makes "free delivery over 999" and "free delivery to Mumbai" the same kind
+-- of thing.
+--
+-- Safe to re-run.
+
+CREATE TABLE IF NOT EXISTS shipping_rate_rules (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+
+    -- Shown to operators and echoed on a quote, so a shopper asking "why does
+    -- this cost that" has an answer that is not a row id.
+    name VARCHAR(100) NOT NULL,
+
+    -- The option this rule prices. NULL applies it to every option, which is
+    -- what a value threshold usually wants -- earning free delivery should not
+    -- depend on which service was picked.
+    method_code VARCHAR(50) NULL,
+
+    -- ============================================
+    -- WHAT THE RULE MATCHES
+    -- ============================================
+    --
+    -- Every condition left at its permissive value matches everything, so a
+    -- rule states only what it cares about. All stated conditions must hold.
+
+    -- Destination is expressed against what serviceable_pincodes already
+    -- knows: the pincode itself, or the city or state it resolves to. A second
+    -- notion of "where" -- zones, regions, postcode ranges -- would have to be
+    -- kept in step with that table by hand.
+    destination_scope ENUM('any', 'pincode', 'city', 'state') NOT NULL DEFAULT 'any',
+    destination_value VARCHAR(100) NULL,
+
+    -- Half-open weight and value windows: the minimum is inclusive and the
+    -- maximum is exclusive, so adjacent bands tile without overlapping and
+    -- without a gap. NULL is unbounded on that side.
+    min_weight_kg DECIMAL(10,3) NULL,
+    max_weight_kg DECIMAL(10,3) NULL,
+
+    -- Compared against the post-discount subtotal, which is the same base the
+    -- tax and shipping rules have used since the pricing engine landed.
+    -- Earning free delivery on a discount the shopper did not pay for is how
+    -- a promotion funds its own shipping twice.
+    min_order_value DECIMAL(10,2) NULL,
+    max_order_value DECIMAL(10,2) NULL,
+
+    -- ============================================
+    -- WHAT THE RULE DOES
+    -- ============================================
+    --
+    --   set_rate   replaces the option's rate outright
+    --   surcharge  adds to it
+    --   waive      covers part or all of it
+    --
+    -- `amount` is required for set_rate and surcharge. On a waive it may be
+    -- NULL, meaning "cover the default option's rate" -- the standard cost of
+    -- delivery -- which is what free shipping has always meant here and what
+    -- keeps an upgrade costing its difference rather than nothing.
+    effect ENUM('set_rate', 'surcharge', 'waive') NOT NULL,
+    amount DECIMAL(10,2) NULL,
+
+    -- Lowest number is considered first. Only one set_rate can win; surcharges
+    -- all apply; the largest single waiver applies, because stacking waivers
+    -- is how a store ends up paying customers to accept delivery.
+    priority INT NOT NULL DEFAULT 100,
+
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    CONSTRAINT chk_shipping_rules_amount CHECK (amount IS NULL OR amount >= 0),
+    CONSTRAINT chk_shipping_rules_weight CHECK (
+        min_weight_kg IS NULL OR max_weight_kg IS NULL OR max_weight_kg > min_weight_kg
+    ),
+    CONSTRAINT chk_shipping_rules_value CHECK (
+        min_order_value IS NULL OR max_order_value IS NULL OR max_order_value > min_order_value
+    ),
+    -- A scoped destination without a value matches nothing and is almost
+    -- certainly a half-finished rule; an 'any' scope with a value is a stated
+    -- condition that would be silently ignored. Both are refused.
+    CONSTRAINT chk_shipping_rules_destination CHECK (
+        (destination_scope = 'any' AND destination_value IS NULL)
+        OR (destination_scope <> 'any' AND destination_value IS NOT NULL)
+    ),
+
+    CONSTRAINT fk_shipping_rules_method
+        FOREIGN KEY (method_code) REFERENCES shipping_methods(code)
+        ON DELETE CASCADE ON UPDATE CASCADE,
+
+    -- The pricing access path: every active rule, in the order they are
+    -- considered. The whole set is small and is read as one, so this is a scan
+    -- of the index rather than a lookup through it.
+    INDEX idx_shipping_rules_active_priority (is_active, priority),
+    INDEX idx_shipping_rules_method (method_code)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================
+-- THE THRESHOLD THAT ALREADY EXISTED
+-- ============================================
+--
+-- 999 and "the whole standard rate" are exactly what the pricing engine has
+-- applied since it took ownership of totals, so this seed changes nobody's
+-- bill. It only moves the decision somewhere it can be changed.
+--
+-- No destination or weight rule is seeded. Those are commercial decisions, and
+-- a migration that quietly started surcharging heavy parcels would change what
+-- customers pay without anyone deciding to.
+
+INSERT INTO shipping_rate_rules (
+    name, method_code, destination_scope, min_order_value, effect, amount, priority
+)
+SELECT
+    'Free delivery over 999', NULL, 'any', 999.00, 'waive', NULL, 100
+FROM DUAL
+WHERE NOT EXISTS (
+    SELECT 1 FROM shipping_rate_rules WHERE name = 'Free delivery over 999'
+);


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

> Builds on `feat/1430-shipping-options`, which is in review. Review this one after that; the diff below includes its commits until it merges.

A delivery option carries one flat rate. Real delivery pricing is not flat — it moves with where the parcel is going, how heavy it is and what the basket is worth — and hardcoding those three would put the store's commercial policy in a deployment. Rates are now derived from rules, and the free-shipping threshold is one of those rules rather than a special case beside them.

**A rule states only what it cares about.** Every condition left alone matches everything, so "surcharge heavy parcels" is one row and does not have to enumerate destinations. What it can match on is the option, the destination, the weight and the basket value; what it can then do is replace the rate, add to it, or waive part of it. Weight and value bands are half-open, so bands written back to back neither overlap nor leave a gap between them.

**Surcharges accumulate and waivers do not.** Two reasons to charge more are two costs: a remote destination does not become free because the parcel is also heavy. Two reasons to charge nothing are still one delivery, so the largest waiver applies rather than the sum — otherwise a store can end up owing money on the shipping line. One rate override wins, by stated priority, and the rest are ignored.

**The free-shipping threshold stops being a constant.** It was a number in the pricing engine, which is why it could not be varied by destination, run as a campaign, or turned off. It is seeded here as a waiver over basket value at exactly the figure already in force, so nobody's bill changes; what changes is that it can now be moved, scoped or withdrawn without a release. Expressing it this way is what makes "free delivery over 999" and "free delivery to this state" the same kind of thing.

**The shopper is told how far away it is.** The cart and the checkout summary report the nearest threshold the basket has not yet reached and what it would take to reach it. The nearest, deliberately: telling somebody about a large threshold while they are a little short of a smaller one is worse than saying nothing. A threshold the basket could never satisfy — one scoped somewhere the parcel is not going — is not dangled at all, because spending more would not earn it.

**Destination builds on serviceability rather than beside it.** A rule names a pincode, or the city or state that pincode resolves to through the table the store already keeps. A rule scoped to a place does not fire when no place is known, which is the whole of the cart page: an unknown destination is quoted without the surcharge it might attract *and* without the waiver it might earn, and neither error is one the shopper discovers at the last step. Weight comes from the catalogue, with a configured assumption for the products that have never had one recorded — treating those as weightless would put most baskets in the lightest band of every weight rule.

**A cheap destination cannot be bought.** The quote takes the destination it is given, but the order is priced against the address it is actually placed with, and the total the client claims is verified against that. Naming somewhere cheaper to get a quote and shipping somewhere else gets the order refused, not discounted.

---

## 🔗 Related Issue

Part of #1430

---

## 🛠️ Type of Change

- [ ] Bug fix
- [x] New feature
- [x] UI/UX improvement
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

No image. On the cart page a reviewer sees a new line under the Shipping row reading "Add ₹200 more to qualify for free delivery", which updates as quantities change and becomes "Your order qualifies for free delivery" once the threshold is crossed. The same line appears on checkout under the delivery options. Entering a PIN code on the checkout form re-prices the summary, so an option whose rate depends on the destination shows its real figure before the order is placed rather than after.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Only the threshold is seeded.** No destination or weight rule ships with this. Those are commercial decisions, and a migration that quietly started surcharging heavy parcels would change what customers pay without anyone deciding to.

**If the rules cannot be read.** Pricing degrades to each option's own flat rate, which means charging rather than giving delivery away. That is the safe direction for an unreadable table, and it is logged.

**The engine still has a threshold of its own.** It is now the fallback for a caller pricing a basket with no rules to hand, and the migration seeds the rule with the same figure so the two start out saying the same thing. Anything that prices through the delivery options gets the rule.

**Left as it is.** Weight is summed from the catalogue rather than from packed dimensions, and there is no volumetric weight. Couriers bill on both; that needs a notion of packing this store does not have yet, and it is a separate decision.

**Note on CI.** Two frontend scripts do not parse on `main`, which fails the syntax gate for every branch regardless of its contents and causes the test and boot jobs to skip. Neither file is touched here; reported in #1416.
