### PR TITLE
Get main green: repair the bad merges, and the failures the red gate was hiding

### DIFF
--- a/backend/controllers/cartController.js
+++ b/backend/controllers/cartController.js
@@ -11,6 +11,7 @@ const {
 } = require("../services/cart.service");
 const cartLifecycle = require("../services/cartLifecycleService");
 const guestCart = require("../services/guestCartService");
+const cartRestoreService = require("../services/cartRestoreService");
 
 // Every handler below works from the cart, not from the account (#1427). The
 // two are the same thing for a signed-in shopper and the account is still
@@ -74,6 +75,44 @@ const issuedToken = (cart) => (
 );
 
 const cartController = {
+    // Spend a restore link from a recovery message and hand back the basket.
+    //
+    // Restored verbatim in #1444: this handler and its route were dropped when
+    // cartRoutes.js was rewritten for guest carts (#1427), which left
+    // cartRestoreService, its migrations and its public-route declaration in
+    // place with nothing reaching them. Every recovery email sent since has
+    // linked to a 404.
+    //
+    // The only unauthenticated cart endpoint, and deliberately the only one:
+    // the caller is anonymous, so there is no account here to write to and this
+    // reads. The lines go into whichever basket the browser already owns, and a
+    // signed-in shopper's existing sync then persists them under their own
+    // session -- which keeps every cart *write* behind authentication, exactly
+    // as it was.
+    restoreFromLink: async (req, res) => {
+        try {
+            const token = sanitizeString(req.body?.token || req.query?.token || "");
+            const restored = await cartRestoreService.redeemRestoreToken(token);
+
+            return res.status(200).json({
+                success: true,
+                message: "Your basket is back",
+                ...restored
+            });
+        } catch (error) {
+            // Nothing about the account, the cart or the reason a token is
+            // unknown travels back: every refusal is either "not valid" or
+            // "no longer usable".
+            return res.status(error.status || 500).json({
+                success: false,
+                code: error.code || "CART_RESTORE_FAILED",
+                message: error.status
+                    ? error.message
+                    : "Could not restore this basket"
+            });
+        }
+    },
+
     // Get the current cart (joined with product data)
     getUserCart: async (req, res) => {
         try {

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -1263,6 +1263,11 @@ module.exports = {
     getOrderById,
     getOrderTimeline,
     getFulfilmentReport,
+    // Defined above but left out of this list, so `orderController.getRecoveryReport`
+    // was `undefined` and `router.get("/reports/recovery", …)` threw
+    // "argument handler must be a function" while orderRoutes.js was being
+    // required -- the whole server failed to boot (#1444).
+    getRecoveryReport,
     lookupGuestOrder,
     getOrderStatus,
     updateOrderStatus,

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -14,6 +14,11 @@ const CURRENCY = require("../config/currency");
 const { generateInvoicePdf } = require("../services/invoice.service");
 const inventoryReservationService = require("../services/inventoryReservationService");
 const stockCounter = require("../services/stockCounterService");
+// Read in the catch blocks of createOrder and createPaymentIntent, to tell an
+// unknown delivery method from a server fault. The require went missing, so
+// the branch meant to classify the error threw a ReferenceError of its own and
+// buried whatever actually went wrong (#1444).
+const shippingService = require("../services/shipping.service");
 
 const {
     safeNumber,

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -56,7 +56,25 @@ async function authMiddleware(req, res, next) {
     }
 
     // Security check: SQL injection attempt
-    if (/'\s*OR\s*'/i.test(token) || /--/.test(token)) {
+    //
+    // `|| /--/.test(token)` used to be part of this, and it rejected roughly
+    // one legitimate token in a hundred (#1444).
+    //
+    // A JWT is base64url, and base64url's alphabet is A-Z a-z 0-9 plus `-` and
+    // `_`. Two adjacent hyphens are ordinary token content, not a SQL comment:
+    // across a ~200-character token the odds of the pair turning up somewhere
+    // are just under 1%. Those requests were answered "Authorization header
+    // required" -- as though no token had been sent at all -- so the shopper
+    // saw a sign-out that no amount of retrying reproduced, on a token that was
+    // perfectly valid and would work again the moment it was reissued.
+    //
+    // The quote-OR pattern stays: `'` is not in the base64url alphabet, so it
+    // cannot match a well-formed token and only fires on something that was
+    // never a JWT to begin with.
+    //
+    // Neither pattern is what makes this safe in any case. The token is a
+    // signed credential verified below, and it is never interpolated into SQL.
+    if (/'\s*OR\s*'/i.test(token)) {
         return res.status(401).json({
             success: false,
             message: 'Authorization header required'

--- a/backend/openapi/ecommerce.openapi.yaml
+++ b/backend/openapi/ecommerce.openapi.yaml
@@ -934,6 +934,14 @@ components:
           items:
             $ref: "#/components/schemas/ShippingOption"
         freeShipping:
+          # `type` is required alongside `nullable`: without it a validator
+          # cannot tell what the non-null case is, and ajv refuses to compile
+          # the schema at all -- "nullable cannot be used without type". That
+          # took down every fixture in the contract suite, not only this one,
+          # because compilation happens before any payload is looked at
+          # (#1444). FreeShippingProgress is an object, so this states what
+          # was already meant.
+          type: object
           nullable: true
           allOf:
             - $ref: "#/components/schemas/FreeShippingProgress"

--- a/backend/routes/cartRoutes.js
+++ b/backend/routes/cartRoutes.js
@@ -4,6 +4,21 @@ const { optionalAuth } = require("../middleware/authMiddleware");
 const cartIdentity = require("../middleware/cartIdentity");
 const cartController = require("../controllers/cartController");
 
+// Restore a basket from a recovery link (#1429).
+//
+// Declared BEFORE the router-level middleware below, and the placement is the
+// point: the link is meant to work before sign-in, and the request names no
+// cart, so there is nothing for `cartIdentity` to resolve or to refuse. Its
+// authority is the single-purpose, expiring, single-use token in the body,
+// checked by cartRestoreService. `config/routePolicy.js` declares it as the
+// one public cart route.
+//
+// This route and its handler were dropped when this file was rewritten for
+// guest carts (#1427). The service, its migrations and its public-route
+// declaration all survived, so nothing failed loudly -- every recovery email
+// sent since has simply linked to a 404 (#1444).
+router.post("/restore", cartController.restoreFromLink);
+
 // A basket exists before the shopper does (#1427). `optionalAuth` attaches the
 // account when there is one and is deliberately not a policy in its own right;
 // `cartIdentity` is the guard, and it is what decides -- and refuses -- which

--- a/backend/services/order.service.js
+++ b/backend/services/order.service.js
@@ -11,6 +11,11 @@ const { validatePromo } = require("./promo.service");
 const pricing = require("./pricing.service");
 const cartLifecycle = require("./cartLifecycleService");
 const { generateOrderNumber } = require("./orderNumber.service");
+// `resolveOrderLines` and the stock deduction in `createOrder` both go through
+// this, and neither could: the require went missing, so `stockCounter` was a
+// free variable and every call threw `ReferenceError: stockCounter is not
+// defined`. That is order creation, not an edge case (#1444).
+const stockCounter = require("./stockCounterService");
 
 // Marks the one failure the client can act on, so controllers can answer with
 // the specific figures instead of a generic server error.

--- a/backend/tests/authMiddleware.test.js
+++ b/backend/tests/authMiddleware.test.js
@@ -1,5 +1,23 @@
 // backend/tests/authMiddleware.test.js
 
+// authMiddleware checks each token against the revocation list, which lives in
+// Redis (#1261), so this suite was reaching for a Redis that is not running.
+// services/refreshTokenService.js flips a `redisReady` flag from the resolution
+// of a connect() that never resolves here, and which side of that flag a given
+// request landed on depended on machine load: under a full parallel run every
+// valid-token case in this file would occasionally fail at once, with `next`
+// uncalled and `req.user` undefined, as though a good token had been rejected
+// (#1444).
+//
+// This suite is about JWT verification. Whether Redis is up is not part of that
+// question, so it is taken out of the picture -- an empty revocation list is
+// the right default, and the suites that test revocation mock the specific
+// commands they need.
+jest.mock('../config/redis', () => {
+    const { createRedisMock } = require('./helpers/redisMock');
+    return createRedisMock();
+});
+
 const { authMiddleware, optionalAuth } = require('../middleware/authMiddleware');
 const jwt = require('jsonwebtoken');
 const express = require('express');
@@ -75,8 +93,13 @@ const generateToken = (user, secret = 'test-secret', expiresIn = '1h') => {
     return jwt.sign(user, secret, { expiresIn });
 };
 
+// '-1s', not '0s'. jwt.verify refuses a token once the clock is *past* `exp`,
+// so a token that expires at the instant it is issued is not yet expired when
+// it is checked. The two callers each papered over that differently -- one with
+// a 100ms setTimeout, the other by hand-writing an `exp` an hour in the past --
+// and the first of those was a flake, not a fix (#1444).
 const generateExpiredToken = (user, secret = 'test-secret') => {
-    return jwt.sign(user, secret, { expiresIn: '0s' });
+    return jwt.sign(user, secret, { expiresIn: '-1s' });
 };
 
 // ============================================
@@ -139,21 +162,21 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Valid Tokens', () => {
-        test('should accept valid Bearer token', () => {
+        test('should accept valid Bearer token', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user).toBeDefined();
             expect(mockReq.user.userId).toBe(userFixtures.regularUser.userId);
         });
 
-        test('should attach user data to request', () => {
+        test('should attach user data to request', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expect(mockReq.user).toEqual(expect.objectContaining({
                 userId: userFixtures.regularUser.userId,
                 username: userFixtures.regularUser.username,
@@ -161,11 +184,11 @@ describe('Auth Middleware Tests', () => {
             }));
         });
 
-        test('should handle admin user token', () => {
+        test('should handle admin user token', async () => {
             const token = generateToken(userFixtures.adminUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user.role).toBe('admin');
         });
@@ -176,41 +199,41 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Invalid Tokens', () => {
-        test('should reject request without authorization header', () => {
-            authMiddleware(mockReq, mockRes, mockNext);
+        test('should reject request without authorization header', async () => {
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes);
             expect(mockNext).not.toHaveBeenCalled();
         });
 
-        test('should reject invalid token', () => {
+        test('should reject invalid token', async () => {
             mockReq.headers.authorization = 'Bearer invalid-token';
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes, 'Invalid or expired token');
             expect(mockNext).not.toHaveBeenCalled();
         });
 
-        test('should reject malformed token', () => {
+        test('should reject malformed token', async () => {
             mockReq.headers.authorization = 'Bearer malformed.token.here';
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes, 'Invalid or expired token');
         });
 
-        test('should reject token with invalid signature', () => {
+        test('should reject token with invalid signature', async () => {
             const token = jwt.sign({ userId: 1 }, 'wrong-secret');
             mockReq.headers.authorization = `Bearer ${token}`;
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes, 'Invalid or expired token');
         });
 
-        test('should reject empty authorization header', () => {
+        test('should reject empty authorization header', async () => {
             mockReq.headers.authorization = 'Bearer ';
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes, 'Authorization header required');
         });
 
-        test('should reject malformed authorization header (no Bearer)', () => {
+        test('should reject malformed authorization header (no Bearer)', async () => {
             mockReq.headers.authorization = 'Token invalid';
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes, 'Authorization header required');
         });
     });
@@ -220,25 +243,27 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Expired Tokens', () => {
-        test('should reject expired token', (done) => {
+        test('should reject expired token', async () => {
             const expiredToken = generateExpiredToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${expiredToken}`;
 
-            setTimeout(() => {
-                authMiddleware(mockReq, mockRes, mockNext);
-                expectUnauthorized(mockRes, 'Invalid or expired token');
-                expect(mockNext).not.toHaveBeenCalled();
-                done();
-            }, 100);
+            // Was a setTimeout + done() waiting 100ms for a token minted with
+            // `expiresIn: '0s'` to become expired. Awaiting the middleware is
+            // what this actually needed, and the token is now unambiguously in
+            // the past, so there is nothing left to wait for.
+            await authMiddleware(mockReq, mockRes, mockNext);
+
+            expectUnauthorized(mockRes, 'Invalid or expired token');
+            expect(mockNext).not.toHaveBeenCalled();
         });
 
-        test('should reject token with expired claim', () => {
+        test('should reject token with expired claim', async () => {
             const token = jwt.sign(
                 { userId: 1, exp: Math.floor(Date.now() / 1000) - 3600 },
                 secret
             );
             mockReq.headers.authorization = `Bearer ${token}`;
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes, 'Invalid or expired token');
         });
     });
@@ -248,27 +273,27 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Role-Based Access', () => {
-        test('should allow admin to access admin routes', () => {
+        test('should allow admin to access admin routes', async () => {
             const token = generateToken(userFixtures.adminUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
             mockReq.role = 'admin';
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user.role).toBe('admin');
         });
 
-        test('should allow regular user to access user routes', () => {
+        test('should allow regular user to access user routes', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
             mockReq.role = 'user';
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user.role).toBe('user');
         });
 
-        test('should reject user without required role', () => {
+        test('should reject user without required role', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
             mockReq.requiredRole = 'admin';
@@ -276,7 +301,7 @@ describe('Auth Middleware Tests', () => {
             // Assuming middleware checks role
             // This test would pass if middleware has role checking
             // If not, this test might need adjustment
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             // Expect next or unauthorized depending on implementation
         });
     });
@@ -286,17 +311,30 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Environment Variable Tests', () => {
-        const originalEnv = process.env;
+        // Restore by key rather than by reassigning `process.env`.
+        //
+        // `process.env = { ...originalEnv }` followed by
+        // `process.env = originalEnv` looks symmetrical and is not: assigning
+        // to process.env replaces Node's env store, and the saved reference no
+        // longer restores what was there. JWT_SECRET therefore stayed deleted
+        // after this block, and the next suite to call the middleware failed
+        // with "JWT_SECRET environment variable is required" -- a failure two
+        // describes away from its cause (#1444).
+        let savedSecret;
 
         beforeEach(() => {
-            process.env = { ...originalEnv };
+            savedSecret = process.env.JWT_SECRET;
         });
 
         afterEach(() => {
-            process.env = originalEnv;
+            if (savedSecret === undefined) {
+                delete process.env.JWT_SECRET;
+            } else {
+                process.env.JWT_SECRET = savedSecret;
+            }
         });
 
-        test('should use JWT secret from environment', () => {
+        test('should use JWT secret from environment', async () => {
             process.env.JWT_SECRET = 'env_secret_1234567890';
             const token = jwt.sign(
                 { userId: 1 },
@@ -304,16 +342,23 @@ describe('Auth Middleware Tests', () => {
             );
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
         });
 
-        test('should handle missing JWT secret', () => {
+        test('should handle missing JWT secret', async () => {
             delete process.env.JWT_SECRET;
 
-            expect(() => {
-                authMiddleware(mockReq, mockRes, mockNext);
-            }).toThrow();
+            // `authMiddleware` is async, so it returns a rejected promise
+            // rather than throwing synchronously. The old `expect(fn).toThrow()`
+            // could never see that: it reported "did not throw" and left the
+            // rejection unhandled, which crashed the worker outright when this
+            // test was run on its own.
+            await expect(
+                authMiddleware(mockReq, mockRes, mockNext)
+            ).rejects.toThrow('JWT_SECRET environment variable is required');
+
+            expect(mockNext).not.toHaveBeenCalled();
         });
     });
 
@@ -322,16 +367,24 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Performance Tests', () => {
-        test('should verify token within 10ms', () => {
+        test('should verify token within 10ms', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
+            // Awaited, because authMiddleware is async: the loop below used to
+            // fire and forget, so `duration` measured how long it takes to
+            // *start* a hundred verifications, not to finish them, and the
+            // assertion passed no matter how slow verification actually was.
+            //
+            // The hundred stray promises then resolved during whichever tests
+            // happened to be running next, which is where the intermittent
+            // failures in this file came from (#1444).
             const start = performance.now();
             for (let i = 0; i < 100; i++) {
                 const req = createMockRequest({ authorization: `Bearer ${token}` });
                 const res = createMockResponse();
                 const next = jest.fn();
-                authMiddleware(req, res, next);
+                await authMiddleware(req, res, next);
             }
             const duration = performance.now() - start;
 
@@ -340,15 +393,21 @@ describe('Auth Middleware Tests', () => {
 
         test('should handle 100 concurrent auth requests', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
-            const promises = Array(100).fill().map(() => {
+
+            // The middleware's own promises, not a hundred already-resolved
+            // stand-ins. `Promise.resolve()` could never have failed, so this
+            // case asserted nothing about concurrency.
+            const results = Array(100).fill().map(() => {
                 const req = createMockRequest({ authorization: `Bearer ${token}` });
                 const res = createMockResponse();
                 const next = jest.fn();
-                authMiddleware(req, res, next);
-                return Promise.resolve();
+                return authMiddleware(req, res, next).then(() => next);
             });
 
-            await expect(Promise.all(promises)).resolves.not.toThrow();
+            const nexts = await Promise.all(results);
+
+            expect(nexts).toHaveLength(100);
+            expect(nexts.every((next) => next.mock.calls.length === 1)).toBe(true);
         });
     });
 
@@ -357,34 +416,84 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Security Tests', () => {
-        test('should be resistant to timing attacks', () => {
+        test('should be resistant to timing attacks', async () => {
             const validToken = generateToken(userFixtures.regularUser, secret);
             const invalidToken = 'malformed.token.here';
 
+            // Awaited for the same reason as the performance case above:
+            // unawaited, both timings measured the synchronous prologue of an
+            // async function and were always within a hair of each other, so
+            // the comparison could not have detected a timing leak.
             const start1 = performance.now();
             const req1 = createMockRequest({ authorization: `Bearer ${validToken}` });
             const res1 = createMockResponse();
             const next1 = jest.fn();
-            authMiddleware(req1, res1, next1);
+            await authMiddleware(req1, res1, next1);
             const time1 = performance.now() - start1;
 
             const start2 = performance.now();
             const req2 = createMockRequest({ authorization: `Bearer ${invalidToken}` });
             const res2 = createMockResponse();
             const next2 = jest.fn();
-            authMiddleware(req2, res2, next2);
+            await authMiddleware(req2, res2, next2);
             const time2 = performance.now() - start2;
 
             expect(Math.abs(time1 - time2)).toBeLessThan(50);
         });
 
-        test('should handle SQL injection attempts in token', () => {
+        test('should handle SQL injection attempts in token', async () => {
             const injectionToken = "Bearer ' OR '1'='1";
             mockReq.headers.authorization = injectionToken;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes);
             expect(mockNext).not.toHaveBeenCalled();
+        });
+
+        // #1444. The injection heuristic also matched `--`, which is a SQL
+        // comment and is equally a pair of ordinary base64url characters. Just
+        // under 1% of tokens contain it somewhere, and every one of those was
+        // answered "Authorization header required" -- indistinguishable from
+        // sending no token at all.
+        //
+        // This is why the suite failed intermittently: `jwt.sign` produces a
+        // fresh signature each run, so which run happened to mint a token
+        // containing `--` was luck. Pinned deterministically here rather than
+        // left to a random draw.
+        test('accepts a valid token whose base64url contains a double hyphen', async () => {
+            // Mint until the encoding contains `--`. Signature bytes are
+            // effectively random, so this finds one in a few dozen attempts.
+            let token = null;
+            for (let i = 0; i < 5000 && token === null; i++) {
+                const candidate = jwt.sign({ userId: 1, seq: i }, secret);
+                if (candidate.includes('--')) token = candidate;
+            }
+
+            expect(token).not.toBeNull();
+
+            mockReq.headers.authorization = `Bearer ${token}`;
+            await authMiddleware(mockReq, mockRes, mockNext);
+
+            expect(mockNext).toHaveBeenCalled();
+            expect(mockRes.status).not.toHaveBeenCalled();
+            expect(mockReq.user.userId).toBe(1);
+        });
+
+        test('rejects an invalid-signature token containing a double hyphen for the right reason', async () => {
+            let token = null;
+            for (let i = 0; i < 5000 && token === null; i++) {
+                const candidate = jwt.sign({ userId: 1, seq: i }, 'wrong-secret');
+                if (candidate.includes('--')) token = candidate;
+            }
+
+            expect(token).not.toBeNull();
+
+            mockReq.headers.authorization = `Bearer ${token}`;
+            await authMiddleware(mockReq, mockRes, mockNext);
+
+            // "Invalid or expired token" -- the signature failed. Not
+            // "Authorization header required", which claims nothing was sent.
+            expectUnauthorized(mockRes, 'Invalid or expired token');
         });
     });
 
@@ -404,48 +513,47 @@ describe('Auth Middleware Tests', () => {
             mockNext = jest.fn();
         });
 
-        test('should call next without token', () => {
-            optionalAuth(mockReq, mockRes, mockNext);
+        test('should call next without token', async () => {
+            await optionalAuth(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user).toBeUndefined();
         });
 
-        test('should attach user with valid token', () => {
+        test('should attach user with valid token', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            optionalAuth(mockReq, mockRes, mockNext);
+            await optionalAuth(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user).toBeDefined();
             expect(mockReq.user.userId).toBe(userFixtures.regularUser.userId);
         });
 
-        test('should handle expired token gracefully', (done) => {
+        test('should handle expired token gracefully', async () => {
             const expiredToken = generateExpiredToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${expiredToken}`;
 
-            setTimeout(() => {
-                optionalAuth(mockReq, mockRes, mockNext);
-                // optionalAuth should still call next even with expired token
-                expect(mockNext).toHaveBeenCalled();
-                done();
-            }, 100);
+            await optionalAuth(mockReq, mockRes, mockNext);
+
+            // optionalAuth should still call next even with expired token
+            expect(mockNext).toHaveBeenCalled();
+            expect(mockReq.user).toBeUndefined();
         });
 
-        test('should handle invalid token gracefully', () => {
+        test('should handle invalid token gracefully', async () => {
             mockReq.headers.authorization = 'Bearer invalid-token';
 
-            optionalAuth(mockReq, mockRes, mockNext);
+            await optionalAuth(mockReq, mockRes, mockNext);
             // optionalAuth should still call next even with invalid token
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user).toBeUndefined();
         });
 
-        test('should attach user with admin role', () => {
+        test('should attach user with admin role', async () => {
             const token = generateToken(userFixtures.adminUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            optionalAuth(mockReq, mockRes, mockNext);
+            await optionalAuth(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user).toBeDefined();
             expect(mockReq.user.role).toBe('admin');
@@ -555,38 +663,38 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Negative Test Cases', () => {
-        test('should reject token with missing userId', () => {
+        test('should reject token with missing userId', async () => {
             const token = jwt.sign(
                 { username: 'testuser' },
                 secret
             );
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes);
         });
 
-        test('should reject token with empty payload', () => {
+        test('should reject token with empty payload', async () => {
             const token = jwt.sign({}, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes);
         });
 
-        test('should reject XSS attempt in token', () => {
+        test('should reject XSS attempt in token', async () => {
             const xssToken = 'Bearer <script>alert("xss")</script>';
             mockReq.headers.authorization = xssToken;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes);
         });
 
-        test('should reject excessively long token', () => {
+        test('should reject excessively long token', async () => {
             const longToken = 'Bearer ' + 'a'.repeat(10000);
             mockReq.headers.authorization = longToken;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes);
         });
     });

--- a/backend/tests/helpers/redisMock.js
+++ b/backend/tests/helpers/redisMock.js
@@ -1,0 +1,123 @@
+// backend/tests/helpers/redisMock.js
+//
+// A stand-in for `config/redis` that never opens a socket. Addresses #1444.
+//
+// `config/redis` sets `lazyConnect` under Jest so the module graph can be
+// loaded without a server, but `services/refreshTokenService.js` then calls
+// `redis.connect()` at module scope -- which is exactly the thing lazyConnect
+// was deferring. Any suite that reaches authMiddleware (and so
+// refreshTokenService) therefore ended up talking to a Redis that is not
+// there, and got one of two failures depending on how complete its own mock
+// was:
+//
+//   TypeError: redis.connect is not a function      -- partial mock, suite
+//                                                      failed to run at all
+//   MaxRetriesPerRequestError: ... limit (which is 3) -- no mock, ioredis
+//                                                      exhausted its retries
+//                                                      mid-request
+//
+// Both are environment noise rather than anything about the code under test,
+// and both are avoided by giving the double the whole surface the app uses,
+// including the connection lifecycle.
+//
+// Commands resolve rather than reject. A suite that wants to see failure
+// handling should override the specific command it cares about -- a double
+// that fails everything cannot tell "handles a Redis outage" from "never
+// reached Redis".
+
+'use strict';
+
+/**
+ * Build a fresh ioredis-shaped double.
+ *
+ * Every command is an independent `jest.fn()` so a suite can override one
+ * without disturbing the rest, and a fresh instance per call keeps call counts
+ * from leaking between suites.
+ *
+ * @returns {object}
+ */
+function createRedisMock() {
+    const client = {
+        // Connection lifecycle. `connect` resolving is what stops
+        // refreshTokenService's module-scope call from starting a real one.
+        connect: jest.fn().mockResolvedValue(undefined),
+        quit: jest.fn().mockResolvedValue('OK'),
+        disconnect: jest.fn(),
+        status: 'ready',
+
+        // Event emitter surface. The app registers 'connect', 'error' and
+        // 'ready' handlers; returning `this` keeps the chaining ioredis allows.
+        on: jest.fn(function on() { return this; }),
+        once: jest.fn(function once() { return this; }),
+        off: jest.fn(function off() { return this; }),
+        removeListener: jest.fn(function removeListener() { return this; }),
+        emit: jest.fn(),
+
+        // Commands, in the shapes the callers expect back.
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn().mockResolvedValue('OK'),
+        setex: jest.fn().mockResolvedValue('OK'),
+        del: jest.fn().mockResolvedValue(0),
+        exists: jest.fn().mockResolvedValue(0),
+        incr: jest.fn().mockResolvedValue(1),
+        expire: jest.fn().mockResolvedValue(1),
+        ttl: jest.fn().mockResolvedValue(-2),
+        keys: jest.fn().mockResolvedValue([]),
+        scan: jest.fn().mockResolvedValue(['0', []]),
+        eval: jest.fn().mockResolvedValue(null),
+        evalsha: jest.fn().mockResolvedValue(null),
+        hget: jest.fn().mockResolvedValue(null),
+        hset: jest.fn().mockResolvedValue(1),
+        hgetall: jest.fn().mockResolvedValue({}),
+        sadd: jest.fn().mockResolvedValue(1),
+        srem: jest.fn().mockResolvedValue(1),
+        smembers: jest.fn().mockResolvedValue([]),
+        sismember: jest.fn().mockResolvedValue(0),
+        ping: jest.fn().mockResolvedValue('PONG'),
+        defineCommand: jest.fn(),
+        // Pub/sub. The pattern variants are what @socket.io/redis-adapter
+        // reaches for on the subscriber connection; without them the adapter
+        // logs "psubscribe is not a function" and falls back, which is noise
+        // in the output of a suite that is not testing the adapter.
+        subscribe: jest.fn().mockResolvedValue(1),
+        unsubscribe: jest.fn().mockResolvedValue(1),
+        publish: jest.fn().mockResolvedValue(0),
+        psubscribe: jest.fn().mockResolvedValue(1),
+        punsubscribe: jest.fn().mockResolvedValue(1),
+
+        // utils/socketManager.js takes two of these for the socket.io Redis
+        // adapter. A subscriber connection cannot also issue commands, which is
+        // why the real client is duplicated rather than shared -- the double
+        // mirrors that by handing back a fresh instance.
+        duplicate: jest.fn(() => createRedisMock()),
+
+        // Pipelines and transactions. `exec` returns the [err, result] tuples
+        // ioredis produces, so a caller destructuring them gets what it expects.
+        pipeline: jest.fn(() => createChain()),
+        multi: jest.fn(() => createChain())
+    };
+
+    /**
+     * A chainable pipeline/multi whose `exec` resolves to an empty result set.
+     *
+     * @returns {object}
+     */
+    function createChain() {
+        const chain = {
+            exec: jest.fn().mockResolvedValue([])
+        };
+
+        for (const command of ['get', 'set', 'setex', 'del', 'incr', 'expire', 'eval']) {
+            chain[command] = jest.fn(() => chain);
+        }
+
+        return chain;
+    }
+
+    // config/redis exports the client itself and hangs the options off it.
+    client.REDIS_OPTIONS = { host: '127.0.0.1', port: 6379, lazyConnect: true };
+
+    return client;
+}
+
+module.exports = { createRedisMock };

--- a/backend/tests/loginLockout.test.js
+++ b/backend/tests/loginLockout.test.js
@@ -30,11 +30,23 @@ jest.mock('../config/db', () => ({
 // deliberately runs it against an unreachable Redis, because the per-process
 // fallback that serves an outage has to enforce exactly the same policy as the
 // shared path. The Redis path is covered in loginLockoutService.test.js.
-jest.mock('../config/redis', () => ({
-    eval: jest.fn().mockRejectedValue(new Error('ECONNREFUSED')),
-    del: jest.fn().mockRejectedValue(new Error('ECONNREFUSED')),
-    scan: jest.fn().mockRejectedValue(new Error('ECONNREFUSED'))
-}));
+//
+// Only the three commands the fallback path touches reject; the rest of the
+// client comes from the shared double. The partial mock that used to stand here
+// had no `connect`, and services/refreshTokenService.js calls it at module
+// scope, so requiring authController died with
+// `TypeError: redis.connect is not a function` and the suite failed to run --
+// never reaching a single assertion below (#1444).
+jest.mock('../config/redis', () => {
+    const { createRedisMock } = require('./helpers/redisMock');
+    const client = createRedisMock();
+
+    client.eval = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    client.del = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    client.scan = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+    return client;
+});
 
 jest.mock('../config/logger', () => ({
     info: jest.fn(),

--- a/backend/tests/mergeScarRegression.test.js
+++ b/backend/tests/mergeScarRegression.test.js
@@ -10,6 +10,10 @@
 
 const fs = require('fs');
 const path = require('path');
+// Frontend scripts are classic <script> files, not modules, so the only way to
+// exercise one from Jest is to compile it into a sandbox with the globals the
+// page would have supplied.
+const vm = require('vm');
 
 const BACKEND_DIR = path.resolve(__dirname, '..');
 const REPO_ROOT = path.resolve(BACKEND_DIR, '..');
@@ -188,6 +192,106 @@ describe('frontend/scripts/product-cards-home.js', () => {
 
     it('resolves the wishlist through the shared helper', () => {
         expect(source).toMatch(/const isWishlisted = isProductWishlisted\(product\.id, wishlistIds\)/);
+    });
+
+    // #1444. The same function was broken a second time: an `<img …>` fragment
+    // was left at statement position -- outside any template literal -- and the
+    // stock bindings the return template reads went missing with it. The
+    // fragment is a SyntaxError; the missing bindings would have been a
+    // ReferenceError on the first card had it ever run.
+    it('has no HTML fragment outside a template literal', () => {
+        // The card renders one image, and it belongs inside the return
+        // template. A second `<img` in this function is the orphan again.
+        expect(countMatches(source, /<img\b/g)).toBe(1);
+
+        const cardTemplate = source.indexOf('return `\n        <div class="pro ');
+        expect(cardTemplate).toBeGreaterThan(-1);
+        expect(source.indexOf('<img')).toBeGreaterThan(cardTemplate);
+    });
+
+    it('declares the stock bindings its card template reads', () => {
+        expect(source).toMatch(/^\s+const stock = Number\(product\.stock\) \|\| 0;$/m);
+        expect(source).toMatch(/^\s+const outOfStock = isOutOfStock\(stock\);$/m);
+        expect(source).toMatch(/^\s+const outOfStockClass = outOfStock \? "out-of-stock" : "";$/m);
+    });
+
+    // The class shop.js puts on its own cards, and the one
+    // styles/product-card.css dims. A card marked with anything else looks
+    // in-stock however empty the shelf is.
+    it('marks sold-out cards with the class the stylesheet targets', () => {
+        const css = read('frontend/styles/product-card.css');
+        expect(css).toMatch(/\.pro\.out-of-stock\b/);
+    });
+
+    // Evaluating the file proves what a regex cannot: that every binding the
+    // template reads actually resolves. The module is a classic <script>, so it
+    // is run in a sandbox with the globals index.html would have provided.
+    it('renders a card without reaching for an undeclared binding', () => {
+        const sandbox = {
+            document: { getElementById: () => null },
+            window: {},
+            console,
+            formatPrice: (value) => `₹${value}`,
+            defaultImage: (value) => value || '',
+            escapeHTML: (value) => String(value == null ? '' : value),
+            handleImageError: () => {},
+            AppUtils: undefined
+        };
+        sandbox.globalThis = sandbox;
+
+        vm.createContext(sandbox);
+        new vm.Script(source, { filename: 'product-cards-home.js' }).runInContext(sandbox);
+
+        const inStock = sandbox.createProductCard(
+            { id: 'p1', name: 'Tee', price: 19.99, stock: 12, image: '/t.jpg' },
+            new Set()
+        );
+        expect(inStock).toContain('data-id="p1"');
+        expect(inStock).toContain('In Stock');
+        expect(inStock).not.toContain('class="pro out-of-stock');
+
+        const soldOut = sandbox.createProductCard(
+            { id: 'p2', name: 'Cap', price: 9.99, stock: 0, image: '/c.jpg' },
+            new Set()
+        );
+        expect(soldOut).toContain('pro out-of-stock');
+        expect(soldOut).toContain('Sold Out');
+        expect(soldOut).toContain('disabled');
+    });
+});
+
+describe('frontend/scripts/shop.js', () => {
+    const source = read('frontend/scripts/shop.js');
+
+    // #1444. The DOMContentLoaded listener was left unclosed and the body of
+    // `clearAllFilters` ran straight on from it, so the file did not parse and
+    // the entire shop page was dead.
+    it('declares clearAllFilters exactly once', () => {
+        expect(countMatches(source, /^function clearAllFilters\(\) \{$/gm)).toBe(1);
+    });
+
+    it('closes the DOMContentLoaded listener before the next declaration', () => {
+        const listener = source.indexOf('document.addEventListener(\n    "DOMContentLoaded"');
+        expect(listener).toBeGreaterThan(-1);
+
+        const declaration = source.indexOf('function clearAllFilters() {');
+        expect(declaration).toBeGreaterThan(listener);
+
+        // `}\n);` -- the closing of the arrow function and of the call it is an
+        // argument to. Dropping the `);` is what merged the two together.
+        expect(source.slice(listener, declaration)).toMatch(/\}\s*\);\s*$/m);
+    });
+
+    // setupClearFilters binds the handler by name; a rename on one side only
+    // would leave the button wired to nothing.
+    it('binds the clear-filters button to that function', () => {
+        expect(source).toMatch(/clearFiltersBtn\.addEventListener\('click', clearAllFilters\)/);
+    });
+
+    it('declares the filter state it assigns, rather than leaking it onto window', () => {
+        for (const name of ['currentCategory', 'currentSearch', 'showAllHoodies']) {
+            expect(source).toMatch(new RegExp(`^let ${name} = `, 'm'));
+        }
     });
 });
 

--- a/backend/tests/moduleExports.test.js
+++ b/backend/tests/moduleExports.test.js
@@ -218,3 +218,46 @@ describe('envValidator url handling', () => {
         expect(validator.isURL('', { require_tld: false })).toBe(false);
     });
 });
+
+describe('orderController (#1444)', () => {
+    const fs = require('fs');
+    const path = require('path');
+
+    const controller = require('../controllers/orderController');
+    const routesSource = fs.readFileSync(
+        path.join(__dirname, '..', 'routes', 'orderRoutes.js'),
+        'utf8'
+    );
+
+    /**
+     * Every `orderController.<name>` the router reaches for.
+     *
+     * Derived from the source rather than hard-coded, so a handler added to a
+     * route tomorrow is covered without anyone remembering to list it here.
+     */
+    const referenced = Array.from(
+        new Set(
+            Array.from(routesSource.matchAll(/orderController\.(\w+)/g), (m) => m[1])
+        )
+    ).sort();
+
+    test('the router references at least the handlers we know about', () => {
+        // A guard on the regex itself: if it silently stopped matching, every
+        // assertion below would pass over an empty list.
+        expect(referenced).toContain('createOrder');
+        expect(referenced).toContain('getRecoveryReport');
+        expect(referenced.length).toBeGreaterThan(10);
+    });
+
+    // getRecoveryReport was defined in the controller but missing from
+    // module.exports, so it resolved to `undefined` and Express threw
+    // "argument handler must be a function" while orderRoutes.js was still
+    // being required. The server did not boot at all.
+    test.each(referenced)('exports %s as a function', (name) => {
+        expect(typeof controller[name]).toBe('function');
+    });
+
+    test('orderRoutes mounts without throwing', () => {
+        expect(() => require('../routes/orderRoutes')).not.toThrow();
+    });
+});

--- a/backend/tests/orderController.test.js
+++ b/backend/tests/orderController.test.js
@@ -46,6 +46,10 @@ const { createOrderService, validateOrderDataService, getOrderSummaryById } = re
 const paymentService = require("../services/payment.service");
 const { generateInvoicePdf } = require("../services/invoice.service");
 const inventoryReservationService = require("../services/inventoryReservationService");
+// Ownership moved out of these handlers and onto the routes in #1425, so the
+// cases that cover it now exercise the middleware directly. It reads through
+// the same mocked config/db as everything else here.
+const { requireOwnership, ownerFromTable } = require("../middleware/requireOwnership");
 
 const {
     createOrder,
@@ -353,15 +357,50 @@ describe("cancelUserOrder", () => {
         db.getConnection.mockResolvedValue(connection);
     });
 
-    test("prevents cancelling someone else's order", async () => {
-        connection.query.mockResolvedValueOnce([[{ user_id: 99, status: "pending" }]]);
+    // Ownership left this controller in #1425 and now lives in
+    // requireOwnership, declared on the route in orderRoutes.js -- the handler
+    // says so in a comment and no longer compares ids at all. This assertion
+    // stayed pointed at the controller, so it had been failing ever since
+    // (#1444). Re-aimed at the middleware that actually holds the rule, with
+    // the same scenario, rather than deleted.
+    test("the route guard prevents cancelling someone else's order", async () => {
+        // Built exactly as orderRoutes.js builds it for the cancel route: no
+        // privileged bypass, because staff have never been able to cancel on a
+        // customer's behalf through this endpoint.
+        const guard = requireOwnership(ownerFromTable({ table: "orders" }), {
+            resourceName: "Order",
+            allowPrivileged: false
+        });
+
+        db.query.mockResolvedValueOnce([[{ ownerId: 99 }]]);
 
         const req = { params: { id: VALID_ORDER_ID }, user: { id: 1 } };
         const res = mockRes();
+        const next = jest.fn();
 
-        await cancelUserOrder(req, res);
+        await guard(req, res, next);
 
+        expect(next).not.toHaveBeenCalled();
+        // 404, not 403: a 403 confirms the id is real, which turns the id space
+        // into an enumeration oracle.
         expect(res.statusCode).toBe(404);
+    });
+
+    test("the route guard lets the owner reach the handler", async () => {
+        const guard = requireOwnership(ownerFromTable({ table: "orders" }), {
+            resourceName: "Order",
+            allowPrivileged: false
+        });
+
+        db.query.mockResolvedValueOnce([[{ ownerId: 1 }]]);
+
+        const req = { params: { id: VALID_ORDER_ID }, user: { id: 1 } };
+        const res = mockRes();
+        const next = jest.fn();
+
+        await guard(req, res, next);
+
+        expect(next).toHaveBeenCalled();
     });
 
     test("rejects cancelling an already-shipped order", async () => {
@@ -559,14 +598,43 @@ describe("downloadInvoice", () => {
         expect(res.statusCode).toBe(404);
     });
 
-    test("blocks a user from downloading someone else's invoice", async () => {
-        db.query.mockResolvedValueOnce([[{ id: VALID_ORDER_ID, user_id: 99 }]]);
+    // Same move as the cancel guard above: downloadInvoice used to compare ids
+    // and answer 403, and #1425 replaced that with requireOwnership on the
+    // route -- which answers 404 by design, so a caller cannot learn that an
+    // order id exists by being refused it. The old assertion outlived the
+    // behaviour it described (#1444).
+    test("the route guard blocks a user from downloading someone else's invoice", async () => {
+        const guard = requireOwnership(ownerFromTable({ table: "orders" }), {
+            resourceName: "Order"
+        });
+
+        db.query.mockResolvedValueOnce([[{ ownerId: 99 }]]);
+
         const req = { params: { id: VALID_ORDER_ID }, user: { id: 1, role: "user" } };
         const res = mockRes();
+        const next = jest.fn();
 
-        await downloadInvoice(req, res);
+        await guard(req, res, next);
 
-        expect(res.statusCode).toBe(403);
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(404);
+    });
+
+    test("the route guard lets an admin through, unlike the cancel guard", async () => {
+        // The invoice guard keeps the privileged bypass; the cancel guard
+        // deliberately does not. Pinning both means a refactor cannot quietly
+        // level them.
+        const guard = requireOwnership(ownerFromTable({ table: "orders" }), {
+            resourceName: "Order"
+        });
+
+        const req = { params: { id: VALID_ORDER_ID }, user: { id: 1, role: "admin" } };
+        const res = mockRes();
+        const next = jest.fn();
+
+        await guard(req, res, next);
+
+        expect(next).toHaveBeenCalled();
     });
 
     test("streams a PDF for the order owner", async () => {

--- a/backend/tests/serverBootstrap.test.js
+++ b/backend/tests/serverBootstrap.test.js
@@ -26,6 +26,22 @@ process.env.JWT_SECRET = process.env.JWT_SECRET || 'test_jwt_secret_at_least_32_
 process.env.PORT = process.env.PORT || '5099';
 process.env.FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:5500';
 
+// Requiring ../server builds the whole module graph, and part of that graph
+// reaches for Redis: services/refreshTokenService.js calls redis.connect() at
+// module scope, which defeats the lazyConnect config/redis sets under Jest.
+// With no server listening, ioredis exhausted its retries part-way through a
+// request and the probe below failed with MaxRetriesPerRequestError instead of
+// an HTTP status -- an environment failure wearing the costume of a routing
+// one (#1444).
+//
+// This suite is about wiring: does requiring the server produce an app with
+// these routers mounted. Whether Redis is up is not part of that question, so
+// it is taken out of the picture.
+jest.mock('../config/redis', () => {
+    const { createRedisMock } = require('./helpers/redisMock');
+    return createRedisMock();
+});
+
 const fs = require('fs');
 const path = require('path');
 const request = require('supertest');

--- a/frontend/scripts/product-cards-home.js
+++ b/frontend/scripts/product-cards-home.js
@@ -117,18 +117,21 @@ function createProductCard(
             }
         ).join("");
 
-            <img
-                src="${defaultImage(product.image)}"
-                alt="${safeText(product.name, "Product")}"
-                loading="lazy"
-                onerror="this.onerror=null; this.src='data:image/svg+xml;charset=UTF-8,%3Csvg xmlns=\\'http://www.w3.org/2000/svg\\' width=\\'200\\' height=\\'200\\' viewBox=\\'0 0 200 200\\'%3E%3Crect fill=\\'%23eee\\' width=\\'200\\' height=\\'200\\'/%3E%3Ctext fill=\\'%23999\\' font-family=\\'sans-serif\\' font-size=\\'14\\' x=\\'50%25\\' y=\\'50%25\\' text-anchor=\\'middle\\' dominant-baseline=\\'middle\\'%3ENo Image%3C/text%3E%3C/svg%3E';"
-            >
-
-    // The pre-`isProductWishlisted` version of this lookup was left in place
-    // here by a bad merge (#1341): it re-declared `wishlistIds`, which is
-    // already this function's parameter, and `isWishlisted`, already assigned
-    // above -- a SyntaxError that took the whole homepage grid offline. It also
-    // read a `wishlistSet` binding that does not exist in this scope.
+    // Stock state, read once and reused by the badge, the overlay, the
+    // low-stock line and the three disabled buttons below.
+    //
+    // These three bindings, and the orphaned image tag that stood here instead
+    // of them, were the two halves of the bad merge that took the homepage
+    // grid offline (#1444). The fragment sat at statement position --
+    // outside any template literal -- so the whole file was a SyntaxError, and
+    // the declarations the template needs went with it. The product image is
+    // rendered by the `return` template below; nothing is lost by dropping the
+    // fragment.
+    const stock = Number(product.stock) || 0;
+    const outOfStock = isOutOfStock(stock);
+    // `.pro.out-of-stock` is what styles/product-card.css dims and disables --
+    // same class shop.js puts on its cards, so both grids look the same.
+    const outOfStockClass = outOfStock ? "out-of-stock" : "";
 
     return `
         <div class="pro ${outOfStockClass} fade-in" data-id="${product.id}">

--- a/frontend/scripts/shop.js
+++ b/frontend/scripts/shop.js
@@ -18,6 +18,14 @@ let priceTouched = false;
 let productObserver = null;
 const loadedProductIds = new Set();
 
+// Legacy filter-button state, read and written by setupCategoryFilters,
+// setupSearch and clearAllFilters. These were only ever assigned, never
+// declared, so each one leaked onto `window` -- harmless while the file did
+// not parse at all, and worth closing now that it does (#1444).
+let currentCategory = "all";
+let currentSearch = "";
+let showAllHoodies = false;
+
 // Local fallback sample products (used when backend returns no products)
 const fallbackProducts = [
     // T-SHIRTS (~5)
@@ -1306,7 +1314,17 @@ document.addEventListener(
             });
         });
     }
-    
+);
+
+// Clear every active filter and go back to the default catalogue view.
+//
+// The `);` above and this declaration are what a bad merge dropped (#1444):
+// the DOMContentLoaded listener was left unclosed and this function's body ran
+// straight on from it, so the file did not parse and the whole shop page --
+// search, filters, sorting, the product list -- was dead. `setupClearFilters`
+// at the bottom binds this by name, and every binding the body reads is
+// already declared above.
+function clearAllFilters() {
     // Reset category
     filterButtons.forEach(btn => {
         btn.classList.remove('active-filter');


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`npm test` fails at the first gate on `main`. Two tracked frontend scripts do not
parse, so the syntax job goes red and every job that `needs: syntax` — the boot
check and the Jest suite — never starts. No PR can currently get a green run.

Unblocking the gate then exposed a second gate failure and, behind that, sixteen
already-broken tests. All of it is repaired here, because a PR titled "main is
red" that leaves main red at the next gate has not done its job.

### 1. The parse gate

Both files are bad merges that kept fragments of two sides, and a script that
does not parse is not partly broken: the browser discards the whole file. So
these are also two user-facing outages.

**`product-cards-home.js`** had a bare `<img …>` block at statement position,
outside any template literal, where the card's stock bindings used to be. The
`return` template already renders the image, so the fragment goes and `stock` /
`outOfStock` / `outOfStockClass` come back — without them `createProductCard`
would have thrown a `ReferenceError` on the first card even once it parsed.

**`shop.js`** had its `DOMContentLoaded` listener left unclosed, with the body of
`clearAllFilters` running on from it; the `);` and the function header were both
dropped. `setupClearFilters` already binds it by name, so restoring those two
lines is the whole fix.

### 2. The boot gate

`getRecoveryReport` was defined in `orderController.js` but missing from
`module.exports`, so `orderRoutes.js` threw `argument handler must be a function`
while it was being required. **The server did not boot at all.**

### 3. Four production defects the Jest job had never been able to report

| Where | What |
| --- | --- |
| `services/order.service.js` | never required `stockCounterService`, so `resolveOrderLines` and the deduction in `createOrder` both threw `ReferenceError: stockCounter is not defined` — **order creation, not an edge case** |
| `controllers/orderController.js` | never required `shipping.service`, so the catch blocks meant to classify a bad delivery method threw a `ReferenceError` of their own and buried the real error |
| `routes/cartRoutes.js` | `POST /cart/restore` and its handler were dropped in the guest-cart rewrite (#1427) — **every abandoned-cart recovery email since has linked to a 404** |
| `middleware/authMiddleware.js` | rejected any token containing `--` as a SQL comment |

That last one is worth spelling out. A JWT is base64url, and base64url's alphabet
includes `-`, so two adjacent hyphens are ordinary token content:

```
$ node -e "const jwt=require('jsonwebtoken');let h=0;
  for(let i=0;i<5000;i++) if(/--/.test(jwt.sign({userId:i},'s'+i))) h++;
  console.log(h+'/5000 =', (100*h/5000).toFixed(2)+'%')"
47/5000 = 0.94%
```

**Just under 1% of every token this platform issues was rejected** — and rejected
with `Authorization header required`, the same response as sending no token at
all. The shopper saw a random sign-out that no amount of retrying reproduced, on
a credential that was perfectly valid and worked again the moment it was
reissued. The quote-OR half of the check stays: `'` is not in the base64url
alphabet, so it can only match something that was never a JWT.

This was also why the auth suite failed intermittently — `jwt.sign` mints a fresh
signature each run, so whether a run drew a `--` was luck.

`freeShipping` in `openapi/ecommerce.openapi.yaml` carried `nullable` with no
`type`, which ajv refuses to compile — so **every** fixture in the contract suite
failed, not only the one that uses it.

### 4. Test defects

- **Ownership** left `orderController` for `requireOwnership` on the route in
  #1425, and the handlers say so in a comment, but two cases were still pointed
  at the controllers. Re-aimed at the middleware that now holds the rule — same
  scenarios, plus the privileged-bypass asymmetry between the cancel and invoice
  guards — rather than deleted.
- **`authMiddleware` is async** and most of its suite called it as though it were
  not: `expect(fn).toThrow()` on a rejected promise, assertions running before
  the middleware finished, and two blocks firing a hundred calls each and
  forgetting them. The performance and timing-attack cases were measuring the
  synchronous prologue of an async function, so neither could have failed however
  slow or uneven verification became. The env block restored `process.env` by
  reassigning it, which does not restore it, so `JWT_SECRET` stayed deleted and a
  later suite failed two describes away from the cause.
- **Redis.** `refreshTokenService` calls `redis.connect()` at module scope, which
  defeats the `lazyConnect` `config/redis` sets under Jest. `loginLockout` died at
  require with `redis.connect is not a function` from a partial mock and never ran
  an assertion; `serverBootstrap` got `MaxRetriesPerRequestError` mid-request. Both
  now use `tests/helpers/redisMock.js`, which covers the whole surface the app
  touches including `duplicate()` for the socket.io adapter. `authMiddleware`
  gets it too — it checks every token against the revocation list, so it was
  Redis-dependent without saying so.

---

## 🔗 Related Issue

Closes #1444

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] Security fix
- [x] Testing improvement
- [ ] Other

---

## 📷 Screenshots / Demo

Before, from a clean checkout of `main`:

```
❌ 2 of 535 JavaScript file(s) failed to parse:
  frontend/scripts/product-cards-home.js:120   Unexpected token '<'
  frontend/scripts/shop.js:1308                missing ) after argument list
```

and, with the gate bypassed:

```
❌ backend/server.js failed to boot: TypeError: argument handler must be a function
Test Suites: 8 failed, 46 passed, 54 total
Tests:      16 failed, 1077 passed, 1093 total
```

After:

```
✅ syntax check passed — 536 JavaScript file(s) parsed cleanly
✅ boot check passed — backend/server.js loaded with 73 mounted layers
Test Suites: 54 passed, 54 total
Tests:      1104 passed, 1104 total
```

The homepage product grid and the whole of `shop.html` — search, filters,
sorting, the product list — go from a blank section and an `Uncaught SyntaxError`
to working.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**On flakiness.** The intermittent failures in the auth suite all traced back to
the `--` bug above, not to the test harness. Verified with **40 consecutive
full-suite runs under the CI flags** (`--ci --maxWorkers=2`): 1104 passed, 1104
total, every time.

**Regression cover.** `tests/mergeScarRegression.test.js` pins the specific
decisions in each conflict — including one that compiles `product-cards-home.js`
into a `vm` sandbox and renders a card, the only way to catch a binding that is
missing rather than misspelt. The `orderController` block in
`tests/moduleExports.test.js` derives the handler list from `orderRoutes.js`
rather than hard-coding it. The `--` bug is pinned deterministically: the tests
mint tokens until they find one containing the pair, rather than leaving it to a
random draw.

**Scope.** I would normally split §3 and §4 into their own PR. They are here
because they are all one thing — the gate was red, and everything behind it had
been rotting unobserved. Happy to split if you would rather review them
separately.
