### PR TITLE
Stop /forgot-password telling callers whether an address has an account

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -5,7 +5,25 @@
 
 const bcrypt = require("bcryptjs");
 const crypto = require("crypto");
+// Four imports this file uses but never declared. Not part of #1455, but the
+// reset path below calls two of them, so it could not be tested without them:
+//
+//   jwt                 -- generateAccessToken:106 calls jwt.sign
+//   revokeUserSessions  -- resetPassword, deactivate and delete-account all
+//   REVOKE_REASON          call these when invalidating sessions
+//   logger              -- used by the new suppression log below
+//
+// Each was a `ReferenceError: <name> is not defined` at the point of use. They
+// are inside handlers rather than at module scope, so the file loads fine, the
+// syntax gate passes and the boot check passes -- it only fails when someone
+// actually signs in or resets a password. See the PR description.
+const jwt = require("jsonwebtoken");
 const db = require("../config/db");
+const logger = require("../config/logger");
+const {
+    revokeUserSessions,
+    REVOKE_REASON
+} = require("../services/authSessionService");
 const { sanitizeString, safeArray } = require("../utils/helpers");
 const { getClearCookieOptions } = require("../config/cookieConfig");
 const { PERMISSIONS, hasPermission } = require("../config/policy");
@@ -14,6 +32,10 @@ const agentIdentityService = require("../services/agentIdentityService");
 // Lockout state lives in Redis so it survives a restart and is observed by
 // every instance; the policy it enforces is unchanged.
 const loginLockoutService = require("../services/loginLockoutService");
+// The per-address "send me a code" budget, moved out of a module-scope Map for
+// the same reasons (#1455). This is the anti-mail-bomb limit; the per-caller
+// limit is the route middleware in middleware/rateLimiter.js.
+const otpRequestLimiter = require("../services/otpRequestLimiter");
 // A basket built before signing in belongs to the account afterwards (#1427).
 const { mergeGuestCartOnSignIn } = require("../services/cartMergeService");
 
@@ -27,9 +49,20 @@ const { encrypt, decrypt } = require('../utils/encryption');
 
 // ==================== CONSTANTS ====================
 const OTP_EXPIRY_MINUTES = parseInt(process.env.OTP_EXPIRY_MINUTES) || 10;
-const OTP_RATE_LIMIT_WINDOW = 5 * 60 * 1000; // 5 minutes
-const OTP_RATE_LIMIT_MAX = 3; // Max 3 OTP requests per window
 const CLEANUP_INTERVAL = 5 * 60 * 1000; // 5 minutes
+
+// The one sentence /forgot-password says, whatever it finds behind the address.
+//
+// Three branches used to answer here with three different (status, success,
+// message) triples -- unknown address, unverified account, verified account --
+// which is an account-existence oracle for anyone who can send a POST (#1455).
+// Every path now ends on this exact response, so the reply carries no
+// information about the account. It is a constant rather than three string
+// literals specifically so the three call sites cannot drift apart again.
+const FORGOT_PASSWORD_RESPONSE = Object.freeze({
+    success: true,
+    message: "If that address has an account, a reset code is on its way to it."
+});
 const {
     MAX_LOGIN_ATTEMPTS,
     LOGIN_LOCKOUT_DURATION,
@@ -41,24 +74,19 @@ const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const strongPasswordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])/;
 const otpRegex = /^\d{6}$/;
 
-// ==================== RATE LIMITING ====================
-const otpRateLimiter = new Map();
-
 // ==================== PENDING SIGNUPS CACHE ====================
 const pendingSignups = new Map();
 
-// Clean up expired pending signups every 5 minutes
+// Clean up expired pending signups every 5 minutes.
+//
+// This used to sweep the OTP rate limiter's Map too. That Map is gone --
+// services/otpRequestLimiter.js keeps the counters in Redis now, where they
+// expire on their own and are shared between instances (#1455).
 setInterval(() => {
     const now = Date.now();
     for (const [email, data] of pendingSignups.entries()) {
         if (now > data.expiresAt) {
             pendingSignups.delete(email);
-        }
-    }
-    // Clean up expired rate limiter entries
-    for (const [key, data] of otpRateLimiter.entries()) {
-        if (now > data.resetTime) {
-            otpRateLimiter.delete(key);
         }
     }
 }, CLEANUP_INTERVAL);
@@ -128,27 +156,20 @@ function sendAuthResponse(res, { message, accessToken, refreshToken, user, famil
     });
 }
 
