### PR TITLE
Merge a guest basket into the account at sign-in

### DIFF
--- a/backend/config/cartConfig.js
+++ b/backend/config/cartConfig.js
@@ -26,7 +26,15 @@ const CART_CONFIG = Object.freeze({
     // Ceiling on batches in a single run, so a large backlog is drained over
     // several scheduled runs instead of one that never ends. At the defaults a
     // run transitions at most 10,000 carts.
-    SWEEP_MAX_BATCHES: Number(process.env.CART_SWEEP_MAX_BATCHES) || 20
+    SWEEP_MAX_BATCHES: Number(process.env.CART_SWEEP_MAX_BATCHES) || 20,
+
+    // How long the token that reaches a guest basket keeps working. It is a
+    // bearer credential sitting in browser storage, so it has to expire even
+    // though the basket behind it is worth very little: a fortnight is longer
+    // than anyone deliberates over a purchase and short enough that a token
+    // copied off a shared machine goes stale on its own.
+    GUEST_TOKEN_TTL_MINUTES:
+        Number(process.env.CART_GUEST_TOKEN_TTL_MINUTES) || 14 * MINUTES_PER_DAY
 });
 
 module.exports = CART_CONFIG;

--- a/backend/config/cartConfig.js
+++ b/backend/config/cartConfig.js
@@ -34,7 +34,13 @@ const CART_CONFIG = Object.freeze({
     // than anyone deliberates over a purchase and short enough that a token
     // copied off a shared machine goes stale on its own.
     GUEST_TOKEN_TTL_MINUTES:
-        Number(process.env.CART_GUEST_TOKEN_TTL_MINUTES) || 14 * MINUTES_PER_DAY
+        Number(process.env.CART_GUEST_TOKEN_TTL_MINUTES) || 14 * MINUTES_PER_DAY,
+
+    // The most of one line a cart may hold. It matches the per-item ceiling
+    // the order routes already enforce, and exists here because combining two
+    // baskets is the one operation that can push a line past a limit the
+    // shopper never typed.
+    MAX_LINE_QUANTITY: Number(process.env.CART_MAX_LINE_QUANTITY) || 100
 });
 
 module.exports = CART_CONFIG;

--- a/backend/config/policy.js
+++ b/backend/config/policy.js
@@ -157,6 +157,23 @@ function isPolicyMiddleware(middleware) {
 }
 
 /**
+ * Whether the middleware's decision admits a caller with no account.
+ *
+ * A guard that lets anonymous traffic through is still a guard -- it decides
+ * which resource the caller may reach on some other evidence -- but it is a
+ * materially different decision from "must be signed in", and the audit has
+ * to be able to tell the two apart. Declaring it in the marker means the
+ * difference is stated by the middleware itself rather than inferred from
+ * where it happens to be mounted.
+ *
+ * @param {*} middleware
+ * @returns {boolean}
+ */
+function isGuestCapableMiddleware(middleware) {
+    return isPolicyMiddleware(middleware) && middleware[POLICY_MARKER].guest === true;
+}
+
+/**
  * Reduce anything role-shaped to a comparable string.
  * Roles arrive from JWT claims and from MySQL, so casing and padding vary.
  *
@@ -315,6 +332,7 @@ module.exports = {
     POLICY_MARKER,
     markPolicyMiddleware,
     isPolicyMiddleware,
+    isGuestCapableMiddleware,
     normalizeRole,
     isValidRole,
     isAdminRole,

--- a/backend/config/routePolicy.js
+++ b/backend/config/routePolicy.js
@@ -15,6 +15,7 @@ const PUBLIC_REASON = Object.freeze({
     AUTH_ENTRY: 'the caller has no credentials yet, by definition',
     PRE_AUTH_QUOTE: 'quoted before an account exists, so guest checkout works',
     SIGNED_TOKEN: 'authorised by an unguessable token in the URL, not by session',
+    ORDER_CREDENTIALS: 'authorised by the order number and the email it was placed with',
     WEBHOOK: 'authenticated by provider signature inside the handler'
 });
 
@@ -52,6 +53,8 @@ const PUBLIC_ROUTES = Object.freeze([
     { method: 'POST', path: '/api/promos/validate', reason: PUBLIC_REASON.PRE_AUTH_QUOTE },
     { method: 'POST', path: '/api/checkout/quote', reason: PUBLIC_REASON.PRE_AUTH_QUOTE },
 
+    { method: 'POST', path: '/api/orders/lookup', reason: PUBLIC_REASON.ORDER_CREDENTIALS },
+
     { method: 'GET', path: '/api/wishlist/share/:token', reason: PUBLIC_REASON.SIGNED_TOKEN },
     { method: 'POST', path: '/api/auth/erasure/confirm', reason: PUBLIC_REASON.SIGNED_TOKEN },
     { method: 'GET', path: '/api/auth/erasure/receipt/:receiptId', reason: PUBLIC_REASON.SIGNED_TOKEN },
@@ -61,7 +64,8 @@ const PUBLIC_ROUTES = Object.freeze([
 ]);
 
 const GUEST_REASON = Object.freeze({
-    CART_TOKEN: 'the shopper holds an unguessable cart token instead of a session'
+    CART_TOKEN: 'the shopper holds an unguessable cart token instead of a session',
+    GUEST_CHECKOUT: 'buying is what the storefront is for, and an account is not a prerequisite'
 });
 
 /**
@@ -82,7 +86,10 @@ const GUEST_ROUTES = Object.freeze([
     { method: 'POST', path: '/api/cart/add', reason: GUEST_REASON.CART_TOKEN },
     { method: 'PUT', path: '/api/cart/update', reason: GUEST_REASON.CART_TOKEN },
     { method: 'DELETE', path: '/api/cart/remove/:productId', reason: GUEST_REASON.CART_TOKEN },
-    { method: 'DELETE', path: '/api/cart/clear', reason: GUEST_REASON.CART_TOKEN }
+    { method: 'DELETE', path: '/api/cart/clear', reason: GUEST_REASON.CART_TOKEN },
+
+    { method: 'POST', path: '/api/orders', reason: GUEST_REASON.GUEST_CHECKOUT },
+    { method: 'POST', path: '/api/orders/create-payment-intent', reason: GUEST_REASON.GUEST_CHECKOUT }
 ]);
 
 /**

--- a/backend/config/routePolicy.js
+++ b/backend/config/routePolicy.js
@@ -60,6 +60,31 @@ const PUBLIC_ROUTES = Object.freeze([
     { method: 'POST', path: '/api/courier-webhooks/:provider', reason: PUBLIC_REASON.WEBHOOK }
 ]);
 
+const GUEST_REASON = Object.freeze({
+    CART_TOKEN: 'the shopper holds an unguessable cart token instead of a session'
+});
+
+/**
+ * Routes a caller with no account may reach, and on what evidence.
+ *
+ * Distinct from `PUBLIC_ROUTES`, which is the list of routes that make no
+ * access decision at all. These do: they identify a resource and refuse
+ * anything that is not it. What they do not require is an account.
+ *
+ * Serving a guest is a product decision with a security consequence, so it is
+ * written down in the same reviewed file for the same reason the public list
+ * is -- and the audit checks the list against the routers, so a guard that
+ * quietly starts admitting anonymous callers shows up here or fails.
+ */
+const GUEST_ROUTES = Object.freeze([
+    { method: 'GET', path: '/api/cart', reason: GUEST_REASON.CART_TOKEN },
+    { method: 'POST', path: '/api/cart/sync', reason: GUEST_REASON.CART_TOKEN },
+    { method: 'POST', path: '/api/cart/add', reason: GUEST_REASON.CART_TOKEN },
+    { method: 'PUT', path: '/api/cart/update', reason: GUEST_REASON.CART_TOKEN },
+    { method: 'DELETE', path: '/api/cart/remove/:productId', reason: GUEST_REASON.CART_TOKEN },
+    { method: 'DELETE', path: '/api/cart/clear', reason: GUEST_REASON.CART_TOKEN }
+]);
+
 /**
  * The routers the audit covers, with the prefix each is mounted under.
  *
@@ -100,9 +125,25 @@ function isPublicRoute(method, path) {
     ));
 }
 
+/**
+ * @param {string} method
+ * @param {string} path
+ * @returns {boolean} true when the route is declared reachable without an account
+ */
+function isGuestRoute(method, path) {
+    const wanted = String(method || '').toUpperCase();
+
+    return GUEST_ROUTES.some((entry) => (
+        entry.path === path && (entry.method === '*' || entry.method === wanted)
+    ));
+}
+
 module.exports = {
     PUBLIC_REASON,
     PUBLIC_ROUTES,
+    GUEST_REASON,
+    GUEST_ROUTES,
     AUDITED_MOUNTS,
-    isPublicRoute
+    isPublicRoute,
+    isGuestRoute
 };

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -14,6 +14,8 @@ const agentIdentityService = require("../services/agentIdentityService");
 // Lockout state lives in Redis so it survives a restart and is observed by
 // every instance; the policy it enforces is unchanged.
 const loginLockoutService = require("../services/loginLockoutService");
+// A basket built before signing in belongs to the account afterwards (#1427).
+const { mergeGuestCartOnSignIn } = require("../services/cartMergeService");
 
 // Appwrite SDK
 const { Client, Account, ID, Databases } = require('node-appwrite');
@@ -105,7 +107,7 @@ function generateRefreshToken() {
     return refreshTokenService.generateRawRefreshToken();
 }
 
