### PR TITLE
Stop serving drafts, withdrawn and archived products to shoppers

### DIFF
--- a/backend/constants/productVisibility.js
+++ b/backend/constants/productVisibility.js
@@ -1,0 +1,120 @@
+// backend/constants/productVisibility.js
+//
+// One definition of "a shopper may see this product" (#1456).
+//
+// `products` carries two independent visibility columns:
+//
+//   deleted_at  DATETIME                                        -- soft delete
+//   status      ENUM('draft','active','inactive','archived')    -- lifecycle
+//                                                DEFAULT 'draft'
+//
+// Before this module, every public query filtered on `deleted_at` and nothing
+// read `status` at all -- so drafts were on the shop page, and an admin setting
+// a product to `inactive` to take it off sale had no effect. The autocomplete
+// query filtered on neither, so soft-deleted products appeared in the dropdown
+// and linked to a detail page that 404s.
+//
+// Both halves of that came from the condition being retyped at each call site.
+// It lives here now so a new query gets it by importing rather than by
+// remembering, and so there is one place to change if the rules ever move.
+//
+// The lifecycle, for reference:
+//
+//   draft     -- being prepared, never been on sale. Not public.
+//   active    -- on sale. The only public state.
+//   inactive  -- deliberately withdrawn, expected back. Not public.
+//   archived  -- retired, or soft-deleted (see deleteProduct). Not public.
+
+'use strict';
+
+/** Every value the `products.status` column will accept. */
+const PRODUCT_STATUSES = Object.freeze([
+    'draft',
+    'active',
+    'inactive',
+    'archived'
+]);
+
+/**
+ * The statuses a shopper may see.
+ *
+ * A list rather than a single string because "published" is a concept that
+ * tends to grow a second member (scheduled, clearance, ...), and every caller
+ * below already handles a list.
+ */
+const PUBLIC_PRODUCT_STATUSES = Object.freeze(['active']);
+
+/**
+ * What `createProduct` writes when the caller does not say.
+ *
+ * `active`, not the column's `draft`, and that difference is deliberate. The
+ * create endpoint is admin-only and its callers have always expected the
+ * product to be on sale afterwards -- it looked that way because nothing read
+ * `status`. Defaulting to `draft` here would keep the column honest and silently
+ * change what the endpoint does, which is a bigger surprise than this one.
+ * Pass `status: 'draft'` explicitly to stage a product instead.
+ */
+const DEFAULT_PRODUCT_STATUS = 'active';
+
+/** The status a product is moved to when it is withdrawn from sale. */
+const ARCHIVED_PRODUCT_STATUS = 'archived';
+
+/**
+ * Is this a value the column will accept?
+ *
+ * @param {unknown} status
+ * @returns {boolean}
+ */
+const isValidProductStatus = (status) =>
+    typeof status === 'string'
+    && PRODUCT_STATUSES.includes(status.trim().toLowerCase());
+
+/**
+ * Coerce caller input to a storable status.
+ *
+ * Returns `null` for anything the enum does not cover, so a caller can tell
+ * "not supplied" from "supplied but wrong" and answer 400 rather than writing a
+ * value MySQL would reject in strict mode (or silently truncate outside it).
+ *
+ * @param {unknown} status
+ * @returns {string|null}
+ */
+const normalizeProductStatus = (status) => {
+    if (status === undefined || status === null || status === '') {
+        return null;
+    }
+    if (!isValidProductStatus(status)) {
+        return null;
+    }
+    return String(status).trim().toLowerCase();
+};
+
+/**
+ * The WHERE fragment restricting a query to what shoppers may see.
+ *
+ * Returns parameters rather than interpolating the statuses, so the fragment
+ * stays safe if `PUBLIC_PRODUCT_STATUSES` ever becomes configurable, and so it
+ * reads the same as every other condition around it.
+ *
+ * @param {string} [alias='p'] Table alias used for `products` in the query.
+ * @returns {{sql: string, params: string[]}}
+ */
+const publicProductCondition = (alias = 'p') => {
+    const prefix = alias ? `${alias}.` : '';
+    const placeholders = PUBLIC_PRODUCT_STATUSES.map(() => '?').join(', ');
+
+    return {
+        sql: `${prefix}deleted_at IS NULL AND ${prefix}status IN (${placeholders})`,
+        params: [...PUBLIC_PRODUCT_STATUSES]
+    };
+};
+
+module.exports = {
+    PRODUCT_STATUSES,
+    PUBLIC_PRODUCT_STATUSES,
+    DEFAULT_PRODUCT_STATUS,
+    ARCHIVED_PRODUCT_STATUS,
+    isValidProductStatus,
+    normalizeProductStatus,
+    publicProductCondition
+};

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -2,6 +2,17 @@ const db = require("../config/db");
 const productService = require("../services/productService");
 const stockCounter = require("../services/stockCounterService");
 