-function isOTPRateLimited(email) {
-    const now = Date.now();
-    const key = `otp_${email}`;
-    const record = otpRateLimiter.get(key);
-    
-    if (!record) {
-        otpRateLimiter.set(key, { count: 1, resetTime: now + OTP_RATE_LIMIT_WINDOW });
-        return false;
-    }
-    
-    if (now > record.resetTime) {
-        otpRateLimiter.set(key, { count: 1, resetTime: now + OTP_RATE_LIMIT_WINDOW });
-        return false;
-    }
-    
-    if (record.count >= OTP_RATE_LIMIT_MAX) {
-        return true;
-    }
-    
-    record.count++;
-    return false;
+/**
+ * Take one request from the per-address code-sending budget.
+ *
+ * Thin wrapper over the service so the two callers read the same way. The
+ * counters used to be a module-scope `Map` here: a restart cleared them, two
+ * instances each kept their own, and the map grew one entry per address asked
+ * about until a five-minute sweep ran (#1455).
+ *
+ * @param {string} email
+ * @returns {Promise<boolean>} true when the budget is spent.
+ */
+async function isOTPRateLimited(email) {
+    const { allowed } = await otpRequestLimiter.consume(email);
+    return !allowed;
 }
 
 const {
@@ -180,10 +201,10 @@ const signup = async (req, res) => {
         }
 
         // Rate limiting
-        if (isOTPRateLimited(cleanEmail)) {
-            return res.status(429).json({ 
-                success: false, 
-                message: "Too many OTP requests. Please wait 5 minutes." 
+        if (await isOTPRateLimited(cleanEmail)) {
+            return res.status(429).json({
+                success: false,
+                message: "Too many OTP requests. Please wait 5 minutes."
             });
         }
 
@@ -441,50 +462,87 @@ const logout = async (req, res) => {
     }
 };
 // ==================== 5. FORGOT PASSWORD ====================
+/**
+ * Start a password reset.
+ *
+ * Every outcome ends on FORGOT_PASSWORD_RESPONSE. That is the whole point of
+ * this handler (#1455): it previously answered
+ *
+ *   unknown address     -> 200 "If the email is registered, an OTP has been sent."
+ *   unverified account  -> 400 "Please verify your email first ..."
+ *   verified account    -> 200 "OTP sent to your email"
+ *
+ * so three POSTs recovered two bits of state about any address a caller cared
+ * to name. The branching still happens -- it just happens silently, on this
+ * side, and the caller cannot see which branch ran.
+ *
+ * Four things follow from that and are easy to undo by accident, so they are
+ * spelled out here:
+ *
+ *   1. A malformed address gets the same response too. "That is not an email"
+ *      is genuinely caller-side information rather than account information, so
+ *      returning 400 would be defensible -- but it costs nothing to be uniform
+ *      and the client validates the format anyway.
+ *
+ *   2. An exhausted per-address budget also gets it. A 429 keyed on the
+ *      *subject* would say "somebody asked about this address recently", which
+ *      is exactly the kind of fact this handler exists to withhold. The
+ *      per-caller 429 from forgotPasswordLimiter is fine and still applies --
+ *      it describes the caller, not the account.
+ *
+ *   3. A failure from Appwrite is logged and swallowed. A 500 on send-failure
+ *      but a 200 on unknown-address is a slower version of the same oracle,
+ *      since only a real address reaches the send at all.
+ *
+ *   4. Unverified accounts are sent the code rather than refused. Redeeming a
+ *      code mailed to an address *is* proof of control of that address, so
+ *      there is nothing for the old gate to protect -- and it permanently
+ *      stranded anyone who signed up, never clicked, and later forgot the
+ *      password, since reset is the only way back in. resetPassword sets
+ *      is_verified on the way through.
+ */
 const forgotPassword = async (req, res) => {
+    const respond = () => res.status(200).json(FORGOT_PASSWORD_RESPONSE);
+
     try {
         const { email } = req.body;
         const cleanEmail = sanitizeString(email).toLowerCase();
 
         if (!emailRegex.test(cleanEmail)) {
-            return res.status(400).json({ success: false, message: "Invalid email format" });
+            return respond();
         }
 
-        // Rate limiting
-        if (isOTPRateLimited(cleanEmail)) {
-            return res.status(429).json({ 
-                success: false, 
-                message: "Too many OTP requests. Please wait 5 minutes." 
-            });
+        // Anti-mail-bomb, per address. Consumed before the lookup so the number
+        // of database queries an address attracts does not track its existence.
+        if (await isOTPRateLimited(cleanEmail)) {
+            logger.warn(
+                'Password reset code suppressed: per-address budget exhausted'
+            );
+            return respond();
         }
 
-        const [users] = await db.query(`SELECT id, is_verified AS email_verified FROM users WHERE email = ? LIMIT 1`, [cleanEmail]);
+        const [users] = await db.query(
+            `SELECT id, is_verified AS email_verified FROM users WHERE email = ? LIMIT 1`,
+            [cleanEmail]
+        );
+
         if (!safeArray(users).length) {
-            // Security: Don't reveal if email exists
-            return res.status(200).json({ 
-                success: true, 
-                message: "If the email is registered, an OTP has been sent." 
-            });
+            return respond();
         }
 
-        const user = users[0];
-        if (!user.email_verified) {
-            return res.status(400).json({ 
-                success: false, 
-                message: "Please verify your email first before requesting password reset." 
-            });
+        try {
+            await appwriteAccount.createEmailToken(ID.unique(), cleanEmail);
+        } catch (sendError) {
+            // Logged, not surfaced -- see (3) above.
+            console.error("FORGOT PASSWORD SEND ERROR:", sendError);
         }
 
-        // Send OTP via Appwrite
-        await appwriteAccount.createEmailToken(ID.unique(), cleanEmail);
-        
-        return res.status(200).json({
-            success: true,
-            message: "OTP sent to your email"
-        });
+        return respond();
     } catch (error) {
         console.error("FORGOT PASSWORD ERROR:", error);
-        return res.status(500).json({ success: false, message: "Failed to send reset OTP" });
+        // Even an unexpected failure answers the same way. Anything else and
+        // the error itself becomes the signal.
+        return respond();
     }
 };
 
@@ -534,9 +592,27 @@ const resetPassword = async (req, res) => {
             console.warn("Failed to update password in Appwrite:", pwErr.message);
         }
 
-        // Update password in MySQL
+        // Update password in MySQL.
+        //
+        // `is_verified` is set in the same statement. The code that got the
+        // caller here was mailed to this address and they read it, which is the
+        // entire content of "this address is verified" -- so an account that
+        // completes a reset has verified itself by definition.
+        //
+        // That is also what makes it safe for forgotPassword to have stopped
+        // refusing unverified accounts (#1455): before, such an account was
+        // told to verify first, could not, and was locked out for good, because
+        // reset is the only way back in for someone who has lost the password.
         const hashedPassword = await bcrypt.hash(newPassword, 10);
-        await db.query(`UPDATE users SET password = ? WHERE email = ?`, [hashedPassword, appwriteUser.email]);
+        await db.query(
+            `UPDATE users SET password = ?, is_verified = 1 WHERE email = ?`,
+            [hashedPassword, appwriteUser.email]
+        );
+
+        // The address has demonstrably reached its owner, so the anti-mail-bomb
+        // budget has done its job; hand it back rather than making a legitimate
+        // second attempt wait out the window.
+        await otpRequestLimiter.release(appwriteUser.email);
 
         // A reset is the path someone takes when they may have lost control of
         // the account, so every existing session goes -- there is no session to

--- a/backend/services/otpRequestLimiter.js
+++ b/backend/services/otpRequestLimiter.js
@@ -1,0 +1,256 @@
+// backend/services/otpRequestLimiter.js
+//
+// The per-address budget for "send me a code" endpoints, held in Redis (#1455).
+//
+// There are two limits on these endpoints and they do different jobs, which is
+// why both exist:
+//
+//   middleware/rateLimiter.js  -- per *caller*. Stops one client hammering the
+//                                 endpoint. Answers with 429, which is honest:
+//                                 it describes the caller's own behaviour and
+//                                 says nothing about any account.
+//
+//   this module                -- per *subject*, i.e. per address being asked
+//                                 about. Stops a hundred callers between them
+//                                 mail-bombing one victim, which the per-caller
+//                                 limit cannot see.
+//
+// The per-subject budget deliberately does **not** surface as a 429. Whether a
+// given address has been asked about recently is information about that address,
+// and this whole area exists because that kind of information was leaking. The
+// caller is told the same thing either way and the send is simply skipped --
+// see `forgotPassword` in controllers/authController.js.
+//
+// This state used to be a `Map` in the auth controller's module scope, which
+// meant a restart cleared every budget, two instances each kept their own, and
+// the map grew one entry per distinct address until a five-minute sweep ran.
+// The policy -- 3 requests per 5 minutes per address -- is unchanged; only where
+// the counters live has moved. The Redis-outage behaviour matches
+// services/loginLockoutService.js and config/redisRateLimitStore.js: fall back
+// to per-process counting and log loudly, because refusing every password reset
+// while Redis is down would be a worse failure than counting imprecisely.
+
+'use strict';
+
+const crypto = require('crypto');
+const redis = require('../config/redis');
+const logger = require('../config/logger');
+
+// Same defaults the controller's Map used, still overridable by env so the
+// value is not baked into two places.
+const OTP_REQUEST_MAX =
+    parseInt(process.env.OTP_REQUEST_MAX, 10) || 3;
+
+const OTP_REQUEST_WINDOW_MS =
+    parseInt(process.env.OTP_REQUEST_WINDOW_MS, 10) || 5 * 60 * 1000;
+
+const KEY_PREFIX = 'auth:otp-budget';
+const OUTAGE_LOG_INTERVAL_MS = 60 * 1000;
+const SCAN_BATCH = 100;
+
+/**
+ * Increment a counter and set its expiry on first use, in one round trip.
+ *
+ * INCR-then-EXPIRE from the client side has a window where the process dies
+ * between the two calls and leaves a counter with no TTL -- which would lock
+ * that address out permanently. Doing both inside the script removes it.
+ *
+ * `string.format('%d', ...)` rather than `tostring`: Lua numbers are doubles and
+ * `tostring` renders large millisecond values in exponential notation, silently
+ * losing the low digits. Same reason as the scripts in loginLockoutService.
+ */
+const CONSUME_SCRIPT = `
+local key = KEYS[1]
+local windowMs = tonumber(ARGV[1])
+
+local count = redis.call('INCR', key)
+if count == 1 then
+    redis.call('PEXPIRE', key, string.format('%d', windowMs))
+end
+
+local ttl = redis.call('PTTL', key)
+
+-- A key with no TTL should not exist, but if one somehow does it would never
+-- expire and would bar the address for good. Repair it rather than trust it.
+if ttl < 0 then
+    redis.call('PEXPIRE', key, string.format('%d', windowMs))
+    ttl = windowMs
+end
+
+return { count, ttl }
+`;
+
+/**
+ * Normalise an address and hash it into a key.
+ *
+ * Lowercased and trimmed first, because sign-in resolves the account that way:
+ * without it "User@x.com" and "user@x.com" are one account but two budgets, and
+ * the limit is bypassed by holding down shift.
+ *
+ * Hashed rather than interpolated because the value arrives on a public
+ * endpoint. That keeps arbitrary caller input out of the keyspace, and stops a
+ * `SCAN auth:otp-budget:*` from returning a list of customer addresses.
+ *
+ * @param {string} subject
+ * @returns {string}
+ */
+const budgetKey = (subject) => {
+    const normalized = String(subject || '').trim().toLowerCase();
+    const digest = crypto.createHash('sha256').update(normalized).digest('hex');
+    return `${KEY_PREFIX}:${digest}`;
+};
+
+// Per-process fallback, used only while Redis is unreachable.
+const fallbackCounters = new Map();
+let lastOutageLogAt = 0;
+
+const reportOutage = (operation, error) => {
+    const now = Date.now();
+    if (now - lastOutageLogAt < OUTAGE_LOG_INTERVAL_MS) {
+        return;
+    }
+
+    lastOutageLogAt = now;
+    logger.error(
+        `OTP request budget store unavailable (${operation}): ${error.message}. `
+        + 'Falling back to per-process counting; budgets are not shared across '
+        + 'instances and will not survive a restart.'
+    );
+};
+
+/**
+ * The fallback path. Same arithmetic, in memory.
+ *
+ * Unlike the `Map` this replaced, expired records are dropped on read rather
+ * than waiting for a sweep, so the map only holds addresses seen inside the
+ * current window.
+ *
+ * @param {string} key
+ * @param {number} now
+ * @returns {{ count: number, resetInMs: number }}
+ */
+const consumeLocally = (key, now) => {
+    const record = fallbackCounters.get(key);
+
+    if (!record || now >= record.expiresAt) {
+        const expiresAt = now + OTP_REQUEST_WINDOW_MS;
+        fallbackCounters.set(key, { count: 1, expiresAt });
+        return { count: 1, resetInMs: OTP_REQUEST_WINDOW_MS };
+    }
+
+    record.count += 1;
+    return { count: record.count, resetInMs: record.expiresAt - now };
+};
+
+/**
+ * Take one request from the budget for `subject`.
+ *
+ * Always consumes, including on the request that trips the limit, so a caller
+ * sitting on a refused address does not get a free retry every window boundary.
+ *
+ * @param {string} subject Address the code would be sent to.
+ * @returns {Promise<{allowed: boolean, count: number, limit: number, resetInMs: number}>}
+ */
+const consume = async (subject) => {
+    const key = budgetKey(subject);
+    const now = Date.now();
+
+    let count;
+    let resetInMs;
+
+    try {
+        const result = await redis.eval(
+            CONSUME_SCRIPT,
+            1,
+            key,
+            OTP_REQUEST_WINDOW_MS
+        );
+
+        // ioredis hands back an array of strings for a Lua table of numbers.
+        count = Number(Array.isArray(result) ? result[0] : result);
+        resetInMs = Number(Array.isArray(result) ? result[1] : OTP_REQUEST_WINDOW_MS);
+
+        // A double that cannot be read is not a reason to refuse a password
+        // reset; treat it the same way as an outage.
+        if (!Number.isFinite(count)) {
+            throw new Error('OTP budget script returned a non-numeric count');
+        }
+    } catch (error) {
+        reportOutage('consume', error);
+        ({ count, resetInMs } = consumeLocally(key, now));
+    }
+
+    return {
+        allowed: count <= OTP_REQUEST_MAX,
+        count,
+        limit: OTP_REQUEST_MAX,
+        resetInMs: Number.isFinite(resetInMs) && resetInMs > 0
+            ? resetInMs
+            : OTP_REQUEST_WINDOW_MS
+    };
+};
+
+/**
+ * Give an address its budget back.
+ *
+ * Called once a code has actually been redeemed: the address has demonstrably
+ * reached its owner, so the anti-mail-bomb counter has done its job and should
+ * not hold a legitimate retry against them.
+ *
+ * @param {string} subject
+ * @returns {Promise<void>}
+ */
+const release = async (subject) => {
+    const key = budgetKey(subject);
+    fallbackCounters.delete(key);
+
+    try {
+        await redis.del(key);
+    } catch (error) {
+        reportOutage('release', error);
+    }
+};
+
+/**
+ * Drop every tracked budget. Test-only; production keys expire on their own.
+ *
+ * @returns {Promise<void>}
+ */
+const clear = async () => {
+    fallbackCounters.clear();
+    // Reset the once-a-minute outage log throttle too. Without this the first
+    // test to simulate an outage swallows the log line every later test in the
+    // same file would assert on, because the throttle is module state and Jest
+    // does not reset it between tests.
+    lastOutageLogAt = 0;
+
+    try {
+        // SCAN rather than KEYS so this cannot block a shared Redis.
+        let cursor = '0';
+        do {
+            const [nextCursor, keys] = await redis.scan(
+                cursor,
+                'MATCH',
+                `${KEY_PREFIX}:*`,
+                'COUNT',
+                SCAN_BATCH
+            );
+            cursor = nextCursor;
+
+            if (keys.length > 0) {
+                await redis.del(...keys);
+            }
+        } while (cursor !== '0');
+    } catch (error) {
+        reportOutage('clear', error);
+    }
+};
+
+module.exports = {
+    consume,
+    release,
+    clear,
+    budgetKey,
+    OTP_REQUEST_MAX,
+    OTP_REQUEST_WINDOW_MS
+};

--- a/backend/tests/forgotPasswordEnumeration.test.js
+++ b/backend/tests/forgotPasswordEnumeration.test.js
@@ -1,0 +1,287 @@
+// backend/tests/forgotPasswordEnumeration.test.js
+//
+// /api/auth/forgot-password must answer identically whatever it finds behind
+// the address (#1455).
+//
+// It used to answer three ways -- 200 "If the email is registered..." for an
+// unknown address, 400 "Please verify your email first..." for an unverified
+// account, 200 "OTP sent to your email" for a verified one -- which is an
+// account-existence oracle for anyone who can send a POST.
+//
+// The assertions here are deliberately written as "every case produces the same
+// bytes" rather than "case X produces string Y". Pinning the literals would let
+// someone change one branch's copy and still have a green suite; comparing the
+// cases against each other is the property that actually matters, and it stays
+// true if the wording is later reworded.
+
+const mockCreateEmailToken = jest.fn().mockResolvedValue({ userId: 'appwrite-user' });
+
+jest.mock('../config/db', () => ({
+    query: jest.fn().mockResolvedValue([[]]),
+    getConnection: jest.fn()
+}));
+
+jest.mock('../config/redis', () => ({
+    eval: jest.fn().mockResolvedValue([1, 300000]),
+    del: jest.fn().mockResolvedValue(1),
+    scan: jest.fn().mockResolvedValue(['0', []]),
+    connect: jest.fn().mockResolvedValue(undefined),
+    on: jest.fn(function on() { return this; }),
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue('OK'),
+    setex: jest.fn().mockResolvedValue('OK'),
+    duplicate: jest.fn(function duplicate() { return this; }),
+    status: 'ready'
+}));
+
+jest.mock('../config/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+// The controller builds an Appwrite client at module scope. Only the one call
+// forgotPassword makes is interesting; the rest of the SDK is stubbed so the
+// module can load without credentials or a network.
+jest.mock('node-appwrite', () => ({
+    Client: jest.fn().mockImplementation(() => ({
+        setEndpoint() { return this; },
+        setProject() { return this; },
+        setSession() { return this; }
+    })),
+    Account: jest.fn().mockImplementation(() => ({
+        createEmailToken: (...args) => mockCreateEmailToken(...args),
+        createSession: jest.fn(),
+        get: jest.fn(),
+        updatePassword: jest.fn(),
+        deleteSession: jest.fn()
+    })),
+    Databases: jest.fn().mockImplementation(() => ({})),
+    ID: { unique: () => 'unique-id' }
+}));
+
+const db = require('../config/db');
+const redis = require('../config/redis');
+const otpRequestLimiter = require('../services/otpRequestLimiter');
+const { forgotPassword } = require('../controllers/authController');
+
+const UNKNOWN = 'nobody@example.com';
+const UNVERIFIED = 'signed-up-never-clicked@example.com';
+const VERIFIED = 'real-customer@example.com';
+
+/** Rows the users lookup returns for each of the three cases. */
+const rowsFor = (email) => {
+    if (email === VERIFIED) return [{ id: 'user-1', email_verified: 1 }];
+    if (email === UNVERIFIED) return [{ id: 'user-2', email_verified: 0 }];
+    return [];
+};
+
+/** A minimal res that records what the handler said. */
+const makeRes = () => {
+    const res = {
+        statusCode: null,
+        body: null,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        }
+    };
+    return res;
+};
+
+/**
+ * Call the handler and return everything a caller could observe.
+ *
+ * @param {string} email
+ * @returns {Promise<{statusCode: number, body: object}>}
+ */
+const ask = async (email) => {
+    const res = makeRes();
+    await forgotPassword({ body: { email }, headers: {}, ip: '203.0.113.10' }, res);
+    return { statusCode: res.statusCode, body: res.body };
+};
+
+beforeEach(async () => {
+    jest.clearAllMocks();
+    await otpRequestLimiter.clear();
+    jest.clearAllMocks();
+
+    // The budget is a real counter for these tests, not a stub that always
+    // answers "first request" -- otherwise the suppression case below can never
+    // be reached. The double implements the [count, ttl] contract the service's
+    // Lua script has, keyed the same way Redis would key it.
+    const counts = new Map();
+    redis.eval.mockImplementation(async (_script, _numKeys, key, windowMs) => {
+        const next = (counts.get(key) || 0) + 1;
+        counts.set(key, next);
+        return [next, Number(windowMs)];
+    });
+
+    db.query.mockImplementation(async (_sql, params) => [rowsFor(params?.[0])]);
+    mockCreateEmailToken.mockResolvedValue({ userId: 'appwrite-user' });
+});
+
+describe('the response carries no information about the account', () => {
+    test('unknown, unverified and verified addresses get byte-identical replies', async () => {
+        const unknown = await ask(UNKNOWN);
+        const unverified = await ask(UNVERIFIED);
+        const verified = await ask(VERIFIED);
+
+        expect(unknown).toEqual(unverified);
+        expect(unverified).toEqual(verified);
+    });
+
+    test('all three are 200 with success: true', async () => {
+        // The status code alone used to separate registered from unregistered.
+        for (const email of [UNKNOWN, UNVERIFIED, VERIFIED]) {
+            const { statusCode, body } = await ask(email);
+            expect(statusCode).toBe(200);
+            expect(body.success).toBe(true);
+        }
+    });
+
+    test('the message names no account state', async () => {
+        const { body } = await ask(VERIFIED);
+
+        // The old copy said "OTP sent to your email" for a verified account and
+        // "Please verify your email first" for an unverified one. Neither the
+        // address nor either word may appear.
+        expect(body.message).not.toContain(VERIFIED);
+        expect(body.message.toLowerCase()).not.toMatch(/verify your email/);
+        expect(body.message.toLowerCase()).not.toMatch(/\bregistered\b/);
+    });
+
+    test('a malformed address is answered the same way', async () => {
+        const malformed = await ask('not-an-email');
+        const unknown = await ask(UNKNOWN);
+
+        expect(malformed).toEqual(unknown);
+    });
+
+    test('a missing body field is answered the same way', async () => {
+        const res = makeRes();
+        await forgotPassword({ body: {}, headers: {}, ip: '203.0.113.10' }, res);
+
+        expect({ statusCode: res.statusCode, body: res.body })
+            .toEqual(await ask(UNKNOWN));
+    });
+});
+
+describe('what actually happens behind the uniform response', () => {
+    test('a verified account is sent a code', async () => {
+        await ask(VERIFIED);
+        expect(mockCreateEmailToken)
+            .toHaveBeenCalledWith('unique-id', VERIFIED);
+    });
+
+    test('an unverified account is sent one too', async () => {
+        // Redeeming a code mailed to an address proves control of it, which is
+        // the whole content of "verified". Refusing here used to strand anyone
+        // who signed up, never clicked, and then forgot their password --
+        // reset is the only way back in.
+        await ask(UNVERIFIED);
+        expect(mockCreateEmailToken)
+            .toHaveBeenCalledWith('unique-id', UNVERIFIED);
+    });
+
+    test('an unknown address is not mailed', async () => {
+        await ask(UNKNOWN);
+        expect(mockCreateEmailToken).not.toHaveBeenCalled();
+    });
+
+    test('a malformed address never reaches the database', async () => {
+        await ask('not-an-email');
+        expect(db.query).not.toHaveBeenCalled();
+    });
+
+    test('the address is lowercased before lookup', async () => {
+        await ask('  REAL-CUSTOMER@EXAMPLE.COM  ');
+        expect(db.query).toHaveBeenCalledWith(expect.any(String), [VERIFIED]);
+    });
+});
+
+describe('failures do not become a signal', () => {
+    test('a send failure still answers like everything else', async () => {
+        // A 500 on send-failure and a 200 on unknown-address is the same oracle
+        // wearing a different hat: only a real address reaches the send at all.
+        mockCreateEmailToken.mockRejectedValue(new Error('provider down'));
+
+        const failed = await ask(VERIFIED);
+        mockCreateEmailToken.mockResolvedValue({ userId: 'x' });
+        const unknown = await ask(UNKNOWN);
+
+        expect(failed).toEqual(unknown);
+    });
+
+    test('a database failure still answers like everything else', async () => {
+        db.query.mockRejectedValue(new Error('ER_LOCK_WAIT_TIMEOUT'));
+
+        const broken = await ask(VERIFIED);
+
+        db.query.mockImplementation(async (_sql, params) => [rowsFor(params?.[0])]);
+        const unknown = await ask(UNKNOWN);
+
+        expect(broken).toEqual(unknown);
+    });
+});
+
+describe('the per-address budget', () => {
+    test('suppresses the send once spent, without changing the response', async () => {
+        // A 429 keyed on the *subject* would say "somebody asked about this
+        // address recently", which is exactly what this endpoint must not say.
+        // The per-caller 429 from the route limiter is unaffected.
+        const budget = otpRequestLimiter.OTP_REQUEST_MAX;
+
+        for (let i = 0; i < budget; i++) {
+            await ask(VERIFIED);
+        }
+        expect(mockCreateEmailToken).toHaveBeenCalledTimes(budget);
+
+        const overBudget = await ask(VERIFIED);
+
+        expect(mockCreateEmailToken).toHaveBeenCalledTimes(budget);
+        expect(overBudget.statusCode).toBe(200);
+        expect(overBudget).toEqual(await ask(UNKNOWN));
+    });
+
+    test('is consumed before the lookup, so query count does not track existence', async () => {
+        // If the budget were spent after the lookup, an unknown address would
+        // cost one query and a known one would cost one query plus a send --
+        // and the number of queries an address attracts would itself be the
+        // answer. Both cases must look the same from outside.
+        const budget = otpRequestLimiter.OTP_REQUEST_MAX;
+
+        for (let i = 0; i <= budget; i++) {
+            await ask(UNKNOWN);
+        }
+        const unknownQueries = db.query.mock.calls.length;
+
+        jest.clearAllMocks();
+        db.query.mockImplementation(async (_sql, params) => [rowsFor(params?.[0])]);
+
+        for (let i = 0; i <= budget; i++) {
+            await ask(VERIFIED);
+        }
+
+        expect(db.query.mock.calls.length).toBe(unknownQueries);
+    });
+
+    test('one address being exhausted does not affect another', async () => {
+        for (let i = 0; i <= otpRequestLimiter.OTP_REQUEST_MAX; i++) {
+            await ask(VERIFIED);
+        }
+
+        jest.clearAllMocks();
+        db.query.mockImplementation(async (_sql, params) => [rowsFor(params?.[0])]);
+
+        await ask('someone-else@example.com');
+        // Unknown address, so no send -- but it got as far as the lookup, which
+        // is what shows the budget is per address and not global.
+        expect(db.query).toHaveBeenCalled();
+    });
+});

--- a/backend/tests/otpRequestLimiter.test.js
+++ b/backend/tests/otpRequestLimiter.test.js
@@ -1,0 +1,250 @@
+// backend/tests/otpRequestLimiter.test.js
+//
+// The per-address code-sending budget (#1455): the arithmetic, the key it
+// counts against, and what it does when Redis is not there.
+//
+// The behaviour this replaced lived in a module-scope `Map` in authController
+// and had no tests at all, which is how it stayed per-process and unbounded
+// through several rounds of work on that file.
+
+const REDIS_KEY_PATTERN = /^auth:otp-budget:[0-9a-f]{64}$/;
+
+jest.mock('../config/redis', () => ({
+    eval: jest.fn(),
+    del: jest.fn().mockResolvedValue(1),
+    scan: jest.fn().mockResolvedValue(['0', []])
+}));
+
+jest.mock('../config/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+const crypto = require('crypto');
+const redis = require('../config/redis');
+const logger = require('../config/logger');
+const limiter = require('../services/otpRequestLimiter');
+
+const EMAIL = 'shopper@example.com';
+const EXPECTED_KEY =
+    `auth:otp-budget:${crypto.createHash('sha256').update(EMAIL).digest('hex')}`;
+
+/**
+ * Make Redis behave like a real counter for the duration of one test.
+ *
+ * The service's contract with the script is "give me back [count, ttl]", so the
+ * double implements exactly that and nothing else.
+ *
+ * @returns {Map<string, number>} the counts, for assertions.
+ */
+const withCountingRedis = () => {
+    const counts = new Map();
+
+    redis.eval.mockImplementation(async (_script, _numKeys, key, windowMs) => {
+        const next = (counts.get(key) || 0) + 1;
+        counts.set(key, next);
+        return [next, Number(windowMs)];
+    });
+
+    return counts;
+};
+
+beforeEach(async () => {
+    jest.clearAllMocks();
+    redis.del.mockResolvedValue(1);
+    redis.scan.mockResolvedValue(['0', []]);
+    // Clear the in-process fallback so an outage test does not leak counts into
+    // the next one.
+    redis.eval.mockResolvedValue([1, limiter.OTP_REQUEST_WINDOW_MS]);
+    await limiter.clear();
+    jest.clearAllMocks();
+});
+
+describe('key derivation', () => {
+    test('one account, one budget, whatever the caller capitalises', () => {
+        // Sign-in resolves the account on a lowercased address. If the budget
+        // keyed on the raw string, holding down shift would mint a fresh one.
+        expect(limiter.budgetKey('Shopper@Example.com')).toBe(EXPECTED_KEY);
+        expect(limiter.budgetKey('  SHOPPER@EXAMPLE.COM  ')).toBe(EXPECTED_KEY);
+    });
+
+    test('keeps caller-supplied text out of the keyspace', () => {
+        // The value arrives on an unauthenticated endpoint. Hashing stops
+        // arbitrary input becoming a Redis key name, and stops a
+        // `SCAN auth:otp-budget:*` returning a list of customer addresses.
+        expect(limiter.budgetKey(EMAIL)).not.toContain(EMAIL);
+        expect(limiter.budgetKey(EMAIL)).toMatch(REDIS_KEY_PATTERN);
+    });
+
+    test('distinct addresses do not share a budget', () => {
+        expect(limiter.budgetKey('a@example.com'))
+            .not.toBe(limiter.budgetKey('b@example.com'));
+    });
+
+    test('a missing address still produces a usable key', () => {
+        expect(limiter.budgetKey(undefined)).toMatch(REDIS_KEY_PATTERN);
+        expect(limiter.budgetKey(null)).toMatch(REDIS_KEY_PATTERN);
+    });
+});
+
+describe('consuming the budget', () => {
+    test('allows exactly OTP_REQUEST_MAX requests, then refuses', async () => {
+        withCountingRedis();
+
+        for (let attempt = 1; attempt <= limiter.OTP_REQUEST_MAX; attempt++) {
+            const result = await limiter.consume(EMAIL);
+            expect(result.allowed).toBe(true);
+            expect(result.count).toBe(attempt);
+        }
+
+        const refused = await limiter.consume(EMAIL);
+        expect(refused.allowed).toBe(false);
+        expect(refused.count).toBe(limiter.OTP_REQUEST_MAX + 1);
+    });
+
+    test('keeps counting past the limit', async () => {
+        // Consuming on the refused request too is deliberate: if the counter
+        // stopped moving, a caller parked on a refused address would get a free
+        // attempt on every window boundary.
+        withCountingRedis();
+
+        for (let i = 0; i < limiter.OTP_REQUEST_MAX + 3; i++) {
+            await limiter.consume(EMAIL);
+        }
+
+        const result = await limiter.consume(EMAIL);
+        expect(result.count).toBe(limiter.OTP_REQUEST_MAX + 4);
+        expect(result.allowed).toBe(false);
+    });
+
+    test('budgets are per address', async () => {
+        const counts = withCountingRedis();
+
+        for (let i = 0; i <= limiter.OTP_REQUEST_MAX; i++) {
+            await limiter.consume('victim@example.com');
+        }
+
+        // Exhausting one address must not touch another's.
+        const other = await limiter.consume('bystander@example.com');
+        expect(other.allowed).toBe(true);
+        expect(other.count).toBe(1);
+        expect(counts.size).toBe(2);
+    });
+
+    test('passes the window to Redis so the counter can expire itself', async () => {
+        withCountingRedis();
+
+        await limiter.consume(EMAIL);
+
+        expect(redis.eval).toHaveBeenCalledWith(
+            expect.stringContaining('PEXPIRE'),
+            1,
+            EXPECTED_KEY,
+            limiter.OTP_REQUEST_WINDOW_MS
+        );
+    });
+
+    test('reports a reset delay even when Redis returns a nonsense TTL', async () => {
+        redis.eval.mockResolvedValue([1, -1]);
+
+        const result = await limiter.consume(EMAIL);
+
+        expect(result.resetInMs).toBe(limiter.OTP_REQUEST_WINDOW_MS);
+    });
+});
+
+describe('releasing the budget', () => {
+    test('drops the key so a redeemed code does not cost the next attempt', async () => {
+        await limiter.release(EMAIL);
+        expect(redis.del).toHaveBeenCalledWith(EXPECTED_KEY);
+    });
+
+    test('a failing del is logged, not thrown', async () => {
+        redis.del.mockRejectedValue(new Error('connection reset'));
+
+        await expect(limiter.release(EMAIL)).resolves.toBeUndefined();
+        expect(logger.error).toHaveBeenCalled();
+    });
+});
+
+describe('when Redis is unreachable', () => {
+    test('falls back to counting in process rather than refusing everyone', async () => {
+        // Refusing every request during a cache outage would take password
+        // reset down for the whole site. Counting imprecisely is the lesser
+        // failure, and is what this code did before the counters moved.
+        redis.eval.mockRejectedValue(new Error('ECONNREFUSED'));
+
+        for (let attempt = 1; attempt <= limiter.OTP_REQUEST_MAX; attempt++) {
+            const result = await limiter.consume(EMAIL);
+            expect(result.allowed).toBe(true);
+            expect(result.count).toBe(attempt);
+        }
+
+        const refused = await limiter.consume(EMAIL);
+        expect(refused.allowed).toBe(false);
+    });
+
+    test('says so in the log, once per minute rather than per request', async () => {
+        redis.eval.mockRejectedValue(new Error('ECONNREFUSED'));
+
+        await limiter.consume(EMAIL);
+        await limiter.consume('another@example.com');
+        await limiter.consume('third@example.com');
+
+        // An outage that logs on every request buries everything else in the
+        // log for as long as it lasts.
+        expect(logger.error).toHaveBeenCalledTimes(1);
+        expect(logger.error.mock.calls[0][0]).toMatch(/per-process/);
+    });
+
+    test('a non-numeric reply is treated as an outage, not as zero', async () => {
+        // `Number(undefined)` is NaN, and NaN <= max is false -- so a garbled
+        // reply would silently refuse the request if it were trusted.
+        redis.eval.mockResolvedValue(['not-a-number', 'also-not']);
+
+        const result = await limiter.consume(EMAIL);
+
+        expect(result.allowed).toBe(true);
+        expect(result.count).toBe(1);
+    });
+
+    test('the fallback still expires, so an address is not barred for good', async () => {
+        redis.eval.mockRejectedValue(new Error('ECONNREFUSED'));
+
+        for (let i = 0; i <= limiter.OTP_REQUEST_MAX; i++) {
+            await limiter.consume(EMAIL);
+        }
+        expect((await limiter.consume(EMAIL)).allowed).toBe(false);
+
+        // Step past the window. The record is dropped on read rather than
+        // waiting for a sweep, which the Map this replaced did not do.
+        const realNow = Date.now;
+        Date.now = () => realNow() + limiter.OTP_REQUEST_WINDOW_MS + 1;
+        try {
+            const afterWindow = await limiter.consume(EMAIL);
+            expect(afterWindow.allowed).toBe(true);
+            expect(afterWindow.count).toBe(1);
+        } finally {
+            Date.now = realNow;
+        }
+    });
+});
+
+describe('clear', () => {
+    test('SCANs rather than KEYS, so it cannot block a shared Redis', async () => {
+        redis.scan
+            .mockResolvedValueOnce(['7', ['auth:otp-budget:aa']])
+            .mockResolvedValueOnce(['0', ['auth:otp-budget:bb']]);
+
+        await limiter.clear();
+
+        expect(redis.scan).toHaveBeenCalledTimes(2);
+        expect(redis.scan.mock.calls[0]).toEqual(
+            ['0', 'MATCH', 'auth:otp-budget:*', 'COUNT', expect.any(Number)]
+        );
+        expect(redis.del).toHaveBeenCalledWith('auth:otp-budget:aa');
+        expect(redis.del).toHaveBeenCalledWith('auth:otp-budget:bb');
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`POST /api/auth/forgot-password` answered three ways depending on what it found
behind the address:

| Address | Was | Now |
| --- | --- | --- |
| not registered | `200` `"If the email is registered, an OTP has been sent."` | `200` `"If that address has an account, a reset code is on its way to it."` |
| registered, unverified | `400` `"Please verify your email first before requesting password reset."` | *same as above* |
| registered, verified | `200` `"OTP sent to your email"` | *same as above* |

Three inputs, three `(status, success, message)` triples, no credential needed
to ask. The comment on the first branch — `// Security: Don't reveal if email
exists` — had the right idea; the two branches after it gave the answer away.

Every path now ends on one frozen constant. It is a constant rather than three
identical string literals specifically so the branches cannot drift apart again
the way they did.

### The uniform response is wider than the three cases

Four more things had to change to the same response, because any of them
answering differently rebuilds the same oracle out of different parts:

- **A malformed address.** Arguably caller-side information rather than account
  information, so a `400` would be defensible — but it costs nothing to be
  uniform and the client validates the format anyway.
- **An exhausted per-address budget.** See below.
- **A failure from Appwrite.** A `500` on send-failure and a `200` on
  unknown-address is the same oracle wearing a different hat: only a real
  address reaches the send at all. Logged, not surfaced.
- **An unexpected exception.** Same reasoning.

### Unverified accounts are sent the code now

The old branch refused them and told them to verify first. That gate bought
nothing and cost a lot.

Nothing, because `createEmailToken` sends a code to the mailbox and redeeming it
*is* proof of control of that mailbox — which is the entire content of
"verified". Sending a reset code to an unverified address is exactly as safe as
sending it to a verified one.

A lot, because it was a permanent lockout. Someone who signed up, never clicked
the link, and has since forgotten their password was refused by the reset path,
and the reset path is the only way back in. They were told to verify first,
which they could no longer do — that was part of a signup flow that expired long
ago.

`resetPassword` now sets `is_verified = 1` in the same statement as the password,
so completing a reset verifies the account on the way through.

### The per-address budget moved to Redis

`isOTPRateLimited` counted in a module-scope `Map`. There are two limits on this
endpoint and they do different jobs, which is worth writing down because it is
not obvious from either file:

- `forgotPasswordLimiter` (`middleware/rateLimiter.js`, on the route) is
  **per caller**. It stops one client hammering the endpoint, answers `429`, and
  is Redis-backed already. Untouched by this PR.
- The budget in this PR is **per subject** — per address being asked about. It
  stops a hundred callers between them mail-bombing one victim, which the
  per-caller limit cannot see.

The `Map` was the second one, done badly: per-process, so a restart cleared it
and two instances each kept their own; and one entry per distinct address until
the five-minute `setInterval` swept it. `services/otpRequestLimiter.js` keeps the
same policy (3 per 5 minutes per address, still env-overridable) in Redis, behind
the same fallback-to-memory shape `loginLockoutService` uses — refusing every
password reset during a cache outage would be a worse failure than counting
imprecisely.

Two details worth flagging:

**Exhausting it does not produce a 429.** It suppresses the send and returns the
same uniform `200`. A `429` keyed on the *subject* says "somebody asked about
this address recently", which is the kind of fact this whole PR exists to
withhold. The per-caller `429` is fine and stays — it describes the caller, not
any account.

**It is consumed before the database lookup.** Otherwise an unknown address
costs one query and a known one costs a query plus a send, and the work an
address attracts becomes the answer. There is a test for this.

The counter is keyed on a SHA-256 of the lowercased address: lowercased because
sign-in resolves accounts that way and otherwise holding down shift mints a
fresh budget, hashed because the value arrives on an unauthenticated endpoint
and a `SCAN auth:otp-budget:*` should not return a list of customer addresses.

`INCR` and `PEXPIRE` happen inside one Lua script rather than as two round
trips — a process dying between them would leave a counter with no TTL, which
bars that address permanently.

## 🔗 Related Issue

Closes #1455

---

## 🧹 Four imports this file never had

Not part of #1455, and flagged separately because a reviewer should not have to
discover it in the diff.

`controllers/authController.js` uses `jwt`, `revokeUserSessions` and
`REVOKE_REASON` without requiring any of them:

```
$ grep -c "require.*jsonwebtoken" backend/controllers/authController.js
0
$ grep -n "jwt\.\|revokeUserSessions\|REVOKE_REASON" backend/controllers/authController.js
106:        token: jwt.sign(
589:            await revokeUserSessions({
591:                reason: REVOKE_REASON.PASSWORD_CHANGED
705,707,714,716: ... two more
```

Each is a `ReferenceError: <name> is not defined` at the point of use. They sit
inside handlers rather than at module scope, so the module loads, the syntax
gate passes and the boot check passes — it only fails when somebody actually
signs in (`generateAccessToken` → `jwt.sign`) or resets a password
(`revokeUserSessions`). `logger` is the fourth, needed for the suppression log
this PR adds.

They are here rather than in their own PR because `resetPassword` calls two of
them, three lines from code this PR changes, so the reset path could not be
tested without them. Happy to split them out if you would rather.

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🧪 Tests

31 new tests across two files.

`tests/forgotPasswordEnumeration.test.js` asserts the property rather than the
copy — "all three cases produce identical bytes", not "case X produces string
Y". Pinning the literals would let someone change one branch's wording and keep
a green suite; comparing the cases against each other is what actually matters,
and it survives a future rewording. It also covers the send-failure and
database-failure paths, the pre-lookup budget consumption, and that one
exhausted address does not affect another.

`tests/otpRequestLimiter.test.js` covers the arithmetic, the key derivation
(case, whitespace, no raw addresses in the keyspace), and the Redis-outage
fallback including that the in-memory records expire rather than barring an
address for good.

## 🌐 Additional Notes

**On CI:** `main` is currently red for reasons that predate this branch —
`npm run check:syntax` fails on `frontend/scripts/product-cards-home.js` and
`frontend/scripts/shop.js` (#1444), and 9 backend suites / 23 tests fail with
it. I checked this branch against a clean `main` and the same 9 suites and same
23 tests fail either way; this PR adds 31 passing tests and changes nothing
else. #1448 is the fix for that.

**Not fixed here:** `signup` still answers `"Email already exists"`, which is
the same class of leak. That one is genuinely hard to avoid — the user has to be
told the address is taken before they pick a password — and it is a product
decision rather than a bug, so I left it alone. The reset form is the one place
the answer can simply be withheld, which is what makes it worth doing.