-function sendAuthResponse(res, { message, accessToken, refreshToken, user, familyId, security }) {
+function sendAuthResponse(res, { message, accessToken, refreshToken, user, familyId, security, cartMerged }) {
     return res.status(200).json({
         success: true,
         message,
@@ -113,6 +115,10 @@ function sendAuthResponse(res, { message, accessToken, refreshToken, user, famil
         refreshToken,
         familyId: familyId || undefined,
         security: security || undefined,
+        // Reported so the client knows the basket it was holding is now the
+        // account's, and can read it back rather than pushing its own copy
+        // over the top of a merge the server has already done (#1427).
+        cartMerged: cartMerged === true,
         user: {
             id: user.id,
             name: user.name,
@@ -284,7 +290,17 @@ const verifySignup = async (req, res) => {
         
         pendingSignups.delete(cleanEmail);
 
-        return res.status(201).json({ success: true, message: "Account created successfully" });
+        // Registration is the other way a basket acquires an owner. It is the
+        // same merge: the new account has no cart, so one is opened and the
+        // guest's lines move into it, leaving the guest cart closed rather
+        // than orphaned behind a token nobody will present again.
+        const cartMerged = await mergeGuestCartOnSignIn(userId, req);
+
+        return res.status(201).json({
+            success: true,
+            message: "Account created successfully",
+            cartMerged
+        });
     } catch (error) {
         console.error("VERIFY SIGNUP ERROR:", error);
         return res.status(500).json({ success: false, message: "Server error during verification" });
@@ -344,11 +360,17 @@ const login = async (req, res) => {
         const session = await refreshTokenService.issueRefreshFamily(user.id, { ip, userAgent });
         const access = generateAccessToken(user, session.familyId);
 
+        // After the session is issued, and unable to prevent it: the shopper
+        // is signed in either way, and losing a basket is a smaller failure
+        // than being refused entry over one.
+        const cartMerged = await mergeGuestCartOnSignIn(user.id, req);
+
         return sendAuthResponse(res, {
             message: "Login successful",
             accessToken: access.token,
             refreshToken: session.refreshToken,
             familyId: session.familyId,
+            cartMerged,
             user,
             security: {
                 tokenRotation: true,

--- a/backend/controllers/cartController.js
+++ b/backend/controllers/cartController.js
@@ -10,12 +10,81 @@ const {
     resolveCartOwnership
 } = require("../services/cart.service");
 const cartLifecycle = require("../services/cartLifecycleService");
+const guestCart = require("../services/guestCartService");
+
+// Every handler below works from the cart, not from the account (#1427). The
+// two are the same thing for a signed-in shopper and the account is still
+// written on each line, but a guest has only the cart, and one code path that
+// always knows which cart it is holding is worth more than two that differ
+// only in how they found it.
+
+/**
+ * The cart this request may write to, opened if the shopper has none yet.
+ *
+ * A guest token comes back only when one was minted, because that is the only
+ * moment the client can be told what to hold on to.
+ */
+const resolveCartForWrite = async (req, connection) => {
+    const { userId, guestToken } = req.cartIdentity;
+
+    if (userId) {
+        return {
+            cartId: await cartLifecycle.resolveActiveCart(userId, connection),
+            userId,
+            issuedToken: null
+        };
+    }
+
+    const guest = await guestCart.resolveCart(guestToken, connection);
+
+    return { cartId: guest.cartId, userId: null, issuedToken: guest.token };
+};
+
+/**
+ * The cart this request may read, or null.
+ *
+ * Reading never opens one. A visitor who has added nothing has an empty
+ * basket, not a row, and a cart created by a page load would be counted as a
+ * basket that was walked away from.
+ */
+const resolveCartForRead = async (req) => {
+    const { userId, guestToken } = req.cartIdentity;
+
+    return userId
+        ? cartLifecycle.findActiveCartId(userId)
+        : guestCart.findCartIdByToken(guestToken);
+};
+
+// Shopper activity moves two clocks for a guest: the cart's, which the
+// abandonment sweep reads, and the token's, so a credential does not expire
+// under someone who is still shopping.
+const recordActivity = async (cart, connection) => {
+    await cartLifecycle.touchCart(cart.cartId, connection);
+
+    if (!cart.userId) {
+        await guestCart.extendToken(cart.cartId, connection);
+    }
+};
+
+// Returned in the body rather than in a header: a response header has to be
+// named in the CORS exposure list before a browser will let a script read it,
+// and the client already parses every one of these responses.
+const issuedToken = (cart) => (
+    cart.issuedToken ? { cartToken: cart.issuedToken } : {}
+);
 
 const cartController = {
-    // Get the logged-in user's cart (joined with product data)
+    // Get the current cart (joined with product data)
     getUserCart: async (req, res) => {
         try {
-            const userId = req.user.id;
+            const cartId = await resolveCartForRead(req);
+
+            if (!cartId) {
+                return res.status(200).json({
+                    success: true,
+                    cart: []
+                });
+            }
 
             const [rows] = await promisePool.query(`
                 SELECT
@@ -32,9 +101,9 @@ const cartController = {
                     c.created_at AS added_at
                 FROM cart_items c
                 JOIN products p ON c.product_id = p.id
-                WHERE c.user_id = ?
+                WHERE c.cart_id = ?
                 ORDER BY c.created_at DESC
-            `, [userId]);
+            `, [cartId]);
 
             return res.status(200).json({
                 success: true,
@@ -50,18 +119,18 @@ const cartController = {
         }
     },
 
-    // Replace the user's entire cart with the posted lines
+    // Replace the entire cart with the posted lines
     syncCart: async (req, res) => {
         let connection;
 
         try {
-            const userId = req.user.id;
+            const { userId } = req.cartIdentity;
 
             // A client may only replace the cart it already owns. A payload
-            // that declares a different owner — or still declares itself a
-            // guest cart — has not been reconciled against this session, and
-            // adopting it would attach one shopper's basket to another's
-            // account.
+            // that declares a different owner has not been reconciled against
+            // this session, and adopting it would attach one shopper's basket
+            // to another's. An absent viewer reads as the guest owner, so a
+            // guest may only push a payload that says it is a guest's.
             if (
                 req.body.owner !== undefined &&
                 resolveCartOwnership(req.body.owner, userId) !== CART_OWNERSHIP.ADOPT
@@ -78,11 +147,13 @@ const cartController = {
 
             await connection.beginTransaction();
 
-            // /cart/sync is replace-all: drop the user's current reservations
-            // up front so the ones created below match the synced lines.
-            await inventoryReservationService.releaseUserLocks(userId, null, connection);
+            // /cart/sync is replace-all: drop the current reservations up
+            // front so the ones created below match the synced lines.
+            if (userId) {
+                await inventoryReservationService.releaseUserLocks(userId, null, connection);
+            }
 
-            const cartId = await cartLifecycle.resolveActiveCart(userId, connection);
+            const cart = await resolveCartForWrite(req, connection);
 
             let placeholders = [];
             let values = [];
@@ -102,27 +173,34 @@ const cartController = {
                 for (const line of lines) {
                     if (!knownProductIds.has(line.productId)) continue;
 
-                    const reserved = await inventoryReservationService.reserveStock(
-                        userId,
-                        line.productId,
-                        line.quantity,
-                        connection,
-                        line
-                    );
+                    // Reservations are held against an account, so a guest
+                    // basket holds no stock. Nothing is oversold by that: the
+                    // deduction at checkout is guarded on the stock it is
+                    // deducting from. What a guest gives up is the fifteen
+                    // minutes an account gets to finish paying.
+                    if (userId) {
+                        const reserved = await inventoryReservationService.reserveStock(
+                            userId,
+                            line.productId,
+                            line.quantity,
+                            connection,
+                            line
+                        );
 
-                    if (!reserved) {
-                        await connection.rollback();
+                        if (!reserved) {
+                            await connection.rollback();
 
-                        return res.status(400).json({
-                            success: false,
-                            message: `Requested quantity exceeds available stock for product ${line.productId}`
-                        });
+                            return res.status(400).json({
+                                success: false,
+                                message: `Requested quantity exceeds available stock for product ${line.productId}`
+                            });
+                        }
                     }
 
                     placeholders.push("(?, ?, ?, ?, ?, ?, ?)");
                     values.push(
                         userId,
-                        cartId,
+                        cart.cartId,
                         line.productId,
                         line.variantId,
                         line.color,
@@ -134,8 +212,8 @@ const cartController = {
 
             // clear existing cart only after validation succeeds
             await connection.query(
-                "DELETE FROM cart_items WHERE user_id = ?",
-                [userId]
+                "DELETE FROM cart_items WHERE cart_id = ?",
+                [cart.cartId]
             );
 
             if (placeholders.length) {
@@ -145,13 +223,14 @@ const cartController = {
                 );
             }
 
-            await cartLifecycle.touchCart(cartId, connection);
+            await recordActivity(cart, connection);
 
             await connection.commit();
 
             return res.status(200).json({
                 success: true,
-                message: "Cart synced"
+                message: "Cart synced",
+                ...issuedToken(cart)
             });
 
         } catch (error) {
@@ -175,7 +254,7 @@ const cartController = {
         let connection;
         try {
             connection = await promisePool.getConnection();
-            const userId = req.user.id;
+            const { userId } = req.cartIdentity;
 
             // A quantity below 1 is a client error rather than something to
             // clamp, so it is read before normalization floors it.
@@ -188,17 +267,19 @@ const cartController = {
 
             await connection.beginTransaction();
 
-            const cartId = await cartLifecycle.resolveActiveCart(userId, connection);
+            const cart = await resolveCartForWrite(req, connection);
 
-            const reserved = await inventoryReservationService.reserveStock(userId, line.productId, line.quantity, connection, line);
-            if (!reserved) {
-                await connection.rollback();
-                return res.status(400).json({ success: false, message: "Requested quantity exceeds available stock or could not be reserved" });
+            if (userId) {
+                const reserved = await inventoryReservationService.reserveStock(userId, line.productId, line.quantity, connection, line);
+                if (!reserved) {
+                    await connection.rollback();
+                    return res.status(400).json({ success: false, message: "Requested quantity exceeds available stock or could not be reserved" });
+                }
             }
 
             const [existingLines] = await connection.query(
-                "SELECT product_id, variant_id, color, size, quantity FROM cart_items WHERE user_id = ? AND product_id = ?",
-                [userId, line.productId]
+                "SELECT product_id, variant_id, color, size, quantity FROM cart_items WHERE cart_id = ? AND product_id = ?",
+                [cart.cartId, line.productId]
             );
 
             // Adding to a line that is already in the cart is the one place
@@ -208,19 +289,23 @@ const cartController = {
                 mergeCartLines(existingLines, [line])
                     .find((candidate) => cartLineKey(candidate) === key) || line;
 
-            // Updating cart_id on conflict also adopts any line left behind by
-            // a database that predates the cart record.
             await connection.query(
                 `INSERT INTO cart_items (user_id, cart_id, product_id, variant_id, color, size, quantity)
                  VALUES (?, ?, ?, ?, ?, ?, ?)
-                 ON DUPLICATE KEY UPDATE quantity = VALUES(quantity), cart_id = VALUES(cart_id)`,
-                [userId, cartId, line.productId, line.variantId, line.color, line.size, mergedLine.quantity]
+                 ON DUPLICATE KEY UPDATE quantity = VALUES(quantity)`,
+                [userId, cart.cartId, line.productId, line.variantId, line.color, line.size, mergedLine.quantity]
             );
 
-            await cartLifecycle.touchCart(cartId, connection);
+            await recordActivity(cart, connection);
 
             await connection.commit();
-            return res.status(200).json({ success: true, message: "Product added to cart and reserved for 15 minutes" });
+            return res.status(200).json({
+                success: true,
+                message: userId
+                    ? "Product added to cart and reserved for 15 minutes"
+                    : "Product added to cart",
+                ...issuedToken(cart)
+            });
         } catch (error) {
             if (connection) await connection.rollback();
             console.error("ADD TO CART ERROR:", error);
@@ -235,13 +320,23 @@ const cartController = {
         let connection;
         try {
             connection = await promisePool.getConnection();
-            const userId = req.user.id;
+            const { userId } = req.cartIdentity;
 
             const quantity = safeInteger(req.body.quantity, 0);
             const line = normalizeCartLine({ ...req.body, quantity });
 
             if (!line || quantity < 1) {
                 return res.status(400).json({ success: false, message: "Invalid product ID or quantity" });
+            }
+
+            // Changing the quantity of a line implies a basket to change it
+            // in, so this reads the cart rather than opening one. A shopper
+            // with no cart is answered the same way a shopper without that
+            // line is.
+            const cartId = await resolveCartForRead(req);
+
+            if (!cartId) {
+                return res.status(404).json({ success: false, message: "Product not found in cart" });
             }
 
             await connection.beginTransaction();
@@ -255,23 +350,19 @@ const cartController = {
             // Move the reservation for this line to the new quantity (release
             // then re-reserve) so held stock tracks the cart. Other variants of
             // the same product keep their own reservations.
-            await inventoryReservationService.releaseLineLocks(userId, line, connection);
+            if (userId) {
+                await inventoryReservationService.releaseLineLocks(userId, line, connection);
 
-            const reserved = await inventoryReservationService.reserveStock(userId, line.productId, line.quantity, connection, line);
-            if (!reserved) {
-                await connection.rollback();
-                return res.status(400).json({ success: false, message: "Requested quantity exceeds available stock" });
+                const reserved = await inventoryReservationService.reserveStock(userId, line.productId, line.quantity, connection, line);
+                if (!reserved) {
+                    await connection.rollback();
+                    return res.status(400).json({ success: false, message: "Requested quantity exceeds available stock" });
+                }
             }
 
-            const cartId = await cartLifecycle.resolveActiveCart(userId, connection);
-
-            // Quantity only. Folding cart_id into the SET would make
-            // affectedRows non-zero for a line whose quantity did not change,
-            // turning today's "Product not found in cart" answer into a
-            // success. Adoption of pre-#1364 lines is the migration's job.
             const [result] = await connection.query(
-                "UPDATE cart_items SET quantity = ? WHERE user_id = ? AND product_id = ? AND variant_id = ? AND color = ? AND size = ?",
-                [line.quantity, userId, line.productId, line.variantId, line.color, line.size]
+                "UPDATE cart_items SET quantity = ? WHERE cart_id = ? AND product_id = ? AND variant_id = ? AND color = ? AND size = ?",
+                [line.quantity, cartId, line.productId, line.variantId, line.color, line.size]
             );
 
             if (result.affectedRows === 0) {
@@ -279,7 +370,7 @@ const cartController = {
                 return res.status(404).json({ success: false, message: "Product not found in cart" });
             }
 
-            await cartLifecycle.touchCart(cartId, connection);
+            await recordActivity({ cartId, userId }, connection);
 
             await connection.commit();
             return res.status(200).json({ success: true, message: "Cart item updated" });
@@ -296,7 +387,7 @@ const cartController = {
     // parameters because a DELETE carries no body.
     removeCartItem: async (req, res) => {
         try {
-            const userId = req.user.id;
+            const { userId } = req.cartIdentity;
 
             const line = normalizeCartLine({
                 productId: req.params.productId,
@@ -309,9 +400,15 @@ const cartController = {
                 return res.status(400).json({ success: false, message: "Invalid product ID" });
             }
 
+            const cartId = await resolveCartForRead(req);
+
+            if (!cartId) {
+                return res.status(404).json({ success: false, message: "Product not found in cart" });
+            }
+
             const [result] = await promisePool.query(
-                "DELETE FROM cart_items WHERE user_id = ? AND product_id = ? AND variant_id = ? AND color = ? AND size = ?",
-                [userId, line.productId, line.variantId, line.color, line.size]
+                "DELETE FROM cart_items WHERE cart_id = ? AND product_id = ? AND variant_id = ? AND color = ? AND size = ?",
+                [cartId, line.productId, line.variantId, line.color, line.size]
             );
 
             if (result.affectedRows === 0) {
@@ -319,13 +416,14 @@ const cartController = {
             }
 
             // The line is gone, so the stock it was holding must go with it.
-            await inventoryReservationService.releaseLineLocks(userId, line);
+            if (userId) {
+                await inventoryReservationService.releaseLineLocks(userId, line);
+            }
 
-            // Removing a line is shopper activity. Touch rather than resolve:
-            // taking things out of the cart is no reason to create one.
-            await cartLifecycle.touchCart(
-                await cartLifecycle.findActiveCartId(userId)
-            );
+            // Removing a line is shopper activity, but taking things out of
+            // the cart is no reason to create one -- which is why the cart was
+            // read rather than resolved above.
+            await recordActivity({ cartId, userId });
 
             return res.status(200).json({ success: true, message: "Product removed from cart" });
         } catch (error) {
@@ -337,16 +435,23 @@ const cartController = {
     // Clear the entire cart
     clearCart: async (req, res) => {
         try {
-            const userId = req.user.id;
-            await promisePool.query("DELETE FROM cart_items WHERE user_id = ?", [userId]);
-            await inventoryReservationService.releaseUserLocks(userId);
+            const { userId } = req.cartIdentity;
+            const cartId = await resolveCartForRead(req);
+
+            if (!cartId) {
+                return res.status(200).json({ success: true, message: "Cart cleared" });
+            }
+
+            await promisePool.query("DELETE FROM cart_items WHERE cart_id = ?", [cartId]);
+
+            if (userId) {
+                await inventoryReservationService.releaseUserLocks(userId);
+            }
 
             // The cart stays active and empty. Emptying it is a decision the
             // shopper just made, not a cart to close: closing it here would
             // report a deliberate clear-out as an abandonment.
-            await cartLifecycle.touchCart(
-                await cartLifecycle.findActiveCartId(userId)
-            );
+            await recordActivity({ cartId, userId });
 
             return res.status(200).json({ success: true, message: "Cart cleared" });
         } catch (error) {

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -20,6 +20,7 @@ const {
     sanitizeString,
     getPagination,
     buildPaginationMeta,
+    maskPhone,
     safeArray,
     safeUUID
 } = require(
@@ -31,6 +32,34 @@ const addressService = require("../services/addressService");
 // Order status history (#1351). Every status change records who, when, from
 // what, and why -- inside the same transaction as the change itself.
 const orderStatusHistoryService = require("../services/orderStatusHistoryService");
+// Guest checkout (#1427).
+const guestCart = require("../services/guestCartService");
+const { findGuestOrder } = require("../services/guestOrderService");
+
+/**
+ * Whoever is checking out, and the cart they are checking out of (#1427).
+ *
+ * `cartIdentity` has already settled which of the two it is and refused
+ * anything else, so this only has to look the cart up. A guest with no
+ * resolvable cart is not turned away: what is being bought is the posted
+ * basket, priced server-side, and the cart row only exists here so it can be
+ * closed. A shopper whose token went stale between the last cart write and
+ * the checkout has still built a real order.
+ */
+const resolveCheckoutIdentity = async (req, connection) => {
+    const identity = req.cartIdentity || { userId: req.user?.id || null, guestToken: null };
+    const userId = identity.userId || null;
+
+    if (userId) {
+        return { userId, cartId: null, isGuest: false };
+    }
+
+    return {
+        userId: null,
+        cartId: await guestCart.findCartIdByToken(identity.guestToken, connection),
+        isGuest: true
+    };
+};
 
 // create order
 const createOrder =
@@ -54,16 +83,28 @@ const createOrder =
                 addressId
             } = req.body;
 
+            const checkout = await resolveCheckoutIdentity(req, connection);
+
             // Resolve a saved address into the same flat shape the manual form
             // posts, so everything below this point is unchanged whichever way
             // the shopper checked out.
             //
             // The lookup is scoped to the calling user by addressService, so an
             // id belonging to somebody else resolves to null and is rejected as
-            // "not found" rather than silently shipping to a stranger.
+            // "not found" rather than silently shipping to a stranger. A guest
+            // has no address book, so an id from one is simply not theirs.
+            if (addressId && !checkout.userId) {
+                return res.status(404)
+                    .json({
+                        success: false,
+                        message:
+                            "Saved address not found"
+                    });
+            }
+
             if (addressId) {
                 const resolved = await addressService.resolveForOrder(
-                    req.user.id,
+                    checkout.userId,
                     sanitizeString(addressId)
                 );
 
@@ -168,22 +209,31 @@ const createOrder =
             // begin transaction
             await connection.beginTransaction();
 
-            // Validate inventory locks with structured 409 on conflict (#1260)
-            const lockCheck = await inventoryReservationService.validateCartLocksDetailed(
-                req.user.id,
-                items,
-                connection
-            );
-            if (!lockCheck.ok) {
-                await connection.rollback();
-                return res.status(409).json({
-                    success: false,
-                    code: lockCheck.code || "INVENTORY_CONFLICT",
-                    message: lockCheck.message || "Inventory locks expired or insufficient stock",
-                    productId: lockCheck.productId,
-                    availableStock: lockCheck.availableStock,
-                    requested: lockCheck.requested
-                });
+            // Validate inventory locks with structured 409 on conflict (#1260).
+            //
+            // A reservation is held against an account, so a guest basket has
+            // none to validate. Nothing is oversold by skipping the check: the
+            // stock deduction inside the order service is guarded on the stock
+            // it is deducting from, and that is what actually prevents it. A
+            // guest simply does not get the fifteen minutes an account gets to
+            // finish paying.
+            if (checkout.userId) {
+                const lockCheck = await inventoryReservationService.validateCartLocksDetailed(
+                    checkout.userId,
+                    items,
+                    connection
+                );
+                if (!lockCheck.ok) {
+                    await connection.rollback();
+                    return res.status(409).json({
+                        success: false,
+                        code: lockCheck.code || "INVENTORY_CONFLICT",
+                        message: lockCheck.message || "Inventory locks expired or insufficient stock",
+                        productId: lockCheck.productId,
+                        availableStock: lockCheck.availableStock,
+                        requested: lockCheck.requested
+                    });
+                }
             }
 
             // create order via service
@@ -191,7 +241,8 @@ const createOrder =
                 await createOrderService(
                     connection,
                     {
-                        user_id: req.user.id,
+                        user_id: checkout.userId,
+                        cart_id: checkout.cartId,
                         customer_name: sanitizeString(customer.name),
                         customer_email: sanitizeString(customer.email),
                         customer_phone: sanitizeString(customer.phone),
@@ -208,7 +259,9 @@ const createOrder =
                 );
             
             // Consume inventory locks after successful stock deduction
-            await inventoryReservationService.consumeLocks(req.user.id, items, connection);
+            if (checkout.userId) {
+                await inventoryReservationService.consumeLocks(checkout.userId, items, connection);
+            }
 
             // The order's first history entry, written before the commit so it
             // shares the order's fate. Without it a brand-new order has an
@@ -219,7 +272,7 @@ const createOrder =
                 fromStatus: null,
                 toStatus: "pending",
                 source: "customer",
-                changedBy: safeUUID(req.user?.id),
+                changedBy: safeUUID(checkout.userId),
                 changedByName: sanitizeString(customer.name || ""),
                 reason: "Order placed",
                 metadata: { paymentMethod: sanitizeString(paymentMethod).toLowerCase() },
@@ -234,7 +287,7 @@ const createOrder =
             // timestamp must not fail a placed order. The service swallows its
             // own errors.
             if (addressId) {
-                await addressService.markAddressUsed(req.user.id, addressId);
+                await addressService.markAddressUsed(checkout.userId, addressId);
             }
 
             return res.status(201)
@@ -246,6 +299,10 @@ const createOrder =
                         addressId || null,
                     orderId:
                         result.orderId,
+                    // The only handle a guest will have on this order, so it
+                    // is returned whoever placed it rather than only to them.
+                    orderNumber:
+                        result.orderNumber,
                     breakdown:
                         result.breakdown
                 });
@@ -257,8 +314,10 @@ const createOrder =
 
             // Release reservation locks if the transaction failed mid-checkout
             try {
-                if (req.user?.id) {
-                    await inventoryReservationService.releaseUserLocks(req.user.id);
+                if (req.cartIdentity?.userId || req.user?.id) {
+                    await inventoryReservationService.releaseUserLocks(
+                        req.cartIdentity?.userId || req.user.id
+                    );
                 }
             } catch (_) { /* ignore */ }
 
@@ -782,6 +841,8 @@ const createPaymentIntent = async (req, res) => {
 
         const { customer, address, items, total, promoCode } = req.body;
 
+        const checkout = await resolveCheckoutIdentity(req, connection);
+
         if (!customer || !customer.name || !customer.email) {
             return res.status(400).json({ success: false, message: "Customer information required" });
         }
@@ -798,25 +859,30 @@ const createPaymentIntent = async (req, res) => {
 
         await connection.beginTransaction();
 
-        const lockCheck = await inventoryReservationService.validateCartLocksDetailed(
-            req.user.id,
-            items,
-            connection
-        );
-        if (!lockCheck.ok) {
-            await connection.rollback();
-            return res.status(409).json({
-                success: false,
-                code: lockCheck.code || "INVENTORY_CONFLICT",
-                message: lockCheck.message || "Inventory locks expired or insufficient stock",
-                productId: lockCheck.productId,
-                availableStock: lockCheck.availableStock,
-                requested: lockCheck.requested
-            });
+        // A guest holds no reservations to validate; see createOrder above for
+        // why that does not put stock at risk.
+        if (checkout.userId) {
+            const lockCheck = await inventoryReservationService.validateCartLocksDetailed(
+                checkout.userId,
+                items,
+                connection
+            );
+            if (!lockCheck.ok) {
+                await connection.rollback();
+                return res.status(409).json({
+                    success: false,
+                    code: lockCheck.code || "INVENTORY_CONFLICT",
+                    message: lockCheck.message || "Inventory locks expired or insufficient stock",
+                    productId: lockCheck.productId,
+                    availableStock: lockCheck.availableStock,
+                    requested: lockCheck.requested
+                });
+            }
         }
 
         const result = await createOrderService(connection, {
-            user_id: req.user.id,
+            user_id: checkout.userId,
+            cart_id: checkout.cartId,
             customer_name: sanitizeString(customer.name),
             customer_email: sanitizeString(customer.email),
             customer_phone: sanitizeString(customer.phone),
@@ -830,7 +896,9 @@ const createPaymentIntent = async (req, res) => {
             promo_code: promoCode ? sanitizeString(promoCode) : null
         });
 
-        await inventoryReservationService.consumeLocks(req.user.id, items, connection);
+        if (checkout.userId) {
+            await inventoryReservationService.consumeLocks(checkout.userId, items, connection);
+        }
 
         // Charge what the engine priced, never what the browser claimed.
         const chargeableTotal = result.breakdown.total;
@@ -842,13 +910,15 @@ const createPaymentIntent = async (req, res) => {
             charge: () =>
                 paymentService.createPaymentIntent(chargeableTotal, CURRENCY.code, {
                     orderId: result.orderId,
-                    userId: req.user.id
+                    userId: checkout.userId
                 }),
             rollback: async () => {
                 await connection.rollback();
             },
             releaseLocks: async () => {
-                await inventoryReservationService.releaseUserLocks(req.user.id);
+                if (checkout.userId) {
+                    await inventoryReservationService.releaseUserLocks(checkout.userId);
+                }
             }
         });
         if (!paymentIntentResult.success) {
@@ -867,6 +937,7 @@ const createPaymentIntent = async (req, res) => {
             success: true,
             clientSecret: paymentIntentResult.clientSecret,
             orderId: result.orderId,
+            orderNumber: result.orderNumber,
             breakdown: result.breakdown
         });
 
@@ -876,8 +947,10 @@ const createPaymentIntent = async (req, res) => {
         }
 
         try {
-            if (req.user?.id) {
-                await inventoryReservationService.releaseUserLocks(req.user.id);
+            if (req.cartIdentity?.userId || req.user?.id) {
+                await inventoryReservationService.releaseUserLocks(
+                    req.cartIdentity?.userId || req.user.id
+                );
             }
         } catch (_) { /* ignore */ }
 
@@ -1028,6 +1101,76 @@ const getOrderTimeline = async (req, res) => {
 };
 
 /**
+ * POST /api/orders/lookup
+ *
+ * An order found without an account, on the pair the shopper was given at
+ * checkout: the order number and the email it was placed with (#1427).
+ *
+ * The credentials arrive in the body rather than the path so they do not
+ * accumulate in access logs, proxy caches and browser history, which is where
+ * a bearer credential in a URL ends up.
+ *
+ * Every failure is the same 404 with the same wording. Distinguishing "no such
+ * order" from "wrong email" would answer, one request at a time, whether a
+ * given address has ever shopped here.
+ */
+const lookupGuestOrder = async (req, res) => {
+    try {
+        const order = await findGuestOrder({
+            orderNumber: req.body?.orderNumber,
+            email: req.body?.email
+        });
+
+        if (!order) {
+            return res.status(404).json({
+                success: false,
+                message: "No order matches that order number and email address"
+            });
+        }
+
+        return res.status(200).json({
+            success: true,
+            order: {
+                orderNumber: order.order_number,
+                status: order.status,
+                paymentStatus: order.payment_status,
+                paymentMethod: order.payment_method,
+                placedAt: order.created_at,
+                updatedAt: order.updated_at,
+                trackingNumber: order.tracking_number,
+                customerName: order.customer_name,
+                // The caller proved they know the email, so it is theirs to
+                // see. They proved nothing about the phone number, and a
+                // number is worth more to somebody who should not have it
+                // than it is to the shopper reading their own order.
+                customerPhone: maskPhone(order.customer_phone),
+                deliveryAddress: {
+                    fullAddress: order.full_address,
+                    city: order.city,
+                    state: order.state,
+                    zip: order.zip
+                },
+                totals: {
+                    subtotal: order.subtotal,
+                    tax: order.tax,
+                    shipping: order.shipping_cost,
+                    discount: order.discount_amount,
+                    total: order.total
+                },
+                items: safeArray(order.items)
+            }
+        });
+    } catch (error) {
+        console.error("GUEST ORDER LOOKUP ERROR:", error);
+
+        return res.status(500).json({
+            success: false,
+            message: "Failed to look up the order"
+        });
+    }
+};
+
+/**
  * GET /api/orders/reports/fulfilment  (admin)
  *
  * Average hours to ship and to deliver. This is what the shipped_at /
@@ -1059,6 +1202,7 @@ module.exports = {
     getOrderById,
     getOrderTimeline,
     getFulfilmentReport,
+    lookupGuestOrder,
     getOrderStatus,
     updateOrderStatus,
     cancelUserOrder,

--- a/backend/middleware/cartIdentity.js
+++ b/backend/middleware/cartIdentity.js
@@ -1,0 +1,86 @@
+// backend/middleware/cartIdentity.js
+//
+// Which cart this request is allowed to touch (#1427).
+//
+// The cart endpoints used to answer that with `req.user.id` and nothing else,
+// which is why a basket could not exist before an account did. There are now
+// two ways to be identified -- a session, or a token the client holds -- and
+// this settles which one applies before any handler runs.
+//
+// It is a policy middleware, not a convenience. It makes an access decision:
+// it binds the request to exactly one cart and refuses to let anything else be
+// named. That the decision can come out in a guest's favour is declared in the
+// marker, so `config/routePolicy.js` has to say which routes that is
+// acceptable on and the route audit checks the two agree.
+//
+// The account always wins. A signed-in shopper presenting a cart token gets
+// their account cart, never the guest one -- folding a guest basket into an
+// account is a deliberate step with its own rules, not something that happens
+// because a stale header survived a login.
+
+const { markPolicyMiddleware } = require('../config/policy');
+const { COOKIE_NAMES } = require('../utils/tokens');
+const guestCart = require('../services/guestCartService');
+
+/**
+ * Whether the caller presented credentials at all.
+ *
+ * The distinction that matters is between "no account" and "an account whose
+ * token has expired". Both arrive here without `req.user`, and treating the
+ * second as a guest would silently swap a signed-in shopper's basket for an
+ * empty one instead of letting the client refresh and carry on. So a request
+ * carrying credentials that did not authenticate is answered as it always
+ * was, and only a request carrying none is treated as a guest.
+ *
+ * @param {object} req
+ * @returns {boolean}
+ */
+function presentedCredentials(req) {
+    const authHeader = req.headers?.authorization;
+
+    if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
+        return authHeader.slice(7).trim().length > 0;
+    }
+
+    return Boolean(req.cookies && req.cookies[COOKIE_NAMES.accessToken]);
+}
+
+/**
+ * Populate `req.cartIdentity`.
+ *
+ * Resolving the identity is all that happens here. The cart row itself is
+ * resolved by the handler, inside whatever transaction it opens, because
+ * creating a cart is a write and a read has no business making one.
+ */
+function cartIdentity(req, res, next) {
+    const userId = req.user?.id || req.user?.userId || null;
+
+    if (userId) {
+        req.cartIdentity = { userId, guestToken: null, isGuest: false };
+        return next();
+    }
+
+    if (presentedCredentials(req)) {
+        return res.status(401).json({
+            success: false,
+            message: 'Invalid or expired token'
+        });
+    }
+
+    req.cartIdentity = {
+        userId: null,
+        guestToken: guestCart.readTokenFromRequest(req),
+        isGuest: true
+    };
+
+    return next();
+}
+
+markPolicyMiddleware(cartIdentity, {
+    authentication: 'optional',
+    guest: true,
+    identity: 'cart-token'
+});
+
+module.exports = cartIdentity;
+module.exports.cartIdentity = cartIdentity;

--- a/backend/middleware/corsMiddleware.js
+++ b/backend/middleware/corsMiddleware.js
@@ -53,7 +53,9 @@ const corsOptions = {
 
   methods: ["GET", "POST", "PUT", "PATCH", "DELETE"],
 
-  allowedHeaders: ["Content-Type", "Authorization"],
+  // X-Cart-Token is how a shopper without an account is identified, so a
+  // browser that cannot send it cannot have a basket at all.
+  allowedHeaders: ["Content-Type", "Authorization", "X-Cart-Token"],
 };
 
 // Export the configured middleware

--- a/backend/middleware/rateLimiter.js
+++ b/backend/middleware/rateLimiter.js
@@ -52,6 +52,10 @@ const OTP_WINDOW_MS =
     parseInt(process.env.RATE_LIMIT_OTP_WINDOW_MS, 10)
     || 5 * 60 * 1000; // 5 minutes
 
+const GUEST_ORDER_LOOKUP_MAX =
+    parseInt(process.env.RATE_LIMIT_GUEST_ORDER_LOOKUP_MAX, 10)
+    || 10;
+
 // ==================== CUSTOM KEY GENERATOR ====================
 // A limit is only as good as the identity it counts against, so the identity is
 // picked deliberately here.
@@ -215,6 +219,23 @@ const otpRequestLimiter = createLimiter({
     logPrefix: "OTP request rate limit exceeded"
 });
 
+// ==================== GUEST ORDER LOOKUP LIMITER ====================
+// Not an auth endpoint, but the same abuse: an unauthenticated caller
+// submitting a credential pair and being told whether it was right. Left with
+// the other credential limiters so the defence is maintained alongside them
+// rather than drifting off on its own.
+//
+// The order number carries sixty-four bits, so this is not really about making
+// guessing infeasible -- it already is. It bounds a bulk probe against a list
+// of numbers obtained some other way, and it caps what the endpoint costs.
+const guestOrderLookupLimiter = createLimiter({
+    name: "guest-order-lookup",
+    windowMs: DEFAULT_WINDOW_MS,
+    max: GUEST_ORDER_LOOKUP_MAX,
+    message: `Too many order lookups. Please try again after ${DEFAULT_WINDOW_MS / 60000} minutes.`,
+    logPrefix: "Guest order lookup rate limit exceeded"
+});
+
 // ==================== SUSPICIOUS IP RATE LIMITER ====================
 const suspiciousIpKeyGenerator = (req) => {
     const address = req.ip || req.socket?.remoteAddress;
@@ -246,6 +267,7 @@ module.exports = {
     otpVerifyLimiter,
     resetPasswordLimiter,
     otpRequestLimiter,
+    guestOrderLookupLimiter,
     suspiciousIpLimiter,
     customKeyGenerator,
     onLimitReached

--- a/backend/middleware/routeAudit.js
+++ b/backend/middleware/routeAudit.js
@@ -13,8 +13,8 @@
 // database, so it can run during bootstrap or inside a unit test without any
 // chance of hanging.
 
-const { isPolicyMiddleware } = require('../config/policy');
-const { AUDITED_MOUNTS, isPublicRoute } = require('../config/routePolicy');
+const { isGuestCapableMiddleware, isPolicyMiddleware } = require('../config/policy');
+const { AUDITED_MOUNTS, isGuestRoute, isPublicRoute } = require('../config/routePolicy');
 
 /**
  * Join a mount prefix and a route path into the path a client would call.
@@ -39,7 +39,8 @@ function joinPaths(basePath, routePath) {
  *
  * @param {object} router an Express Router or app
  * @param {string} [basePath='']
- * @returns {Array<{method: string, path: string, handlers: string[], isProtected: boolean}>}
+ * @returns {Array<{method: string, path: string, handlers: string[],
+ *   isProtected: boolean, admitsGuests: boolean}>}
  */
 function collectRoutes(router, basePath = '') {
     const stack = router?.stack || router?.router?.stack || router?._router?.stack;
@@ -73,7 +74,8 @@ function collectRoutes(router, basePath = '') {
                 method: method === '_all' ? 'ALL' : method.toUpperCase(),
                 path: joinPaths(basePath, layer.route.path),
                 handlers: guards.map((guard) => guard.name || '<anonymous>'),
-                isProtected: guards.some(isPolicyMiddleware)
+                isProtected: guards.some(isPolicyMiddleware),
+                admitsGuests: guards.some(isGuestCapableMiddleware)
             });
         }
     }
@@ -98,6 +100,25 @@ function collectMountedRoutes(mounts) {
 function findUnprotectedRoutes(mounts) {
     return collectMountedRoutes(mounts)
         .filter((route) => !route.isProtected && !isPublicRoute(route.method, route.path))
+        .map(({ method, path }) => ({ method, path }));
+}
+
+/**
+ * Routes whose guard admits a caller with no account, without that having
+ * been declared in the registry.
+ *
+ * The reverse of `findUnprotectedRoutes`: these routes are guarded, so the
+ * unprotected check is satisfied and says nothing. What it cannot see is a
+ * guard being widened -- somebody swapping an authenticator for one that also
+ * serves guests, on a route where that was never the intention. Declaring the
+ * guest surface separately makes widening it an edit to a reviewed list.
+ *
+ * @param {Array<{basePath: string, router: object}>} mounts
+ * @returns {Array<{method: string, path: string}>}
+ */
+function findUndeclaredGuestRoutes(mounts) {
+    return collectMountedRoutes(mounts)
+        .filter((route) => route.admitsGuests && !isGuestRoute(route.method, route.path))
         .map(({ method, path }) => ({ method, path }));
 }
 
@@ -144,6 +165,29 @@ function assertRoutesProtected(mounts = loadAuditedMounts()) {
 }
 
 /**
+ * Throw unless every route that admits a guest is declared as one.
+ *
+ * @param {Array<{basePath: string, router: object}>} [mounts]
+ * @throws {Error} listing every undeclared route
+ */
+function assertGuestRoutesDeclared(mounts = loadAuditedMounts()) {
+    const undeclared = findUndeclaredGuestRoutes(mounts);
+
+    if (undeclared.length === 0) {
+        return;
+    }
+
+    const listing = undeclared
+        .map(({ method, path }) => `  ${method} ${path}`)
+        .join('\n');
+
+    throw new Error(
+        'Routes are reachable without an account but are not on the guest ' +
+        `allowlist in config/routePolicy.js:\n${listing}`
+    );
+}
+
+/**
  * Bootstrap hook.
  *
  * Off unless ROUTE_POLICY_AUDIT is set, so an existing deployment does not
@@ -165,6 +209,7 @@ function runStartupAudit({ mode = process.env.ROUTE_POLICY_AUDIT, mounts } = {})
 
     if (mode === 'enforce') {
         assertRoutesProtected(resolved);
+        assertGuestRoutesDeclared(resolved);
         return [];
     }
 
@@ -174,6 +219,10 @@ function runStartupAudit({ mode = process.env.ROUTE_POLICY_AUDIT, mounts } = {})
         console.warn(`[route-policy] no policy declared for ${method} ${path}`);
     }
 
+    for (const { method, path } of findUndeclaredGuestRoutes(resolved)) {
+        console.warn(`[route-policy] reachable without an account and not declared: ${method} ${path}`);
+    }
+
     return unprotected;
 }
 
@@ -181,7 +230,9 @@ module.exports = {
     collectRoutes,
     collectMountedRoutes,
     findUnprotectedRoutes,
+    findUndeclaredGuestRoutes,
     loadAuditedMounts,
     assertRoutesProtected,
+    assertGuestRoutesDeclared,
     runStartupAudit
 };

--- a/backend/routes/cartRoutes.js
+++ b/backend/routes/cartRoutes.js
@@ -1,24 +1,22 @@
 const express = require("express");
 const router = express.Router();
-const authMiddleware = require("../middleware/authMiddleware");
+const { optionalAuth } = require("../middleware/authMiddleware");
+const cartIdentity = require("../middleware/cartIdentity");
 const cartController = require("../controllers/cartController");
 
-// Get user cart
-router.get("/", authMiddleware, cartController.getUserCart);
+// A basket exists before the shopper does (#1427). `optionalAuth` attaches the
+// account when there is one and is deliberately not a policy in its own right;
+// `cartIdentity` is the guard, and it is what decides -- and refuses -- which
+// cart the request may reach. Both are router-level so the pair cannot be
+// forgotten on a route added later.
+router.use(optionalAuth);
+router.use(cartIdentity);
 
-// Replace user cart with the posted items
-router.post("/sync", authMiddleware, cartController.syncCart);
-
-// Add product to cart
-router.post("/add", authMiddleware, cartController.addToCart);
-
-// Update product quantity in cart
-router.put("/update", authMiddleware, cartController.updateCartItem);
-
-// Remove specific product from cart
-router.delete("/remove/:productId", authMiddleware, cartController.removeCartItem);
-
-// Clear the entire cart
-router.delete("/clear", authMiddleware, cartController.clearCart);
+router.get("/", cartController.getUserCart);
+router.post("/sync", cartController.syncCart);
+router.post("/add", cartController.addToCart);
+router.put("/update", cartController.updateCartItem);
+router.delete("/remove/:productId", cartController.removeCartItem);
+router.delete("/clear", cartController.clearCart);
 
 module.exports = router;

--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -2,9 +2,12 @@
 const express = require("express");
 const router = express.Router();
 const authMiddleware = require("../middleware/authMiddleware");
+const { optionalAuth } = authMiddleware;
+const cartIdentity = require("../middleware/cartIdentity");
 const { authorizeRoles } = require("../middleware/rbacMiddleware");
 const { ROLES } = require("../config/policy");
 const { requireOwnership, ownerFromTable } = require("../middleware/requireOwnership");
+const { guestOrderLookupLimiter } = require("../middleware/rateLimiter");
 const orderController = require("../controllers/orderController");
 const { safeArray, safeNumber, sanitizeString } = require("../utils/helpers");
 
@@ -259,18 +262,49 @@ router.get("/status/check", (req, res) => {
 // Validate order data before submission
 router.post("/validate", orderController.validateOrder);
 
+// Find an order without an account, on the order number and the email it was
+// placed with (#1427). Rate-limited because it is an unauthenticated endpoint
+// that says whether a credential pair was right; see guestOrderService.js for
+// why every failure looks identical.
+router.post("/lookup", guestOrderLookupLimiter, (req, res, next) => {
+    const orderNumber = sanitizeString(req.body?.orderNumber);
+    const email = sanitizeString(req.body?.email);
+
+    // Only that both were supplied. Whether either is *correct* is the
+    // handler's answer to give, and it gives the same one for both.
+    if (!orderNumber || !email) {
+        return res.status(400).json({
+            success: false,
+            message: "Order number and email are required"
+        });
+    }
+
+    next();
+}, orderController.lookupGuestOrder);
+
 // ==================== USER ENDPOINTS ====================
 
-// Create payment intent
+// Create payment intent.
+//
+// Guest-reachable on the same terms as order creation (#1427). Leaving it
+// behind authentication would mean a shopper without an account could pay by
+// anything except a card, which is not a meaningful guest checkout.
 router.post(
     "/create-payment-intent",
-    authMiddleware,
+    optionalAuth,
+    cartIdentity,
     require("../middleware/checkoutChallengeMiddleware").checkoutChallengeMiddleware,
     orderController.createPaymentIntent
 );
 
-// Create order
-router.post("/", authMiddleware, require("../middleware/checkoutChallengeMiddleware").checkoutChallengeMiddleware, (req, res, next) => {
+// Create order.
+//
+// The one route on this router that a shopper without an account may reach
+// (#1427). `optionalAuth` attaches the account when there is one; `cartIdentity`
+// is the guard, settling whether this is an account checkout or a guest one and
+// refusing anything in between. The bot-resistance gate is unchanged and still
+// runs -- it already read the caller as optional.
+router.post("/", optionalAuth, cartIdentity, require("../middleware/checkoutChallengeMiddleware").checkoutChallengeMiddleware, (req, res, next) => {
     const { items, total, paymentMethod } = req.body;
 
     // Validate items

--- a/backend/services/cartLifecycleService.js
+++ b/backend/services/cartLifecycleService.js
@@ -12,16 +12,20 @@
 // shopper did something, which is the clock abandonment is later measured
 // against.
 //
-// A cart has exactly two exits, and both live here:
+// A cart has exactly three exits:
 //
 //   active -> converted, at the moment an order is created from it, inside the
 //             order's own transaction so a cart is never recorded as converted
 //             against an order that rolled back;
 //   active -> abandoned, once it has gone untouched for longer than the
-//             configured threshold, applied by the scheduled sweep.
+//             configured threshold, applied by the scheduled sweep;
+//   active -> merged, when a guest basket is folded into an account's cart at
+//             sign-in. That one is applied by services/cartMergeService.js,
+//             which owns the rules for combining two carts; the status itself
+//             is written here.
 //
-// Both are terminal. Nothing moves a cart back to active; the shopper's next
-// action resolves a new one.
+// All three are terminal. Nothing moves a cart back to active; the shopper's
+// next action resolves a new one.
 //
 // Guest carts do exist now (#1427), and services/guestCartService.js resolves
 // them, because finding one is a question about a token rather than about an
@@ -39,7 +43,10 @@ const { safeInteger, safeUUID } = require('../utils/helpers');
 const CART_STATUS = Object.freeze({
     ACTIVE: 'active',
     CONVERTED: 'converted',
-    ABANDONED: 'abandoned'
+    ABANDONED: 'abandoned',
+    // A guest basket folded into an account's cart at sign-in (#1427). The
+    // third and last exit, and terminal like the other two.
+    MERGED: 'merged'
 });
 
 // mysql2's code for a unique-key collision.

--- a/backend/services/cartLifecycleService.js
+++ b/backend/services/cartLifecycleService.js
@@ -23,10 +23,12 @@
 // Both are terminal. Nothing moves a cart back to active; the shopper's next
 // action resolves a new one.
 //
-// Guest carts: `carts.user_id` is nullable so a pre-sign-in basket can be
-// persisted later, but nothing creates one yet -- every cart endpoint is behind
-// authentication. Resolving a cart therefore requires an account, and says so
-// rather than quietly inventing an ownerless row.
+// Guest carts do exist now (#1427), and services/guestCartService.js resolves
+// them, because finding one is a question about a token rather than about an
+// account. Everything past that point is shared: a cart with no owner is
+// touched, converted and swept by the functions below on exactly the same
+// terms as any other. Resolving an *account's* cart still requires an account,
+// and says so rather than quietly inventing an ownerless row.
 
 const crypto = require('crypto');
 const db = require('../config/db');
@@ -147,14 +149,45 @@ async function touchCart(cartId, connection) {
 }
 
 /**
- * active -> converted, for the account that just placed an order.
+ * active -> converted, for a named cart.
  *
  * Call inside the order's transaction: if the order rolls back, so must the
  * claim that a cart became it. The status guard makes the write idempotent --
  * a retry finds the cart already converted and reports that it changed
  * nothing, rather than overwriting the first order id with the second.
  *
- * A guest checkout has no cart to convert, and that is not an error.
+ * Whose cart it is does not matter here. A guest cart converts on exactly the
+ * same terms as an account's, which is the point: the exit belongs to the
+ * cart, not to the owner it may not have (#1427).
+ *
+ * @param {string} cartId
+ * @param {string} orderId
+ * @param {object} [connection]
+ * @returns {Promise<{cartId: string|null, converted: boolean}>}
+ */
+async function markCartConvertedById(cartId, orderId, connection) {
+    const cart = safeUUID(cartId);
+    const order = safeUUID(orderId);
+
+    if (!cart || !order) {
+        return { cartId: null, converted: false };
+    }
+
+    const [result] = await runner(connection).query(
+        `UPDATE carts
+         SET status = ?, converted_order_id = ?, converted_at = NOW()
+         WHERE id = ? AND status = ?`,
+        [CART_STATUS.CONVERTED, order, cart, CART_STATUS.ACTIVE]
+    );
+
+    return { cartId: cart, converted: result.affectedRows > 0 };
+}
+
+/**
+ * active -> converted, for the account that just placed an order.
+ *
+ * A checkout with no account behind it has no cart to find this way, and that
+ * is not an error -- the caller names the cart instead.
  *
  * @param {string} userId
  * @param {string} orderId
@@ -175,14 +208,7 @@ async function markCartConverted(userId, orderId, connection) {
         return { cartId: null, converted: false };
     }
 
-    const [result] = await runner(connection).query(
-        `UPDATE carts
-         SET status = ?, converted_order_id = ?, converted_at = NOW()
-         WHERE id = ? AND status = ?`,
-        [CART_STATUS.CONVERTED, order, cartId, CART_STATUS.ACTIVE]
-    );
-
-    return { cartId, converted: result.affectedRows > 0 };
+    return markCartConvertedById(cartId, order, connection);
 }
 
 /**
@@ -296,5 +322,6 @@ module.exports = {
     resolveActiveCart,
     touchCart,
     markCartConverted,
+    markCartConvertedById,
     sweepAbandonedCarts
 };

--- a/backend/services/cartMergeService.js
+++ b/backend/services/cartMergeService.js
@@ -1,0 +1,220 @@
+// backend/services/cartMergeService.js
+//
+// Folding a guest basket into an account's cart (#1427).
+//
+// A shopper who fills a basket and then signs in must not lose it, and must
+// not come away with two. Both halves of that were previously left to the
+// browser, which is why the outcome depended on which page the shopper landed
+// on and on whether a stale flag in local storage said the merge had already
+// happened.
+//
+// Three rules define it here:
+//
+//   * one cart survives. The account's active cart absorbs the guest's lines
+//     and the guest cart takes its terminal exit, so the single-active-cart
+//     guarantee the schema enforces is never even approached -- a merged cart
+//     is not active, so it holds no slot;
+//   * only an ownerless cart may be absorbed. A cart with a `user_id` belongs
+//     to somebody, and presenting its token must never move it to a different
+//     account. That is enforced by the lookup, which will not return one;
+//   * the same line from both baskets is one line with the quantities added,
+//     which is the rule `cart.service.mergeCartLines` already states for
+//     everything else that combines carts.
+//
+// Merging never fails a sign-in. A shopper who cannot get in because their
+// basket could not be combined is worse off than one who has to add an item
+// again, so the caller is expected to treat a failure as "no merge" and carry
+// on.
+
+const db = require('../config/db');
+const cartConfig = require('../config/cartConfig');
+const logger = require('../utils/logger');
+const guestCart = require('./guestCartService');
+const cartLifecycle = require('./cartLifecycleService');
+const inventoryReservationService = require('./inventoryReservationService');
+const { mergeCartLines, normalizeCartLines } = require('./cart.service');
+const { safeArray, safeUUID } = require('../utils/helpers');
+
+/**
+ * Fold the basket a token reaches into the account's cart.
+ *
+ * Runs in its own transaction unless the caller supplies a connection, so the
+ * whole merge -- the account's new lines, the guest's removed ones and the
+ * guest cart's status -- either happens or does not. A partial merge is the
+ * one outcome that could genuinely lose a basket.
+ *
+ * @param {string} userId
+ * @param {string|null} guestToken
+ * @param {object} [connection] - Join the caller's transaction instead.
+ * @returns {Promise<{merged: boolean, cartId: string|null, lines: number}>}
+ */
+async function mergeGuestCart(userId, guestToken, connection) {
+    const owner = safeUUID(userId);
+
+    if (!owner || !guestCart.isWellFormedToken(guestToken)) {
+        return { merged: false, cartId: null, lines: 0 };
+    }
+
+    if (connection) {
+        return runMerge(owner, guestToken, connection);
+    }
+
+    const ownConnection = await db.getConnection();
+
+    try {
+        await ownConnection.beginTransaction();
+        const result = await runMerge(owner, guestToken, ownConnection);
+        await ownConnection.commit();
+
+        return result;
+    } catch (error) {
+        await ownConnection.rollback();
+        throw error;
+    } finally {
+        ownConnection.release();
+    }
+}
+
+/**
+ * The same merge, with a sign-in's tolerance for failure.
+ *
+ * Sign-in and registration call this rather than `mergeGuestCart` directly:
+ * they have already decided that the shopper is getting in, and a basket is
+ * not worth taking that back.
+ *
+ * @param {string} userId
+ * @param {object} req - Carries the presented cart token.
+ * @returns {Promise<boolean>} whether anything moved
+ */
+async function mergeGuestCartOnSignIn(userId, req) {
+    try {
+        const { merged, lines } = await mergeGuestCart(
+            userId,
+            guestCart.readTokenFromRequest(req)
+        );
+
+        if (merged) {
+            logger.info(`Merged ${lines} guest cart line(s) into the cart of user ${userId}`);
+        }
+
+        return merged;
+    } catch (error) {
+        logger.error(`Guest cart merge failed for user ${userId}: ${error.message}`);
+
+        return false;
+    }
+}
+
+async function runMerge(owner, guestToken, connection) {
+    const guestCartId = await guestCart.findCartIdByToken(guestToken, connection);
+
+    if (!guestCartId) {
+        return { merged: false, cartId: null, lines: 0 };
+    }
+
+    const guestLines = await readCartLines(guestCartId, connection);
+
+    // The account's cart is resolved even for an empty guest basket, because
+    // the guest cart still has to be closed: leaving it active would leave a
+    // live basket behind a token the shopper has just stopped using, and the
+    // sweep would eventually record it as abandoned.
+    const accountCartId = await cartLifecycle.resolveActiveCart(owner, connection);
+
+    if (!guestLines.length) {
+        await closeGuestCart(guestCartId, accountCartId, connection);
+
+        return { merged: false, cartId: accountCartId, lines: 0 };
+    }
+
+    const accountLines = await readCartLines(accountCartId, connection);
+    const merged = mergeCartLines(accountLines, guestLines).map(capQuantity);
+
+    // Replace rather than upsert: the merged set is the answer for the whole
+    // cart, and inserting line by line over the existing rows would leave the
+    // outcome depending on which of them happened to be there already.
+    await connection.query('DELETE FROM cart_items WHERE cart_id IN (?, ?)', [
+        accountCartId,
+        guestCartId
+    ]);
+
+    await connection.query(
+        `INSERT INTO cart_items (user_id, cart_id, product_id, variant_id, color, size, quantity)
+         VALUES ${merged.map(() => '(?, ?, ?, ?, ?, ?, ?)').join(',')}`,
+        merged.flatMap((line) => [
+            owner,
+            accountCartId,
+            line.productId,
+            line.variantId,
+            line.color,
+            line.size,
+            line.quantity
+        ])
+    );
+
+    await closeGuestCart(guestCartId, accountCartId, connection);
+    await cartLifecycle.touchCart(accountCartId, connection);
+    await holdStockForMergedLines(owner, merged, connection);
+
+    return { merged: true, cartId: accountCartId, lines: merged.length };
+}
+
+async function readCartLines(cartId, connection) {
+    const [rows] = await connection.query(
+        `SELECT product_id, variant_id, color, size, quantity
+         FROM cart_items WHERE cart_id = ?`,
+        [cartId]
+    );
+
+    return normalizeCartLines(safeArray(rows));
+}
+
+async function closeGuestCart(guestCartId, accountCartId, connection) {
+    await connection.query(
+        `UPDATE carts
+         SET status = ?, merged_into_cart_id = ?, merged_at = NOW()
+         WHERE id = ? AND status = ?`,
+        [cartLifecycle.CART_STATUS.MERGED, accountCartId, guestCartId, cartLifecycle.CART_STATUS.ACTIVE]
+    );
+}
+
+// A line the shopper reaches by adding to it is capped at checkout; a line
+// reached by adding two baskets together was not capped anywhere, so a merge
+// could produce a cart that no checkout would accept.
+function capQuantity(line) {
+    return {
+        ...line,
+        quantity: Math.min(line.quantity, cartConfig.MAX_LINE_QUANTITY)
+    };
+}
+
+/**
+ * Take reservations on the merged lines, as a cart write would.
+ *
+ * Best effort, deliberately. A reservation is a courtesy hold and the answer
+ * to "somebody else took the last one" belongs at checkout, where it can be
+ * explained; arriving as a failed sign-in it would be inexplicable.
+ */
+async function holdStockForMergedLines(owner, lines, connection) {
+    await inventoryReservationService.releaseUserLocks(owner, null, connection);
+
+    for (const line of lines) {
+        try {
+            await inventoryReservationService.reserveStock(
+                owner,
+                line.productId,
+                line.quantity,
+                connection,
+                line
+            );
+        } catch (error) {
+            logger.warn(
+                `Could not hold stock for ${line.productId} while merging a guest cart: ${error.message}`
+            );
+        }
+    }
+}
+
+module.exports = {
+    mergeGuestCart,
+    mergeGuestCartOnSignIn
+};

--- a/backend/services/guestCartService.js
+++ b/backend/services/guestCartService.js
@@ -1,0 +1,213 @@
+// backend/services/guestCartService.js
+//
+// The basket of a shopper we do not know yet (#1427).
+//
+// An account cart is found by asking who is signed in. A guest cart has no
+// such question to ask, so the client holds a token and the cart is whatever
+// that token resolves to. That makes the token a bearer credential, and the
+// two properties everything here exists to protect are:
+//
+//   * it must be unguessable, because guessing one is reaching into somebody
+//     else's basket -- so it is 256 bits from the CSPRNG, not a uuid and not
+//     anything derived from the cart id;
+//   * it must not be readable out of the database, for the same reason a
+//     password is not stored in plaintext -- so only its SHA-256 is kept, and
+//     a presented token is hashed before it is looked up.
+//
+// A plain hash is the right primitive here rather than a slow KDF: the input
+// is full-entropy random, so there is no dictionary to run and nothing for
+// work factor to buy.
+//
+// The single-active-cart guarantee is not this module's to enforce. A guest
+// cart holds a NULL `user_id`, so the generated `active_marker` behind
+// `uq_carts_one_active` is NULL for every one of them and they cannot collide
+// with each other or with an account's cart. See migration 0027.
+
+const crypto = require('crypto');
+const db = require('../config/db');
+const cartConfig = require('../config/cartConfig');
+const { CART_STATUS } = require('./cartLifecycleService');
+const { sanitizeString } = require('../utils/helpers');
+
+// 32 bytes, base64url-encoded: 256 bits of entropy in 43 unpadded characters,
+// safe in a header and in browser storage without further escaping.
+const TOKEN_BYTES = 32;
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+// A header rather than a cookie: a cookie would be attached to cross-site
+// requests by the browser whether the shopper meant it or not, which is the
+// shape of a CSRF, and this token is the only thing standing between a request
+// and a basket.
+const TOKEN_HEADER = 'X-Cart-Token';
+
+/**
+ * Run against the caller's transaction when there is one, the pool otherwise.
+ */
+function runner(connection) {
+    return connection || db;
+}
+
+/**
+ * A fresh cart token.
+ *
+ * @returns {string}
+ */
+function issueToken() {
+    return crypto.randomBytes(TOKEN_BYTES).toString('base64url');
+}
+
+/**
+ * Whether a value could be a token this service issued.
+ *
+ * Checked before the token reaches a query so that a junk header costs a
+ * regex rather than a database round trip.
+ *
+ * @param {*} token
+ * @returns {boolean}
+ */
+function isWellFormedToken(token) {
+    return typeof token === 'string' && TOKEN_PATTERN.test(token);
+}
+
+/**
+ * The stored form of a token.
+ *
+ * @param {*} token
+ * @returns {string|null} hex SHA-256, or null when the input is not a token
+ */
+function hashToken(token) {
+    if (!isWellFormedToken(token)) {
+        return null;
+    }
+
+    return crypto.createHash('sha256').update(token, 'utf8').digest('hex');
+}
+
+/**
+ * The live guest cart a token reaches, or null.
+ *
+ * "Live" means active and unexpired. A token whose cart was converted at
+ * checkout, swept as abandoned, or whose expiry has passed resolves to
+ * nothing, and the caller treats that exactly as it treats no token at all --
+ * the shopper starts a new basket rather than being shown an error about one
+ * they cannot see.
+ *
+ * @param {string} token
+ * @param {object} [connection]
+ * @returns {Promise<string|null>} cart id
+ */
+async function findCartIdByToken(token, connection) {
+    const tokenHash = hashToken(token);
+
+    if (!tokenHash) return null;
+
+    const [rows] = await runner(connection).query(
+        `SELECT id FROM carts
+         WHERE guest_token_hash = ?
+           AND status = ?
+           AND user_id IS NULL
+           AND (guest_token_expires_at IS NULL OR guest_token_expires_at > NOW())
+         LIMIT 1`,
+        [tokenHash, CART_STATUS.ACTIVE]
+    );
+
+    return rows.length ? rows[0].id : null;
+}
+
+/**
+ * Open a cart for a shopper with no account.
+ *
+ * @param {object} [connection]
+ * @returns {Promise<{cartId: string, token: string}>}
+ */
+async function createCart(connection) {
+    const cartId = crypto.randomUUID();
+    const token = issueToken();
+
+    await runner(connection).query(
+        `INSERT INTO carts (
+            id, user_id, guest_token_hash, guest_token_expires_at, status, last_activity_at
+         ) VALUES (?, NULL, ?, DATE_ADD(NOW(), INTERVAL ? MINUTE), ?, NOW())`,
+        [cartId, hashToken(token), guestTokenTtlMinutes(), CART_STATUS.ACTIVE]
+    );
+
+    return { cartId, token };
+}
+
+/**
+ * The cart the presented token reaches, or a new one.
+ *
+ * `token` is only returned when one was minted, so a caller can tell the
+ * difference between "hold on to this" and "keep the one you already have"
+ * without comparing strings.
+ *
+ * @param {string|null} token
+ * @param {object} [connection]
+ * @returns {Promise<{cartId: string, token: string|null, isNew: boolean}>}
+ */
+async function resolveCart(token, connection) {
+    const existing = await findCartIdByToken(token, connection);
+
+    if (existing) {
+        return { cartId: existing, token: null, isNew: false };
+    }
+
+    const created = await createCart(connection);
+
+    return { ...created, isNew: true };
+}
+
+/**
+ * Push the token's expiry out from now.
+ *
+ * Called on shopper activity for the same reason `last_activity_at` is: a
+ * basket someone is still adding to must not have its credential expire
+ * underneath them. Guarded on the cart still being active so a converted cart
+ * cannot have its token brought back to life.
+ *
+ * @param {string} cartId
+ * @param {object} [connection]
+ * @returns {Promise<void>}
+ */
+async function extendToken(cartId, connection) {
+    if (!cartId) return;
+
+    await runner(connection).query(
+        `UPDATE carts
+         SET guest_token_expires_at = DATE_ADD(NOW(), INTERVAL ? MINUTE)
+         WHERE id = ? AND guest_token_hash IS NOT NULL AND status = ?`,
+        [guestTokenTtlMinutes(), cartId, CART_STATUS.ACTIVE]
+    );
+}
+
+/**
+ * The token the client presented, if it presented a usable one.
+ *
+ * @param {object} req
+ * @returns {string|null}
+ */
+function readTokenFromRequest(req) {
+    const presented = sanitizeString(
+        typeof req?.get === 'function'
+            ? req.get(TOKEN_HEADER)
+            : req?.headers?.[TOKEN_HEADER.toLowerCase()]
+    );
+
+    return isWellFormedToken(presented) ? presented : null;
+}
+
+function guestTokenTtlMinutes() {
+    return Math.max(1, Number(cartConfig.GUEST_TOKEN_TTL_MINUTES) || 0);
+}
+
+module.exports = {
+    TOKEN_HEADER,
+    issueToken,
+    isWellFormedToken,
+    hashToken,
+    findCartIdByToken,
+    createCart,
+    resolveCart,
+    extendToken,
+    readTokenFromRequest
+};

--- a/backend/services/guestOrderService.js
+++ b/backend/services/guestOrderService.js
@@ -1,0 +1,132 @@
+// backend/services/guestOrderService.js
+//
+// Finding an order without an account (#1427).
+//
+// A guest has no order list to open, so the order is reached by presenting the
+// pair they were given at checkout: the order number, which is unguessable,
+// and the email the order was placed with, which is not. The number carries
+// the security; the email is there so that a number seen over someone's
+// shoulder is not on its own enough.
+//
+// The thing this must not become is an oracle. Three questions are worth
+// money to someone probing it -- does this order number exist, was it placed
+// with this email, does this person shop here -- and the answer to all three
+// has to be the same silence:
+//
+//   * one outcome for every failure, whether the number is unknown, the email
+//     is wrong or the order belongs to an account;
+//   * the email compared over digests in constant time, so neither its length
+//     nor the position of the first differing character is measurable;
+//   * the comparison performed even when no order was found, so the presence
+//     of a row is not readable from how long the answer took.
+//
+// Rate limiting is the fourth measure and lives on the route, because it is
+// about the caller rather than about the order.
+
+const crypto = require('crypto');
+const db = require('../config/db');
+const { normalizeOrderNumber } = require('./orderNumber.service');
+const { safeArray, sanitizeString } = require('../utils/helpers');
+
+// Compared against a presented email when no order was found, so the failing
+// path does the same work as the succeeding one.
+const ABSENT_EMAIL = '\u0000no-such-order';
+
+/**
+ * Whether two email addresses are the same one, without saying how they differ.
+ *
+ * Addresses are compared case-insensitively on the whole string. The local
+ * part is case-sensitive per the RFC and case-insensitive in every mail system
+ * anyone actually uses, and a shopper who typed a capital at checkout must
+ * still be able to find their order.
+ *
+ * Digests rather than the addresses themselves: `timingSafeEqual` throws on
+ * unequal lengths, and reaching for a length check first would leak the length.
+ *
+ * @param {*} presented
+ * @param {*} recorded
+ * @returns {boolean}
+ */
+function emailsMatch(presented, recorded) {
+    const digest = (value) => crypto
+        .createHash('sha256')
+        .update(sanitizeString(value).toLowerCase(), 'utf8')
+        .digest();
+
+    return crypto.timingSafeEqual(digest(presented), digest(recorded));
+}
+
+/**
+ * The order behind an order number and the email it was placed with.
+ *
+ * Only orders with no account behind them are reachable. An account's order is
+ * read through the account, and letting one be reached this way would turn the
+ * endpoint into a way of testing whether a given address shops here.
+ *
+ * @param {object} credentials
+ * @param {string} credentials.orderNumber
+ * @param {string} credentials.email
+ * @param {object} [connection]
+ * @returns {Promise<object|null>} the order with its lines, or null
+ */
+async function findGuestOrder({ orderNumber, email }, connection) {
+    const client = connection || db;
+    const number = normalizeOrderNumber(orderNumber);
+
+    if (!number) {
+        return null;
+    }
+
+    const [rows] = await client.query(
+        `SELECT
+            id,
+            order_number,
+            customer_name,
+            customer_email,
+            customer_phone,
+            city,
+            state,
+            zip,
+            full_address,
+            payment_method,
+            payment_status,
+            status,
+            subtotal,
+            tax,
+            shipping_cost,
+            discount_amount,
+            total,
+            tracking_number,
+            created_at,
+            updated_at
+         FROM orders
+         WHERE order_number = ? AND user_id IS NULL
+         LIMIT 1`,
+        [number]
+    );
+
+    const order = safeArray(rows)[0] || null;
+
+    // Run the comparison either way. Returning early on a missing row would
+    // make "no such order" measurably faster than "wrong email", which is the
+    // enumeration this endpoint exists to refuse.
+    const matches = emailsMatch(email, order ? order.customer_email : ABSENT_EMAIL);
+
+    if (!order || !matches) {
+        return null;
+    }
+
+    const [items] = await client.query(
+        `SELECT product_id, name, price, qty, color, size, total
+         FROM order_items
+         WHERE order_id = ?`,
+        [order.id]
+    );
+
+    return { ...order, items: safeArray(items) };
+}
+
+module.exports = {
+    emailsMatch,
+    findGuestOrder
+};

--- a/backend/services/metricsAggregationService.js
+++ b/backend/services/metricsAggregationService.js
@@ -29,6 +29,14 @@ const TIME_PERIODS = {
     CUSTOM: 'custom'
 };
 
+// A guest basket folded into an account's cart at sign-in is not a second
+// shopping session (#1427) -- it is the same basket, seen before and after the
+// shopper identified themselves. Counting both would put a cart in the
+// denominator of every cart rate for each time somebody signed in, which
+// depresses conversion and abandonment alike by an amount that has nothing to
+// do with trading.
+const EXCLUDE_MERGED_CARTS = "AND c.status <> 'merged'";
+
 // ============================================
 // METRICS AGGREGATION SERVICE
 // ============================================
@@ -81,6 +89,7 @@ class MetricsAggregationService extends EventEmitter {
                     / NULLIF(COUNT(*), 0)) * 100 as conversion_rate
             FROM carts c
             WHERE c.created_at BETWEEN ? AND ?
+              ${EXCLUDE_MERGED_CARTS}
         `;
 
         // A cart has no category of its own; the category of what is in it is
@@ -187,6 +196,7 @@ class MetricsAggregationService extends EventEmitter {
                 GROUP BY ci.cart_id
             ) v ON v.cart_id = c.id
             WHERE c.created_at BETWEEN ? AND ?
+              ${EXCLUDE_MERGED_CARTS}
         `;
 
         if (filters.category) {

--- a/backend/services/order.service.js
+++ b/backend/services/order.service.js
@@ -10,6 +10,7 @@ const logger = require("../utils/logger");
 const { validatePromo } = require("./promo.service");
 const pricing = require("./pricing.service");
 const cartLifecycle = require("./cartLifecycleService");
+const { generateOrderNumber } = require("./orderNumber.service");
 
 // Marks the one failure the client can act on, so controllers can answer with
 // the specific figures instead of a generic server error.
@@ -267,6 +268,10 @@ const createOrderService = async (connection, orderData) => {
             // deletes the saved address -- and this only records *which* saved
             // address the order came from.
             address_id,
+            // The cart this order was placed from (#1427). Named explicitly
+            // because a guest's cart cannot be found from `user_id`, which is
+            // the only handle the account path ever needed.
+            cart_id,
         } = orderData;
 
         // validate empty cart
@@ -321,10 +326,15 @@ const createOrderService = async (connection, orderData) => {
         const crypto = require("crypto");
         const orderId = crypto.randomUUID();
 
+        // What the shopper is given to find this order again. An account
+        // holder has their order list; a guest has only this (#1427).
+        const orderNumber = generateOrderNumber();
+
         // create order
         const orderQuery = `
             INSERT INTO orders (
                 id,
+                order_number,
                 user_id,
                 customer_name,
                 customer_email,
@@ -349,11 +359,12 @@ const createOrderService = async (connection, orderData) => {
                 created_at,
                 updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
         `;
 
         const [orderResult] = await connection.query(orderQuery, [
             orderId,
+            orderNumber,
             safeUUID(user_id),
             customer_name,
             customer_email,
@@ -442,17 +453,27 @@ const createOrderService = async (connection, orderData) => {
         // Close the cart and clear it. Both happen on this connection, inside
         // the caller's transaction: a cart must never be recorded as converted
         // against an order that then rolls back.
-        if (user_id) {
-            const { cartId, converted } = await cartLifecycle.markCartConverted(
-                user_id,
-                orderId,
-                connection,
+        //
+        // A named cart is converted directly; otherwise the account's active
+        // cart is found the way it always was. A guest checkout takes the
+        // first path -- there is no account to find a cart from -- and the
+        // lines are then cleared by cart rather than by owner, which is the
+        // only handle a guest cart's lines have.
+        const closedCart = cart_id
+            ? await cartLifecycle.markCartConvertedById(cart_id, orderId, connection)
+            : await cartLifecycle.markCartConverted(user_id, orderId, connection);
+
+        if (closedCart.converted) {
+            logger.info(`Cart ${closedCart.cartId} converted into order ${orderId}`);
+        }
+
+        if (closedCart.cartId) {
+            await connection.query(
+                "DELETE FROM cart_items WHERE cart_id = ?",
+                [closedCart.cartId]
             );
-
-            if (converted) {
-                logger.info(`Cart ${cartId} converted into order ${orderId}`);
-            }
-
+            logger.info(`Cleared cart ${closedCart.cartId}`);
+        } else if (user_id) {
             await connection.query(
                 "DELETE FROM cart_items WHERE user_id = ?",
                 [user_id]
@@ -486,6 +507,7 @@ const createOrderService = async (connection, orderData) => {
         return {
             success: true,
             orderId: orderId,
+            orderNumber,
             subtotal: breakdown.subtotal,
             total: breakdown.total,
             finalAmount: breakdown.total,
@@ -507,6 +529,7 @@ const getOrderSummaryById = async (connection, orderId) => {
         const query = `
             SELECT 
                 o.id,
+                o.order_number,
                 o.customer_name,
                 o.customer_email,
                 o.customer_phone,

--- a/backend/services/orderNumber.service.js
+++ b/backend/services/orderNumber.service.js
@@ -1,0 +1,68 @@
+// backend/services/orderNumber.service.js
+//
+// The handle a shopper is given for an order (#1427).
+//
+// An account holder never needs one: they open their order list and pick. A
+// guest has no list, so the number is how they find the order again, and it is
+// half of what authorises that lookup -- the other half being the email the
+// order was placed with, which for anyone's own address is not a secret.
+//
+// All of the weight therefore sits on the random suffix. Sixty-four bits from
+// the CSPRNG, not a counter and nothing derived from the order's primary key:
+// a sequence tells anyone holding one number what the neighbouring ones are,
+// and a derivation hands the number to anyone who has seen an order URL.
+//
+// The date prefix is for the person reading it out. It narrows nothing an
+// attacker did not already know.
+
+const crypto = require('crypto');
+
+const SUFFIX_BYTES = 8;
+const PREFIX = 'ORD';
+
+// What a number looks like, so a lookup can reject a malformed one before it
+// costs a query. Kept deliberately loose on the suffix length: numbers minted
+// by a future change must still be presentable.
+const ORDER_NUMBER_PATTERN = /^ORD-\d{8}-[0-9A-F]{8,32}$/;
+
+/**
+ * A fresh order number.
+ *
+ * @param {Date} [placedAt] - Defaults to now; the date the number carries.
+ * @returns {string}
+ */
+function generateOrderNumber(placedAt = new Date()) {
+    const year = placedAt.getFullYear();
+    const month = String(placedAt.getMonth() + 1).padStart(2, '0');
+    const day = String(placedAt.getDate()).padStart(2, '0');
+    const suffix = crypto.randomBytes(SUFFIX_BYTES).toString('hex').toUpperCase();
+
+    return `${PREFIX}-${year}${month}${day}-${suffix}`;
+}
+
+/**
+ * The canonical form of a number a shopper typed.
+ *
+ * Case and surrounding whitespace are forgiven because the number travels
+ * through email clients, phone calls and clipboards. Nothing else is: a
+ * lenient parser here would be a lenient parser on the one input an order
+ * lookup authorises against.
+ *
+ * @param {*} value
+ * @returns {string|null} the number, or null when it is not one
+ */
+function normalizeOrderNumber(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const normalized = value.trim().toUpperCase();
+
+    return ORDER_NUMBER_PATTERN.test(normalized) ? normalized : null;
+}
+
+module.exports = {
+    ORDER_NUMBER_PATTERN,
+    generateOrderNumber,
+    normalizeOrderNumber
+};

--- a/backend/tests/cartLifecycle.test.js
+++ b/backend/tests/cartLifecycle.test.js
@@ -169,12 +169,33 @@ describe('active -> converted', () => {
             .resolves.toEqual({ cartId: CART, converted: false });
     });
 
-    test('a guest checkout has no cart to convert, and that is not an error', async () => {
+    test('an account is not how a guest cart is found, and that is not an error', async () => {
         const connection = fakeConnection(() => [[]]);
 
         await expect(cartLifecycle.markCartConverted(null, ORDER, connection))
             .resolves.toEqual({ cartId: null, converted: false });
         expect(connection.query).not.toHaveBeenCalled();
+    });
+
+    // A guest cart converts on exactly the same terms; the caller names it
+    // rather than reaching it through an owner it does not have (#1427).
+    test('a named cart converts without an account being involved at all', async () => {
+        const connection = fakeConnection(() => [{ affectedRows: 1 }]);
+
+        await expect(cartLifecycle.markCartConvertedById(CART, ORDER, connection))
+            .resolves.toEqual({ cartId: CART, converted: true });
+
+        expect(callsMatching(connection.calls, /SELECT id FROM carts/i)).toHaveLength(0);
+
+        const [update] = callsMatching(connection.calls, /UPDATE carts/i);
+        expect(update.params).toEqual(['converted', ORDER, CART, 'active']);
+    });
+
+    test('a named cart already converted is not re-pointed at a second order', async () => {
+        const connection = fakeConnection(() => [{ affectedRows: 0 }]);
+
+        await expect(cartLifecycle.markCartConvertedById(CART, ORDER, connection))
+            .resolves.toEqual({ cartId: CART, converted: false });
     });
 });
 

--- a/backend/tests/cartLifecycle.test.js
+++ b/backend/tests/cartLifecycle.test.js
@@ -386,6 +386,20 @@ describe('reporting reads cart state', () => {
         expect(params[params.length - 1]).toBe(7);
     });
 
+    // A guest basket merged at sign-in is the same basket as the account cart
+    // it went into, so counting both would move every cart rate for a reason
+    // that has nothing to do with trading (#1427).
+    test('a basket counted once before sign-in is not counted twice after it', async () => {
+        db.query.mockResolvedValue([[{}]]);
+
+        await metrics.getConversionRate('week');
+        await metrics.getAbandonedCartRate('week');
+
+        for (const [sql] of db.query.mock.calls) {
+            expect(sql).toMatch(/c\.status <> 'merged'/i);
+        }
+    });
+
     test('an empty result set reads as zero rather than NaN', async () => {
         db.query.mockResolvedValue([[]]);
 

--- a/backend/tests/cartMerge.test.js
+++ b/backend/tests/cartMerge.test.js
@@ -1,0 +1,296 @@
+// backend/tests/cartMerge.test.js
+//
+// Folding a guest basket into an account's cart at sign-in (#1427).
+//
+// The database is mocked at the module boundary. What is pinned here is not
+// SQL text but the four things a merge has to be true of:
+//
+//   * the account ends up with one cart, and the guest cart takes a terminal
+//     exit that is neither "converted" nor "abandoned";
+//   * the same line from both baskets is one line with the quantities added;
+//   * only an ownerless cart can be absorbed, so presenting a token can never
+//     move somebody else's basket onto your account;
+//   * none of it can fail a sign-in.
+
+jest.mock('../config/db', () => {
+    const query = jest.fn();
+    const pool = { query, getConnection: jest.fn() };
+    pool.promise = pool;
+    return pool;
+});
+
+jest.mock('../utils/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+jest.mock('../services/inventoryReservationService', () => ({
+    releaseUserLocks: jest.fn().mockResolvedValue(undefined),
+    reserveStock: jest.fn().mockResolvedValue(true)
+}));
+
+const db = require('../config/db');
+const logger = require('../utils/logger');
+const inventoryReservationService = require('../services/inventoryReservationService');
+const guestCart = require('../services/guestCartService');
+const cartMerge = require('../services/cartMergeService');
+const cartConfig = require('../config/cartConfig');
+
+const USER = '11111111-1111-4111-8111-111111111111';
+const ACCOUNT_CART = '33333333-3333-4333-8333-333333333333';
+const GUEST_CART = '44444444-4444-4444-8444-444444444444';
+const PRODUCT_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const PRODUCT_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+function line(productId, quantity, overrides = {}) {
+    return { product_id: productId, variant_id: 0, color: '', size: '', quantity, ...overrides };
+}
+
+/**
+ * A connection double wired for the merge's sequence of reads.
+ *
+ * The guest cart lookup and the account cart lookup are both "SELECT id FROM
+ * carts", told apart by which predicate they carry.
+ */
+function mergeConnection({ guestCartId = GUEST_CART, guestLines = [], accountLines = [] } = {}) {
+    const calls = [];
+
+    const connection = {
+        calls,
+        query: jest.fn(async (sql, params = []) => {
+            calls.push({ sql, params });
+
+            if (/guest_token_hash = \?/i.test(sql)) {
+                return [guestCartId ? [{ id: guestCartId }] : []];
+            }
+
+            if (/SELECT id FROM carts/i.test(sql)) {
+                return [[{ id: ACCOUNT_CART }]];
+            }
+
+            if (/FROM cart_items WHERE cart_id = \?/i.test(sql)) {
+                return [params[0] === GUEST_CART ? guestLines : accountLines];
+            }
+
+            return [{ affectedRows: 1 }];
+        })
+    };
+
+    return connection;
+}
+
+function callsMatching(calls, regex) {
+    return calls.filter(({ sql }) => regex.test(sql));
+}
+
+/** The rows the merge inserted, read back out of the flattened parameter list. */
+function insertedLines(calls) {
+    const insert = callsMatching(calls, /INSERT INTO cart_items/i)[0];
+
+    if (!insert) return [];
+
+    const columns = 7;
+    const rows = [];
+
+    for (let i = 0; i < insert.params.length; i += columns) {
+        const [userId, cartId, productId, variantId, color, size, quantity] =
+            insert.params.slice(i, i + columns);
+        rows.push({ userId, cartId, productId, variantId, color, size, quantity });
+    }
+
+    return rows;
+}
+
+afterEach(() => {
+    db.query.mockReset();
+    logger.info.mockClear();
+    logger.error.mockClear();
+    inventoryReservationService.reserveStock.mockClear();
+    inventoryReservationService.releaseUserLocks.mockClear();
+});
+
+describe('what a merge does', () => {
+    const token = guestCart.issueToken();
+
+    test('adds the quantities of a line both baskets hold, and keeps the rest', async () => {
+        const connection = mergeConnection({
+            accountLines: [line(PRODUCT_A, 1)],
+            guestLines: [line(PRODUCT_A, 2), line(PRODUCT_B, 3)]
+        });
+
+        const result = await cartMerge.mergeGuestCart(USER, token, connection);
+
+        expect(result).toEqual({ merged: true, cartId: ACCOUNT_CART, lines: 2 });
+
+        const rows = insertedLines(connection.calls);
+        expect(rows).toHaveLength(2);
+        expect(rows.find((row) => row.productId === PRODUCT_A).quantity).toBe(3);
+        expect(rows.find((row) => row.productId === PRODUCT_B).quantity).toBe(3);
+    });
+
+    test('every surviving line lands on the account cart, owned by the account', async () => {
+        const connection = mergeConnection({ guestLines: [line(PRODUCT_A, 1)] });
+
+        await cartMerge.mergeGuestCart(USER, token, connection);
+
+        for (const row of insertedLines(connection.calls)) {
+            expect(row.cartId).toBe(ACCOUNT_CART);
+            expect(row.userId).toBe(USER);
+        }
+    });
+
+    test('the guest cart is closed as merged, naming the cart it went into', async () => {
+        const connection = mergeConnection({ guestLines: [line(PRODUCT_A, 1)] });
+
+        await cartMerge.mergeGuestCart(USER, token, connection);
+
+        const [close] = callsMatching(connection.calls, /merged_into_cart_id/i);
+        expect(close.params).toEqual(['merged', ACCOUNT_CART, GUEST_CART, 'active']);
+    });
+
+    // Not `abandoned`, which would say the shopper walked away from a basket
+    // they in fact signed in to keep, and not `converted`, which would claim
+    // an order that does not exist.
+    test('the exit it takes is neither of the other two', async () => {
+        const connection = mergeConnection({ guestLines: [line(PRODUCT_A, 1)] });
+
+        await cartMerge.mergeGuestCart(USER, token, connection);
+
+        const [close] = callsMatching(connection.calls, /merged_into_cart_id/i);
+        expect(close.params).not.toContain('abandoned');
+        expect(close.params).not.toContain('converted');
+    });
+
+    test('both carts are emptied before the merged set is written', async () => {
+        const connection = mergeConnection({
+            accountLines: [line(PRODUCT_A, 1)],
+            guestLines: [line(PRODUCT_B, 1)]
+        });
+
+        await cartMerge.mergeGuestCart(USER, token, connection);
+
+        const [clear] = callsMatching(connection.calls, /DELETE FROM cart_items/i);
+        expect(clear.params).toEqual([ACCOUNT_CART, GUEST_CART]);
+
+        const clearIndex = connection.calls.indexOf(clear);
+        const insertIndex = connection.calls.findIndex(
+            ({ sql }) => /INSERT INTO cart_items/i.test(sql)
+        );
+        expect(clearIndex).toBeLessThan(insertIndex);
+    });
+
+    // Adding two baskets is the one way a line can grow past a limit nobody
+    // typed, and a cart no checkout would accept is worse than a short one.
+    test('a combined line is capped at what checkout will accept', async () => {
+        const connection = mergeConnection({
+            accountLines: [line(PRODUCT_A, cartConfig.MAX_LINE_QUANTITY)],
+            guestLines: [line(PRODUCT_A, 50)]
+        });
+
+        await cartMerge.mergeGuestCart(USER, token, connection);
+
+        expect(insertedLines(connection.calls)[0].quantity)
+            .toBe(cartConfig.MAX_LINE_QUANTITY);
+    });
+
+    test('holds stock for the merged lines, replacing what was held before', async () => {
+        const connection = mergeConnection({ guestLines: [line(PRODUCT_A, 2)] });
+
+        await cartMerge.mergeGuestCart(USER, token, connection);
+
+        expect(inventoryReservationService.releaseUserLocks)
+            .toHaveBeenCalledWith(USER, null, connection);
+        expect(inventoryReservationService.reserveStock)
+            .toHaveBeenCalledWith(USER, PRODUCT_A, 2, connection, expect.anything());
+    });
+
+    // A hold is a courtesy. "Somebody took the last one" is an answer checkout
+    // can explain; arriving as a failed sign-in it would be inexplicable.
+    test('a reservation it cannot get does not undo the merge', async () => {
+        inventoryReservationService.reserveStock.mockRejectedValueOnce(
+            new Error('nothing left')
+        );
+
+        const connection = mergeConnection({ guestLines: [line(PRODUCT_A, 2)] });
+
+        await expect(cartMerge.mergeGuestCart(USER, token, connection))
+            .resolves.toMatchObject({ merged: true });
+    });
+});
+
+describe('what a merge refuses to do', () => {
+    test('an empty guest basket still closes, so no live cart is left behind', async () => {
+        const connection = mergeConnection({ guestLines: [] });
+
+        const result = await cartMerge.mergeGuestCart(USER, guestCart.issueToken(), connection);
+
+        expect(result).toEqual({ merged: false, cartId: ACCOUNT_CART, lines: 0 });
+        expect(callsMatching(connection.calls, /INSERT INTO cart_items/i)).toHaveLength(0);
+        expect(callsMatching(connection.calls, /merged_into_cart_id/i)).toHaveLength(1);
+    });
+
+    test('a token that reaches nothing changes nothing', async () => {
+        const connection = mergeConnection({ guestCartId: null });
+
+        await expect(cartMerge.mergeGuestCart(USER, guestCart.issueToken(), connection))
+            .resolves.toEqual({ merged: false, cartId: null, lines: 0 });
+
+        expect(callsMatching(connection.calls, /INSERT INTO cart_items/i)).toHaveLength(0);
+    });
+
+    // The lookup will only return a cart with no owner, so a token for an
+    // account's cart resolves to nothing and no basket changes hands. Asserted
+    // on the query because that predicate is the whole defence.
+    test('only an ownerless cart is even a candidate', async () => {
+        const connection = mergeConnection({ guestLines: [line(PRODUCT_A, 1)] });
+
+        await cartMerge.mergeGuestCart(USER, guestCart.issueToken(), connection);
+
+        const [lookup] = callsMatching(connection.calls, /guest_token_hash = \?/i);
+        expect(lookup.sql).toMatch(/user_id IS NULL/i);
+    });
+
+    test('nothing happens without an account to merge into', async () => {
+        const connection = mergeConnection();
+
+        await expect(cartMerge.mergeGuestCart(null, guestCart.issueToken(), connection))
+            .resolves.toEqual({ merged: false, cartId: null, lines: 0 });
+
+        expect(connection.query).not.toHaveBeenCalled();
+    });
+
+    test('a token that is not one costs no query', async () => {
+        const connection = mergeConnection();
+
+        await expect(cartMerge.mergeGuestCart(USER, 'nonsense', connection))
+            .resolves.toEqual({ merged: false, cartId: null, lines: 0 });
+
+        expect(connection.query).not.toHaveBeenCalled();
+    });
+});
+
+describe('merging at sign-in', () => {
+    const requestWith = (token) => ({
+        headers: token ? { 'x-cart-token': token } : {},
+        get: (name) => (token && String(name).toLowerCase() === 'x-cart-token' ? token : undefined)
+    });
+
+    test('reports nothing to merge when the shopper brought no basket', async () => {
+        await expect(cartMerge.mergeGuestCartOnSignIn(USER, requestWith(null)))
+            .resolves.toBe(false);
+    });
+
+    // The property that matters most: a sign-in cannot be lost to a cart.
+    test('swallows a failure rather than letting it reach the sign-in', async () => {
+        db.getConnection.mockRejectedValue(new Error('pool exhausted'));
+
+        await expect(cartMerge.mergeGuestCartOnSignIn(USER, requestWith(guestCart.issueToken())))
+            .resolves.toBe(false);
+
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.stringContaining('Guest cart merge failed')
+        );
+    });
+});

--- a/backend/tests/fixtures/policySnapshot.json
+++ b/backend/tests/fixtures/policySnapshot.json
@@ -134,6 +134,7 @@
     "POST /api/auth/verify-signup",
     "POST /api/checkout/quote",
     "POST /api/courier-webhooks/:provider",
+    "POST /api/orders/lookup",
     "POST /api/orders/validate",
     "POST /api/promos/validate",
     "POST /api/wishlist-notify/unsubscribe"
@@ -144,6 +145,8 @@
     "GET /api/cart",
     "POST /api/cart/add",
     "POST /api/cart/sync",
+    "POST /api/orders",
+    "POST /api/orders/create-payment-intent",
     "PUT /api/cart/update"
   ]
 }

--- a/backend/tests/fixtures/policySnapshot.json
+++ b/backend/tests/fixtures/policySnapshot.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Pinned authorization policy. Changing a role's permissions or opening a route to anonymous traffic must show up as an edit to this file, reviewed on its own terms. Lists are sorted; the test sorts both sides before comparing.",
+  "_comment": "Pinned authorization policy. Changing a role's permissions, opening a route to anonymous traffic, or letting one be reached without an account must show up as an edit to this file, reviewed on its own terms. Lists are sorted; the test sorts both sides before comparing.",
   "rolePermissions": {
     "customer": [
       "address:manage:own",
@@ -137,5 +137,13 @@
     "POST /api/orders/validate",
     "POST /api/promos/validate",
     "POST /api/wishlist-notify/unsubscribe"
+  ],
+  "guestRoutes": [
+    "DELETE /api/cart/clear",
+    "DELETE /api/cart/remove/:productId",
+    "GET /api/cart",
+    "POST /api/cart/add",
+    "POST /api/cart/sync",
+    "PUT /api/cart/update"
   ]
 }

--- a/backend/tests/guestCart.test.js
+++ b/backend/tests/guestCart.test.js
@@ -1,0 +1,288 @@
+// backend/tests/guestCart.test.js
+//
+// The basket of a shopper with no account (#1427).
+//
+// The database is mocked at the module boundary, as the rest of this suite
+// does. What is pinned here is not SQL text but the properties the token has
+// to hold whatever the SQL looks like:
+//
+//   * it is unguessable, and the database never holds a usable copy of it;
+//   * it reaches exactly one live cart, and nothing else;
+//   * a signed-in shopper is never handed a guest cart by presenting one;
+//   * a caller whose session expired is told so, rather than quietly demoted
+//     to a guest and shown an empty basket.
+
+jest.mock('../config/db', () => {
+    const query = jest.fn();
+    const pool = { query, getConnection: jest.fn() };
+    pool.promise = pool;
+    return pool;
+});
+
+jest.mock('../utils/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+const crypto = require('crypto');
+
+const db = require('../config/db');
+const guestCart = require('../services/guestCartService');
+const cartIdentity = require('../middleware/cartIdentity');
+const cartConfig = require('../config/cartConfig');
+
+const CART = '44444444-4444-4444-8444-444444444444';
+const USER = '11111111-1111-4111-8111-111111111111';
+
+/** A connection double that records every statement and answers by pattern. */
+function fakeConnection(responder) {
+    const calls = [];
+
+    return {
+        calls,
+        query: jest.fn(async (sql, params = []) => {
+            calls.push({ sql, params });
+            return responder(sql, params);
+        })
+    };
+}
+
+function callsMatching(calls, regex) {
+    return calls.filter(({ sql }) => regex.test(sql));
+}
+
+/** An Express-shaped request: `req.get` is how the middleware reads headers. */
+function fakeRequest({ headers = {}, cookies = {}, user = null } = {}) {
+    return {
+        headers,
+        cookies,
+        user,
+        get: (name) => headers[String(name).toLowerCase()]
+    };
+}
+
+function fakeResponse() {
+    const res = {
+        statusCode: null,
+        body: null,
+        status(code) {
+            res.statusCode = code;
+            return res;
+        },
+        json(payload) {
+            res.body = payload;
+            return res;
+        }
+    };
+
+    return res;
+}
+
+afterEach(() => {
+    db.query.mockReset();
+});
+
+describe('the token a guest holds', () => {
+    test('is long, random, and not repeated', () => {
+        const tokens = new Set(
+            Array.from({ length: 50 }, () => guestCart.issueToken())
+        );
+
+        expect(tokens.size).toBe(50);
+
+        for (const token of tokens) {
+            expect(guestCart.isWellFormedToken(token)).toBe(true);
+            // 43 base64url characters is 32 bytes; anything materially
+            // shorter would be worth guessing at.
+            expect(token).toHaveLength(43);
+        }
+    });
+
+    test('is never stored in a form that can be presented back', () => {
+        const token = guestCart.issueToken();
+        const stored = guestCart.hashToken(token);
+
+        expect(stored).toBe(
+            crypto.createHash('sha256').update(token, 'utf8').digest('hex')
+        );
+        expect(stored).not.toContain(token);
+        expect(guestCart.isWellFormedToken(stored)).toBe(false);
+    });
+
+    test('rejects anything that is not one before it reaches a query', () => {
+        for (const rubbish of [null, undefined, 42, '', 'short', `${'a'.repeat(43)}!`]) {
+            expect(guestCart.isWellFormedToken(rubbish)).toBe(false);
+            expect(guestCart.hashToken(rubbish)).toBeNull();
+        }
+    });
+});
+
+describe('resolving a guest cart', () => {
+    test('looks the token up by hash, never by the token itself', async () => {
+        const token = guestCart.issueToken();
+        const connection = fakeConnection(() => [[{ id: CART }]]);
+
+        await expect(guestCart.findCartIdByToken(token, connection)).resolves.toBe(CART);
+
+        const [lookup] = connection.calls;
+        expect(lookup.params[0]).toBe(guestCart.hashToken(token));
+        expect(lookup.params).not.toContain(token);
+    });
+
+    test('only reaches a cart that is active, ownerless and unexpired', async () => {
+        const connection = fakeConnection(() => [[{ id: CART }]]);
+
+        await guestCart.findCartIdByToken(guestCart.issueToken(), connection);
+
+        const [lookup] = connection.calls;
+        expect(lookup.sql).toMatch(/status = \?/i);
+        expect(lookup.sql).toMatch(/user_id IS NULL/i);
+        expect(lookup.sql).toMatch(/guest_token_expires_at/i);
+        expect(lookup.params).toContain('active');
+    });
+
+    test('a token that reaches nothing costs no query beyond the regex', async () => {
+        await expect(guestCart.findCartIdByToken('not-a-token')).resolves.toBeNull();
+        expect(db.query).not.toHaveBeenCalled();
+    });
+
+    // A cart converted at checkout, or swept as abandoned, is not an error to
+    // report -- the shopper simply starts a new basket.
+    test('an exhausted token opens a new cart rather than failing', async () => {
+        let selects = 0;
+
+        const connection = fakeConnection((sql) => {
+            if (/SELECT id FROM carts/i.test(sql)) {
+                selects += 1;
+                return [[]];
+            }
+            return [{ affectedRows: 1 }];
+        });
+
+        const resolved = await guestCart.resolveCart(guestCart.issueToken(), connection);
+
+        expect(selects).toBe(1);
+        expect(resolved.isNew).toBe(true);
+        expect(guestCart.isWellFormedToken(resolved.token)).toBe(true);
+        expect(resolved.cartId).toMatch(/^[0-9a-f-]{36}$/i);
+    });
+
+    test('an existing cart is reused and no second token is minted', async () => {
+        const connection = fakeConnection((sql) => {
+            if (/SELECT id FROM carts/i.test(sql)) return [[{ id: CART }]];
+            return [{ affectedRows: 1 }];
+        });
+
+        const resolved = await guestCart.resolveCart(guestCart.issueToken(), connection);
+
+        expect(resolved).toEqual({ cartId: CART, token: null, isNew: false });
+        expect(callsMatching(connection.calls, /INSERT INTO carts/i)).toHaveLength(0);
+    });
+
+    test('a new cart is opened with no owner, so it cannot take the account slot', async () => {
+        const connection = fakeConnection((sql) => {
+            if (/SELECT id FROM carts/i.test(sql)) return [[]];
+            return [{ affectedRows: 1 }];
+        });
+
+        const { token } = await guestCart.createCart(connection);
+
+        const [insert] = callsMatching(connection.calls, /INSERT INTO carts/i);
+        expect(insert.sql).toMatch(/VALUES\s*\(\?,\s*NULL,/i);
+        expect(insert.params).toContain(guestCart.hashToken(token));
+        expect(insert.params).not.toContain(token);
+    });
+
+    test('the expiry is the configured one, applied by the database clock', async () => {
+        const connection = fakeConnection(() => [{ affectedRows: 1 }]);
+
+        await guestCart.createCart(connection);
+
+        const [insert] = connection.calls;
+        expect(insert.sql).toMatch(/DATE_ADD\(NOW\(\), INTERVAL \? MINUTE\)/i);
+        expect(insert.params).toContain(cartConfig.GUEST_TOKEN_TTL_MINUTES);
+    });
+
+    test('activity pushes the expiry out, but not on a cart that has closed', async () => {
+        const connection = fakeConnection(() => [{ affectedRows: 1 }]);
+
+        await guestCart.extendToken(CART, connection);
+
+        const [update] = connection.calls;
+        expect(update.sql).toMatch(/guest_token_expires_at = DATE_ADD/i);
+        expect(update.sql).toMatch(/status = \?/i);
+        expect(update.params).toContain('active');
+    });
+});
+
+describe('deciding whose cart a request is for', () => {
+    const run = (req) => {
+        const res = fakeResponse();
+        let advanced = false;
+
+        cartIdentity(req, res, () => { advanced = true; });
+
+        return { res, advanced };
+    };
+
+    test('the account wins, even when a cart token is also presented', () => {
+        const req = fakeRequest({
+            user: { id: USER },
+            headers: { 'x-cart-token': guestCart.issueToken() }
+        });
+
+        const { advanced } = run(req);
+
+        expect(advanced).toBe(true);
+        expect(req.cartIdentity).toEqual({ userId: USER, guestToken: null, isGuest: false });
+    });
+
+    test('a caller with no credentials at all is a guest', () => {
+        const token = guestCart.issueToken();
+        const req = fakeRequest({ headers: { 'x-cart-token': token } });
+
+        const { advanced } = run(req);
+
+        expect(advanced).toBe(true);
+        expect(req.cartIdentity).toEqual({ userId: null, guestToken: token, isGuest: true });
+    });
+
+    test('a guest with no token yet is still a guest', () => {
+        const req = fakeRequest();
+
+        run(req);
+
+        expect(req.cartIdentity).toEqual({ userId: null, guestToken: null, isGuest: true });
+    });
+
+    test('junk in the header is ignored rather than carried into a query', () => {
+        const req = fakeRequest({ headers: { 'x-cart-token': "' OR '1'='1" } });
+
+        run(req);
+
+        expect(req.cartIdentity.guestToken).toBeNull();
+    });
+
+    // The regression this guards: an expired session arrives here looking
+    // exactly like a guest, and answering it with an empty basket would swap a
+    // shopper's cart out from under them instead of letting the client refresh.
+    test('an expired session is a 401, not a demotion to guest', () => {
+        const req = fakeRequest({ headers: { authorization: 'Bearer expired.jwt.value' } });
+
+        const { res, advanced } = run(req);
+
+        expect(advanced).toBe(false);
+        expect(res.statusCode).toBe(401);
+        expect(req.cartIdentity).toBeUndefined();
+    });
+
+    test('the same is true of a session carried in a cookie', () => {
+        const req = fakeRequest({ cookies: { accessToken: 'expired.jwt.value' } });
+
+        const { res } = run(req);
+
+        expect(res.statusCode).toBe(401);
+    });
+});

--- a/backend/tests/guestOrder.test.js
+++ b/backend/tests/guestOrder.test.js
@@ -1,0 +1,212 @@
+// backend/tests/guestOrder.test.js
+//
+// Buying, and then finding the order, without an account (#1427).
+//
+// The database is mocked at the module boundary. What is pinned here is not
+// SQL text but the properties the lookup has to hold whatever the SQL looks
+// like, because they are the ones a change could quietly remove:
+//
+//   * the order number is unguessable and is not derived from the order;
+//   * a failure says nothing about which half of the pair was wrong;
+//   * an account's order is not reachable this way at all;
+//   * the email comparison happens whether or not a row was found, so the
+//     existence of one is not readable from the timing.
+
+jest.mock('../config/db', () => {
+    const query = jest.fn();
+    const pool = { query, getConnection: jest.fn() };
+    pool.promise = pool;
+    return pool;
+});
+
+jest.mock('../utils/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+const db = require('../config/db');
+const {
+    ORDER_NUMBER_PATTERN,
+    generateOrderNumber,
+    normalizeOrderNumber
+} = require('../services/orderNumber.service');
+const { emailsMatch, findGuestOrder } = require('../services/guestOrderService');
+
+const ORDER_ID = '22222222-2222-4222-8222-222222222222';
+const EMAIL = 'Shopper@Example.com';
+
+function guestOrderRow(overrides = {}) {
+    return {
+        id: ORDER_ID,
+        order_number: 'ORD-20260801-A1B2C3D4E5F60718',
+        customer_name: 'A Shopper',
+        customer_email: 'shopper@example.com',
+        customer_phone: '9876543210',
+        city: 'Pune',
+        state: 'MH',
+        zip: '411001',
+        full_address: '12 Somewhere Lane',
+        payment_method: 'cod',
+        payment_status: 'pending',
+        status: 'pending',
+        subtotal: '1000.00',
+        tax: '180.00',
+        shipping_cost: '0.00',
+        discount_amount: '0.00',
+        total: '1180.00',
+        tracking_number: null,
+        created_at: '2026-08-01 10:00:00',
+        updated_at: '2026-08-01 10:00:00',
+        ...overrides
+    };
+}
+
+/** Answers the order select with `rows`, and any item select with none. */
+function respondWith(rows) {
+    db.query.mockImplementation(async (sql) => {
+        if (/FROM orders/i.test(sql)) return [rows];
+        return [[]];
+    });
+}
+
+afterEach(() => {
+    db.query.mockReset();
+});
+
+describe('the number a shopper is given', () => {
+    test('is unguessable, and no two are alike', () => {
+        const numbers = new Set(Array.from({ length: 50 }, () => generateOrderNumber()));
+
+        expect(numbers.size).toBe(50);
+
+        for (const number of numbers) {
+            expect(number).toMatch(ORDER_NUMBER_PATTERN);
+            // Sixteen hex characters is sixty-four bits. A counter, or
+            // anything derived from the order id, would carry none.
+            expect(number.split('-')[2]).toHaveLength(16);
+        }
+    });
+
+    test('carries the date it was placed, for the person reading it out', () => {
+        const number = generateOrderNumber(new Date(2026, 0, 9));
+
+        expect(number.startsWith('ORD-20260109-')).toBe(true);
+    });
+
+    test('forgives case and stray whitespace, and nothing else', () => {
+        const number = generateOrderNumber();
+
+        expect(normalizeOrderNumber(`  ${number.toLowerCase()} `)).toBe(number);
+        expect(normalizeOrderNumber('ORD-2026-0801-ABC')).toBeNull();
+        expect(normalizeOrderNumber('%')).toBeNull();
+        expect(normalizeOrderNumber(null)).toBeNull();
+        expect(normalizeOrderNumber(42)).toBeNull();
+    });
+});
+
+describe('comparing the email an order was placed with', () => {
+    test('ignores case, because the shopper will not remember theirs', () => {
+        expect(emailsMatch('Shopper@Example.com', 'shopper@example.com')).toBe(true);
+        expect(emailsMatch('  shopper@example.com  ', 'shopper@example.com')).toBe(true);
+    });
+
+    test('rejects a different address, whatever its length', () => {
+        expect(emailsMatch('someone@example.com', 'shopper@example.com')).toBe(false);
+        expect(emailsMatch('s@e.co', 'shopper@example.com')).toBe(false);
+        expect(emailsMatch('', 'shopper@example.com')).toBe(false);
+    });
+});
+
+describe('finding a guest order', () => {
+    test('returns the order and its lines when both halves are right', async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/FROM orders/i.test(sql)) return [[guestOrderRow()]];
+            return [[{ product_id: 'p1', name: 'Thing', price: '1000.00', qty: 1 }]];
+        });
+
+        const order = await findGuestOrder({
+            orderNumber: 'ORD-20260801-A1B2C3D4E5F60718',
+            email: EMAIL
+        });
+
+        expect(order.order_number).toBe('ORD-20260801-A1B2C3D4E5F60718');
+        expect(order.items).toHaveLength(1);
+    });
+
+    test('only looks at orders with no account behind them', async () => {
+        respondWith([guestOrderRow()]);
+
+        await findGuestOrder({
+            orderNumber: 'ORD-20260801-A1B2C3D4E5F60718',
+            email: EMAIL
+        });
+
+        const [sql, params] = db.query.mock.calls[0];
+        expect(sql).toMatch(/user_id IS NULL/i);
+        expect(params).toEqual(['ORD-20260801-A1B2C3D4E5F60718']);
+    });
+
+    test('a wrong email finds nothing, and the order is not leaked in passing', async () => {
+        respondWith([guestOrderRow()]);
+
+        await expect(findGuestOrder({
+            orderNumber: 'ORD-20260801-A1B2C3D4E5F60718',
+            email: 'someone-else@example.com'
+        })).resolves.toBeNull();
+
+        // The lines are only fetched once the pair has been accepted.
+        expect(db.query.mock.calls.filter(([sql]) => /FROM order_items/i.test(sql)))
+            .toHaveLength(0);
+    });
+
+    test('an unknown order number finds nothing', async () => {
+        respondWith([]);
+
+        await expect(findGuestOrder({
+            orderNumber: 'ORD-20260801-FFFFFFFFFFFFFFFF',
+            email: EMAIL
+        })).resolves.toBeNull();
+    });
+
+    // The two failures have to be indistinguishable from the outside, which
+    // means the work done on each has to be the same: a missing row must not
+    // skip the comparison a present one performs.
+    test('the missing-row path does the same comparison the wrong-email path does', async () => {
+        respondWith([]);
+
+        const comparisons = [];
+        const spy = jest.spyOn(require('crypto'), 'createHash');
+
+        await findGuestOrder({
+            orderNumber: 'ORD-20260801-FFFFFFFFFFFFFFFF',
+            email: EMAIL
+        });
+
+        comparisons.push(spy.mock.calls.length);
+        spy.mockClear();
+
+        respondWith([guestOrderRow()]);
+
+        await findGuestOrder({
+            orderNumber: 'ORD-20260801-A1B2C3D4E5F60718',
+            email: 'someone-else@example.com'
+        });
+
+        comparisons.push(spy.mock.calls.length);
+        spy.mockRestore();
+
+        expect(comparisons[0]).toBe(comparisons[1]);
+        expect(comparisons[0]).toBeGreaterThan(0);
+    });
+
+    test('a malformed order number is refused before it reaches a query', async () => {
+        await expect(findGuestOrder({
+            orderNumber: "' OR '1'='1",
+            email: EMAIL
+        })).resolves.toBeNull();
+
+        expect(db.query).not.toHaveBeenCalled();
+    });
+});

--- a/backend/tests/policy.test.js
+++ b/backend/tests/policy.test.js
@@ -4,7 +4,12 @@
 // exercise it directly rather than through a mounted app.
 
 const policy = require('../config/policy');
-const { PUBLIC_ROUTES, isPublicRoute } = require('../config/routePolicy');
+const {
+    GUEST_ROUTES,
+    PUBLIC_ROUTES,
+    isGuestRoute,
+    isPublicRoute
+} = require('../config/routePolicy');
 const snapshot = require('./fixtures/policySnapshot.json');
 
 const {
@@ -14,8 +19,10 @@ const {
     expandRoles,
     hasPermission,
     isAdminRole,
+    isGuestCapableMiddleware,
     isPolicyMiddleware,
     isValidRole,
+    markPolicyMiddleware,
     normalizeRole,
     permissionsForRole,
     roleOf,
@@ -177,6 +184,30 @@ describe('authorize middleware', () => {
     });
 });
 
+describe('guest-capable guards', () => {
+    // "Guarded" and "requires an account" are different claims, and a guard
+    // that stops being the second while staying the first is exactly the
+    // change the unprotected-route check cannot see.
+    test('a guard says for itself whether it admits a caller with no account', () => {
+        const admitsGuests = markPolicyMiddleware(
+            (req, res, next) => next(),
+            { authentication: 'optional', guest: true }
+        );
+        const requiresAccount = markPolicyMiddleware(
+            (req, res, next) => next(),
+            { authentication: true }
+        );
+
+        expect(isGuestCapableMiddleware(admitsGuests)).toBe(true);
+        expect(isGuestCapableMiddleware(requiresAccount)).toBe(false);
+    });
+
+    test('an unmarked handler claims nothing, whatever it is called', () => {
+        expect(isGuestCapableMiddleware(function allowGuests(req, res, next) { next(); })).toBe(false);
+        expect(isGuestCapableMiddleware(null)).toBe(false);
+    });
+});
+
 describe('pinned policy', () => {
     // A permission grant that widens by accident is invisible in a diff of the
     // map alone; requiring the snapshot to be edited too makes it deliberate.
@@ -211,5 +242,26 @@ describe('pinned policy', () => {
         expect(isPublicRoute('get', '/api/products')).toBe(true);
         expect(isPublicRoute('DELETE', '/api/products')).toBe(false);
         expect(isPublicRoute('GET', '/api/orders')).toBe(false);
+    });
+
+    test('the routes reachable without an account are the ones on record', () => {
+        const declared = GUEST_ROUTES.map(({ method, path }) => `${method} ${path}`);
+        expect(sorted(declared)).toEqual(sorted(snapshot.guestRoutes));
+    });
+
+    test('every guest route carries a reason', () => {
+        for (const route of GUEST_ROUTES) {
+            expect(typeof route.reason).toBe('string');
+            expect(route.reason.length).toBeGreaterThan(0);
+        }
+    });
+
+    // Serving a guest is not the same as serving everybody: the cart routes
+    // still decide which cart the caller reaches.
+    test('a guest route is not thereby a public one', () => {
+        expect(isGuestRoute('GET', '/api/cart')).toBe(true);
+        expect(isPublicRoute('GET', '/api/cart')).toBe(false);
+        expect(isGuestRoute('POST', '/api/cart')).toBe(false);
+        expect(isGuestRoute('GET', '/api/orders')).toBe(false);
     });
 });

--- a/backend/tests/routeAudit.test.js
+++ b/backend/tests/routeAudit.test.js
@@ -15,7 +15,9 @@ const {
     collectRoutes,
     collectMountedRoutes,
     findUnprotectedRoutes,
+    findUndeclaredGuestRoutes,
     assertRoutesProtected,
+    assertGuestRoutesDeclared,
     runStartupAudit
 } = require('../middleware/routeAudit');
 const { AUDITED_MOUNTS } = require('../config/routePolicy');
@@ -23,6 +25,10 @@ const { PERMISSIONS, authorize, markPolicyMiddleware } = require('../config/poli
 
 const ok = (req, res) => res.json({ success: true });
 const guard = markPolicyMiddleware((req, res, next) => next(), { authentication: true });
+const guestGuard = markPolicyMiddleware(
+    (req, res, next) => next(),
+    { authentication: 'optional', guest: true }
+);
 
 describe('collectRoutes', () => {
     test('reports every method registered on a path', () => {
@@ -142,6 +148,56 @@ describe('findUnprotectedRoutes', () => {
     });
 });
 
+describe('findUndeclaredGuestRoutes', () => {
+    // A guard that admits anonymous callers still satisfies the unprotected
+    // check, so widening one is invisible there. This is the check that sees
+    // it.
+    test('flags a route that admits guests without that being declared', () => {
+        const router = express.Router();
+        router.use(guestGuard);
+        router.get('/wishlists', ok);
+
+        expect(findUndeclaredGuestRoutes([{ basePath: '/api', router }])).toEqual([
+            { method: 'GET', path: '/api/wishlists' }
+        ]);
+    });
+
+    test('stays quiet about the guest routes on record', () => {
+        const router = express.Router();
+        router.use(guestGuard);
+        router.get('/', ok);
+        router.post('/add', ok);
+
+        expect(findUndeclaredGuestRoutes([{ basePath: '/api/cart', router }])).toEqual([]);
+    });
+
+    test('says nothing about a route that requires an account', () => {
+        const router = express.Router();
+        router.use(guard);
+        router.get('/:id', ok);
+
+        expect(findUndeclaredGuestRoutes([{ basePath: '/api/orders', router }])).toEqual([]);
+    });
+
+    test('names every offender at once', () => {
+        const router = express.Router();
+        router.use(guestGuard);
+        router.get('/:id', ok);
+        router.delete('/:id', ok);
+
+        let message = '';
+        try {
+            assertGuestRoutesDeclared([{ basePath: '/api/orders', router }]);
+        } catch (error) {
+            message = error.message;
+        }
+
+        expect(message).toContain('GET /api/orders/:id');
+        expect(message).toContain('DELETE /api/orders/:id');
+        expect(message).toContain('routePolicy');
+    });
+});
+
 describe('assertRoutesProtected', () => {
     test('passes when every route declares a policy', () => {
         const router = express.Router();
@@ -196,6 +252,33 @@ describe('runStartupAudit', () => {
 
     test('refuses to start in enforce mode', () => {
         expect(() => runStartupAudit({ mode: 'enforce', mounts: buildLeakyMount() })).toThrow();
+    });
+
+    test('refuses to start on an undeclared guest route too', () => {
+        const router = express.Router();
+        router.use(guestGuard);
+        router.get('/:id', ok);
+
+        expect(() => runStartupAudit({
+            mode: 'enforce',
+            mounts: [{ basePath: '/api/orders', router }]
+        })).toThrow(/without an account/i);
+    });
+
+    test('reports an undeclared guest route in warn mode', () => {
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const router = express.Router();
+        router.use(guestGuard);
+        router.get('/:id', ok);
+
+        runStartupAudit({ mode: 'warn', mounts: [{ basePath: '/api/orders', router }] });
+
+        expect(console.warn).toHaveBeenCalledWith(
+            expect.stringContaining('without an account')
+        );
+
+        console.warn.mockRestore();
     });
 });
 

--- a/frontend/scripts/auth.js
+++ b/frontend/scripts/auth.js
@@ -384,6 +384,12 @@ if (otpForm) {
             const response = await verifySignupUser(email, otp);
 
             if (response.success) {
+                // The basket built before registering now belongs to the new
+                // account, so the token that reached it as a guest is spent.
+                if (response.cartMerged) {
+                    AppUtils.clearCartToken();
+                }
+
                 AppUtils.notify("Account created successfully! Please login.", "success");
                 resetOtpTimer('resend-signup-otp-link', 'resend-signup-timer');
                 setTimeout(() => {

--- a/frontend/scripts/checkout.js
+++ b/frontend/scripts/checkout.js
@@ -8,18 +8,9 @@ const appliedCoupon =
         ""
     );
 
-// require authentication
-const currentUser =
-    AppUtils.requireAuth();
-
-if (
-    !currentUser
-) {
-
-    throw new Error(
-        "Authentication required"
-    );
-}
+// No sign-in gate. Requiring an account before a stranger can pay is the
+// abandonment this page exists to stop causing; the order carries the contact
+// details either way, and the server settles who placed it.
 
 // EMPTY CART REDIRECT
 if (
@@ -926,6 +917,10 @@ if (
             // Whichever branch runs, the id of the order the server created.
             let placedOrderId = null;
 
+            // And the number the shopper was given for it. It is the only
+            // handle a guest has, so it is what the confirmation page is sent.
+            let placedOrderNumber = null;
+
             try {
                 if (selectedPaymentMethod === "card") {
                     // 1. Create Payment Intent (PoW gate may challenge first)
@@ -940,6 +935,7 @@ if (
                     }
 
                     placedOrderId = intentRes.orderId;
+                    placedOrderNumber = intentRes.orderNumber;
 
                     // 2. Confirm Card Payment with Stripe
                     const { error, paymentIntent } = await stripe.confirmCardPayment(intentRes.clientSecret, {
@@ -973,12 +969,21 @@ if (
                     }
 
                     placedOrderId = data.orderId;
+                    placedOrderNumber = data.orderNumber;
 
                     AppUtils.notify("Order placed successfully! 🎉", "success");
                 }
 
+                // What the confirmation page needs to read this order back
+                // when there is no account to read it through.
+                AppUtils.rememberGuestOrder(
+                    placedOrderNumber,
+                    order.customer.email
+                );
+
                 // clear cart
                 AppUtils.clearCart();
+                AppUtils.clearCartToken();
                 AppUtils.removeStorage("appliedCoupon");
 
                 // update ui
@@ -1003,7 +1008,7 @@ if (
                     () => {
 
                         window.location.href =
-                            `success.html?id=${placedOrderId}`;
+                            `success.html?id=${encodeURIComponent(placedOrderId)}`;
 
                     },
                     1200

--- a/frontend/scripts/config.js
+++ b/frontend/scripts/config.js
@@ -79,6 +79,11 @@ const CONFIG = {
         USER:
             "user",
 
+        // What a shopper without an account is identified by. Nothing else
+        // reaches their basket, so losing this key loses the basket.
+        CART_TOKEN:
+            "cartToken",
+
         RECENTLY_VIEWED:
             "recentlyViewed"
     }

--- a/frontend/scripts/success.js
+++ b/frontend/scripts/success.js
@@ -1,15 +1,7 @@
-// require auth
-const currentUser =
-    AppUtils.requireAuth();
-
-if (
-    !currentUser
-) {
-
-    throw new Error(
-        "Authentication required"
-    );
-}
+// No sign-in gate: a shopper who just paid without an account still has to be
+// shown what they bought. There are two ways to reach the order and the page
+// takes whichever applies -- an account reads it by id, a guest reads it back
+// with the order number and the email it was placed with.
 
 // get order id from url
 const orderId =
@@ -17,9 +9,14 @@ const orderId =
         window.location.search
     ).get("id");
 
+const guestOrder =
+    AppUtils.readGuestOrder();
+
 // invalid access
 if (
     !orderId
+    &&
+    !guestOrder
 ) {
 
     AppUtils.notify(
@@ -38,7 +35,7 @@ if (
     );
 
     throw new Error(
-        "Missing order ID"
+        "Missing order reference"
     );
 }
 
@@ -61,15 +58,71 @@ const elements = {
         )
 };
 
+// Read the order the way this shopper is entitled to. An account holder reads
+// their own order by id; anyone else presents the pair they were given at
+// checkout. `id` is preferred when both are available because it is the
+// authoritative read and carries the full record.
+async function requestOrder() {
+
+    if (
+        orderId
+        &&
+        AppUtils.isAuthenticated()
+    ) {
+
+        const response =
+            await AppUtils.apiRequest(
+                `/orders/${orderId}`
+            );
+
+        return response && response.order
+            ? { success: response.success, order: response.order }
+            : { success: false };
+    }
+
+    const response =
+        await AppUtils.apiRequest(
+            "/orders/lookup",
+            {
+                method: "POST",
+                body: JSON.stringify(guestOrder)
+            }
+        );
+
+    if (
+        !response
+        ||
+        !response.success
+        ||
+        !response.order
+    ) {
+
+        return { success: false };
+    }
+
+    // The guest view names its fields for the client rather than after the
+    // columns, so it is mapped onto the shape this page already renders.
+    return {
+        success: true,
+
+        order: {
+            order_number: response.order.orderNumber,
+            created_at: response.order.placedAt,
+            total: response.order.totals
+                ? response.order.totals.total
+                : null,
+            items: response.order.items
+        }
+    };
+}
+
 // fetch order
 async function fetchOrder() {
 
     try {
 
         const response =
-            await AppUtils.apiRequest(
-                `/orders/${orderId}`
-            );
+            await requestOrder();
 
         if (
             !response.success
@@ -98,9 +151,10 @@ async function fetchOrder() {
         const order =
             response.order;
 
-        // render order id
+        // render order id — the order number in preference to the internal id,
+        // since that is what the shopper was given and what support will ask for
 if (elements.orderId) {
-    elements.orderId.innerText = order.id || "N/A";
+    elements.orderId.innerText = order.order_number || order.id || "N/A";
 }
 
 // render order date
@@ -114,9 +168,10 @@ if (elements.orderDate) {
 // render order total
 const orderTotal = document.getElementById("order-total");
 if (orderTotal) {
-    orderTotal.innerText = order.total_price
-        ? AppUtils.formatPrice(order.total_price)
-        : "N/A";
+    // `total` is the column; `total_price` was never one, so this read has
+    // always shown N/A.
+    const total = order.total ?? order.total_price;
+    orderTotal.innerText = total ? AppUtils.formatPrice(total) : "N/A";
 }
 
 // render order items

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -389,6 +389,52 @@ const refreshAccessToken = () => {
     return pendingRefresh;
 };
 
+// The basket of a shopper with no account lives on the server like anyone
+// else's; this is the only thing that reaches it. It is sent on every request
+// rather than only on cart calls, because the endpoints that will later accept
+// a guest basket are not all under /cart.
+const CART_TOKEN_HEADER = "X-Cart-Token";
+
+const getCartToken = () => {
+
+    return localStorage.getItem(
+        CONFIG.STORAGE_KEYS.CART_TOKEN
+    );
+};
+
+// The server returns a token only when it has just minted one, which it does
+// when the request presented no usable token. So whatever comes back is the
+// token that reaches the basket the request actually wrote to, and it replaces
+// whatever was held before.
+const rememberCartToken = (
+    data
+) => {
+
+    if (
+        !data
+        ||
+        typeof data.cartToken !== "string"
+    ) {
+
+        return;
+    }
+
+    try {
+
+        localStorage.setItem(
+            CONFIG.STORAGE_KEYS.CART_TOKEN,
+            data.cartToken
+        );
+
+    } catch (error) {
+
+        console.error(
+            "Cart token storage error:",
+            error
+        );
+    }
+};
+
 // api request
 const apiRequest =
     async (
@@ -424,6 +470,9 @@ const apiRequest =
             const token =
                 getToken();
 
+            const cartToken =
+                getCartToken();
+
             const headers = {
 
                 "Content-Type":
@@ -433,6 +482,13 @@ const apiRequest =
                     ? {
                         Authorization:
                             `Bearer ${token}`
+                    }
+                    : {}),
+
+                ...(cartToken
+                    ? {
+                        [CART_TOKEN_HEADER]:
+                            cartToken
                     }
                     : {}),
 
@@ -533,6 +589,10 @@ const apiRequest =
 
                 throw failure;
             }
+
+            rememberCartToken(
+                data
+            );
 
             return data;
 
@@ -1362,20 +1422,13 @@ const addCartItem = async (
         );
     }
 
-    // Guests have nothing to reserve against, so the local write is the whole
-    // operation.
-    if (
-        !isAuthenticated()
-    ) {
-
-        return saveCart(
-            cart
-        );
-    }
-
     // /cart/add is the only endpoint that creates the 15-minute inventory lock
     // the checkout flow later validates, so an add has to route through it. The
     // local write is not pushed separately because this request carries it.
+    //
+    // A guest goes the same way. There is no reservation to take against an
+    // account that does not exist, but the line still has to reach the stored
+    // basket, and this is the request that puts it there.
     const saved =
         saveCart(
             cart,
@@ -1420,8 +1473,8 @@ const addCartItem = async (
         return saved;
     }
 
-    // The account does not hold this line, so the browser must stop pretending
-    // it does.
+    // The stored cart does not hold this line, so the browser must stop
+    // pretending it does.
     notify(
         (
             response
@@ -1496,12 +1549,14 @@ const clearCart = () => {
     );
 };
 
-// ---------- Backend cart integration (authenticated users) ----------
-// Guests keep using localStorage only. For signed-in users every cart mutation
-// is mirrored to the persistent backend cart (/api/cart) so carts survive
-// across devices/sessions and the inventory-reservation workflow is exercised.
-// The account is the authority: a change the server refuses does not survive
-// locally.
+// ---------- Backend cart integration ----------
+// Every cart mutation is mirrored to the persistent backend cart (/api/cart),
+// whether or not the shopper has an account. For a signed-in shopper that is
+// what makes a cart survive across devices and sessions and what exercises the
+// inventory-reservation workflow; for a guest it is what makes the basket a
+// thing the shop can see at all, rather than something that exists only in one
+// browser until it is cleared. The server is the authority either way: a
+// change it refuses does not survive locally.
 
 // Real lines, one per variant choice. Flattening colour and size away here is
 // what used to make the shopper's choice vanish on the round trip and left
@@ -1533,7 +1588,7 @@ const enqueueOfflineCartMutation = (cart) => {
 };
 
 const processOfflineCartQueue = async () => {
-    if (!navigator.onLine || !isAuthenticated()) return;
+    if (!navigator.onLine) return;
     const queue = getOfflineCartQueue();
     if (!queue.length) return;
 
@@ -1588,7 +1643,7 @@ const pushCartToBackend = async (cart) => {
 
     notify(
         (response && response.message)
-        || "Your cart could not be saved to your account.",
+        || "Your cart could not be saved.",
         "error"
     );
 
@@ -1605,10 +1660,6 @@ const pushCartToBackend = async (cart) => {
 let pendingCartSync = null;
 
 const syncCartWithBackend = (cart) => {
-    if (!isAuthenticated()) {
-        return Promise.resolve(false);
-    }
-
     if (pendingCartSync) {
         clearTimeout(pendingCartSync.timeoutId);
     } else {
@@ -1679,11 +1730,15 @@ const fetchServerCart = async () => {
     return null;
 };
 
-// Page-load lifecycle: the account cart REPLACES the local mirror. Nothing is
+// Page-load lifecycle: the stored cart REPLACES the local mirror. Nothing is
 // merged here — merging what is only a mirror of the same cart is what made
 // carts inflate on their own with nobody touching them.
+//
+// A guest hydrates too, but only once there is a token to hydrate against. A
+// visitor who has never added anything has no stored cart to read, and asking
+// for one would open a basket nobody started.
 const hydrateCartFromServer = async () => {
-    if (!isAuthenticated()) {
+    if (!isAuthenticated() && !getCartToken()) {
         return getCart();
     }
 
@@ -2068,10 +2123,11 @@ window.addEventListener("storage", (event) => {
     dispatchCartUpdated(getCart());
 });
 
-// Hydrate the persistent backend cart for already–signed-in users on load, so
-// a cart created on another device/session follows them here. Combining a guest
-// cart into the account is a separate, deliberate step that belongs to sign-in.
-if (getToken() && getUser()) {
+// Hydrate the persistent backend cart on load, so a cart created on another
+// device or session follows a signed-in shopper here and a guest's basket
+// survives a reload. Combining a guest cart into an account is a separate,
+// deliberate step that belongs to sign-in.
+if ((getToken() && getUser()) || getCartToken()) {
     hydrateCartFromServer().catch((error) => {
         console.warn("Initial cart hydration failed:", error);
     });

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -1239,13 +1239,6 @@ const readCartEnvelope = (
                     0
                 ),
 
-        guestCartMerged:
-            !isLegacyPayload
-            &&
-            Boolean(
-                stored.guestCartMerged
-            ),
-
         items
     };
 };
@@ -1348,28 +1341,10 @@ const getCart = () => {
     return [];
 };
 
-// Items from a guest cart that a signed-in shopper brought with them, waiting
-// to be folded into the account exactly once.
-const getGuestCartCandidates = () => {
-
-    const envelope =
-        readCartEnvelope();
-
-    return (
-        envelope
-        &&
-        envelope.owner ===
-        GUEST_CART_OWNER
-    )
-        ? envelope.items
-        : [];
-};
-
 const saveCart = (
     cart,
     {
-        sync = true,
-        guestCartMerged = false
+        sync = true
     } = {}
 ) => {
 
@@ -1381,9 +1356,6 @@ const saveCart = (
             .filter(
                 Boolean
             );
-
-    const previous =
-        readCartEnvelope();
 
     const owner =
         getCartOwner();
@@ -1397,19 +1369,6 @@ const saveCart = (
 
             updatedAt:
                 Date.now(),
-
-            // The merge flag belongs to the account, so it only carries over a
-            // write by that same account.
-            guestCartMerged:
-                guestCartMerged
-                ||
-                Boolean(
-                    previous
-                    &&
-                    previous.owner === owner
-                    &&
-                    previous.guestCartMerged
-                ),
 
             items:
                 normalizedCart
@@ -1845,45 +1804,23 @@ const hydrateCartFromServer = async () => {
     return saveCart(serverCart, { sync: false });
 };
 
-// Sign-in lifecycle: fold a guest cart into the account cart. This is the one
-// deliberate combine, and the envelope records that it happened so a reload
-// cannot repeat it.
+// Sign-in lifecycle. The server folds the guest basket into the account's cart
+// as it issues the session (#1427), so by the time this runs the account's
+// cart already holds both and the only thing left to do is read it back.
+//
+// Combining here as well would count the guest's lines a second time, and the
+// flag that used to stop a reload repeating the merge is gone with it: the
+// guest cart is closed on the server, so a repeat has nothing to find. The
+// token is dropped for the same reason -- the cart it reached no longer
+// exists as a cart anyone can add to.
 const mergeGuestCartIntoAccount = async () => {
     if (!isAuthenticated()) {
         return getCart();
     }
 
-    const envelope = readCartEnvelope();
-    const alreadyMerged =
-        envelope
-        && envelope.owner === getCartOwner()
-        && envelope.guestCartMerged;
+    clearCartToken();
 
-    const guestCart = getGuestCartCandidates();
-
-    if (alreadyMerged || !guestCart.length) {
-        return hydrateCartFromServer();
-    }
-
-    const serverCart = await fetchServerCart();
-
-    // Without the account cart there is nothing sound to merge into, so the
-    // guest cart stays a guest cart and the next sign-in can try again.
-    if (!serverCart) {
-        return getCart();
-    }
-
-    serverAcknowledgedItems = serverCart;
-
-    const merged = mergeCartLines(serverCart, guestCart);
-
-    saveCart(merged, { sync: false, guestCartMerged: true });
-
-    // Pushed directly rather than through the debounce: this is a one-shot step
-    // and the shopper is waiting on its outcome.
-    const accepted = await pushCartToBackend(merged);
-
-    return accepted ? merged : getCart();
+    return hydrateCartFromServer();
 };
 
 const getCartCount = (

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -435,6 +435,98 @@ const rememberCartToken = (
     }
 };
 
+// A cart that became an order is closed, so the token that reached it no
+// longer reaches anything. Dropping it means the next basket starts clean
+// rather than on the back of a request the server has to refuse first.
+const clearCartToken = () => {
+
+    try {
+
+        localStorage.removeItem(
+            CONFIG.STORAGE_KEYS.CART_TOKEN
+        );
+
+    } catch (error) {
+
+        console.error(
+            "Cart token storage error:",
+            error
+        );
+    }
+};
+
+// Reading back an order that no account owns takes the order number and the
+// email it was placed with. Both are held in session storage rather than put
+// in the URL of the confirmation page: the email is half of what authorises
+// the lookup, and a URL ends up in history, in referrers and in access logs.
+// Session storage is also scoped to the tab, so it goes when the tab does.
+const GUEST_ORDER_KEY = "guestOrder";
+
+const rememberGuestOrder = (
+    orderNumber,
+    email
+) => {
+
+    if (
+        !orderNumber
+        ||
+        !email
+    ) {
+
+        return;
+    }
+
+    try {
+
+        sessionStorage.setItem(
+            GUEST_ORDER_KEY,
+            JSON.stringify({
+                orderNumber,
+                email
+            })
+        );
+
+    } catch (error) {
+
+        console.error(
+            "Guest order storage error:",
+            error
+        );
+    }
+};
+
+const readGuestOrder = () => {
+
+    try {
+
+        const stored =
+            JSON.parse(
+                sessionStorage.getItem(
+                    GUEST_ORDER_KEY
+                )
+                ||
+                "null"
+            );
+
+        return stored
+            &&
+            stored.orderNumber
+            &&
+            stored.email
+            ? stored
+            : null;
+
+    } catch (error) {
+
+        console.error(
+            "Guest order storage error:",
+            error
+        );
+
+        return null;
+    }
+};
+
 // api request
 const apiRequest =
     async (
@@ -2066,6 +2158,10 @@ window.AppUtils = {
     updateCartItemQty,
     removeCartItem,
     clearCart,
+    getCartToken,
+    clearCartToken,
+    rememberGuestOrder,
+    readGuestOrder,
     getCartCount,
     isAuthenticated,
     syncCartWithBackend,

--- a/migrations/0039_guest_carts.sql
+++ b/migrations/0039_guest_carts.sql
@@ -1,0 +1,201 @@
+-- ============================================
+-- GUEST CARTS
+-- ============================================
+--
+-- Migration 0027 made `carts.user_id` nullable so a basket could exist before
+-- we know who the shopper is, and said plainly that nothing created one yet.
+-- This is the other half.
+--
+-- Two things were missing. A cart with no account has nothing to identify it
+-- by, so the client needs to hold something; and the lines themselves are
+-- still keyed by account -- `cart_items.user_id` is NOT NULL and part of the
+-- primary key -- so a line cannot exist without one however nullable the cart
+-- row is. Both are addressed here.
+
+-- ============================================
+-- WHAT THE CLIENT HOLDS
+-- ============================================
+--
+-- The token is a bearer credential: whoever presents it gets the cart. Only
+-- its SHA-256 is stored, for the same reason a password is not stored in
+-- plaintext -- a read of this table must not hand over live baskets. The
+-- column is CHAR(64) because that is the width of a hex-encoded SHA-256, and
+-- UNIQUE so one token can never resolve to two carts. Account carts store
+-- NULL, and NULLs do not collide in a UNIQUE index.
+--
+-- The expiry is separate from `last_activity_at`, which the abandonment sweep
+-- owns. A cart may be swept as abandoned while the token that reaches it is
+-- still valid, and a token has to stop working eventually whatever the cart
+-- did: an unexpiring bearer credential in someone's browser storage is a
+-- standing invitation.
+
+DELIMITER //
+
+CREATE PROCEDURE AddGuestCartToken()
+BEGIN
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'carts'
+        AND COLUMN_NAME = 'guest_token_hash'
+    ) THEN
+        ALTER TABLE carts
+        ADD COLUMN guest_token_hash CHAR(64) NULL AFTER user_id,
+        ADD COLUMN guest_token_expires_at DATETIME NULL AFTER guest_token_hash;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'carts'
+        AND INDEX_NAME = 'uq_carts_guest_token'
+    ) THEN
+        CREATE UNIQUE INDEX uq_carts_guest_token ON carts (guest_token_hash);
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL AddGuestCartToken();
+DROP PROCEDURE AddGuestCartToken;
+
+-- ============================================
+-- THE LINE BELONGS TO THE CART, NOT THE ACCOUNT
+-- ============================================
+--
+-- Migration 0027 added `cart_items.cart_id` alongside the existing key and
+-- backfilled it, deliberately leaving the primary key alone because the
+-- guarantee it carries -- one row per product plus variant plus colour plus
+-- size -- was independent of which cart the line belonged to. That is still
+-- true. What has changed is who the guarantee is scoped to: the cart, which
+-- every line now has, rather than the account, which a guest line does not.
+--
+-- So the same guarantee is re-expressed over `cart_id`, and `user_id` becomes
+-- optional. It is not dropped: it still carries the owner for the cascade on
+-- account deletion and for the queries that read a shopper's lines directly,
+-- and for an account cart it is still written on every line.
+--
+-- The backfill from 0027 is repeated first. It is a no-op on a database that
+-- has already run it, and it is what makes `cart_id NOT NULL` safe on one that
+-- acquired rows between the two migrations.
+
+DELIMITER //
+
+CREATE PROCEDURE KeyCartLinesByCart()
+BEGIN
+    DECLARE owner_fk VARCHAR(64) DEFAULT NULL;
+
+    INSERT INTO carts (id, user_id, status, last_activity_at, created_at)
+    SELECT
+        UUID(),
+        ci.user_id,
+        'active',
+        MAX(ci.updated_at),
+        MIN(ci.created_at)
+    FROM cart_items ci
+    WHERE ci.cart_id IS NULL
+      AND NOT EXISTS (
+          SELECT 1 FROM carts c
+          WHERE c.user_id = ci.user_id AND c.status = 'active'
+      )
+    GROUP BY ci.user_id;
+
+    UPDATE cart_items ci
+    JOIN carts c
+      ON c.user_id = ci.user_id
+     AND c.status = 'active'
+    SET ci.cart_id = c.id
+    WHERE ci.cart_id IS NULL;
+
+    IF EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'cart_items'
+        AND COLUMN_NAME = 'cart_id'
+        AND IS_NULLABLE = 'YES'
+    ) THEN
+        ALTER TABLE cart_items
+        MODIFY COLUMN cart_id CHAR(36) NOT NULL;
+    END IF;
+
+    -- The foreign key on user_id needs an index with user_id leftmost. It is
+    -- about to lose the primary key it has been using for that, so the
+    -- standalone index is ensured before rather than after.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'cart_items'
+        AND INDEX_NAME = 'idx_cart_items_user'
+    ) THEN
+        CREATE INDEX idx_cart_items_user ON cart_items (user_id);
+    END IF;
+
+    -- Two deployment shapes, as migration 0020 found: one keys the table on
+    -- the line itself, the other on a surrogate id with the line as a unique
+    -- key. The first has a primary key to move; the second only needs the
+    -- cart-scoped key adding beside what it has.
+    IF EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'cart_items'
+        AND INDEX_NAME = 'PRIMARY'
+        AND COLUMN_NAME = 'user_id'
+    ) THEN
+        ALTER TABLE cart_items
+        DROP PRIMARY KEY,
+        ADD PRIMARY KEY (cart_id, product_id, variant_id, color, size);
+    ELSEIF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'cart_items'
+        AND INDEX_NAME = 'uq_cart_items_line'
+    ) THEN
+        ALTER TABLE cart_items
+        ADD UNIQUE KEY uq_cart_items_line (cart_id, product_id, variant_id, color, size);
+    END IF;
+
+    -- The constraint is unnamed in the baseline schema, so it is looked up
+    -- rather than guessed at, and re-added under a name the next migration can
+    -- refer to.
+    SET owner_fk = (
+        SELECT CONSTRAINT_NAME
+        FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'cart_items'
+        AND COLUMN_NAME = 'user_id'
+        AND REFERENCED_TABLE_NAME = 'users'
+        LIMIT 1
+    );
+
+    IF EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'cart_items'
+        AND COLUMN_NAME = 'user_id'
+        AND IS_NULLABLE = 'NO'
+    ) THEN
+        IF owner_fk IS NOT NULL THEN
+            SET @drop_owner_fk = CONCAT(
+                'ALTER TABLE cart_items DROP FOREIGN KEY `', owner_fk, '`'
+            );
+            PREPARE drop_owner_fk_stmt FROM @drop_owner_fk;
+            EXECUTE drop_owner_fk_stmt;
+            DEALLOCATE PREPARE drop_owner_fk_stmt;
+            SET owner_fk = NULL;
+        END IF;
+
+        ALTER TABLE cart_items
+        MODIFY COLUMN user_id CHAR(36) NULL;
+    END IF;
+
+    IF owner_fk IS NULL THEN
+        ALTER TABLE cart_items
+        ADD CONSTRAINT fk_cart_items_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL KeyCartLinesByCart();
+DROP PROCEDURE KeyCartLinesByCart;

--- a/migrations/0040_order_numbers.sql
+++ b/migrations/0040_order_numbers.sql
@@ -1,0 +1,38 @@
+-- ============================================
+-- ORDER NUMBERS
+-- ============================================
+--
+-- `orders.order_number` has been in the schema, unique and indexed, since the
+-- baseline. Nothing has ever written it, so every row holds NULL and the only
+-- handle on an order is its primary key.
+--
+-- That was survivable while every order belonged to an account: the account
+-- lists its own orders and never has to name one. A shopper without an account
+-- has no list to read, so they need something they can be given at checkout
+-- and quote back afterwards -- and it cannot be the primary key, which is an
+-- internal identifier that turns up in URLs and logs and was never meant to
+-- prove anything.
+--
+-- So the number has to be unguessable. Half of what authorises a guest order
+-- lookup is knowing it; the other half is the email the order was placed with,
+-- which for a shopper's own address is not a secret at all. Sixty-four bits of
+-- randomness in the suffix is what carries that weight. The date prefix is
+-- there for the humans reading it out over the phone and adds nothing to the
+-- entropy.
+--
+-- The column stays nullable. Two other checkout paths -- the agent checkout
+-- and the standalone checkout service -- also insert orders and do not supply
+-- a number yet; making it mandatory before they do would turn a schema change
+-- into an outage on paths this change does not touch.
+
+UPDATE orders
+SET order_number = CONCAT(
+    'ORD-',
+    DATE_FORMAT(COALESCE(created_at, NOW()), '%Y%m%d'),
+    '-',
+    -- UUID() rather than the id alone: derived from the id, the number would
+    -- be recoverable by anyone who has seen an order URL, which is exactly the
+    -- property it must not have.
+    UPPER(SUBSTRING(SHA2(CONCAT(id, UUID()), 256), 1, 16))
+)
+WHERE order_number IS NULL OR order_number = '';

--- a/migrations/0041_cart_merge.sql
+++ b/migrations/0041_cart_merge.sql
@@ -1,0 +1,85 @@
+-- ============================================
+-- MERGING A GUEST BASKET INTO AN ACCOUNT
+-- ============================================
+--
+-- A shopper who builds a basket and then signs in has to end up with one cart
+-- holding both. That leaves the guest cart needing somewhere to go, and none
+-- of the three states it could already be in is the truth:
+--
+--   `active` would leave two live carts for the same shopper, one of them
+--   unreachable, and the abandonment sweep would eventually write the guest
+--   one off as a basket that was walked away from -- which is the opposite of
+--   what happened;
+--
+--   `abandoned` says the same thing outright, and would put a floor under the
+--   abandonment rate made entirely of shoppers who did sign in;
+--
+--   `converted` claims an order that does not exist, and `converted_order_id`
+--   would be NULL on a row the conversion figures count.
+--
+-- So there is a fourth exit. Like the other two it is terminal, and like them
+-- it is recorded with what it went to and when.
+--
+-- The one-active-cart guarantee survives untouched, and by the same mechanism
+-- as before: `active_marker` is generated from `status`, so a merged cart's
+-- marker is NULL and it holds no slot. The expression is unchanged -- only the
+-- set of values the column can take is wider -- so the generated column and
+-- the unique index behind it carry on meaning exactly what migration 0027 said
+-- they mean.
+
+DELIMITER //
+
+CREATE PROCEDURE AddMergedCartStatus()
+BEGIN
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'carts'
+        AND COLUMN_NAME = 'status'
+        AND COLUMN_TYPE LIKE '%''merged''%'
+    ) THEN
+        ALTER TABLE carts
+        MODIFY COLUMN status
+            ENUM('active', 'converted', 'abandoned', 'merged')
+            NOT NULL DEFAULT 'active';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'carts'
+        AND COLUMN_NAME = 'merged_into_cart_id'
+    ) THEN
+        ALTER TABLE carts
+        ADD COLUMN merged_into_cart_id CHAR(36) NULL AFTER abandoned_at,
+        ADD COLUMN merged_at DATETIME NULL AFTER merged_into_cart_id;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'carts'
+        AND INDEX_NAME = 'idx_carts_merged_into'
+    ) THEN
+        CREATE INDEX idx_carts_merged_into ON carts (merged_into_cart_id);
+    END IF;
+
+    -- ON DELETE SET NULL rather than CASCADE, for the same reason
+    -- `converted_order_id` uses it: losing the surviving cart must not delete
+    -- the record that a basket was folded into it.
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'carts'
+        AND CONSTRAINT_NAME = 'fk_carts_merged_into'
+    ) THEN
+        ALTER TABLE carts
+        ADD CONSTRAINT fk_carts_merged_into
+        FOREIGN KEY (merged_into_cart_id) REFERENCES carts(id) ON DELETE SET NULL;
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL AddMergedCartStatus();
+DROP PROCEDURE AddMergedCartStatus;

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -44,7 +44,7 @@ now resolved to one shape, produced by one owning migration.
 
 | Table | Was declared in | Resolution |
 | --- | --- | --- |
-| `cart_items` | baseline and a standalone cart change file | Baseline shape wins: the primary key is the full cart line (user, product, variant, colour, size), which is what the cart code's upsert relies on. The standalone file's surrogate key was retired. |
+| `cart_items` | baseline and a standalone cart change file | Baseline shape wins; the standalone file's surrogate key was retired. The key is the full cart line — product, variant, colour, size — scoped to the cart the line is in. It was scoped to the account until guest baskets arrived, which need a line the account cannot identify. |
 | `chat_conversations`, `chat_messages` | baseline and a chat feature file | Baseline shape wins. The chat file's copies referenced users by integer id and dropped the priority, moderation and soft-delete columns the baseline carries. |
 | `blocked_ips` | crawler protection and crawler verification | Union of both. Crawler protection owns the table and keeps `expires_at`; the verification audit columns are added by an explicit `ALTER TABLE`. |
 | `device_fingerprints` | bot protection and synthetic identity fraud | Union of both. Bot protection owns the table and keeps `is_suspicious`; the client-environment columns are added by an explicit `ALTER TABLE`. |


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

> Builds on `feat/1427-guest-checkout`, which is in review. Merge that first; this branch contains it and the branch beneath it.

A shopper who fills a basket and then signs in keeps it, and comes away with one cart.

**The merge is defined rather than incidental.** It was previously the browser's job, which is why the outcome depended on which page the shopper landed on and on whether a flag in local storage said it had already happened. It now happens on the server as the session is issued, in one transaction: the account's cart absorbs the guest's lines, the guest cart takes a terminal exit, and either both of those are true or neither is. A partial merge is the one outcome that could genuinely lose a basket. Registration is the other way a basket acquires an owner and goes through exactly the same path.

**The guest cart needed somewhere to go, and none of the three states it could already be in was the truth.** Leaving it active would leave two live carts for one shopper, one of them unreachable, and the abandonment sweep would eventually write it off as a basket that was walked away from — the opposite of what happened. Calling it abandoned says that outright and puts a floor under the abandonment rate made entirely of shoppers who did sign in. Calling it converted claims an order that does not exist. So there is a fourth exit, recorded like the other two with what it went to and when.

**The one-active-cart guarantee is never approached, let alone violated.** It survives by the same mechanism as before: the marker behind the unique index is generated from the status, so a merged cart's marker is null and it holds no slot. The expression is unchanged — only the set of values the column can take is wider.

**Only an ownerless cart can be absorbed.** Presenting a token can never move somebody else's basket onto your account, because the lookup will not return a cart that has an owner. That predicate is the whole defence and is asserted as such.

**Merging cannot fail a sign-in.** A shopper who cannot get in because their basket could not be combined is worse off than one who has to add an item again, so a failure is logged and reported as "no merge" while the sign-in proceeds. Stock is held for the merged lines on the same best-effort terms: "somebody took the last one" is an answer checkout can explain, and arriving as a failed login it would be inexplicable.

**Two smaller things fall out of it.** Adding two baskets together is the one way a line can grow past a limit the shopper never typed, so a combined line is capped at what checkout will accept — a merged cart no checkout would take is worse than a short one. And a merged cart is not a second shopping session, so it is excluded from the denominators of the cart rates; counting it would move conversion and abandonment alike for a reason that has nothing to do with trading.

The client no longer combines anything. It reads the account cart back, and the machinery that existed to stop a reload merging twice goes with it: the guest cart is closed on the server, so a repeat has nothing to find.

---

## 🔗 Related Issue

Part of #1427

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [ ] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Not applicable — the cart looks the same afterwards, which is the point.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**An empty guest basket still closes.** Nothing is merged, but leaving it active would leave a live cart behind a token the shopper has just stopped using, and the sweep would eventually record it as abandoned.

**Cart rates will move on deploy**, in the direction of being correct. Baskets that were previously counted twice — once as a guest cart nobody could reconcile, once as the account cart — are counted once from here.

**Reporting on merges.** The new state and the link between the two carts make "how many shoppers signed in with a basket" answerable, which it was not. Nothing reports on it yet; that is a dashboard change rather than a schema one.

**Note on CI.** Two frontend scripts do not parse on `main`, which fails the syntax gate for every branch regardless of its contents and causes the test and boot jobs to skip. Neither file is touched here; reported in #1416.
