### PR TITLE
Accept UUIDs on the product and order :id routes

### DIFF
--- a/backend/controllers/cartController.js
+++ b/backend/controllers/cartController.js
@@ -11,6 +11,7 @@ const {
 } = require("../services/cart.service");
 const cartLifecycle = require("../services/cartLifecycleService");
 const guestCart = require("../services/guestCartService");
+const cartRestoreService = require("../services/cartRestoreService");
 
 // Every handler below works from the cart, not from the account (#1427). The
 // two are the same thing for a signed-in shopper and the account is still
@@ -74,6 +75,44 @@ const issuedToken = (cart) => (
 );
 
 const cartController = {
+    // Spend a restore link from a recovery message and hand back the basket.
+    //
+    // Restored verbatim in #1444: this handler and its route were dropped when
+    // cartRoutes.js was rewritten for guest carts (#1427), which left
+    // cartRestoreService, its migrations and its public-route declaration in
+    // place with nothing reaching them. Every recovery email sent since has
+    // linked to a 404.
+    //
+    // The only unauthenticated cart endpoint, and deliberately the only one:
+    // the caller is anonymous, so there is no account here to write to and this
+    // reads. The lines go into whichever basket the browser already owns, and a
+    // signed-in shopper's existing sync then persists them under their own
+    // session -- which keeps every cart *write* behind authentication, exactly
+    // as it was.
+    restoreFromLink: async (req, res) => {
+        try {
+            const token = sanitizeString(req.body?.token || req.query?.token || "");
+            const restored = await cartRestoreService.redeemRestoreToken(token);
+
+            return res.status(200).json({
+                success: true,
+                message: "Your basket is back",
+                ...restored
+            });
+        } catch (error) {
+            // Nothing about the account, the cart or the reason a token is
+            // unknown travels back: every refusal is either "not valid" or
+            // "no longer usable".
+            return res.status(error.status || 500).json({
+                success: false,
+                code: error.code || "CART_RESTORE_FAILED",
+                message: error.status
+                    ? error.message
+                    : "Could not restore this basket"
+            });
+        }
+    },
+
     // Get the current cart (joined with product data)
     getUserCart: async (req, res) => {
         try {

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -1263,6 +1263,11 @@ module.exports = {
     getOrderById,
     getOrderTimeline,
     getFulfilmentReport,
+    // Defined above but left out of this list, so `orderController.getRecoveryReport`
+    // was `undefined` and `router.get("/reports/recovery", …)` threw
+    // "argument handler must be a function" while orderRoutes.js was being
+    // required -- the whole server failed to boot (#1444).
+    getRecoveryReport,
     lookupGuestOrder,
     getOrderStatus,
     updateOrderStatus,

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -14,6 +14,11 @@ const CURRENCY = require("../config/currency");
 const { generateInvoicePdf } = require("../services/invoice.service");
 const inventoryReservationService = require("../services/inventoryReservationService");
 const stockCounter = require("../services/stockCounterService");
+// Read in the catch blocks of createOrder and createPaymentIntent, to tell an
+// unknown delivery method from a server fault. The require went missing, so
+// the branch meant to classify the error threw a ReferenceError of its own and
+// buried whatever actually went wrong (#1444).
+const shippingService = require("../services/shipping.service");
 
 const {
     safeNumber,

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -56,7 +56,25 @@ async function authMiddleware(req, res, next) {
     }
 
     // Security check: SQL injection attempt
-    if (/'\s*OR\s*'/i.test(token) || /--/.test(token)) {
+    //
+    // `|| /--/.test(token)` used to be part of this, and it rejected roughly
+    // one legitimate token in a hundred (#1444).
+    //
+    // A JWT is base64url, and base64url's alphabet is A-Z a-z 0-9 plus `-` and
+    // `_`. Two adjacent hyphens are ordinary token content, not a SQL comment:
+    // across a ~200-character token the odds of the pair turning up somewhere
+    // are just under 1%. Those requests were answered "Authorization header
+    // required" -- as though no token had been sent at all -- so the shopper
+    // saw a sign-out that no amount of retrying reproduced, on a token that was
+    // perfectly valid and would work again the moment it was reissued.
+    //
+    // The quote-OR pattern stays: `'` is not in the base64url alphabet, so it
+    // cannot match a well-formed token and only fires on something that was
+    // never a JWT to begin with.
+    //
+    // Neither pattern is what makes this safe in any case. The token is a
+    // signed credential verified below, and it is never interpolated into SQL.
+    if (/'\s*OR\s*'/i.test(token)) {
         return res.status(401).json({
             success: false,
             message: 'Authorization header required'

--- a/backend/middleware/uuidParam.js
+++ b/backend/middleware/uuidParam.js
@@ -1,0 +1,77 @@
+// backend/middleware/uuidParam.js
+//
+// A `router.param` guard for the route segments that carry a UUID.
+//
+// `users`, `products` and `orders` are keyed by CHAR(36) UUIDs -- declared that
+// way in migrations/0001_baseline_schema.sql and settled as the key strategy in
+// migrations/0023_settle_uuid_key_strategy.sql. Two routers nonetheless
+// validated `:id` with `parseInt`:
+//
+//     const parsedId = parseInt(id, 10);
+//     if (!parsedId || parsedId < 1) return res.status(400)...
+//
+// `parseInt` reads a UUID from the left and stops at the first character that
+// is not a digit. So the guard behaved two different ways depending on nothing
+// more than the first character of the key:
+//
+//   "550e8400-e29b-41d4-a716-446655440000" -> 550  -> truthy -> passes
+//   "f47ac10b-58cc-4372-a567-0e02b2c3d479" -> NaN  -> falsy  -> 400
+//
+// A v4 UUID starts with a hex letter six times out of sixteen, so roughly 37%
+// of products and orders answered "Invalid product ID" for a perfectly valid
+// id, and the other 63% got through on a number that was never the id. The
+// handlers then re-read `req.params.id` through `safeUUID` and worked, which is
+// why the guard survived: it never validated anything, it only ever produced
+// false rejections (#1443).
+//
+// This module replaces both with one definition. Declaring it once is the
+// point -- the third router to grow a UUID `:id` should not have to rediscover
+// any of the above.
+
+const { safeUUID } = require('../utils/helpers');
+
+/**
+ * Build a `router.param` handler that accepts a UUID and rejects anything else.
+ *
+ * The validated id is attached as `req[attachAs]` when asked for, so a handler
+ * can take it without re-parsing. `req.params` is deliberately left alone --
+ * handlers already read it through `safeUUID`, and a param guard that rewrites
+ * the request is harder to reason about than one that only ever answers yes or
+ * no.
+ *
+ * @param {object} [options]
+ * @param {string} [options.resourceName="Resource"] - Used in the rejection
+ *   message, e.g. "Product" produces "Invalid product ID".
+ * @param {string} [options.attachAs] - Property to hang the validated id on,
+ *   e.g. "productId" for `req.productId`.
+ * @returns {import('express').RequestParamHandler}
+ */
+function uuidParam(options = {}) {
+    const resourceName = options.resourceName || 'Resource';
+    const attachAs = options.attachAs || null;
+
+    // "Invalid product ID", not "Invalid Product ID" -- the exact message the
+    // controllers already send for this condition, so a client matching on the
+    // text keeps working and the two layers cannot disagree.
+    const message = `Invalid ${resourceName.toLowerCase()} ID`;
+
+    return function validateUuidParam(req, res, next, value) {
+        const id = safeUUID(value);
+
+        if (!id) {
+            return res.status(400).json({
+                success: false,
+                message
+            });
+        }
+
+        if (attachAs) {
+            req[attachAs] = id;
+        }
+
+        return next();
+    };
+}
+
+module.exports = uuidParam;
+module.exports.uuidParam = uuidParam;

--- a/backend/openapi/ecommerce.openapi.yaml
+++ b/backend/openapi/ecommerce.openapi.yaml
@@ -934,6 +934,14 @@ components:
           items:
             $ref: "#/components/schemas/ShippingOption"
         freeShipping:
+          # `type` is required alongside `nullable`: without it a validator
+          # cannot tell what the non-null case is, and ajv refuses to compile
+          # the schema at all -- "nullable cannot be used without type". That
+          # took down every fixture in the contract suite, not only this one,
+          # because compilation happens before any payload is looked at
+          # (#1444). FreeShippingProgress is an object, so this states what
+          # was already meant.
+          type: object
           nullable: true
           allOf:
             - $ref: "#/components/schemas/FreeShippingProgress"

--- a/backend/routes/cartRoutes.js
+++ b/backend/routes/cartRoutes.js
@@ -4,6 +4,21 @@ const { optionalAuth } = require("../middleware/authMiddleware");
 const cartIdentity = require("../middleware/cartIdentity");
 const cartController = require("../controllers/cartController");
 
+// Restore a basket from a recovery link (#1429).
+//
+// Declared BEFORE the router-level middleware below, and the placement is the
+// point: the link is meant to work before sign-in, and the request names no
+// cart, so there is nothing for `cartIdentity` to resolve or to refuse. Its
+// authority is the single-purpose, expiring, single-use token in the body,
+// checked by cartRestoreService. `config/routePolicy.js` declares it as the
+// one public cart route.
+//
+// This route and its handler were dropped when this file was rewritten for
+// guest carts (#1427). The service, its migrations and its public-route
+// declaration all survived, so nothing failed loudly -- every recovery email
+// sent since has simply linked to a 404 (#1444).
+router.post("/restore", cartController.restoreFromLink);
+
 // A basket exists before the shopper does (#1427). `optionalAuth` attaches the
 // account when there is one and is deliberately not a policy in its own right;
 // `cartIdentity` is the guard, and it is what decides -- and refuses -- which

--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -7,9 +7,10 @@ const cartIdentity = require("../middleware/cartIdentity");
 const { authorizeRoles } = require("../middleware/rbacMiddleware");
 const { ROLES } = require("../config/policy");
 const { requireOwnership, ownerFromTable } = require("../middleware/requireOwnership");
+const uuidParam = require("../middleware/uuidParam");
 const { guestOrderLookupLimiter } = require("../middleware/rateLimiter");
 const orderController = require("../controllers/orderController");
-const { safeArray, safeNumber, sanitizeString } = require("../utils/helpers");
+const { safeArray, safeNumber, sanitizeString, safeUUID } = require("../utils/helpers");
 
 // ============================================
 // CONSTANTS
@@ -40,17 +41,6 @@ const ownsOrderStrictly = requireOwnership(ownerFromTable({ table: "orders" }), 
 // ============================================
 // VALIDATION FUNCTIONS
 // ============================================
-
-/**
- * Validate order ID
- */
-function validateOrderId(id) {
-    const parsedId = parseInt(id, 10);
-    if (!parsedId || parsedId < 1) {
-        throw new Error('Invalid order ID');
-    }
-    return parsedId;
-}
 
 /**
  * Validate items array
@@ -210,6 +200,10 @@ function validateDate(dateStr) {
 
 /**
  * Validate order IDs for bulk operations
+ *
+ * Nothing wires this up yet, but it carried the same `parseInt` defect as the
+ * `:id` guard did (#1443) and would have taken it with it the moment a bulk
+ * route was added. `orders.id` is a UUID here as everywhere else.
  */
 function validateOrderIds(orderIds) {
     const errors = [];
@@ -220,8 +214,7 @@ function validateOrderIds(orderIds) {
     }
 
     for (let i = 0; i < orderIds.length; i++) {
-        const id = parseInt(orderIds[i], 10);
-        if (isNaN(id) || id < 1) {
+        if (!safeUUID(orderIds[i])) {
             errors.push(`Order ID at index ${i} is invalid`);
         }
     }
@@ -237,17 +230,13 @@ function validateOrderIds(orderIds) {
 // ============================================
 
 // Validate order ID parameter
-router.param("id", (req, res, next, id) => {
-    try {
-        req.orderId = validateOrderId(id);
-        next();
-    } catch (error) {
-        return res.status(400).json({
-            success: false,
-            message: error.message
-        });
-    }
-});
+//
+// `orders.id` is a CHAR(36) UUID. This guard used to run the segment through
+// `parseInt`, so an order whose id began with a hex letter answered 400 on
+// every one of the routes below -- the timeline, the invoice, the summary and
+// cancellation included -- while the rest passed on a truncated number that
+// was never the id (#1443). See middleware/uuidParam.js.
+router.param("id", uuidParam({ resourceName: "Order", attachAs: "orderId" }));
 
 // Order API status
 router.get("/status/check", (req, res) => {

--- a/backend/routes/productRoutes.js
+++ b/backend/routes/productRoutes.js
@@ -38,6 +38,7 @@ const {
 const { authorizeRoles } = require("../middleware/rbacMiddleware");
 const { ROLES } = require("../config/policy");
 const { requireOwnership, ownerFromTable } = require("../middleware/requireOwnership");
+const uuidParam = require("../middleware/uuidParam");
 
 // Product Q&A (#1353).
 const productQA = require("../controllers/productQAController");
@@ -54,14 +55,12 @@ const ownsReview = requireOwnership(
 // --------------------------------------------------------------
 // Validate product ID
 // --------------------------------------------------------------
-router.param("id", (req, res, next, id) => {
-    const parsedId = parseInt(id, 10);
-    if (!parsedId || parsedId < 1) {
-        return res.status(400).json({ success: false, message: "Invalid product ID" });
-    }
-    req.productId = parsedId;
-    next();
-});
+//
+// `products.id` is a CHAR(36) UUID. This guard used to run the segment through
+// `parseInt`, which rejected every UUID beginning with a hex letter -- roughly
+// 37% of them -- and let the rest through on a truncated number that was never
+// the id (#1443). See middleware/uuidParam.js for the whole story.
+router.param("id", uuidParam({ resourceName: "Product", attachAs: "productId" }));
 
 // --------------------------------------------------------------
 // Routes

--- a/backend/services/order.service.js
+++ b/backend/services/order.service.js
@@ -11,6 +11,11 @@ const { validatePromo } = require("./promo.service");
 const pricing = require("./pricing.service");
 const cartLifecycle = require("./cartLifecycleService");
 const { generateOrderNumber } = require("./orderNumber.service");
+// `resolveOrderLines` and the stock deduction in `createOrder` both go through
+// this, and neither could: the require went missing, so `stockCounter` was a
+// free variable and every call threw `ReferenceError: stockCounter is not
+// defined`. That is order creation, not an edge case (#1444).
+const stockCounter = require("./stockCounterService");
 
 // Marks the one failure the client can act on, so controllers can answer with
 // the specific figures instead of a generic server error.

--- a/backend/tests/authMiddleware.test.js
+++ b/backend/tests/authMiddleware.test.js
@@ -1,5 +1,23 @@
 // backend/tests/authMiddleware.test.js
 
+// authMiddleware checks each token against the revocation list, which lives in
+// Redis (#1261), so this suite was reaching for a Redis that is not running.
+// services/refreshTokenService.js flips a `redisReady` flag from the resolution
+// of a connect() that never resolves here, and which side of that flag a given
+// request landed on depended on machine load: under a full parallel run every
+// valid-token case in this file would occasionally fail at once, with `next`
+// uncalled and `req.user` undefined, as though a good token had been rejected
+// (#1444).
+//
+// This suite is about JWT verification. Whether Redis is up is not part of that
+// question, so it is taken out of the picture -- an empty revocation list is
+// the right default, and the suites that test revocation mock the specific
+// commands they need.
+jest.mock('../config/redis', () => {
+    const { createRedisMock } = require('./helpers/redisMock');
+    return createRedisMock();
+});
+
 const { authMiddleware, optionalAuth } = require('../middleware/authMiddleware');
 const jwt = require('jsonwebtoken');
 const express = require('express');
@@ -75,8 +93,13 @@ const generateToken = (user, secret = 'test-secret', expiresIn = '1h') => {
     return jwt.sign(user, secret, { expiresIn });
 };
 
+// '-1s', not '0s'. jwt.verify refuses a token once the clock is *past* `exp`,
+// so a token that expires at the instant it is issued is not yet expired when
+// it is checked. The two callers each papered over that differently -- one with
+// a 100ms setTimeout, the other by hand-writing an `exp` an hour in the past --
+// and the first of those was a flake, not a fix (#1444).
 const generateExpiredToken = (user, secret = 'test-secret') => {
-    return jwt.sign(user, secret, { expiresIn: '0s' });
+    return jwt.sign(user, secret, { expiresIn: '-1s' });
 };
 
 // ============================================
@@ -139,21 +162,21 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Valid Tokens', () => {
-        test('should accept valid Bearer token', () => {
+        test('should accept valid Bearer token', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user).toBeDefined();
             expect(mockReq.user.userId).toBe(userFixtures.regularUser.userId);
         });
 
-        test('should attach user data to request', () => {
+        test('should attach user data to request', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expect(mockReq.user).toEqual(expect.objectContaining({
                 userId: userFixtures.regularUser.userId,
                 username: userFixtures.regularUser.username,
@@ -161,11 +184,11 @@ describe('Auth Middleware Tests', () => {
             }));
         });
 
-        test('should handle admin user token', () => {
+        test('should handle admin user token', async () => {
             const token = generateToken(userFixtures.adminUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user.role).toBe('admin');
         });
@@ -176,41 +199,41 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Invalid Tokens', () => {
-        test('should reject request without authorization header', () => {
-            authMiddleware(mockReq, mockRes, mockNext);
+        test('should reject request without authorization header', async () => {
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes);
             expect(mockNext).not.toHaveBeenCalled();
         });
 
-        test('should reject invalid token', () => {
+        test('should reject invalid token', async () => {
             mockReq.headers.authorization = 'Bearer invalid-token';
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes, 'Invalid or expired token');
             expect(mockNext).not.toHaveBeenCalled();
         });
 
-        test('should reject malformed token', () => {
+        test('should reject malformed token', async () => {
             mockReq.headers.authorization = 'Bearer malformed.token.here';
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes, 'Invalid or expired token');
         });
 
-        test('should reject token with invalid signature', () => {
+        test('should reject token with invalid signature', async () => {
             const token = jwt.sign({ userId: 1 }, 'wrong-secret');
             mockReq.headers.authorization = `Bearer ${token}`;
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes, 'Invalid or expired token');
         });
 
-        test('should reject empty authorization header', () => {
+        test('should reject empty authorization header', async () => {
             mockReq.headers.authorization = 'Bearer ';
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes, 'Authorization header required');
         });
 
-        test('should reject malformed authorization header (no Bearer)', () => {
+        test('should reject malformed authorization header (no Bearer)', async () => {
             mockReq.headers.authorization = 'Token invalid';
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes, 'Authorization header required');
         });
     });
@@ -220,25 +243,27 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Expired Tokens', () => {
-        test('should reject expired token', (done) => {
+        test('should reject expired token', async () => {
             const expiredToken = generateExpiredToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${expiredToken}`;
 
-            setTimeout(() => {
-                authMiddleware(mockReq, mockRes, mockNext);
-                expectUnauthorized(mockRes, 'Invalid or expired token');
-                expect(mockNext).not.toHaveBeenCalled();
-                done();
-            }, 100);
+            // Was a setTimeout + done() waiting 100ms for a token minted with
+            // `expiresIn: '0s'` to become expired. Awaiting the middleware is
+            // what this actually needed, and the token is now unambiguously in
+            // the past, so there is nothing left to wait for.
+            await authMiddleware(mockReq, mockRes, mockNext);
+
+            expectUnauthorized(mockRes, 'Invalid or expired token');
+            expect(mockNext).not.toHaveBeenCalled();
         });
 
-        test('should reject token with expired claim', () => {
+        test('should reject token with expired claim', async () => {
             const token = jwt.sign(
                 { userId: 1, exp: Math.floor(Date.now() / 1000) - 3600 },
                 secret
             );
             mockReq.headers.authorization = `Bearer ${token}`;
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes, 'Invalid or expired token');
         });
     });
@@ -248,27 +273,27 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Role-Based Access', () => {
-        test('should allow admin to access admin routes', () => {
+        test('should allow admin to access admin routes', async () => {
             const token = generateToken(userFixtures.adminUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
             mockReq.role = 'admin';
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user.role).toBe('admin');
         });
 
-        test('should allow regular user to access user routes', () => {
+        test('should allow regular user to access user routes', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
             mockReq.role = 'user';
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user.role).toBe('user');
         });
 
-        test('should reject user without required role', () => {
+        test('should reject user without required role', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
             mockReq.requiredRole = 'admin';
@@ -276,7 +301,7 @@ describe('Auth Middleware Tests', () => {
             // Assuming middleware checks role
             // This test would pass if middleware has role checking
             // If not, this test might need adjustment
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             // Expect next or unauthorized depending on implementation
         });
     });
@@ -286,17 +311,30 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Environment Variable Tests', () => {
-        const originalEnv = process.env;
+        // Restore by key rather than by reassigning `process.env`.
+        //
+        // `process.env = { ...originalEnv }` followed by
+        // `process.env = originalEnv` looks symmetrical and is not: assigning
+        // to process.env replaces Node's env store, and the saved reference no
+        // longer restores what was there. JWT_SECRET therefore stayed deleted
+        // after this block, and the next suite to call the middleware failed
+        // with "JWT_SECRET environment variable is required" -- a failure two
+        // describes away from its cause (#1444).
+        let savedSecret;
 
         beforeEach(() => {
-            process.env = { ...originalEnv };
+            savedSecret = process.env.JWT_SECRET;
         });
 
         afterEach(() => {
-            process.env = originalEnv;
+            if (savedSecret === undefined) {
+                delete process.env.JWT_SECRET;
+            } else {
+                process.env.JWT_SECRET = savedSecret;
+            }
         });
 
-        test('should use JWT secret from environment', () => {
+        test('should use JWT secret from environment', async () => {
             process.env.JWT_SECRET = 'env_secret_1234567890';
             const token = jwt.sign(
                 { userId: 1 },
@@ -304,16 +342,23 @@ describe('Auth Middleware Tests', () => {
             );
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
         });
 
-        test('should handle missing JWT secret', () => {
+        test('should handle missing JWT secret', async () => {
             delete process.env.JWT_SECRET;
 
-            expect(() => {
-                authMiddleware(mockReq, mockRes, mockNext);
-            }).toThrow();
+            // `authMiddleware` is async, so it returns a rejected promise
+            // rather than throwing synchronously. The old `expect(fn).toThrow()`
+            // could never see that: it reported "did not throw" and left the
+            // rejection unhandled, which crashed the worker outright when this
+            // test was run on its own.
+            await expect(
+                authMiddleware(mockReq, mockRes, mockNext)
+            ).rejects.toThrow('JWT_SECRET environment variable is required');
+
+            expect(mockNext).not.toHaveBeenCalled();
         });
     });
 
@@ -322,16 +367,24 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Performance Tests', () => {
-        test('should verify token within 10ms', () => {
+        test('should verify token within 10ms', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
+            // Awaited, because authMiddleware is async: the loop below used to
+            // fire and forget, so `duration` measured how long it takes to
+            // *start* a hundred verifications, not to finish them, and the
+            // assertion passed no matter how slow verification actually was.
+            //
+            // The hundred stray promises then resolved during whichever tests
+            // happened to be running next, which is where the intermittent
+            // failures in this file came from (#1444).
             const start = performance.now();
             for (let i = 0; i < 100; i++) {
                 const req = createMockRequest({ authorization: `Bearer ${token}` });
                 const res = createMockResponse();
                 const next = jest.fn();
-                authMiddleware(req, res, next);
+                await authMiddleware(req, res, next);
             }
             const duration = performance.now() - start;
 
@@ -340,15 +393,21 @@ describe('Auth Middleware Tests', () => {
 
         test('should handle 100 concurrent auth requests', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
-            const promises = Array(100).fill().map(() => {
+
+            // The middleware's own promises, not a hundred already-resolved
+            // stand-ins. `Promise.resolve()` could never have failed, so this
+            // case asserted nothing about concurrency.
+            const results = Array(100).fill().map(() => {
                 const req = createMockRequest({ authorization: `Bearer ${token}` });
                 const res = createMockResponse();
                 const next = jest.fn();
-                authMiddleware(req, res, next);
-                return Promise.resolve();
+                return authMiddleware(req, res, next).then(() => next);
             });
 
-            await expect(Promise.all(promises)).resolves.not.toThrow();
+            const nexts = await Promise.all(results);
+
+            expect(nexts).toHaveLength(100);
+            expect(nexts.every((next) => next.mock.calls.length === 1)).toBe(true);
         });
     });
 
@@ -357,34 +416,84 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Security Tests', () => {
-        test('should be resistant to timing attacks', () => {
+        test('should be resistant to timing attacks', async () => {
             const validToken = generateToken(userFixtures.regularUser, secret);
             const invalidToken = 'malformed.token.here';
 
+            // Awaited for the same reason as the performance case above:
+            // unawaited, both timings measured the synchronous prologue of an
+            // async function and were always within a hair of each other, so
+            // the comparison could not have detected a timing leak.
             const start1 = performance.now();
             const req1 = createMockRequest({ authorization: `Bearer ${validToken}` });
             const res1 = createMockResponse();
             const next1 = jest.fn();
-            authMiddleware(req1, res1, next1);
+            await authMiddleware(req1, res1, next1);
             const time1 = performance.now() - start1;
 
             const start2 = performance.now();
             const req2 = createMockRequest({ authorization: `Bearer ${invalidToken}` });
             const res2 = createMockResponse();
             const next2 = jest.fn();
-            authMiddleware(req2, res2, next2);
+            await authMiddleware(req2, res2, next2);
             const time2 = performance.now() - start2;
 
             expect(Math.abs(time1 - time2)).toBeLessThan(50);
         });
 
-        test('should handle SQL injection attempts in token', () => {
+        test('should handle SQL injection attempts in token', async () => {
             const injectionToken = "Bearer ' OR '1'='1";
             mockReq.headers.authorization = injectionToken;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes);
             expect(mockNext).not.toHaveBeenCalled();
+        });
+
+        // #1444. The injection heuristic also matched `--`, which is a SQL
+        // comment and is equally a pair of ordinary base64url characters. Just
+        // under 1% of tokens contain it somewhere, and every one of those was
+        // answered "Authorization header required" -- indistinguishable from
+        // sending no token at all.
+        //
+        // This is why the suite failed intermittently: `jwt.sign` produces a
+        // fresh signature each run, so which run happened to mint a token
+        // containing `--` was luck. Pinned deterministically here rather than
+        // left to a random draw.
+        test('accepts a valid token whose base64url contains a double hyphen', async () => {
+            // Mint until the encoding contains `--`. Signature bytes are
+            // effectively random, so this finds one in a few dozen attempts.
+            let token = null;
+            for (let i = 0; i < 5000 && token === null; i++) {
+                const candidate = jwt.sign({ userId: 1, seq: i }, secret);
+                if (candidate.includes('--')) token = candidate;
+            }
+
+            expect(token).not.toBeNull();
+
+            mockReq.headers.authorization = `Bearer ${token}`;
+            await authMiddleware(mockReq, mockRes, mockNext);
+
+            expect(mockNext).toHaveBeenCalled();
+            expect(mockRes.status).not.toHaveBeenCalled();
+            expect(mockReq.user.userId).toBe(1);
+        });
+
+        test('rejects an invalid-signature token containing a double hyphen for the right reason', async () => {
+            let token = null;
+            for (let i = 0; i < 5000 && token === null; i++) {
+                const candidate = jwt.sign({ userId: 1, seq: i }, 'wrong-secret');
+                if (candidate.includes('--')) token = candidate;
+            }
+
+            expect(token).not.toBeNull();
+
+            mockReq.headers.authorization = `Bearer ${token}`;
+            await authMiddleware(mockReq, mockRes, mockNext);
+
+            // "Invalid or expired token" -- the signature failed. Not
+            // "Authorization header required", which claims nothing was sent.
+            expectUnauthorized(mockRes, 'Invalid or expired token');
         });
     });
 
@@ -404,48 +513,47 @@ describe('Auth Middleware Tests', () => {
             mockNext = jest.fn();
         });
 
-        test('should call next without token', () => {
-            optionalAuth(mockReq, mockRes, mockNext);
+        test('should call next without token', async () => {
+            await optionalAuth(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user).toBeUndefined();
         });
 
-        test('should attach user with valid token', () => {
+        test('should attach user with valid token', async () => {
             const token = generateToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            optionalAuth(mockReq, mockRes, mockNext);
+            await optionalAuth(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user).toBeDefined();
             expect(mockReq.user.userId).toBe(userFixtures.regularUser.userId);
         });
 
-        test('should handle expired token gracefully', (done) => {
+        test('should handle expired token gracefully', async () => {
             const expiredToken = generateExpiredToken(userFixtures.regularUser, secret);
             mockReq.headers.authorization = `Bearer ${expiredToken}`;
 
-            setTimeout(() => {
-                optionalAuth(mockReq, mockRes, mockNext);
-                // optionalAuth should still call next even with expired token
-                expect(mockNext).toHaveBeenCalled();
-                done();
-            }, 100);
+            await optionalAuth(mockReq, mockRes, mockNext);
+
+            // optionalAuth should still call next even with expired token
+            expect(mockNext).toHaveBeenCalled();
+            expect(mockReq.user).toBeUndefined();
         });
 
-        test('should handle invalid token gracefully', () => {
+        test('should handle invalid token gracefully', async () => {
             mockReq.headers.authorization = 'Bearer invalid-token';
 
-            optionalAuth(mockReq, mockRes, mockNext);
+            await optionalAuth(mockReq, mockRes, mockNext);
             // optionalAuth should still call next even with invalid token
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user).toBeUndefined();
         });
 
-        test('should attach user with admin role', () => {
+        test('should attach user with admin role', async () => {
             const token = generateToken(userFixtures.adminUser, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            optionalAuth(mockReq, mockRes, mockNext);
+            await optionalAuth(mockReq, mockRes, mockNext);
             expect(mockNext).toHaveBeenCalled();
             expect(mockReq.user).toBeDefined();
             expect(mockReq.user.role).toBe('admin');
@@ -555,38 +663,38 @@ describe('Auth Middleware Tests', () => {
     // ============================================
 
     describe('Negative Test Cases', () => {
-        test('should reject token with missing userId', () => {
+        test('should reject token with missing userId', async () => {
             const token = jwt.sign(
                 { username: 'testuser' },
                 secret
             );
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes);
         });
 
-        test('should reject token with empty payload', () => {
+        test('should reject token with empty payload', async () => {
             const token = jwt.sign({}, secret);
             mockReq.headers.authorization = `Bearer ${token}`;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes);
         });
 
-        test('should reject XSS attempt in token', () => {
+        test('should reject XSS attempt in token', async () => {
             const xssToken = 'Bearer <script>alert("xss")</script>';
             mockReq.headers.authorization = xssToken;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes);
         });
 
-        test('should reject excessively long token', () => {
+        test('should reject excessively long token', async () => {
             const longToken = 'Bearer ' + 'a'.repeat(10000);
             mockReq.headers.authorization = longToken;
 
-            authMiddleware(mockReq, mockRes, mockNext);
+            await authMiddleware(mockReq, mockRes, mockNext);
             expectUnauthorized(mockRes);
         });
     });

--- a/backend/tests/helpers/redisMock.js
+++ b/backend/tests/helpers/redisMock.js
@@ -1,0 +1,123 @@
+// backend/tests/helpers/redisMock.js
+//
+// A stand-in for `config/redis` that never opens a socket. Addresses #1444.
+//
+// `config/redis` sets `lazyConnect` under Jest so the module graph can be
+// loaded without a server, but `services/refreshTokenService.js` then calls
+// `redis.connect()` at module scope -- which is exactly the thing lazyConnect
+// was deferring. Any suite that reaches authMiddleware (and so
+// refreshTokenService) therefore ended up talking to a Redis that is not
+// there, and got one of two failures depending on how complete its own mock
+// was:
+//
+//   TypeError: redis.connect is not a function      -- partial mock, suite
+//                                                      failed to run at all
+//   MaxRetriesPerRequestError: ... limit (which is 3) -- no mock, ioredis
+//                                                      exhausted its retries
+//                                                      mid-request
+//
+// Both are environment noise rather than anything about the code under test,
+// and both are avoided by giving the double the whole surface the app uses,
+// including the connection lifecycle.
+//
+// Commands resolve rather than reject. A suite that wants to see failure
+// handling should override the specific command it cares about -- a double
+// that fails everything cannot tell "handles a Redis outage" from "never
+// reached Redis".
+
+'use strict';
+
+/**
+ * Build a fresh ioredis-shaped double.
+ *
+ * Every command is an independent `jest.fn()` so a suite can override one
+ * without disturbing the rest, and a fresh instance per call keeps call counts
+ * from leaking between suites.
+ *
+ * @returns {object}
+ */
+function createRedisMock() {
+    const client = {
+        // Connection lifecycle. `connect` resolving is what stops
+        // refreshTokenService's module-scope call from starting a real one.
+        connect: jest.fn().mockResolvedValue(undefined),
+        quit: jest.fn().mockResolvedValue('OK'),
+        disconnect: jest.fn(),
+        status: 'ready',
+
+        // Event emitter surface. The app registers 'connect', 'error' and
+        // 'ready' handlers; returning `this` keeps the chaining ioredis allows.
+        on: jest.fn(function on() { return this; }),
+        once: jest.fn(function once() { return this; }),
+        off: jest.fn(function off() { return this; }),
+        removeListener: jest.fn(function removeListener() { return this; }),
+        emit: jest.fn(),
+
+        // Commands, in the shapes the callers expect back.
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn().mockResolvedValue('OK'),
+        setex: jest.fn().mockResolvedValue('OK'),
+        del: jest.fn().mockResolvedValue(0),
+        exists: jest.fn().mockResolvedValue(0),
+        incr: jest.fn().mockResolvedValue(1),
+        expire: jest.fn().mockResolvedValue(1),
+        ttl: jest.fn().mockResolvedValue(-2),
+        keys: jest.fn().mockResolvedValue([]),
+        scan: jest.fn().mockResolvedValue(['0', []]),
+        eval: jest.fn().mockResolvedValue(null),
+        evalsha: jest.fn().mockResolvedValue(null),
+        hget: jest.fn().mockResolvedValue(null),
+        hset: jest.fn().mockResolvedValue(1),
+        hgetall: jest.fn().mockResolvedValue({}),
+        sadd: jest.fn().mockResolvedValue(1),
+        srem: jest.fn().mockResolvedValue(1),
+        smembers: jest.fn().mockResolvedValue([]),
+        sismember: jest.fn().mockResolvedValue(0),
+        ping: jest.fn().mockResolvedValue('PONG'),
+        defineCommand: jest.fn(),
+        // Pub/sub. The pattern variants are what @socket.io/redis-adapter
+        // reaches for on the subscriber connection; without them the adapter
+        // logs "psubscribe is not a function" and falls back, which is noise
+        // in the output of a suite that is not testing the adapter.
+        subscribe: jest.fn().mockResolvedValue(1),
+        unsubscribe: jest.fn().mockResolvedValue(1),
+        publish: jest.fn().mockResolvedValue(0),
+        psubscribe: jest.fn().mockResolvedValue(1),
+        punsubscribe: jest.fn().mockResolvedValue(1),
+
+        // utils/socketManager.js takes two of these for the socket.io Redis
+        // adapter. A subscriber connection cannot also issue commands, which is
+        // why the real client is duplicated rather than shared -- the double
+        // mirrors that by handing back a fresh instance.
+        duplicate: jest.fn(() => createRedisMock()),
+
+        // Pipelines and transactions. `exec` returns the [err, result] tuples
+        // ioredis produces, so a caller destructuring them gets what it expects.
+        pipeline: jest.fn(() => createChain()),
+        multi: jest.fn(() => createChain())
+    };
+
+    /**
+     * A chainable pipeline/multi whose `exec` resolves to an empty result set.
+     *
+     * @returns {object}
+     */
+    function createChain() {
+        const chain = {
+            exec: jest.fn().mockResolvedValue([])
+        };
+
+        for (const command of ['get', 'set', 'setex', 'del', 'incr', 'expire', 'eval']) {
+            chain[command] = jest.fn(() => chain);
+        }
+
+        return chain;
+    }
+
+    // config/redis exports the client itself and hangs the options off it.
+    client.REDIS_OPTIONS = { host: '127.0.0.1', port: 6379, lazyConnect: true };
+
+    return client;
+}
+
+module.exports = { createRedisMock };

--- a/backend/tests/loginLockout.test.js
+++ b/backend/tests/loginLockout.test.js
@@ -30,11 +30,23 @@ jest.mock('../config/db', () => ({
 // deliberately runs it against an unreachable Redis, because the per-process
 // fallback that serves an outage has to enforce exactly the same policy as the
 // shared path. The Redis path is covered in loginLockoutService.test.js.
-jest.mock('../config/redis', () => ({
-    eval: jest.fn().mockRejectedValue(new Error('ECONNREFUSED')),
-    del: jest.fn().mockRejectedValue(new Error('ECONNREFUSED')),
-    scan: jest.fn().mockRejectedValue(new Error('ECONNREFUSED'))
-}));
+//
+// Only the three commands the fallback path touches reject; the rest of the
+// client comes from the shared double. The partial mock that used to stand here
+// had no `connect`, and services/refreshTokenService.js calls it at module
+// scope, so requiring authController died with
+// `TypeError: redis.connect is not a function` and the suite failed to run --
+// never reaching a single assertion below (#1444).
+jest.mock('../config/redis', () => {
+    const { createRedisMock } = require('./helpers/redisMock');
+    const client = createRedisMock();
+
+    client.eval = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    client.del = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    client.scan = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+    return client;
+});
 
 jest.mock('../config/logger', () => ({
     info: jest.fn(),

--- a/backend/tests/mergeScarRegression.test.js
+++ b/backend/tests/mergeScarRegression.test.js
@@ -10,6 +10,10 @@
 
 const fs = require('fs');
 const path = require('path');
+// Frontend scripts are classic <script> files, not modules, so the only way to
+// exercise one from Jest is to compile it into a sandbox with the globals the
+// page would have supplied.
+const vm = require('vm');
 
 const BACKEND_DIR = path.resolve(__dirname, '..');
 const REPO_ROOT = path.resolve(BACKEND_DIR, '..');
@@ -188,6 +192,106 @@ describe('frontend/scripts/product-cards-home.js', () => {
 
     it('resolves the wishlist through the shared helper', () => {
         expect(source).toMatch(/const isWishlisted = isProductWishlisted\(product\.id, wishlistIds\)/);
+    });
+
+    // #1444. The same function was broken a second time: an `<img …>` fragment
+    // was left at statement position -- outside any template literal -- and the
+    // stock bindings the return template reads went missing with it. The
+    // fragment is a SyntaxError; the missing bindings would have been a
+    // ReferenceError on the first card had it ever run.
+    it('has no HTML fragment outside a template literal', () => {
+        // The card renders one image, and it belongs inside the return
+        // template. A second `<img` in this function is the orphan again.
+        expect(countMatches(source, /<img\b/g)).toBe(1);
+
+        const cardTemplate = source.indexOf('return `\n        <div class="pro ');
+        expect(cardTemplate).toBeGreaterThan(-1);
+        expect(source.indexOf('<img')).toBeGreaterThan(cardTemplate);
+    });
+
+    it('declares the stock bindings its card template reads', () => {
+        expect(source).toMatch(/^\s+const stock = Number\(product\.stock\) \|\| 0;$/m);
+        expect(source).toMatch(/^\s+const outOfStock = isOutOfStock\(stock\);$/m);
+        expect(source).toMatch(/^\s+const outOfStockClass = outOfStock \? "out-of-stock" : "";$/m);
+    });
+
+    // The class shop.js puts on its own cards, and the one
+    // styles/product-card.css dims. A card marked with anything else looks
+    // in-stock however empty the shelf is.
+    it('marks sold-out cards with the class the stylesheet targets', () => {
+        const css = read('frontend/styles/product-card.css');
+        expect(css).toMatch(/\.pro\.out-of-stock\b/);
+    });
+
+    // Evaluating the file proves what a regex cannot: that every binding the
+    // template reads actually resolves. The module is a classic <script>, so it
+    // is run in a sandbox with the globals index.html would have provided.
+    it('renders a card without reaching for an undeclared binding', () => {
+        const sandbox = {
+            document: { getElementById: () => null },
+            window: {},
+            console,
+            formatPrice: (value) => `₹${value}`,
+            defaultImage: (value) => value || '',
+            escapeHTML: (value) => String(value == null ? '' : value),
+            handleImageError: () => {},
+            AppUtils: undefined
+        };
+        sandbox.globalThis = sandbox;
+
+        vm.createContext(sandbox);
+        new vm.Script(source, { filename: 'product-cards-home.js' }).runInContext(sandbox);
+
+        const inStock = sandbox.createProductCard(
+            { id: 'p1', name: 'Tee', price: 19.99, stock: 12, image: '/t.jpg' },
+            new Set()
+        );
+        expect(inStock).toContain('data-id="p1"');
+        expect(inStock).toContain('In Stock');
+        expect(inStock).not.toContain('class="pro out-of-stock');
+
+        const soldOut = sandbox.createProductCard(
+            { id: 'p2', name: 'Cap', price: 9.99, stock: 0, image: '/c.jpg' },
+            new Set()
+        );
+        expect(soldOut).toContain('pro out-of-stock');
+        expect(soldOut).toContain('Sold Out');
+        expect(soldOut).toContain('disabled');
+    });
+});
+
+describe('frontend/scripts/shop.js', () => {
+    const source = read('frontend/scripts/shop.js');
+
+    // #1444. The DOMContentLoaded listener was left unclosed and the body of
+    // `clearAllFilters` ran straight on from it, so the file did not parse and
+    // the entire shop page was dead.
+    it('declares clearAllFilters exactly once', () => {
+        expect(countMatches(source, /^function clearAllFilters\(\) \{$/gm)).toBe(1);
+    });
+
+    it('closes the DOMContentLoaded listener before the next declaration', () => {
+        const listener = source.indexOf('document.addEventListener(\n    "DOMContentLoaded"');
+        expect(listener).toBeGreaterThan(-1);
+
+        const declaration = source.indexOf('function clearAllFilters() {');
+        expect(declaration).toBeGreaterThan(listener);
+
+        // `}\n);` -- the closing of the arrow function and of the call it is an
+        // argument to. Dropping the `);` is what merged the two together.
+        expect(source.slice(listener, declaration)).toMatch(/\}\s*\);\s*$/m);
+    });
+
+    // setupClearFilters binds the handler by name; a rename on one side only
+    // would leave the button wired to nothing.
+    it('binds the clear-filters button to that function', () => {
+        expect(source).toMatch(/clearFiltersBtn\.addEventListener\('click', clearAllFilters\)/);
+    });
+
+    it('declares the filter state it assigns, rather than leaking it onto window', () => {
+        for (const name of ['currentCategory', 'currentSearch', 'showAllHoodies']) {
+            expect(source).toMatch(new RegExp(`^let ${name} = `, 'm'));
+        }
     });
 });
 

--- a/backend/tests/moduleExports.test.js
+++ b/backend/tests/moduleExports.test.js
@@ -218,3 +218,46 @@ describe('envValidator url handling', () => {
         expect(validator.isURL('', { require_tld: false })).toBe(false);
     });
 });
+
+describe('orderController (#1444)', () => {
+    const fs = require('fs');
+    const path = require('path');
+
+    const controller = require('../controllers/orderController');
+    const routesSource = fs.readFileSync(
+        path.join(__dirname, '..', 'routes', 'orderRoutes.js'),
+        'utf8'
+    );
+
+    /**
+     * Every `orderController.<name>` the router reaches for.
+     *
+     * Derived from the source rather than hard-coded, so a handler added to a
+     * route tomorrow is covered without anyone remembering to list it here.
+     */
+    const referenced = Array.from(
+        new Set(
+            Array.from(routesSource.matchAll(/orderController\.(\w+)/g), (m) => m[1])
+        )
+    ).sort();
+
+    test('the router references at least the handlers we know about', () => {
+        // A guard on the regex itself: if it silently stopped matching, every
+        // assertion below would pass over an empty list.
+        expect(referenced).toContain('createOrder');
+        expect(referenced).toContain('getRecoveryReport');
+        expect(referenced.length).toBeGreaterThan(10);
+    });
+
+    // getRecoveryReport was defined in the controller but missing from
+    // module.exports, so it resolved to `undefined` and Express threw
+    // "argument handler must be a function" while orderRoutes.js was still
+    // being required. The server did not boot at all.
+    test.each(referenced)('exports %s as a function', (name) => {
+        expect(typeof controller[name]).toBe('function');
+    });
+
+    test('orderRoutes mounts without throwing', () => {
+        expect(() => require('../routes/orderRoutes')).not.toThrow();
+    });
+});

--- a/backend/tests/orderController.test.js
+++ b/backend/tests/orderController.test.js
@@ -46,6 +46,10 @@ const { createOrderService, validateOrderDataService, getOrderSummaryById } = re
 const paymentService = require("../services/payment.service");
 const { generateInvoicePdf } = require("../services/invoice.service");
 const inventoryReservationService = require("../services/inventoryReservationService");
+// Ownership moved out of these handlers and onto the routes in #1425, so the
+// cases that cover it now exercise the middleware directly. It reads through
+// the same mocked config/db as everything else here.
+const { requireOwnership, ownerFromTable } = require("../middleware/requireOwnership");
 
 const {
     createOrder,
@@ -353,15 +357,50 @@ describe("cancelUserOrder", () => {
         db.getConnection.mockResolvedValue(connection);
     });
 
-    test("prevents cancelling someone else's order", async () => {
-        connection.query.mockResolvedValueOnce([[{ user_id: 99, status: "pending" }]]);
+    // Ownership left this controller in #1425 and now lives in
+    // requireOwnership, declared on the route in orderRoutes.js -- the handler
+    // says so in a comment and no longer compares ids at all. This assertion
+    // stayed pointed at the controller, so it had been failing ever since
+    // (#1444). Re-aimed at the middleware that actually holds the rule, with
+    // the same scenario, rather than deleted.
+    test("the route guard prevents cancelling someone else's order", async () => {
+        // Built exactly as orderRoutes.js builds it for the cancel route: no
+        // privileged bypass, because staff have never been able to cancel on a
+        // customer's behalf through this endpoint.
+        const guard = requireOwnership(ownerFromTable({ table: "orders" }), {
+            resourceName: "Order",
+            allowPrivileged: false
+        });
+
+        db.query.mockResolvedValueOnce([[{ ownerId: 99 }]]);
 
         const req = { params: { id: VALID_ORDER_ID }, user: { id: 1 } };
         const res = mockRes();
+        const next = jest.fn();
 
-        await cancelUserOrder(req, res);
+        await guard(req, res, next);
 
+        expect(next).not.toHaveBeenCalled();
+        // 404, not 403: a 403 confirms the id is real, which turns the id space
+        // into an enumeration oracle.
         expect(res.statusCode).toBe(404);
+    });
+
+    test("the route guard lets the owner reach the handler", async () => {
+        const guard = requireOwnership(ownerFromTable({ table: "orders" }), {
+            resourceName: "Order",
+            allowPrivileged: false
+        });
+
+        db.query.mockResolvedValueOnce([[{ ownerId: 1 }]]);
+
+        const req = { params: { id: VALID_ORDER_ID }, user: { id: 1 } };
+        const res = mockRes();
+        const next = jest.fn();
+
+        await guard(req, res, next);
+
+        expect(next).toHaveBeenCalled();
     });
 
     test("rejects cancelling an already-shipped order", async () => {
@@ -559,14 +598,43 @@ describe("downloadInvoice", () => {
         expect(res.statusCode).toBe(404);
     });
 
-    test("blocks a user from downloading someone else's invoice", async () => {
-        db.query.mockResolvedValueOnce([[{ id: VALID_ORDER_ID, user_id: 99 }]]);
+    // Same move as the cancel guard above: downloadInvoice used to compare ids
+    // and answer 403, and #1425 replaced that with requireOwnership on the
+    // route -- which answers 404 by design, so a caller cannot learn that an
+    // order id exists by being refused it. The old assertion outlived the
+    // behaviour it described (#1444).
+    test("the route guard blocks a user from downloading someone else's invoice", async () => {
+        const guard = requireOwnership(ownerFromTable({ table: "orders" }), {
+            resourceName: "Order"
+        });
+
+        db.query.mockResolvedValueOnce([[{ ownerId: 99 }]]);
+
         const req = { params: { id: VALID_ORDER_ID }, user: { id: 1, role: "user" } };
         const res = mockRes();
+        const next = jest.fn();
 
-        await downloadInvoice(req, res);
+        await guard(req, res, next);
 
-        expect(res.statusCode).toBe(403);
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(404);
+    });
+
+    test("the route guard lets an admin through, unlike the cancel guard", async () => {
+        // The invoice guard keeps the privileged bypass; the cancel guard
+        // deliberately does not. Pinning both means a refactor cannot quietly
+        // level them.
+        const guard = requireOwnership(ownerFromTable({ table: "orders" }), {
+            resourceName: "Order"
+        });
+
+        const req = { params: { id: VALID_ORDER_ID }, user: { id: 1, role: "admin" } };
+        const res = mockRes();
+        const next = jest.fn();
+
+        await guard(req, res, next);
+
+        expect(next).toHaveBeenCalled();
     });
 
     test("streams a PDF for the order owner", async () => {

--- a/backend/tests/serverBootstrap.test.js
+++ b/backend/tests/serverBootstrap.test.js
@@ -26,6 +26,22 @@ process.env.JWT_SECRET = process.env.JWT_SECRET || 'test_jwt_secret_at_least_32_
 process.env.PORT = process.env.PORT || '5099';
 process.env.FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:5500';
 
+// Requiring ../server builds the whole module graph, and part of that graph
+// reaches for Redis: services/refreshTokenService.js calls redis.connect() at
+// module scope, which defeats the lazyConnect config/redis sets under Jest.
+// With no server listening, ioredis exhausted its retries part-way through a
+// request and the probe below failed with MaxRetriesPerRequestError instead of
+// an HTTP status -- an environment failure wearing the costume of a routing
+// one (#1444).
+//
+// This suite is about wiring: does requiring the server produce an app with
+// these routers mounted. Whether Redis is up is not part of that question, so
+// it is taken out of the picture.
+jest.mock('../config/redis', () => {
+    const { createRedisMock } = require('./helpers/redisMock');
+    return createRedisMock();
+});
+
 const fs = require('fs');
 const path = require('path');
 const request = require('supertest');

--- a/backend/tests/uuidParam.test.js
+++ b/backend/tests/uuidParam.test.js
@@ -1,0 +1,202 @@
+// backend/tests/uuidParam.test.js
+//
+// Regression tests for #1443.
+//
+// `products.id` and `orders.id` are CHAR(36) UUIDs, and both routers guarded
+// `:id` with `parseInt`. That is not a weaker check than a UUID check -- it is
+// a differently-wrong one, and which way it went depended on nothing but the
+// first character of the key:
+//
+//     parseInt("550e8400-…") === 550   -> truthy -> the request went through
+//     parseInt("f47ac10b-…") === NaN   -> falsy  -> 400 Invalid product ID
+//
+// Six of the sixteen hex digits are letters, so roughly 37% of every product
+// and every order was unreachable by id, and the other 63% got past a guard
+// that had validated nothing.
+//
+// The tests below run the real routers through a real Express app. No database
+// is touched: each route is asserted only to have got *past* the param guard,
+// which is the layer under test.
+
+const express = require('express');
+const request = require('supertest');
+
+const uuidParam = require('../middleware/uuidParam');
+
+// One UUID starting with a digit and one starting with a letter. The whole
+// defect lives in the difference between these two.
+const UUID_LEADING_DIGIT = '550e8400-e29b-41d4-a716-446655440000';
+const UUID_LEADING_LETTER = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+
+describe('uuidParam', () => {
+    /**
+     * Minimal app with the guard wired the way a router wires it.
+     *
+     * @param {object} [options] - Passed straight to uuidParam.
+     * @returns {import('express').Express}
+     */
+    function appWithGuard(options = {}) {
+        const app = express();
+        const router = express.Router();
+
+        router.param('id', uuidParam(options));
+        router.get('/:id', (req, res) => {
+            res.status(200).json({
+                success: true,
+                raw: req.params.id,
+                attached: options.attachAs ? req[options.attachAs] : undefined
+            });
+        });
+
+        app.use('/things', router);
+        return app;
+    }
+
+    describe('accepts every well-formed UUID', () => {
+        const app = appWithGuard();
+
+        test.each([
+            ['leading digit', UUID_LEADING_DIGIT],
+            ['leading letter', UUID_LEADING_LETTER],
+            ['all-letter first block', 'abcdef01-58cc-4372-a567-0e02b2c3d479'],
+            ['uppercase', UUID_LEADING_LETTER.toUpperCase()]
+        ])('%s', async (_label, id) => {
+            const response = await request(app).get(`/things/${id}`);
+
+            expect(response.status).toBe(200);
+            expect(response.body.raw).toBe(id);
+        });
+    });
+
+    describe('rejects what is not a UUID', () => {
+        const app = appWithGuard({ resourceName: 'Product' });
+
+        test.each([
+            ['an integer', '42'],
+            ['zero', '0'],
+            ['a negative number', '-1'],
+            ['a word', 'latest'],
+            ['a truncated UUID', '550e8400-e29b-41d4-a716'],
+            ['a UUID with a non-hex character', '550e8400-e29b-41d4-a716-44665544000z'],
+            ['a SQL fragment', "1' OR '1'='1"]
+        ])('%s', async (_label, id) => {
+            const response = await request(app).get(`/things/${encodeURIComponent(id)}`);
+
+            expect(response.status).toBe(400);
+            expect(response.body).toEqual({
+                success: false,
+                message: 'Invalid product ID'
+            });
+        });
+    });
+
+    test('attaches the validated id under the requested name', async () => {
+        const app = appWithGuard({ resourceName: 'Product', attachAs: 'productId' });
+
+        const response = await request(app).get(`/things/${UUID_LEADING_LETTER}`);
+
+        expect(response.status).toBe(200);
+        // The whole id, not a number parsed off the front of it.
+        expect(response.body.attached).toBe(UUID_LEADING_LETTER);
+    });
+
+    test('names the resource in its rejection message', async () => {
+        const app = appWithGuard({ resourceName: 'Order' });
+
+        const response = await request(app).get('/things/42');
+
+        expect(response.body.message).toBe('Invalid order ID');
+    });
+
+    test('falls back to a generic message when no resource is named', async () => {
+        const response = await request(appWithGuard()).get('/things/42');
+
+        expect(response.body.message).toBe('Invalid resource ID');
+    });
+});
+
+describe('productRoutes :id guard (#1443)', () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/products', require('../routes/productRoutes'));
+
+    // GET /:id is public and unauthenticated, so a UUID that clears the guard
+    // reaches the controller and fails on the database instead -- a 500, not a
+    // 400. The distinction is the point: 400 means the guard refused the id.
+    test('does not reject a UUID beginning with a hex letter', async () => {
+        const response = await request(app).get(`/api/products/${UUID_LEADING_LETTER}`);
+
+        expect(response.status).not.toBe(400);
+    });
+
+    test('still rejects an id that is not a UUID', async () => {
+        const response = await request(app).get('/api/products/42');
+
+        expect(response.status).toBe(400);
+        expect(response.body.message).toBe('Invalid product ID');
+    });
+
+    test('rejects consistently regardless of the leading character', async () => {
+        const [digit, letter] = await Promise.all([
+            request(app).get(`/api/products/${UUID_LEADING_DIGIT}`),
+            request(app).get(`/api/products/${UUID_LEADING_LETTER}`)
+        ]);
+
+        // Before the fix these differed: 200/500 for one, 400 for the other.
+        expect(digit.status).toBe(letter.status);
+    });
+});
+
+describe('orderRoutes :id guard (#1443)', () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/orders', require('../routes/orderRoutes'));
+
+    // Order routes sit behind authMiddleware, so an unauthenticated request
+    // answers 401 once the param guard has passed it. 401 rather than 400 is
+    // exactly the evidence wanted here.
+    test('lets a UUID beginning with a hex letter reach the auth layer', async () => {
+        const response = await request(app).get(`/api/orders/${UUID_LEADING_LETTER}`);
+
+        expect(response.status).not.toBe(400);
+        expect(response.status).toBe(401);
+    });
+
+    test('treats both leading characters the same', async () => {
+        const [digit, letter] = await Promise.all([
+            request(app).get(`/api/orders/${UUID_LEADING_DIGIT}`),
+            request(app).get(`/api/orders/${UUID_LEADING_LETTER}`)
+        ]);
+
+        expect(digit.status).toBe(letter.status);
+    });
+
+    test('still rejects an integer id', async () => {
+        const response = await request(app).get('/api/orders/42');
+
+        expect(response.status).toBe(400);
+        expect(response.body.message).toBe('Invalid order ID');
+    });
+
+    // Every route that hangs off `:id`, not only the bare GET.
+    test.each([
+        ['timeline', '/timeline'],
+        ['summary', '/summary'],
+        ['status', '/status'],
+        ['invoice', '/invoice']
+    ])('%s is reachable with a letter-leading UUID', async (_label, suffix) => {
+        const response = await request(app).get(
+            `/api/orders/${UUID_LEADING_LETTER}${suffix}`
+        );
+
+        expect(response.status).not.toBe(400);
+    });
+
+    test('cancel is reachable with a letter-leading UUID', async () => {
+        const response = await request(app)
+            .patch(`/api/orders/${UUID_LEADING_LETTER}/cancel`)
+            .send({ reason: 'changed my mind' });
+
+        expect(response.status).not.toBe(400);
+    });
+});

--- a/frontend/scripts/product-cards-home.js
+++ b/frontend/scripts/product-cards-home.js
@@ -117,18 +117,21 @@ function createProductCard(
             }
         ).join("");
 
-            <img
-                src="${defaultImage(product.image)}"
-                alt="${safeText(product.name, "Product")}"
-                loading="lazy"
-                onerror="this.onerror=null; this.src='data:image/svg+xml;charset=UTF-8,%3Csvg xmlns=\\'http://www.w3.org/2000/svg\\' width=\\'200\\' height=\\'200\\' viewBox=\\'0 0 200 200\\'%3E%3Crect fill=\\'%23eee\\' width=\\'200\\' height=\\'200\\'/%3E%3Ctext fill=\\'%23999\\' font-family=\\'sans-serif\\' font-size=\\'14\\' x=\\'50%25\\' y=\\'50%25\\' text-anchor=\\'middle\\' dominant-baseline=\\'middle\\'%3ENo Image%3C/text%3E%3C/svg%3E';"
-            >
-
-    // The pre-`isProductWishlisted` version of this lookup was left in place
-    // here by a bad merge (#1341): it re-declared `wishlistIds`, which is
-    // already this function's parameter, and `isWishlisted`, already assigned
-    // above -- a SyntaxError that took the whole homepage grid offline. It also
-    // read a `wishlistSet` binding that does not exist in this scope.
+    // Stock state, read once and reused by the badge, the overlay, the
+    // low-stock line and the three disabled buttons below.
+    //
+    // These three bindings, and the orphaned image tag that stood here instead
+    // of them, were the two halves of the bad merge that took the homepage
+    // grid offline (#1444). The fragment sat at statement position --
+    // outside any template literal -- so the whole file was a SyntaxError, and
+    // the declarations the template needs went with it. The product image is
+    // rendered by the `return` template below; nothing is lost by dropping the
+    // fragment.
+    const stock = Number(product.stock) || 0;
+    const outOfStock = isOutOfStock(stock);
+    // `.pro.out-of-stock` is what styles/product-card.css dims and disables --
+    // same class shop.js puts on its cards, so both grids look the same.
+    const outOfStockClass = outOfStock ? "out-of-stock" : "";
 
     return `
         <div class="pro ${outOfStockClass} fade-in" data-id="${product.id}">

--- a/frontend/scripts/shop.js
+++ b/frontend/scripts/shop.js
@@ -18,6 +18,14 @@ let priceTouched = false;
 let productObserver = null;
 const loadedProductIds = new Set();
 
+// Legacy filter-button state, read and written by setupCategoryFilters,
+// setupSearch and clearAllFilters. These were only ever assigned, never
+// declared, so each one leaked onto `window` -- harmless while the file did
+// not parse at all, and worth closing now that it does (#1444).
+let currentCategory = "all";
+let currentSearch = "";
+let showAllHoodies = false;
+
 // Local fallback sample products (used when backend returns no products)
 const fallbackProducts = [
     // T-SHIRTS (~5)
@@ -1306,7 +1314,17 @@ document.addEventListener(
             });
         });
     }
-    
+);
+
+// Clear every active filter and go back to the default catalogue view.
+//
+// The `);` above and this declaration are what a bad merge dropped (#1444):
+// the DOMContentLoaded listener was left unclosed and this function's body ran
+// straight on from it, so the file did not parse and the whole shop page --
+// search, filters, sorting, the product list -- was dead. `setupClearFilters`
+// at the bottom binds this by name, and every binding the body reads is
+// already declared above.
+function clearAllFilters() {
     // Reset category
     filterButtons.forEach(btn => {
         btn.classList.remove('active-filter');


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`products.id` and `orders.id` are `CHAR(36)` UUIDs — declared that way in
`migrations/0001_baseline_schema.sql` and settled as the key strategy in
`migrations/0023_settle_uuid_key_strategy.sql` — and both routers validated
`:id` with `parseInt`.

That is not a weaker check than a UUID check. It is a differently-wrong one, and
which way it went depended on nothing but the first character of the key:

```js
parseInt("550e8400-e29b-41d4-a716-446655440000", 10)  // 550 -> truthy, guard passed
parseInt("f47ac10b-58cc-4372-a567-0e02b2c3d479", 10)  // NaN -> falsy,  400
```

Six of the sixteen hex digits are letters, so **roughly 37% of products and
orders answered `Invalid product ID` for a perfectly good id**, and the other 63%
got through on a truncated number that was never the id — which the handler then
ignored, re-reading `req.params.id` through `safeUUID`. The guard had never
validated anything; it only ever produced false rejections.

Everything hanging off `:id` was affected: the product detail page, its reviews,
its Q&A, and on the order side the timeline, the summary, the invoice and
cancellation.

`openapi/ecommerce.openapi.yaml` already documents the parameter as
`type: string, format: uuid`, so the code was contradicting its own published
contract. The spec needs no change.

---

## 🔗 Related Issue

Closes #1443

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other

---

## 📷 Screenshots / Demo

Backend only. Before:

```
$ curl -s -o /dev/null -w '%{http_code}\n' localhost:5000/api/products/550e8400-e29b-41d4-a716-446655440000
200
$ curl -s -o /dev/null -w '%{http_code}\n' localhost:5000/api/products/f47ac10b-58cc-4372-a567-0e02b2c3d479
400
```

After, both are treated the same.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**One definition, not two.** `middleware/uuidParam.js` replaces both copies of
the same twelve lines. It answers 400 with the exact message the controllers
already send for this condition, so a client matching on the text keeps working,
and attaches the validated id as `req.productId` / `req.orderId` — which
previously held a truncated integer whenever the guard let a request through, a
trap for the first handler to read it. `req.params` is deliberately left alone: a
param guard that rewrites the request is harder to reason about than one that
only answers yes or no.

**`validateOrderIds`** in `orderRoutes.js` carried the same `parseInt` defect.
Nothing wires it up, so it was not reachable — but it would have taken the bug
with it the moment a bulk route was added.

**Tests.** `tests/uuidParam.test.js` drives the real routers through a real
Express app and asserts the two leading characters are now treated identically,
which is the assertion that fails if this regresses. No database is touched: each
case only asserts a request got *past* the param guard (200/500 for the public
product route, 401 for the authenticated order routes) — a 400 is what "the guard
refused it" looks like, and that is the whole distinction under test.

**Merge order.** Built on #1448, which unblocks the CI syntax and boot gates —
`orderRoutes.js` cannot even be required on `main` today, so this PR's tests
cannot run without it. Merge #1448 first and this diff reduces to the four files
listed above plus the new middleware and test.
