### PR TITLE
Show the delivery estimate on the order timeline

### DIFF
--- a/backend/config/shippingConfig.js
+++ b/backend/config/shippingConfig.js
@@ -29,6 +29,13 @@ const SHIPPING_CONFIG = Object.freeze({
     DEFAULT_ITEM_WEIGHT_KG:
         Number(process.env.SHIPPING_DEFAULT_ITEM_WEIGHT_KG) || 0.5,
 
+    // The destination lead time a delivery window is quoted against. It matches
+    // the default on `serviceable_pincodes.eta_days`, so a pincode nobody has
+    // tuned neither lengthens nor shortens the promise. Somewhere slower than
+    // this pushes the window out by the difference.
+    BASELINE_DESTINATION_ETA_DAYS:
+        Number(process.env.SHIPPING_BASELINE_ETA_DAYS) || 5,
+
     // Used only when `shipping_methods` cannot be read. The rate is the flat
     // rate the pricing engine has always applied, so a store running on the
     // fallback charges what it charged before this existed.
@@ -37,6 +44,8 @@ const SHIPPING_CONFIG = Object.freeze({
         label: "Standard delivery",
         description: "Arrives in three to six days.",
         rate: PRICING_CONFIG.SHIPPING_FLAT_RATE,
+        minDays: 3,
+        maxDays: 6,
         isDefault: true,
         sortOrder: 10,
     }),

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -1009,6 +1009,10 @@ const exportOrders = async (req, res) => {
  *
  * The administrative roles additionally see the actor, the request metadata
  * and internal reasons; everyone else sees only their own stated reasons.
+ *
+ * The delivery option the order was sold, its charge and the window it was
+ * promised for ride along, because "when is this arriving" is the question the
+ * timeline is opened to answer (#1430).
  */
 const getOrderTimeline = async (req, res) => {
     const id = safeUUID(req.params.id);
@@ -1024,7 +1028,9 @@ const getOrderTimeline = async (req, res) => {
     const canReadAnyOrder = hasPermission(req.user, PERMISSIONS.ORDER_READ_ANY);
     const canSeeInternalDetail = isAdminRole(req.user?.role);
 
-    let query = "SELECT id, status, created_at FROM orders WHERE id = ?";
+    let query =
+        "SELECT id, status, created_at, shipping_method, shipping_cost, " +
+        "estimated_delivery_from, estimated_delivery FROM orders WHERE id = ?";
     const params = [id];
 
     if (!canReadAnyOrder) {

--- a/backend/services/order.service.js
+++ b/backend/services/order.service.js
@@ -340,6 +340,15 @@ const createOrderService = async (connection, orderData) => {
             shippingMethod: delivery.selected,
         });
 
+        // The delivery promise is recorded, not recomputed on read. It is a
+        // commitment made now, and an operator retuning an option next month
+        // must not silently move the date this order was sold on. Null when
+        // the chosen option states no window.
+        const estimate = await shipping.estimateDelivery({
+            methodCode: delivery.selected.code,
+            destination: { pincode: zip, city, state },
+        });
+
         const verification = pricing.verifyClaimedTotal(
             claimedTotal,
             breakdown.total,
@@ -382,6 +391,8 @@ const createOrderService = async (connection, orderData) => {
                 tax,
                 shipping_method,
                 shipping_cost,
+                estimated_delivery_from,
+                estimated_delivery,
                 discount,
                 discount_code,
                 promo_code,
@@ -390,7 +401,7 @@ const createOrderService = async (connection, orderData) => {
                 created_at,
                 updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
         `;
 
         const [orderResult] = await connection.query(orderQuery, [
@@ -412,6 +423,8 @@ const createOrderService = async (connection, orderData) => {
             breakdown.tax,
             delivery.selected.code,
             breakdown.shipping,
+            estimate ? estimate.from : null,
+            estimate ? estimate.to : null,
             discountAmount,
             appliedPromoCode,
             appliedPromoCode,

--- a/backend/services/orderStatusHistoryService.js
+++ b/backend/services/orderStatusHistoryService.js
@@ -23,7 +23,10 @@
 // history written *before* a rolled-back status change is worse than none.
 
 const db = require('../config/db');
-const { safeArray, sanitizeString } = require('../utils/helpers');
+const { safeArray, safeNumber, sanitizeString } = require('../utils/helpers');
+// Delivery options (#1430). Needed only to put a label on the method code the
+// order recorded; the dates themselves were computed when the order was placed.
+const shipping = require('./shipping.service');
 
 /**
  * Where a status change came from.
@@ -299,7 +302,10 @@ class OrderStatusHistoryService {
      * without an intervening `out_for_delivery` event.
      */
     async getTimeline(order, options = {}) {
-        const history = await this.getHistory(order.id, options);
+        const [history, delivery] = await Promise.all([
+            this.getHistory(order.id, options),
+            this.describeDelivery(order)
+        ]);
 
         const reached = new Set(history.map((entry) => entry.status));
         const isTerminal = order.status === 'cancelled' || order.status === 'refunded';
@@ -327,7 +333,56 @@ class OrderStatusHistoryService {
             currentStatus: order.status,
             isCancelled: isTerminal,
             steps: isTerminal ? [] : steps,
+            delivery,
             history
+        };
+    }
+
+    /**
+     * What the order was sold, and when it was promised for.
+     *
+     * Read back from the order rather than recomputed: these are the figures
+     * the shopper agreed to at checkout, and a delivery option retuned since
+     * then must not retrospectively change what they were told.
+     *
+     * The estimate is dropped once the order reaches a state where it is no
+     * longer a prediction. A delivered order has a real date and a cancelled
+     * one has no delivery at all; continuing to show "arriving Thursday"
+     * against either is worse than showing nothing.
+     *
+     * Returns null for orders placed before checkout offered a choice, which
+     * recorded no method — the timeline simply says nothing about delivery for
+     * those, rather than guessing what they were sent by.
+     *
+     * @param {Object} order - id, status, and the shipping columns
+     * @returns {Promise<Object|null>}
+     */
+    async describeDelivery(order = {}) {
+        const code = sanitizeString(order.shipping_method);
+
+        if (!code) return null;
+
+        const methods = await shipping.listMethods();
+        const method = methods.find((candidate) => candidate.code === code);
+
+        const isSettled =
+            order.status === 'delivered' ||
+            order.status === 'cancelled' ||
+            order.status === 'refunded';
+
+        const from = order.estimated_delivery_from || null;
+        const to = order.estimated_delivery || null;
+
+        return {
+            method: {
+                code,
+                // A code the options table no longer carries is still shown,
+                // because the order was genuinely sold under it. Falling back
+                // to the code beats rendering an empty label.
+                label: method ? method.label : code
+            },
+            charge: safeNumber(order.shipping_cost, 0),
+            estimate: !isSettled && from && to ? { from, to } : null
         };
     }
 

--- a/backend/services/shipping.service.js
+++ b/backend/services/shipping.service.js
@@ -34,6 +34,11 @@ const toMethod = (row) => ({
     label: sanitizeString(row.label),
     description: sanitizeString(row.description) || null,
     rate: safeNumber(row.base_rate),
+    // Null where an option states no delivery promise, which is different from
+    // promising same-day. Preserved as null so the estimate is omitted rather
+    // than invented.
+    minDays: row.min_days === null ? null : safeInteger(row.min_days, 0),
+    maxDays: row.max_days === null ? null : safeInteger(row.max_days, 0),
     isDefault: Boolean(row.is_default),
     sortOrder: safeInteger(row.sort_order, 0),
 });
@@ -43,7 +48,8 @@ const readMethods = async () => {
 
     try {
         const [rows] = await db.query(
-            `SELECT code, label, description, base_rate, is_default, sort_order
+            `SELECT code, label, description, base_rate, min_days, max_days,
+                    is_default, sort_order
                FROM shipping_methods
               WHERE is_active = 1
               ORDER BY sort_order ASC, code ASC`,
@@ -135,8 +141,12 @@ const listRules = () => {
  * and "the rule says Maharashtra". A pincode the store does not serve resolves
  * to nothing, and rules scoped to a place then simply do not match.
  *
+ * The lead time that record carries comes back too, because it is the one
+ * thing the store knows about how long this destination actually takes, and
+ * the delivery promise is quoted against it.
+ *
  * @param {{ pincode?: string, city?: string, state?: string }} [destination]
- * @returns {Promise<{ pincode: string|null, city: string|null, state: string|null }>}
+ * @returns {Promise<{ pincode: string|null, city: string|null, state: string|null, etaDays: number|null }>}
  */
 const resolveDestination = async (destination = {}) => {
     const pincode = sanitizeString(destination.pincode || destination.zip);
@@ -144,9 +154,10 @@ const resolveDestination = async (destination = {}) => {
         pincode: pincode || null,
         city: sanitizeString(destination.city) || null,
         state: sanitizeString(destination.state) || null,
+        etaDays: null,
     };
 
-    if (!pincode || (resolved.city && resolved.state)) {
+    if (!pincode) {
         return resolved;
     }
 
@@ -159,6 +170,10 @@ const resolveDestination = async (destination = {}) => {
             // Mumbai pincode is somewhere else.
             resolved.city = sanitizeString(row.city) || resolved.city;
             resolved.state = sanitizeString(row.state) || resolved.state;
+            resolved.etaDays =
+                row.eta_days === null || row.eta_days === undefined
+                    ? null
+                    : safeInteger(row.eta_days, 0);
         }
     } catch (error) {
         logger.warn(`Destination ${pincode} could not be resolved: ${error.message}`);
@@ -185,6 +200,113 @@ const basketWeightKg = (lines) =>
 
         return total + unit * qty;
     }, 0);
+
+// Dates are built and formatted in the process's own timezone rather than via
+// an ISO slice, because `orders.created_at` comes back from the driver as a
+// local-time Date. Converting to UTC to format it would move an order placed
+// late in the evening onto the previous day and quietly shift every date the
+// customer is shown.
+const addDays = (date, days) => {
+    const shifted = new Date(date.getTime());
+    shifted.setDate(shifted.getDate() + days);
+    return shifted;
+};
+
+const toDateString = (date) =>
+    [
+        date.getFullYear(),
+        String(date.getMonth() + 1).padStart(2, "0"),
+        String(date.getDate()).padStart(2, "0"),
+    ].join("-");
+
+/**
+ * The window an option promises, as two dates.
+ *
+ * Pure, so the arithmetic can be pinned without a clock or a database.
+ *
+ * The destination shifts the window later but never earlier. Somewhere the
+ * courier is slower to reach genuinely takes longer; somewhere it is faster
+ * to reach might simply be a lead time nobody has kept up to date, and
+ * shortening a promise on that basis is how a store misses it.
+ *
+ * @param {Object} input
+ * @param {Date} input.placedAt
+ * @param {number|null} input.minDays
+ * @param {number|null} input.maxDays
+ * @param {number|null} [input.destinationEtaDays]
+ * @returns {{ from: string, to: string, minDays: number, maxDays: number }|null}
+ */
+const deliveryWindow = ({
+    placedAt,
+    minDays,
+    maxDays,
+    destinationEtaDays = null,
+} = {}) => {
+    if (minDays === null || minDays === undefined) return null;
+    if (maxDays === null || maxDays === undefined) return null;
+
+    const placed = placedAt instanceof Date ? placedAt : new Date(placedAt);
+
+    if (Number.isNaN(placed.getTime())) return null;
+
+    const slowerBy =
+        destinationEtaDays === null || destinationEtaDays === undefined
+            ? 0
+            : Math.max(
+                  0,
+                  safeInteger(destinationEtaDays, 0) -
+                      SHIPPING_CONFIG.BASELINE_DESTINATION_ETA_DAYS,
+              );
+
+    const from = safeInteger(minDays, 0) + slowerBy;
+    const to = safeInteger(maxDays, 0) + slowerBy;
+
+    return {
+        from: toDateString(addDays(placed, from)),
+        to: toDateString(addDays(placed, to)),
+        minDays: from,
+        maxDays: to,
+    };
+};
+
+/**
+ * The delivery promise for one option to one destination.
+ *
+ * Returns null when the option states no window, when the code names nothing,
+ * or when there is no usable placement date -- all three of which mean the
+ * honest answer is to show no estimate at all.
+ *
+ * @param {Object} input
+ * @param {any} input.methodCode
+ * @param {Object} [input.destination]
+ * @param {Date|string} [input.placedAt]
+ * @returns {Promise<Object|null>}
+ */
+const estimateDelivery = async ({
+    methodCode,
+    destination = null,
+    placedAt = new Date(),
+} = {}) => {
+    const [methods, place] = await Promise.all([
+        listMethods(),
+        resolveDestination(destination || {}),
+    ]);
+
+    const method = methods.find(
+        (candidate) => candidate.code === sanitizeString(methodCode),
+    );
+
+    if (!method) return null;
+
+    const window = deliveryWindow({
+        placedAt,
+        minDays: method.minDays,
+        maxDays: method.maxDays,
+        destinationEtaDays: place.etaDays,
+    });
+
+    return window ? { ...window, code: method.code, label: method.label } : null;
+};
 
 /**
  * The option a checkout gets when it does not choose one.
@@ -398,6 +520,8 @@ module.exports = {
     resolveMethod,
     resolveDestination,
     basketWeightKg,
+    deliveryWindow,
+    estimateDelivery,
     toPricingDescriptor,
     quoteOptions,
     clearCache,

--- a/backend/tests/orderStatusHistory.test.js
+++ b/backend/tests/orderStatusHistory.test.js
@@ -396,6 +396,78 @@ describe('getTimeline', () => {
     });
 });
 
+// The delivery promise on the timeline (#1430). The dates are read back from
+// the order rather than recomputed, so an option retuned since the order was
+// placed cannot move a date the shopper was already given.
+describe('the delivery promise', () => {
+    function orderWithDelivery(overrides = {}) {
+        return {
+            id: ORDER,
+            status: 'processing',
+            shipping_method: 'standard',
+            shipping_cost: '49.00',
+            estimated_delivery_from: '2026-08-04',
+            estimated_delivery: '2026-08-07',
+            ...overrides
+        };
+    }
+
+    it('reports the recorded window and what was paid for it', async () => {
+        await expect(
+            service.describeDelivery(orderWithDelivery())
+        ).resolves.toMatchObject({
+            charge: 49,
+            estimate: { from: '2026-08-04', to: '2026-08-07' }
+        });
+    });
+
+    it('says nothing for an order placed before there was a choice', async () => {
+        // Nothing recorded how those were sent, so nothing claims to know.
+        await expect(
+            service.describeDelivery(orderWithDelivery({ shipping_method: null }))
+        ).resolves.toBeNull();
+    });
+
+    it.each(['delivered', 'cancelled', 'refunded'])(
+        'drops the estimate once the order is %s',
+        async (status) => {
+            // A delivered order has a real date and a cancelled one has no
+            // delivery at all. "Arriving Thursday" against either is worse
+            // than showing nothing.
+            const delivery = await service.describeDelivery(
+                orderWithDelivery({ status })
+            );
+
+            expect(delivery.estimate).toBeNull();
+            expect(delivery.method.code).toBe('standard');
+        }
+    );
+
+    it('keeps showing an option the store no longer offers', async () => {
+        // The order was genuinely sold under it, so the code stands in for a
+        // label rather than rendering blank.
+        const delivery = await service.describeDelivery(
+            orderWithDelivery({ shipping_method: 'retired-overnight' })
+        );
+
+        expect(delivery.method).toEqual({
+            code: 'retired-overnight',
+            label: 'retired-overnight'
+        });
+    });
+
+    it('omits the estimate when the order recorded no window', async () => {
+        const delivery = await service.describeDelivery(
+            orderWithDelivery({
+                estimated_delivery_from: null,
+                estimated_delivery: null
+            })
+        );
+
+        expect(delivery.estimate).toBeNull();
+    });
+});
+
 describe('getLastTransitionTo', () => {
     it('answers "when did this ship" without walking the history', async () => {
         db.query.mockResolvedValueOnce([[{ created_at: '2026-02-01 10:00:00' }]]);

--- a/backend/tests/shipping.service.test.js
+++ b/backend/tests/shipping.service.test.js
@@ -38,6 +38,8 @@ const STANDARD = {
     label: 'Standard delivery',
     description: 'Arrives in three to six days.',
     base_rate: '49.00',
+    min_days: 3,
+    max_days: 6,
     is_default: 1,
     sort_order: 10
 };
@@ -47,6 +49,8 @@ const EXPRESS = {
     label: 'Express delivery',
     description: 'Arrives in one to two days.',
     base_rate: '149.00',
+    min_days: 1,
+    max_days: 2,
     is_default: 0,
     sort_order: 20
 };
@@ -311,6 +315,90 @@ describe('rules reaching the quote', () => {
         // because a table could not be read.
         expect(options.map((option) => option.cost)).toEqual([49, 149]);
         expect(freeShipping).toBeNull();
+    });
+});
+
+describe('the delivery window an option promises', () => {
+    // A fixed placement date, so the window is arithmetic rather than a race
+    // with the clock.
+    const PLACED_AT = new Date(2026, 7, 1);
+
+    it('runs from the option\'s near end to its far end', () => {
+        expect(
+            shipping.deliveryWindow({ placedAt: PLACED_AT, minDays: 3, maxDays: 6 })
+        ).toMatchObject({ from: '2026-08-04', to: '2026-08-07' });
+    });
+
+    it('crosses a month boundary correctly', () => {
+        expect(
+            shipping.deliveryWindow({
+                placedAt: new Date(2026, 7, 30),
+                minDays: 3,
+                maxDays: 6
+            })
+        ).toMatchObject({ from: '2026-09-02', to: '2026-09-05' });
+    });
+
+    it('pushes the window out for a destination the courier is slower to reach', () => {
+        const slowerBy = 3;
+
+        expect(
+            shipping.deliveryWindow({
+                placedAt: PLACED_AT,
+                minDays: 3,
+                maxDays: 6,
+                destinationEtaDays:
+                    SHIPPING_CONFIG.BASELINE_DESTINATION_ETA_DAYS + slowerBy
+            })
+        ).toMatchObject({ from: '2026-08-07', to: '2026-08-10' });
+    });
+
+    it('does not pull the window in for a destination that looks faster', () => {
+        // A short lead time may just be a figure nobody has kept up to date.
+        // Shortening a promise on that basis is how a store misses it.
+        expect(
+            shipping.deliveryWindow({
+                placedAt: PLACED_AT,
+                minDays: 3,
+                maxDays: 6,
+                destinationEtaDays: 1
+            })
+        ).toMatchObject({ from: '2026-08-04', to: '2026-08-07' });
+    });
+
+    it('promises nothing when the option states no window', () => {
+        expect(
+            shipping.deliveryWindow({ placedAt: PLACED_AT, minDays: null, maxDays: 6 })
+        ).toBeNull();
+        expect(
+            shipping.deliveryWindow({ placedAt: PLACED_AT, minDays: 3, maxDays: null })
+        ).toBeNull();
+    });
+
+    it('promises nothing when the placement date is unusable', () => {
+        expect(
+            shipping.deliveryWindow({ placedAt: 'not a date', minDays: 3, maxDays: 6 })
+        ).toBeNull();
+    });
+
+    it('names the option the estimate belongs to', async () => {
+        await expect(
+            shipping.estimateDelivery({
+                methodCode: 'express',
+                placedAt: PLACED_AT
+            })
+        ).resolves.toMatchObject({
+            code: 'express',
+            label: 'Express delivery',
+            from: '2026-08-02',
+            to: '2026-08-03'
+        });
+    });
+
+    it('estimates nothing for an option that is not offered', async () => {
+        await expect(
+            shipping.estimateDelivery({ methodCode: 'teleport', placedAt: PLACED_AT })
+        ).resolves.toBeNull();
     });
 });
 

--- a/frontend/order.html
+++ b/frontend/order.html
@@ -184,6 +184,11 @@
                     <div>
                         <p style="margin: 0; font-size: 0.8rem; color: #888;">Estimated Delivery</p>
                         <p style="margin: 4px 0 0; font-weight: 600;" id="estimated-delivery">-</p>
+                        <!--
+                            Which option the order was sold. The date above
+                            means nothing without it (#1430).
+                        -->
+                        <p style="margin: 2px 0 0; font-size: 0.8rem; color: #888;" id="delivery-method"></p>
                     </div>
                     <div>
                         <p style="margin: 0; font-size: 0.8rem; color: #888;">Tracking Number</p>

--- a/frontend/scripts/order-timeline.js
+++ b/frontend/scripts/order-timeline.js
@@ -47,6 +47,32 @@
     }
 
     /**
+     * Format a date-only value for display.
+     *
+     * The delivery window arrives as two YYYY-MM-DD strings. Parsing those
+     * with the Date constructor would read them as UTC midnight and render the
+     * previous day west of Greenwich, so the parts are handed over explicitly.
+     */
+    function formatDay(value) {
+        if (!value) return "";
+
+        var parts = String(value).slice(0, 10).split("-");
+        if (parts.length !== 3) return "";
+
+        var date = new Date(
+            Number(parts[0]),
+            Number(parts[1]) - 1,
+            Number(parts[2])
+        );
+        if (isNaN(date.getTime())) return "";
+
+        return date.toLocaleDateString(undefined, {
+            day: "numeric",
+            month: "short"
+        });
+    }
+
+    /**
      * Format a timestamp for display.
      *
      * Returns an empty string for anything unparseable rather than "Invalid
@@ -111,6 +137,48 @@
 
             existing.textContent = formatted;
         });
+    }
+
+    /**
+     * The delivery promise, on the panel that has always had a slot for it.
+     *
+     * `#estimated-delivery` has read "-" on every order since the page was
+     * written, because nothing recorded a promise to put there. The option the
+     * order was sold goes alongside it, so the date is attributable: "arriving
+     * by the 12th" means something different under standard and under express.
+     *
+     * A window collapses to one date when both ends fall on the same day,
+     * because "8 Aug – 8 Aug" reads as a mistake.
+     */
+    function renderDelivery(delivery) {
+        var target = document.getElementById("estimated-delivery");
+        if (!target) return;
+
+        if (!delivery) {
+            target.textContent = "-";
+            return;
+        }
+
+        var method = document.getElementById("delivery-method");
+
+        if (method) {
+            method.textContent =
+                delivery.charge > 0
+                    ? delivery.method.label
+                    : delivery.method.label + " (free)";
+        }
+
+        if (!delivery.estimate) {
+            // No estimate is a real answer here: the order has arrived, or was
+            // cancelled, or predates the delivery options entirely.
+            target.textContent = "-";
+            return;
+        }
+
+        var from = formatDay(delivery.estimate.from);
+        var to = formatDay(delivery.estimate.to);
+
+        target.textContent = from === to ? from : from + " – " + to;
     }
 
     /**
@@ -188,6 +256,7 @@
             if (!response || !response.success || !response.data) return null;
 
             renderSteps(response.data.steps);
+            renderDelivery(response.data.delivery);
             renderHistory(response.data.history);
 
             return response.data;
@@ -200,7 +269,9 @@
     window.OrderTimeline = {
         load: loadOrderTimeline,
         renderSteps: renderSteps,
+        renderDelivery: renderDelivery,
         renderHistory: renderHistory,
-        formatMoment: formatMoment
+        formatMoment: formatMoment,
+        formatDay: formatDay
     };
 })();

--- a/migrations/0038_delivery_estimate.sql
+++ b/migrations/0038_delivery_estimate.sql
@@ -1,0 +1,120 @@
+-- ============================================
+-- DELIVERY ESTIMATE (#1430)
+-- ============================================
+--
+-- Checkout offers delivery options and prices them, but the difference between
+-- them is a date, and nothing recorded one. `orders.estimated_delivery` has
+-- been in the schema since 0022 and has never had a writer, so the order page
+-- has always shown a dash where the delivery promise belongs.
+--
+-- Two things are added. Each option states the window it promises, and each
+-- order records the window it was sold. The promise is stored rather than
+-- recomputed on read, because it is a commitment made at a moment in time: an
+-- operator retuning an option next month must not silently move the date an
+-- order already promised.
+--
+-- Safe to re-run.
+
+-- ============================================
+-- WHAT EACH OPTION PROMISES
+-- ============================================
+--
+-- Nullable, and null means this option states no promise -- the order page then
+-- shows no estimate rather than a made-up one. That is also what stops this
+-- migration having to guess a window for options an operator added between
+-- 0036 and now.
+--
+-- Days are calendar days from the order being placed. There is no holiday
+-- calendar anywhere in this schema, so a working-day promise is not something
+-- the application could honestly compute; a slightly conservative calendar
+-- window is the better of the two available answers.
+
+DELIMITER //
+
+CREATE PROCEDURE AddDeliveryPromiseColumns()
+BEGIN
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'shipping_methods'
+        AND COLUMN_NAME = 'min_days'
+    ) THEN
+        ALTER TABLE shipping_methods
+        ADD COLUMN min_days INT NULL AFTER base_rate;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'shipping_methods'
+        AND COLUMN_NAME = 'max_days'
+    ) THEN
+        ALTER TABLE shipping_methods
+        ADD COLUMN max_days INT NULL AFTER min_days;
+    END IF;
+
+    -- A window that ends before it begins would render as a promise running
+    -- backwards, and is far easier to reject here than to detect later.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'shipping_methods'
+        AND CONSTRAINT_NAME = 'chk_shipping_methods_days'
+    ) THEN
+        ALTER TABLE shipping_methods
+        ADD CONSTRAINT chk_shipping_methods_days CHECK (
+            min_days IS NULL
+            OR max_days IS NULL
+            OR (min_days >= 0 AND max_days >= min_days)
+        );
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'orders'
+        AND COLUMN_NAME = 'estimated_delivery_from'
+    ) THEN
+        -- The near end of the window. 0022's `estimated_delivery` is the far
+        -- end -- the date the order is promised *by* -- which is the reading it
+        -- already had everywhere it is displayed, so it keeps its name and
+        -- gains a companion rather than being renamed under its readers.
+        ALTER TABLE orders
+        ADD COLUMN estimated_delivery_from DATE NULL AFTER estimated_delivery;
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL AddDeliveryPromiseColumns();
+DROP PROCEDURE AddDeliveryPromiseColumns;
+
+-- ============================================
+-- THE WINDOWS THE SEEDED OPTIONS ALREADY DESCRIBE
+-- ============================================
+--
+-- 0036 seeded both options with a prose description of their window. These are
+-- the same figures in a form the application can date-arithmetic with, so the
+-- text a shopper reads at checkout and the date they are given afterwards
+-- cannot say different things.
+--
+-- Guarded on NULL, so an operator who has already set a window keeps it and a
+-- re-run changes nothing.
+
+UPDATE shipping_methods
+   SET min_days = 3, max_days = 6
+ WHERE code = 'standard' AND min_days IS NULL AND max_days IS NULL;
+
+UPDATE shipping_methods
+   SET min_days = 1, max_days = 2
+ WHERE code = 'express' AND min_days IS NULL AND max_days IS NULL;
+
+-- ============================================
+-- NO BACKFILL
+-- ============================================
+--
+-- Orders placed before delivery options existed recorded no method, so there
+-- is no window to reconstruct for them, and an order that has already been
+-- delivered has an actual date rather than a promised one. Both are left
+-- alone. The timeline shows an estimate where one was recorded and says
+-- nothing where one was not.


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

> Builds on `feat/1430-shipping-rate-rules`, which is in review and itself builds on `feat/1430-shipping-options`. Review this one last; the diff below includes both until they merge.

Checkout offers delivery options and prices them, but the difference a shopper is actually buying is a date, and nothing recorded one. `orders.estimated_delivery` has been in the schema since order status tracking landed and has never had a writer, so the order page has shown a dash where the delivery promise belongs on every order ever placed. This fills it in.

**Each option states the window it promises, and each order records the window it was sold.** The promise is stored rather than recomputed when the page is opened, because it is a commitment made at a moment in time: an operator retuning an option next month must not silently move a date a shopper was already given. An option that states no window produces no estimate, and the page says nothing rather than inventing one.

**The destination lengthens the promise but never shortens it.** Somewhere the courier is slower to reach genuinely takes longer, and the serviceability records already say by how much. Somewhere that looks faster might simply be a lead time nobody has kept up to date, and shortening a promise on that basis is how a store misses it.

**The estimate disappears when it stops being a prediction.** A delivered order has a real date and a cancelled one has no delivery at all; continuing to show "arriving Thursday" against either is worse than showing nothing. Orders placed before there was a choice recorded no method, so the timeline says nothing about delivery for those rather than guessing what they were sent by.

The option is named alongside the date, because the date means something different under each one, and an order sold under an option the store has since retired still shows what it was sold under.

---

## 🔗 Related Issue

Part of #1430

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] New feature
- [x] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

No image. On the order tracking page the **Estimated Delivery** panel, which has read "-" on every order since the page was written, now shows the promised window as a date range — "4 Aug – 7 Aug", collapsing to a single date when both ends fall on the same day — with the delivery option named underneath it and marked free where no charge applied. Open a delivered or cancelled order and the panel returns to a dash, with the option still named.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Calendar days, not working days.** There is no holiday calendar anywhere in this schema, so a working-day promise is not something the application could honestly compute. A slightly conservative calendar window is the better of the two available answers, and the seeded windows are the same figures the option descriptions already stated in prose.

**Dates are handled in local time throughout.** The recorded window is two date-only values, and both the server that writes them and the page that renders them avoid the UTC round trip that would move an order placed late in the evening onto the previous day.

**No backfill.** Orders that recorded no method have no window to reconstruct, and an order that has already arrived has an actual date rather than a promised one. Both are left alone.

**Left as it is.** The estimate is not shown next to each option at checkout, only on the order afterwards. Showing it while choosing is worth doing and is a small addition on top of this, but it is a separate change to the checkout surface.

**Note on CI.** Two frontend scripts do not parse on `main`, which fails the syntax gate for every branch regardless of its contents and causes the test and boot jobs to skip. Neither file is touched here; reported in #1416.