+// One definition of "a shopper may see this", shared by every public query
+// below. Retyping the condition at each call site is exactly how `status` came
+// to be read by nothing at all, and how the autocomplete query came to skip
+// `deleted_at` as well (#1456).
+const {
+    DEFAULT_PRODUCT_STATUS,
+    PRODUCT_STATUSES,
+    normalizeProductStatus,
+    publicProductCondition
+} = require("../constants/productVisibility");
+
 // helper functions
 const {
     safeNumber,
@@ -188,8 +199,13 @@ const getProducts = async (req, res) => {
         const orderByClause =
             SORT_CLAUSES[sanitizeString(req.query.sort)] || DEFAULT_SORT_CLAUSE;
 
-        const filterConditions = ["p.deleted_at IS NULL"];
-        const filterParams = [];
+        // Was `["p.deleted_at IS NULL"]`, which let every `draft`, `inactive`
+        // and `archived` product onto the shop page -- and since createProduct
+        // never wrote the column, that meant every product ever created through
+        // the API (#1456).
+        const visibility = publicProductCondition("p");
+        const filterConditions = [visibility.sql];
+        const filterParams = [...visibility.params];
 
         // category filter (case/format-insensitive)
         if (req.query.category) {
@@ -406,6 +422,11 @@ const getSingleProduct = async (req, res) => {
             });
     }
 
+    // Same rule as the list. A product hidden from the listing but reachable at
+    // its own URL is not hidden -- the URL is in the sitemap, in search results
+    // and in anyone's history (#1456).
+    const detailVisibility = publicProductCondition("p");
+
     try {
         // Stampede-safe cache (XFetch + singleflight) — #1262
         const product = await productService.withProductCache(
@@ -425,9 +446,9 @@ const getSingleProduct = async (req, res) => {
                         p.num_reviews
                     FROM products p
                     LEFT JOIN categories c ON p.category_id = c.id
-                    WHERE p.id = ? AND p.deleted_at IS NULL
+                    WHERE p.id = ? AND ${detailVisibility.sql}
                 `;
-                const [results] = await db.query(query, [id]);
+                const [results] = await db.query(query, [id, ...detailVisibility.params]);
                 return results[0] || null;
             },
             { tags: [`product:${id}`, 'products'] }
@@ -463,8 +484,31 @@ const createProduct = async (req, res) => {
         image,
         category,
         stock,
-        featured
+        featured,
+        status
     } = req.body;
+
+    // The INSERT never listed `status`, so every product created through this
+    // endpoint fell to the column's `DEFAULT 'draft'` -- and then appeared on
+    // the shop page anyway, because nothing read the column (#1456). The two
+    // mistakes cancelled out, which is why nobody noticed.
+    //
+    // Unsupplied means DEFAULT_PRODUCT_STATUS ('active'): this endpoint is
+    // admin-only and its callers have always expected the product to be on sale
+    // afterwards. Supplied-but-not-in-the-enum is a 400 rather than a silent
+    // fallback, because it is a typo in a caller and swallowing it here would
+    // put the product in a state its author did not choose.
+    const requestedStatus =
+        status === undefined || status === null || status === ''
+            ? DEFAULT_PRODUCT_STATUS
+            : normalizeProductStatus(status);
+
+    if (requestedStatus === null) {
+        return res.status(400).json({
+            success: false,
+            message: `status must be one of: ${PRODUCT_STATUSES.join(", ")}`
+        });
+    }
 
     // basic validation
     if (!name || price === undefined) {
@@ -509,10 +553,10 @@ const createProduct = async (req, res) => {
 
         const query = `
             INSERT INTO products
-            (id, name, description, price, image, category_id, stock, featured)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            (id, name, description, price, image, category_id, stock, featured, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         `;
-        
+
         await db.query(
             query,
             [
@@ -530,7 +574,8 @@ const createProduct = async (req, res) => {
                     || featured === 1
                     || featured === "1"
                     ? 1
-                    : 0
+                    : 0,
+                requestedStatus
             ]
         );
 
@@ -539,7 +584,10 @@ const createProduct = async (req, res) => {
         res.status(201).json({
             success: true,
             message: "Product created successfully",
-            productId: productId
+            productId: productId,
+            // Echoed so a caller that did not pass one can see what it got
+            // rather than having to know the default.
+            status: requestedStatus
         });
     } catch (error) {
         console.error(error);
@@ -565,7 +613,8 @@ const updateProduct = async (req, res) => {
         image,
         category,
         stock,
-        featured
+        featured,
+        status
     } = req.body;
 
     if (!id) {
@@ -575,6 +624,22 @@ const updateProduct = async (req, res) => {
                 message:
                     "Invalid product ID"
             });
+    }
+
+    // Publishing and withdrawing have to be possible through this endpoint, or
+    // the column is still unreachable by any caller and the read filters added
+    // in #1456 have no counterpart on the write side. Omitting `status` leaves
+    // it alone -- an admin renaming a product must not accidentally publish it.
+    const nextStatus =
+        status === undefined || status === null || status === ''
+            ? null
+            : normalizeProductStatus(status);
+
+    if (status !== undefined && status !== null && status !== '' && nextStatus === null) {
+        return res.status(400).json({
+            success: false,
+            message: `status must be one of: ${PRODUCT_STATUSES.join(", ")}`
+        });
     }
 
     // basic validation
@@ -635,7 +700,8 @@ const updateProduct = async (req, res) => {
                 image = ?,
                 category_id = COALESCE(?, category_id),
                 ${stockAssignment},
-                featured = ?
+                featured = ?,
+                status = COALESCE(?, status)
             WHERE id = ? AND deleted_at IS NULL
         `;
 
@@ -653,6 +719,7 @@ const updateProduct = async (req, res) => {
                     || featured === "1"
                     ? 1
                     : 0,
+                nextStatus,
                 id
             ]
         );
@@ -733,9 +800,21 @@ const getProductSuggestions = async (req, res) => {
     // Sanitize: trim, limit length, escape special LIKE characters
     const sanitized = keyword.trim().slice(0, 100).replace(/[%_\\]/g, String.raw`\$&`);
     const searchTerm = `%${sanitized}%`;
-    const query = `SELECT id, name FROM products WHERE name LIKE ? LIMIT 10`;
+
+    // This query used to filter on neither `deleted_at` nor `status` -- the one
+    // read in the file that skipped both, and the one whose results are links
+    // to `getSingleProduct`, which enforces them. So the dropdown offered
+    // deleted products and clicking one landed on a 404 (#1456).
+    const visibility = publicProductCondition("");
+
+    const query = `
+        SELECT id, name
+        FROM products
+        WHERE name LIKE ? AND ${visibility.sql}
+        LIMIT 10
+    `;
     try {
-        const [results] = await db.query(query, [searchTerm]);
+        const [results] = await db.query(query, [searchTerm, ...visibility.params]);
         res.json(results);
     } catch (err) {
         console.error("Suggestions error:", err);

--- a/backend/tests/productVisibility.test.js
+++ b/backend/tests/productVisibility.test.js
@@ -1,0 +1,369 @@
+// backend/tests/productVisibility.test.js
+//
+// Which products a shopper may see (#1456).
+//
+// `products` has two visibility columns, `deleted_at` and `status`. Every
+// public query filtered on the first and none of them read the second, so
+// drafts were on sale and an admin marking a product `inactive` changed
+// nothing. The autocomplete query filtered on neither.
+//
+// The tests are split in two: the shared condition itself, and each caller
+// actually using it. The second half is the part that matters -- the bug was
+// never that the condition was wrong, it was that three call sites each wrote
+// their own and two of them forgot something.
+
+jest.mock('../config/db', () => ({
+    query: jest.fn().mockResolvedValue([[]]),
+    getConnection: jest.fn()
+}));
+
+jest.mock('../services/productService', () => ({
+    // The detail and list paths wrap their query in a cache. Run the loader
+    // straight through so the SQL under test is the SQL that executes.
+    withProductCache: jest.fn(async (_key, loader) => loader()),
+    invalidateProductCaches: jest.fn().mockResolvedValue(undefined),
+    onCategoryMutation: jest.fn().mockResolvedValue(undefined),
+    getCategoryTree: jest.fn().mockResolvedValue([])
+}));
+
+jest.mock('../services/stockCounterService', () => ({
+    getVariantRollup: jest.fn().mockResolvedValue({ variantCount: 0, stock: 0 })
+}));
+
+const db = require('../config/db');
+const {
+    PRODUCT_STATUSES,
+    PUBLIC_PRODUCT_STATUSES,
+    DEFAULT_PRODUCT_STATUS,
+    isValidProductStatus,
+    normalizeProductStatus,
+    publicProductCondition
+} = require('../constants/productVisibility');
+
+const {
+    getProducts,
+    getSingleProduct,
+    getProductSuggestions,
+    createProduct,
+    updateProduct
+} = require('../controllers/productController');
+
+const PRODUCT_ID = '3f2504e0-4f89-11d3-9a0c-0305e82c3301';
+
+/** A res double that records the status and body. */
+const makeRes = () => ({
+    statusCode: null,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; }
+});
+
+/** Every SQL string the controller sent during a test. */
+const executedSql = () => db.query.mock.calls.map(([sql]) => String(sql));
+
+/** The first executed statement matching a fragment, with its parameters. */
+const statementMatching = (fragment) =>
+    db.query.mock.calls.find(([sql]) => String(sql).includes(fragment));
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    db.query.mockResolvedValue([[]]);
+});
+
+describe('the shared condition', () => {
+    test('restricts to undeleted products in a public status', () => {
+        const { sql, params } = publicProductCondition('p');
+
+        expect(sql).toContain('p.deleted_at IS NULL');
+        expect(sql).toContain('p.status IN (?)');
+        expect(params).toEqual([...PUBLIC_PRODUCT_STATUSES]);
+    });
+
+    test('binds the statuses rather than interpolating them', () => {
+        // Placeholders, not literals, so the fragment stays safe if the public
+        // set ever becomes configurable.
+        const { sql } = publicProductCondition('p');
+        for (const status of PUBLIC_PRODUCT_STATUSES) {
+            expect(sql).not.toContain(`'${status}'`);
+        }
+    });
+
+    test('supports an unaliased table', () => {
+        // The suggestions query selects from `products` with no alias.
+        const { sql } = publicProductCondition('');
+
+        expect(sql).toContain('deleted_at IS NULL');
+        expect(sql).not.toContain('.deleted_at');
+    });
+
+    test('only "active" is public', () => {
+        expect([...PUBLIC_PRODUCT_STATUSES]).toEqual(['active']);
+        for (const status of ['draft', 'inactive', 'archived']) {
+            expect(PUBLIC_PRODUCT_STATUSES).not.toContain(status);
+        }
+    });
+
+    test('the status list matches the column definition', () => {
+        // If the enum in migrations/0001 ever gains a member, this is the list
+        // that has to learn about it.
+        expect([...PRODUCT_STATUSES])
+            .toEqual(['draft', 'active', 'inactive', 'archived']);
+    });
+});
+
+describe('status validation', () => {
+    test.each(PRODUCT_STATUSES)('accepts %s', (status) => {
+        expect(isValidProductStatus(status)).toBe(true);
+        expect(normalizeProductStatus(status)).toBe(status);
+    });
+
+    test('is case and whitespace insensitive', () => {
+        expect(normalizeProductStatus('  ACTIVE ')).toBe('active');
+        expect(normalizeProductStatus('Draft')).toBe('draft');
+    });
+
+    test('rejects anything outside the enum', () => {
+        // MySQL in strict mode refuses a value outside an enum, so a bad value
+        // has to be caught before the statement rather than after it.
+        for (const bad of ['published', 'live', 'ACTIVE ; DROP', 1, true, {}, []]) {
+            expect(normalizeProductStatus(bad)).toBeNull();
+        }
+    });
+
+    test('distinguishes "not supplied" from "supplied but wrong"', () => {
+        // Both come back null, which is why the callers check for the empty
+        // cases first -- the difference decides between a default and a 400.
+        expect(normalizeProductStatus(undefined)).toBeNull();
+        expect(normalizeProductStatus('')).toBeNull();
+        expect(normalizeProductStatus('nonsense')).toBeNull();
+    });
+});
+
+describe('GET /api/products', () => {
+    test('filters on both columns', async () => {
+        const res = makeRes();
+        await getProducts({ query: {} }, res);
+
+        for (const sql of executedSql()) {
+            expect(sql).toContain('deleted_at IS NULL');
+            expect(sql).toContain('status IN');
+        }
+    });
+
+    test('binds the public statuses ahead of limit and offset', async () => {
+        // The list query appends limit/offset after the filter parameters, so
+        // getting the order wrong here shifts every placeholder.
+        db.query.mockResolvedValue([[{ total: 0 }]]);
+        const res = makeRes();
+        await getProducts({ query: { page: '2', limit: '10' } }, res);
+
+        const listCall = statementMatching('LIMIT ?');
+        expect(listCall).toBeDefined();
+        const params = listCall[1];
+        expect(params.slice(0, PUBLIC_PRODUCT_STATUSES.length))
+            .toEqual([...PUBLIC_PRODUCT_STATUSES]);
+        expect(params.slice(-2)).toEqual([10, 10]);
+    });
+
+    test('the count query is filtered the same way as the page query', async () => {
+        // A count that includes hidden products reports more pages than exist,
+        // and the last ones come back empty.
+        db.query.mockResolvedValue([[{ total: 0 }]]);
+        const res = makeRes();
+        await getProducts({ query: {} }, res);
+
+        const countCall = statementMatching('COUNT(*)');
+        expect(countCall).toBeDefined();
+        expect(String(countCall[0])).toContain('status IN');
+        expect(countCall[1]).toEqual(expect.arrayContaining([...PUBLIC_PRODUCT_STATUSES]));
+    });
+
+    test('keeps filtering when a category or search narrows the query further', async () => {
+        db.query.mockResolvedValue([[{ total: 0 }]]);
+        const res = makeRes();
+        await getProducts(
+            { query: { category: 'toys', search: 'robot', minPrice: '5' } },
+            res
+        );
+
+        for (const sql of executedSql()) {
+            expect(sql).toContain('status IN');
+        }
+    });
+});
+
+describe('GET /api/products/:id', () => {
+    test('filters on both columns', async () => {
+        const res = makeRes();
+        await getSingleProduct({ params: { id: PRODUCT_ID } }, res);
+
+        const [sql, params] = db.query.mock.calls[0];
+        expect(String(sql)).toContain('deleted_at IS NULL');
+        expect(String(sql)).toContain('status IN');
+        expect(params[0]).toBe(PRODUCT_ID);
+        expect(params.slice(1)).toEqual([...PUBLIC_PRODUCT_STATUSES]);
+    });
+
+    test('a non-public product is a 404, not a hidden-but-reachable page', async () => {
+        // Hidden from the listing but live at its own URL is not hidden: the
+        // URL is in the sitemap, in search results and in browser history.
+        db.query.mockResolvedValue([[]]);
+        const res = makeRes();
+        await getSingleProduct({ params: { id: PRODUCT_ID } }, res);
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body.success).toBe(false);
+    });
+});
+
+describe('GET /api/products/search-suggestions', () => {
+    test('filters on both columns', async () => {
+        // This query filtered on neither. It was the only read in the file that
+        // skipped `deleted_at`, and its results are links to getSingleProduct,
+        // which enforces it -- so the dropdown offered rows that 404.
+        const res = makeRes();
+        await getProductSuggestions({ query: { q: 'shirt' } }, res);
+
+        const [sql, params] = db.query.mock.calls[0];
+        expect(String(sql)).toContain('deleted_at IS NULL');
+        expect(String(sql)).toContain('status IN');
+        expect(params[0]).toBe('%shirt%');
+        expect(params.slice(1)).toEqual([...PUBLIC_PRODUCT_STATUSES]);
+    });
+
+    test('still escapes LIKE wildcards', async () => {
+        // Regression guard: the visibility fix rewrote this statement, and the
+        // escaping is easy to lose in a rewrite.
+        const res = makeRes();
+        await getProductSuggestions({ query: { q: '100%_off' } }, res);
+
+        expect(db.query.mock.calls[0][1][0]).toBe('%100\\%\\_off%');
+    });
+
+    test('an empty query does not reach the database', async () => {
+        const res = makeRes();
+        res.json = jest.fn();
+        await getProductSuggestions({ query: { q: '   ' } }, res);
+
+        expect(db.query).not.toHaveBeenCalled();
+        expect(res.json).toHaveBeenCalledWith([]);
+    });
+});
+
+describe('POST /api/products', () => {
+    const body = { name: 'Blue Hoodie', price: 25, category: 'Apparel', stock: 4 };
+
+    beforeEach(() => {
+        // No existing product with the name, then the category lookup.
+        db.query.mockResolvedValue([[]]);
+    });
+
+    test('writes status explicitly instead of falling to the column default', async () => {
+        // The INSERT did not list the column, so every product created through
+        // this endpoint was a `draft` nobody chose.
+        const res = makeRes();
+        await createProduct({ body: { ...body } }, res);
+
+        const insert = statementMatching('INSERT INTO products');
+        expect(insert).toBeDefined();
+        expect(String(insert[0])).toContain('status');
+        expect(insert[1]).toContain(DEFAULT_PRODUCT_STATUS);
+    });
+
+    test('an unsupplied status defaults to on sale', async () => {
+        const res = makeRes();
+        await createProduct({ body: { ...body } }, res);
+
+        expect(res.statusCode).toBe(201);
+        expect(res.body.status).toBe(DEFAULT_PRODUCT_STATUS);
+        expect(PUBLIC_PRODUCT_STATUSES).toContain(res.body.status);
+    });
+
+    test('a caller can stage a product as a draft', async () => {
+        const res = makeRes();
+        await createProduct({ body: { ...body, status: 'draft' } }, res);
+
+        expect(res.statusCode).toBe(201);
+        expect(res.body.status).toBe('draft');
+        expect(statementMatching('INSERT INTO products')[1]).toContain('draft');
+    });
+
+    test('a status outside the enum is a 400, not a silent fallback', async () => {
+        // Swallowing it would put the product in a state its author did not
+        // choose, and MySQL would reject the write anyway in strict mode.
+        const res = makeRes();
+        await createProduct({ body: { ...body, status: 'published' } }, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toContain('status must be one of');
+        expect(statementMatching('INSERT INTO products')).toBeUndefined();
+    });
+});
+
+describe('PUT /api/products/:id', () => {
+    const body = { name: 'Blue Hoodie', price: 25 };
+
+    beforeEach(() => {
+        db.query.mockResolvedValue([{ affectedRows: 1 }]);
+    });
+
+    test('omitting status leaves it alone', async () => {
+        // An admin renaming a product must not publish it as a side effect,
+        // which is why the statement uses COALESCE rather than assigning.
+        const res = makeRes();
+        await updateProduct({ params: { id: PRODUCT_ID }, body: { ...body } }, res);
+
+        const update = statementMatching('UPDATE products');
+        expect(String(update[0])).toContain('status = COALESCE(?, status)');
+        expect(update[1]).toContain(null);
+    });
+
+    test('supplying status changes it', async () => {
+        const res = makeRes();
+        await updateProduct(
+            { params: { id: PRODUCT_ID }, body: { ...body, status: 'inactive' } },
+            res
+        );
+
+        expect(statementMatching('UPDATE products')[1]).toContain('inactive');
+    });
+
+    test('a status outside the enum is a 400', async () => {
+        const res = makeRes();
+        await updateProduct(
+            { params: { id: PRODUCT_ID }, body: { ...body, status: 'live' } },
+            res
+        );
+
+        expect(res.statusCode).toBe(400);
+        expect(statementMatching('UPDATE products')).toBeUndefined();
+    });
+});
+
+describe('migration 0043', () => {
+    const fs = require('fs');
+    const path = require('path');
+
+    const sql = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'migrations', '0043_publish_existing_products.sql'),
+        'utf8'
+    );
+
+    test('publishes the rows that only defaulted to draft', () => {
+        // Without this, turning the filter on empties the catalogue: every
+        // existing row says `draft` because the INSERT never set the column.
+        expect(sql).toMatch(/UPDATE\s+products/i);
+        expect(sql).toMatch(/SET\s+status\s*=\s*'active'/i);
+    });
+
+    test("does not touch a status somebody actually chose", () => {
+        // `inactive` and `archived` can only have been set by hand, so they are
+        // deliberate. Publishing them would override a decision to withdraw.
+        expect(sql).toMatch(/WHERE\s+status\s*=\s*'draft'/i);
+        expect(sql).not.toMatch(/status\s*(!=|<>)\s*'active'/i);
+    });
+
+    test('does not resurrect a soft-deleted product', () => {
+        expect(sql).toMatch(/deleted_at\s+IS\s+NULL/i);
+    });
+});

--- a/migrations/0043_publish_existing_products.sql
+++ b/migrations/0043_publish_existing_products.sql
@@ -1,0 +1,50 @@
+-- ============================================
+-- PUBLISH THE PRODUCTS THAT WERE ONLY VISIBLE BECAUSE NOTHING CHECKED
+-- ============================================
+--
+-- Data-only migration, no schema change. It exists because #1456 switches the
+-- public product queries on to `status`, and without this that switch empties
+-- the catalogue on deploy.
+--
+-- The column has been there since the baseline:
+--
+--     status ENUM('draft','active','inactive','archived') DEFAULT 'draft'
+--
+-- and nothing ever wrote it. `createProduct`'s INSERT did not list it, so every
+-- product created through the API took the DEFAULT and became a `draft`. And
+-- nothing ever read it either -- every public query filtered on `deleted_at`
+-- alone -- so those drafts were on the shop page regardless. The two mistakes
+-- cancelled out exactly, which is why the catalogue has always looked correct.
+--
+-- Turning the read filter on breaks that symmetry. Every existing row says
+-- `draft`, so the shop page would go empty the moment the new code ships. The
+-- rows have to be told what they have actually been all along.
+--
+-- WHAT COUNTS AS "HAS ACTUALLY BEEN ON SALE"
+--
+-- Only `status = 'draft' AND deleted_at IS NULL`.
+--
+-- `draft` because that is the value the DEFAULT produced and therefore the only
+-- one that can be assumed to be unintentional. If a row says `inactive` or
+-- `archived`, somebody set it by hand -- against a UI or a console, since no
+-- endpoint could -- and they meant it. Publishing those would override a
+-- deliberate decision to withdraw a product, which is the opposite of the point.
+--
+-- `deleted_at IS NULL` because a soft-deleted product is not on sale whatever
+-- its status says, and giving it `active` would leave a contradictory row
+-- behind for whoever reads it next.
+--
+-- This is a one-off. From #1456 onward `createProduct` writes the column
+-- explicitly and `updateProduct` can change it, so no future row arrives in
+-- this state and re-running the file is a no-op.
+
+UPDATE products
+   SET status = 'active'
+ WHERE status = 'draft'
+   AND deleted_at IS NULL;
+
+-- The index for the filter this migration makes real. Declared in the baseline
+-- at `INDEX idx_active_products (status, price, deleted_at)` and unused ever
+-- since, because no query mentioned `status`. Nothing to add -- noted here so
+-- the next person to look at the plan for the product list knows it is meant to
+-- be used and is not left wondering whether one is missing.


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`products.status` has existed since the baseline schema and nothing read it.

```sql
-- migrations/0001_baseline_schema.sql:178
status ENUM('draft', 'active', 'inactive', 'archived') DEFAULT 'draft',
```

```
$ grep -n "status" backend/controllers/productController.js | grep -v "res.status"
$   # nothing
```

Every public query filtered on `deleted_at` and stopped there. A product in
`draft` was on the shop page. An admin setting one to `inactive` to take it off
sale changed nothing — it stayed listed, stayed reachable at its own URL, and
could still be added to a cart and checked out.

### Why nobody noticed

The write side was wrong in the opposite direction and the two cancelled out.

```js
// createProduct, before
INSERT INTO products
(id, name, description, price, image, category_id, stock, featured)
```

No `status`, so every product created through the API fell to the column's
`DEFAULT 'draft'` — and was then listed anyway, because nothing read it. The
catalogue has always looked correct. It stops looking correct the moment anyone
tries to use the column for what it is for, and the first person to find that
out would be an admin wondering why a product they withdrew is still selling.

### The condition has one definition now

`backend/constants/productVisibility.js`. The list, the count, the detail page
and the autocomplete all import it instead of writing their own. Retyping it at
each call site is how two of the three came to be missing something:

| Query | `deleted_at` | `status` |
| --- | --- | --- |
| `getProducts` (list + count) | ✅ | ❌ → ✅ |
| `getSingleProduct` | ✅ | ❌ → ✅ |
| `getProductSuggestions` | ❌ → ✅ | ❌ → ✅ |

The suggestions query was the only read in the file that skipped `deleted_at`
too — and its results are links into `getSingleProduct`, which enforces it. So
the dropdown offered soft-deleted products and clicking one landed on a 404. One
query, two missing filters, and the pair of them produced a broken link.

The condition returns bound parameters rather than interpolated literals, so it
stays safe if the public set ever becomes configurable.

### The write side

`createProduct` writes `status` explicitly. Unsupplied defaults to `active`, not
the column's `draft` — deliberately. This endpoint is admin-only and its callers
have always expected the product to be on sale afterwards; it looked that way
because nothing read the column. Defaulting to `draft` here would keep the
column honest and silently change what the endpoint does, which is the bigger
surprise. Pass `status: "draft"` to stage one instead.

A value outside the enum is a `400`, not a silent fallback. MySQL in strict mode
would reject the write anyway, and swallowing a caller's typo would put the
product in a state its author did not choose.

`updateProduct` can change `status` — otherwise the column is still unreachable
by any caller and the read filters have no counterpart on the write side. It
uses `status = COALESCE(?, status)` so omitting the field leaves it alone: an
admin renaming a product must not publish it as a side effect.

### Migration 0043

Data only, no schema change, and it is load-bearing: every existing row says
`draft` for the reason above, so turning the filter on without it empties the
catalogue on deploy.

It touches **only** `status = 'draft' AND deleted_at IS NULL`.

- `draft` because that is the value the `DEFAULT` produced, so it is the only
  one that can be assumed unintentional.
- Not `inactive` or `archived` — no endpoint could set those, so they were set
  by hand and somebody meant them. Publishing them would override a deliberate
  decision to withdraw a product, which is the opposite of the point.
- `deleted_at IS NULL` because a soft-deleted product is not on sale whatever
  its status says, and giving it `active` leaves a contradictory row behind.

One-off: from here on `createProduct` writes the column, so no future row
arrives in this state and re-running the file is a no-op.

Numbered 0043 rather than 0042 because #1450 is carrying 0042. Two branches
claiming one number looks fine in isolation and takes the whole sequence down
once both merge — the `migrations/README.md` note about renumbering is there
from the last time.

## 🔗 Related Issue

Closes #1456

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🧪 Tests

31 new tests in `backend/tests/productVisibility.test.js`, split deliberately:
the shared condition, then each caller actually using it. The bug was never that
the condition was wrong — it was that three call sites each wrote their own, so
the half that matters is the half asserting the SQL each handler emits.

Also covered: the count query filtered the same way as the page query (a count
including hidden products reports pages that come back empty), the parameter
order around `LIMIT`/`OFFSET`, that a non-public product is a `404` rather than
hidden-but-reachable, that the `LIKE` wildcard escaping in the suggestions query
survived its rewrite, and the three properties of the migration.

## 🌐 Additional Notes

**Performance:** `idx_active_products (status, price, deleted_at)` was declared
in the baseline and has been dead weight ever since, because no query mentioned
`status`. These are the queries it was built for.

**Not fixed here**, found while checking every read path — `productRepository.getRelatedProducts()`
also skips both filters, but it is broken for an unrelated reason and is not
routed:

```js
// repositories/productRepository.js:184
WHERE category = ? AND id != ? AND stock > 0
```

`products` has `category_id`, not `category`, so that statement errors on an
unknown column whenever it is called. Nothing calls it — the product page's
related list goes through `/products` (`frontend/scripts/related-products.js:102`),
which this PR filters. Left alone rather than fixed silently; worth its own
issue if anyone plans to route it.

**On CI:** `main` is currently red for reasons that predate this branch —
`npm run check:syntax` fails on two frontend files (#1444) and 9 backend suites
fail with it. Checked against a clean `main`: the same 9 suites and same 23
tests fail either way. This branch adds 31 passing tests. #1448 is the fix.
