### PR TITLE
Withdraw a product instead of erasing everything attached to it

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -680,7 +680,36 @@ const updateProduct = async (req, res) => {
     }
 };
 
-// Delete product
+// ---------- Delete product ----------
+//
+// A soft delete. It used to be `DELETE FROM products WHERE id = ?`, which is
+// not a delete of one row -- fourteen tables cascade off `products(id)` and two
+// more are set to NULL (#1457):
+//
+//   CASCADE     reviews, wishlist_items, cart_items, product_variants,
+//               inventory_transactions, inventory_alerts, inventory_locks,
+//               user_interactions, recently_viewed, product_views,
+//               stock_alert_subscriptions, product_questions (+ answers,
+//               votes), price_drop_baselines, price_drop_notification_log
+//
+//   SET NULL    order_items.product_id, refund_requests.product_id
+//
+// So withdrawing one product from sale erased every review written about it,
+// removed it from every customer's wishlist, dropped it out of carts that were
+// open at that moment, threw away the stock ledger, and cut the link between
+// historical orders and the catalogue -- which is what reorder, "review your
+// purchase", returns and per-product sales reporting are all built on.
+// `order_items` denormalises name and price so invoices still render, but
+// `product_id` is the only way back to the product and it is gone.
+//
+// None of it recoverable, from one admin click, with no confirmation beyond the
+// role check on the route.
+//
+// The schema was always built for the other thing: `products.deleted_at`
+// exists, has its own index, is part of `idx_active_products`, and every read
+// path in the codebase already filters on it. The only statement that would
+// ever set it was this one, and it threw the row away instead. This is not
+// "add soft deletes" -- it is finishing the one that is already there.
 const deleteProduct = async (req, res) => {
     const id =
         safeUUID(
@@ -696,7 +725,20 @@ const deleteProduct = async (req, res) => {
             });
     }
 
-    const query = "DELETE FROM products WHERE id = ?";
+    // `AND deleted_at IS NULL` so deleting an already-deleted product is a 404
+    // rather than a second cheerful success that moves `deleted_at` forward and
+    // loses when it actually happened.
+    //
+    // `status` moves to 'archived' in the same statement, so the two visibility
+    // columns cannot disagree. #1461 adds ARCHIVED_PRODUCT_STATUS in
+    // constants/productVisibility.js; whichever of the two lands second should
+    // swap this literal for it.
+    const query = `
+        UPDATE products
+           SET deleted_at = NOW(),
+               status = 'archived'
+         WHERE id = ? AND deleted_at IS NULL
+    `;
 
     try {
         const [result] = await db.query(query, [id]);
@@ -708,11 +750,126 @@ const deleteProduct = async (req, res) => {
             });
         }
 
+        // Two things genuinely should go, because they are live state rather
+        // than history and keeping them would be worse than losing them:
+        //
+        //   inventory_locks  -- a hold on stock for a product nobody can buy.
+        //                       Left alone it sits there until its own expiry,
+        //                       reserving stock against a withdrawn product.
+        //
+        //   cart_items       -- a line a shopper cannot check out. Leaving it
+        //                       means a basket that fails at payment with no
+        //                       explanation; removing it at least fails early.
+        //
+        // Everything else -- reviews, orders, wishlists, Q&A, the stock ledger,
+        // the interaction history -- is a record of something that happened and
+        // stays. Failures here are logged rather than surfaced: the product is
+        // already withdrawn, which is what the caller asked for, and reporting
+        // a 500 would invite a retry that cannot un-withdraw it.
+        await releaseLiveStateForProduct(id);
+
         await productService.invalidateProductCaches(id);
 
         res.status(200).json({
             success: true,
             message: "Product deleted successfully"
+        });
+    } catch (error) {
+        console.error(error);
+
+        return res.status(500).json({
+            success: false,
+            message: "Server error"
+        });
+    }
+};
+
+/**
+ * Drop the live state pointing at a product that has just been withdrawn.
+ *
+ * Deliberately not a transaction with the delete itself. The withdrawal is the
+ * operation the caller asked for and it has already succeeded; if clearing a
+ * cart line fails, rolling the withdrawal back would leave a product on sale
+ * that an admin has decided should not be, which is the worse of the two
+ * outcomes. Both statements are idempotent, so a retry costs nothing.
+ *
+ * @param {string} id Product id, already validated.
+ * @returns {Promise<void>}
+ */
+async function releaseLiveStateForProduct(id) {
+    for (const [description, statement] of [
+        ["inventory locks", "DELETE FROM inventory_locks WHERE product_id = ?"],
+        ["cart lines", "DELETE FROM cart_items WHERE product_id = ?"]
+    ]) {
+        try {
+            await db.query(statement, [id]);
+        } catch (error) {
+            console.error(
+                `Failed to release ${description} for withdrawn product ${id}:`,
+                error
+            );
+        }
+    }
+}
+
+// ---------- Restore a withdrawn product ----------
+//
+// The counterpart to the soft delete. Without it "soft" is a claim nobody can
+// check: the row is still there, but no caller can bring it back, so from the
+// outside it is the same as the hard delete it replaced.
+//
+// It comes back as a `draft`, not as `active`. An admin restoring a product is
+// undoing a mistake, and the next thing they want is to look at it before
+// customers do -- silently putting it back on sale is a second surprise on top
+// of the first. Publishing is a separate, deliberate act (`PUT` with
+// `status: "active"`, see #1461).
+//
+// The cart lines and inventory locks dropped on the way out are not restored.
+// They were live state belonging to sessions that have moved on; recreating
+// them would put lines back into baskets whose owners never asked for them.
+const restoreProduct = async (req, res) => {
+    const id =
+        safeUUID(
+            req.params.id
+        );
+
+    if (!id) {
+        return res.status(400)
+            .json({
+                success: false,
+                message:
+                    "Invalid product ID"
+            });
+    }
+
+    // `AND deleted_at IS NOT NULL` so restoring a product that was never
+    // deleted is a 404 rather than a silent no-op that reports success --
+    // and, more importantly, so it cannot quietly reset a live product's
+    // status to draft.
+    const query = `
+        UPDATE products
+           SET deleted_at = NULL,
+               status = 'draft'
+         WHERE id = ? AND deleted_at IS NOT NULL
+    `;
+
+    try {
+        const [result] = await db.query(query, [id]);
+
+        if (result.affectedRows === 0) {
+            return res.status(404).json({
+                success: false,
+                message: "No deleted product with that ID"
+            });
+        }
+
+        await productService.invalidateProductCaches(id);
+
+        res.status(200).json({
+            success: true,
+            message:
+                "Product restored as a draft. Set its status to active to put it back on sale.",
+            status: "draft"
         });
     } catch (error) {
         console.error(error);
@@ -800,6 +957,7 @@ module.exports = {
     createProduct,
     updateProduct,
     deleteProduct,
+    restoreProduct,
     getProductSuggestions,
     getCategoryTree,
     invalidateCategoryTreeCache

--- a/backend/repositories/baseRepository.js
+++ b/backend/repositories/baseRepository.js
@@ -6,9 +6,22 @@ const { withTransaction } = require('../config/db');
  * Base Repository class providing common CRUD operations
  */
 class BaseRepository {
-    constructor(tableName, primaryKey = 'id') {
+    /**
+     * @param {string} tableName
+     * @param {string} [primaryKey='id']
+     * @param {object} [options]
+     * @param {string|null} [options.softDeleteColumn=null]
+     *   Column marking a row as deleted. When set, `delete()` stamps it instead
+     *   of removing the row.
+     *
+     *   Declared explicitly rather than sniffed from the schema: a repository
+     *   whose behaviour depends on whether a column happens to exist is a
+     *   repository that silently changes behaviour when someone adds one.
+     */
+    constructor(tableName, primaryKey = 'id', { softDeleteColumn = null } = {}) {
         this.tableName = tableName;
         this.primaryKey = primaryKey;
+        this.softDeleteColumn = softDeleteColumn;
         this.db = db;
         this.cache = new Map();
         this.cacheEnabled = true;
@@ -124,9 +137,53 @@ class BaseRepository {
     }
 
     /**
-     * Delete record by ID
+     * Delete record by ID.
+     *
+     * Soft when the repository declares a `softDeleteColumn`, hard otherwise.
+     *
+     * This is the second door onto the same problem as #1457: the controller's
+     * `DELETE FROM products` was the visible one, but `productService.deleteProduct()`
+     * reaches the row through here, so fixing only the controller would have
+     * left the cascade -- fourteen tables off `products(id)`, plus `order_items`
+     * and `refund_requests` nulled -- one method call away.
+     *
+     * Already-deleted rows are excluded so a repeat call reports `false`
+     * rather than moving the timestamp forward and losing when the deletion
+     * actually happened.
+     *
+     * @param {string|number} id
+     * @returns {Promise<boolean>} whether a row changed.
      */
     async delete(id) {
+        const [result] = this.softDeleteColumn
+            ? await this.db.query(
+                `UPDATE ${this.tableName}
+                    SET ${this.softDeleteColumn} = NOW()
+                  WHERE ${this.primaryKey} = ?
+                    AND ${this.softDeleteColumn} IS NULL`,
+                [id]
+            )
+            : await this.db.query(
+                `DELETE FROM ${this.tableName} WHERE ${this.primaryKey} = ?`,
+                [id]
+            );
+
+        this.cache.delete(id);
+
+        return result.affectedRows > 0;
+    }
+
+    /**
+     * Remove a row for good, cascades and all.
+     *
+     * Split out from `delete()` so that erasing a row is something a caller has
+     * to ask for by name. `dataErasureService` is the legitimate case -- an
+     * erasure request is supposed to destroy data.
+     *
+     * @param {string|number} id
+     * @returns {Promise<boolean>}
+     */
+    async hardDelete(id) {
         const [result] = await this.db.query(
             `DELETE FROM ${this.tableName} WHERE ${this.primaryKey} = ?`,
             [id]

--- a/backend/repositories/productRepository.js
+++ b/backend/repositories/productRepository.js
@@ -3,7 +3,12 @@ const BaseRepository = require('./baseRepository');
 
 class ProductRepository extends BaseRepository {
     constructor() {
-        super('products', 'id');
+        // `products.deleted_at` is filtered by every read path in the codebase
+        // and was set by nothing, because the only statement that would ever
+        // have set it was a hard `DELETE` (#1457). Declaring it here means
+        // `productService.deleteProduct()` cannot reintroduce that cascade
+        // through the repository while the controller is being careful.
+        super('products', 'id', { softDeleteColumn: 'deleted_at' });
     }
 
     /**

--- a/backend/routes/productRoutes.js
+++ b/backend/routes/productRoutes.js
@@ -11,6 +11,7 @@ const {
     createProduct,
     updateProduct,
     deleteProduct,
+    restoreProduct,
     getProductSuggestions,
     getCategoryTree,
     invalidateCategoryTreeCache
@@ -150,6 +151,16 @@ router.get("/:id", getSingleProduct);
 router.post("/", authMiddleware, authorizeRoles(ROLES.ADMIN), validateCreateProduct, createProduct);
 router.put("/:id", authMiddleware, authorizeRoles(ROLES.ADMIN), validateUpdateProduct, updateProduct);
 router.delete("/:id", authMiddleware, authorizeRoles(ROLES.ADMIN), deleteProduct);
+
+// Undo for the above. A soft delete an admin cannot reverse is, from outside,
+// the hard delete it replaced (#1457). Registered after `/:id` so it cannot
+// shadow it, and admin-only for the same reason the delete is.
+router.post(
+    "/:id/restore",
+    authMiddleware,
+    authorizeRoles(ROLES.ADMIN),
+    restoreProduct
+);
 
 // Fallback
 router.use((req, res) => {

--- a/backend/tests/productSoftDelete.test.js
+++ b/backend/tests/productSoftDelete.test.js
@@ -1,0 +1,334 @@
+// backend/tests/productSoftDelete.test.js
+//
+// Withdrawing a product must not erase the history attached to it (#1457).
+//
+// `DELETE /api/products/:id` ran `DELETE FROM products WHERE id = ?`, and
+// fourteen tables cascade off `products(id)` while two more are set to NULL. So
+// one admin click threw away every review of the product, dropped it out of
+// every wishlist and every open cart, deleted the stock ledger, and cut the
+// link between historical `order_items` and the catalogue -- which is what
+// reorder, returns and per-product reporting are built on.
+//
+// The strongest assertion in this file is the plain one: no statement on the
+// request path says `DELETE FROM products`. Everything else describes what
+// replaced it.
+
+jest.mock('../config/db', () => ({
+    query: jest.fn().mockResolvedValue([{ affectedRows: 1 }]),
+    getConnection: jest.fn(),
+    promise: { query: jest.fn().mockResolvedValue([{ affectedRows: 1 }]) },
+    withTransaction: jest.fn()
+}));
+
+jest.mock('../services/productService', () => ({
+    withProductCache: jest.fn(async (_key, loader) => loader()),
+    invalidateProductCaches: jest.fn().mockResolvedValue(undefined),
+    onCategoryMutation: jest.fn().mockResolvedValue(undefined)
+}));
+
+jest.mock('../services/stockCounterService', () => ({
+    getVariantRollup: jest.fn().mockResolvedValue({ variantCount: 0, stock: 0 })
+}));
+
+const db = require('../config/db');
+const productService = require('../services/productService');
+const {
+    deleteProduct,
+    restoreProduct
+} = require('../controllers/productController');
+
+const PRODUCT_ID = '3f2504e0-4f89-11d3-9a0c-0305e82c3301';
+
+const makeRes = () => ({
+    statusCode: null,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; }
+});
+
+/** Every statement the handler sent, whitespace collapsed for matching. */
+const executedSql = () =>
+    db.query.mock.calls.map(([sql]) => String(sql).replace(/\s+/g, ' ').trim());
+
+/** The first statement containing a fragment, with its parameters. */
+const statementMatching = (fragment) =>
+    db.query.mock.calls.find(([sql]) =>
+        String(sql).replace(/\s+/g, ' ').includes(fragment));
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    db.query.mockResolvedValue([{ affectedRows: 1 }]);
+    // Silence the deliberate console.error in the release helper's catch.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    console.error.mockRestore?.();
+});
+
+describe('DELETE /api/products/:id', () => {
+    test('never issues a row delete against products', async () => {
+        const res = makeRes();
+        await deleteProduct({ params: { id: PRODUCT_ID } }, res);
+
+        // The whole issue in one assertion. Fourteen cascades hang off this
+        // statement; none of them can fire if it is not sent.
+        for (const sql of executedSql()) {
+            expect(sql).not.toMatch(/DELETE\s+FROM\s+products\b/i);
+        }
+    });
+
+    test('stamps deleted_at instead', async () => {
+        const res = makeRes();
+        await deleteProduct({ params: { id: PRODUCT_ID } }, res);
+
+        const update = statementMatching('UPDATE products');
+        expect(update).toBeDefined();
+        expect(String(update[0])).toMatch(/deleted_at\s*=\s*NOW\(\)/i);
+        expect(update[1]).toEqual([PRODUCT_ID]);
+    });
+
+    test('archives the status in the same statement', async () => {
+        // Otherwise the two visibility columns can disagree -- a row that is
+        // soft-deleted but still says `active` is a contradiction waiting for
+        // whichever query reads only one of them.
+        const res = makeRes();
+        await deleteProduct({ params: { id: PRODUCT_ID } }, res);
+
+        expect(String(statementMatching('UPDATE products')[0]))
+            .toMatch(/status\s*=\s*'archived'/i);
+    });
+
+    test('guards on deleted_at IS NULL so a repeat call is a 404', async () => {
+        // Without the guard the second call succeeds, moves the timestamp
+        // forward, and loses when the deletion actually happened.
+        const res = makeRes();
+        await deleteProduct({ params: { id: PRODUCT_ID } }, res);
+
+        expect(String(statementMatching('UPDATE products')[0]))
+            .toMatch(/deleted_at\s+IS\s+NULL/i);
+    });
+
+    test('an unknown or already-deleted id is a 404', async () => {
+        db.query.mockResolvedValue([{ affectedRows: 0 }]);
+        const res = makeRes();
+
+        await deleteProduct({ params: { id: PRODUCT_ID } }, res);
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body.success).toBe(false);
+    });
+
+    test('a malformed id never reaches the database', async () => {
+        const res = makeRes();
+        await deleteProduct({ params: { id: 'not-a-uuid' } }, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(db.query).not.toHaveBeenCalled();
+    });
+
+    test('invalidates the product caches', async () => {
+        const res = makeRes();
+        await deleteProduct({ params: { id: PRODUCT_ID } }, res);
+
+        expect(productService.invalidateProductCaches)
+            .toHaveBeenCalledWith(PRODUCT_ID);
+    });
+});
+
+describe('the live state that should go', () => {
+    test('releases inventory locks', async () => {
+        // A hold on stock for a product nobody can buy. Left alone it sits
+        // until its own expiry, reserving stock against a withdrawn product.
+        const res = makeRes();
+        await deleteProduct({ params: { id: PRODUCT_ID } }, res);
+
+        const statement = statementMatching('inventory_locks');
+        expect(statement).toBeDefined();
+        expect(statement[1]).toEqual([PRODUCT_ID]);
+    });
+
+    test('removes the product from open carts', async () => {
+        // A line the shopper cannot check out. Leaving it means a basket that
+        // fails at payment with no explanation.
+        const res = makeRes();
+        await deleteProduct({ params: { id: PRODUCT_ID } }, res);
+
+        const statement = statementMatching('cart_items');
+        expect(statement).toBeDefined();
+        expect(statement[1]).toEqual([PRODUCT_ID]);
+    });
+
+    test('touches nothing that is a record of something that happened', async () => {
+        const res = makeRes();
+        await deleteProduct({ params: { id: PRODUCT_ID } }, res);
+
+        const sql = executedSql().join(' | ');
+        for (const table of [
+            'reviews',
+            'wishlist_items',
+            'order_items',
+            'refund_requests',
+            'product_questions',
+            'inventory_transactions',
+            'user_interactions',
+            'recently_viewed',
+            'stock_alert_subscriptions',
+            'product_variants'
+        ]) {
+            expect(sql).not.toContain(table);
+        }
+    });
+
+    test('the release runs only after the withdrawal succeeds', async () => {
+        db.query.mockResolvedValue([{ affectedRows: 0 }]);
+        const res = makeRes();
+
+        await deleteProduct({ params: { id: PRODUCT_ID } }, res);
+
+        expect(res.statusCode).toBe(404);
+        expect(statementMatching('inventory_locks')).toBeUndefined();
+        expect(statementMatching('cart_items')).toBeUndefined();
+    });
+
+    test('a failed release does not undo the withdrawal', async () => {
+        // The withdrawal is what the caller asked for and it has succeeded.
+        // Reporting 500 here would invite a retry that cannot un-withdraw it,
+        // and rolling back would leave a product on sale an admin has decided
+        // should not be.
+        db.query.mockImplementation(async (sql) => {
+            if (String(sql).includes('inventory_locks')) {
+                throw new Error('ER_LOCK_WAIT_TIMEOUT');
+            }
+            return [{ affectedRows: 1 }];
+        });
+
+        const res = makeRes();
+        await deleteProduct({ params: { id: PRODUCT_ID } }, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.success).toBe(true);
+        // And it still got as far as the second statement.
+        expect(statementMatching('cart_items')).toBeDefined();
+    });
+});
+
+describe('POST /api/products/:id/restore', () => {
+    test('clears deleted_at', async () => {
+        const res = makeRes();
+        await restoreProduct({ params: { id: PRODUCT_ID } }, res);
+
+        const update = statementMatching('UPDATE products');
+        expect(String(update[0])).toMatch(/deleted_at\s*=\s*NULL/i);
+        expect(update[1]).toEqual([PRODUCT_ID]);
+    });
+
+    test('brings the product back as a draft, not straight onto the shop page', async () => {
+        // An admin restoring a product is undoing a mistake and wants to look
+        // at it before customers do. Putting it back on sale silently is a
+        // second surprise on top of the first.
+        const res = makeRes();
+        await restoreProduct({ params: { id: PRODUCT_ID } }, res);
+
+        expect(String(statementMatching('UPDATE products')[0]))
+            .toMatch(/status\s*=\s*'draft'/i);
+        expect(res.body.status).toBe('draft');
+    });
+
+    test('guards on deleted_at IS NOT NULL', async () => {
+        // So restoring a live product cannot quietly reset its status to draft.
+        const res = makeRes();
+        await restoreProduct({ params: { id: PRODUCT_ID } }, res);
+
+        expect(String(statementMatching('UPDATE products')[0]))
+            .toMatch(/deleted_at\s+IS\s+NOT\s+NULL/i);
+    });
+
+    test('restoring something that was never deleted is a 404', async () => {
+        db.query.mockResolvedValue([{ affectedRows: 0 }]);
+        const res = makeRes();
+
+        await restoreProduct({ params: { id: PRODUCT_ID } }, res);
+
+        expect(res.statusCode).toBe(404);
+    });
+
+    test('does not recreate the cart lines and locks that were dropped', async () => {
+        // They belonged to sessions that have long since moved on; putting
+        // lines back into baskets whose owners never asked for them is worse
+        // than leaving them out.
+        const res = makeRes();
+        await restoreProduct({ params: { id: PRODUCT_ID } }, res);
+
+        const sql = executedSql().join(' | ');
+        expect(sql).not.toContain('cart_items');
+        expect(sql).not.toContain('inventory_locks');
+    });
+
+    test('a malformed id never reaches the database', async () => {
+        const res = makeRes();
+        await restoreProduct({ params: { id: '../../etc/passwd' } }, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(db.query).not.toHaveBeenCalled();
+    });
+});
+
+describe('the repository, which is the other door onto the same row', () => {
+    // productService.deleteProduct() reaches products through the repository,
+    // so fixing only the controller would have left the cascade one method
+    // call away.
+    const BaseRepository = require('../repositories/baseRepository');
+
+    /** A repository whose db is a recording double. */
+    const repoWith = (options) => {
+        const repo = new BaseRepository('widgets', 'id', options);
+        repo.db = { query: jest.fn().mockResolvedValue([{ affectedRows: 1 }]) };
+        return repo;
+    };
+
+    test('a soft-delete repository stamps the column instead of deleting', async () => {
+        const repo = repoWith({ softDeleteColumn: 'deleted_at' });
+
+        await repo.delete('abc');
+
+        const sql = repo.db.query.mock.calls[0][0].replace(/\s+/g, ' ');
+        expect(sql).toMatch(/UPDATE widgets/i);
+        expect(sql).toMatch(/deleted_at = NOW\(\)/i);
+        expect(sql).not.toMatch(/DELETE FROM/i);
+    });
+
+    test('and excludes rows already deleted', async () => {
+        const repo = repoWith({ softDeleteColumn: 'deleted_at' });
+
+        await repo.delete('abc');
+
+        expect(repo.db.query.mock.calls[0][0].replace(/\s+/g, ' '))
+            .toMatch(/deleted_at IS NULL/i);
+    });
+
+    test('a repository without the option is unchanged', async () => {
+        // orders, users and wishlist all still take this path.
+        const repo = repoWith({});
+
+        await repo.delete('abc');
+
+        expect(repo.db.query.mock.calls[0][0]).toMatch(/DELETE FROM widgets/i);
+    });
+
+    test('hardDelete is still available, by name', async () => {
+        // Erasure requests are supposed to destroy data. The point is that a
+        // caller has to ask for it rather than get it by default.
+        const repo = repoWith({ softDeleteColumn: 'deleted_at' });
+
+        await repo.hardDelete('abc');
+
+        expect(repo.db.query.mock.calls[0][0]).toMatch(/DELETE FROM widgets/i);
+    });
+
+    test('the product repository declares the column', async () => {
+        const productRepo = require('../repositories/productRepository');
+        expect(productRepo.softDeleteColumn).toBe('deleted_at');
+        expect(productRepo.tableName).toBe('products');
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`DELETE /api/products/:id` ran an unqualified row delete:

```js
// productController.js:698, before
const query = "DELETE FROM products WHERE id = ?";
```

That is not a delete of one row. **Fourteen tables cascade off `products(id)`,
and two more are nulled.**

| | Tables | What went |
| --- | --- | --- |
| `CASCADE` | `reviews`, `wishlist_items`, `cart_items`, `product_variants`, `inventory_transactions`, `inventory_alerts`, `inventory_locks`, `user_interactions`, `recently_viewed`, `product_views`, `stock_alert_subscriptions`, `product_questions` (+ answers, votes), `price_drop_baselines`, `price_drop_notification_log` | every review of the product and the ratings they aggregate to; the product out of every wishlist and out of carts open at that moment; the stock ledger; the whole Q&A thread; every unnotified back-in-stock request |
| `SET NULL` | `order_items.product_id`, `refund_requests.product_id` | the link between **historical orders** and the catalogue |

`order_items` denormalises `name`, `price` and `total`, so an invoice still
renders. But `product_id` is the only way back to the product, so once it is
`NULL`: reorder is dead, "review your purchase" is dead, the returns flow can no
longer identify what is being returned, and every per-product sales report
silently under-counts from that day on. `idx_order_items_product` carries on
indexing a column of `NULL`s.

None of it recoverable, from one admin click, with no confirmation beyond the
role check on the route.

### The schema was always built for the other thing

`products.deleted_at` exists. It has its own index. It is part of
`idx_active_products`. And **every read path in the codebase already filters on
it** — `getProducts`, `getSingleProduct`, `createProduct`'s duplicate check, the
variants query, the review queries, `reviewModerationService`,
`productRepository`. The only statement that would ever have *set* it was this
one, and it threw the row away instead.

So this is not "add soft deletes". It is finishing the one that is already
there, which is why the diff is as small as it is — nothing on the read side had
to change.

### What the endpoint does now

```sql
UPDATE products
   SET deleted_at = NOW(),
       status = 'archived'
 WHERE id = ? AND deleted_at IS NULL
```

`status` moves in the same statement so the two visibility columns cannot
disagree — a row that is soft-deleted but still says `active` is a contradiction
waiting for whichever query reads only one of them.

`AND deleted_at IS NULL` so deleting an already-deleted product is a `404`
rather than a second cheerful success that moves the timestamp forward and loses
when the deletion actually happened.

### Two things do still go

Because they are live state rather than history, and keeping them is worse than
losing them:

- **`inventory_locks`** — a hold on stock for a product nobody can buy. Left
  alone it sits there until its own expiry, reserving stock against a withdrawn
  product.
- **`cart_items`** — a line the shopper cannot check out. Leaving it means a
  basket that fails at payment with no explanation; removing it at least fails
  early and visibly.

Everything else is a record of something that happened and stays.

This is deliberately **not** in a transaction with the withdrawal. The
withdrawal is what the caller asked for and it has already succeeded. If
clearing a cart line fails, rolling back would leave a product on sale that an
admin has decided should not be — the worse of the two outcomes. Failures are
logged; both statements are idempotent so a retry costs nothing.

### `POST /api/products/:id/restore`

Without an undo, "soft" is a claim nobody can check — from outside it is the
same as the hard delete it replaced.

It comes back as a **draft**, not as `active`. An admin restoring a product is
undoing a mistake, and the next thing they want is to look at it before
customers do; silently putting it back on sale is a second surprise on top of
the first. Guarded on `deleted_at IS NOT NULL`, so restoring a live product is a
`404` rather than a no-op that quietly resets its status.

It does not recreate the cart lines and locks dropped on the way out. Those
belonged to sessions that have long since moved on.

### The other door onto the same row

`baseRepository.delete()` had the same shape, and `productService.deleteProduct()`
reaches `products` through it — so fixing only the controller would have left the
entire cascade one method call away.

It is now soft when a repository declares a `softDeleteColumn` and unchanged
otherwise, which `orders`, `users` and `wishlist` all still rely on. The column
is declared explicitly rather than sniffed from the schema: a repository whose
behaviour depends on whether a column happens to exist is one that silently
changes behaviour when somebody adds one.

`hardDelete()` is still there for callers that genuinely mean it — an erasure
request is supposed to destroy data. The point is that it has to be asked for by
name rather than arrived at by default.

## 🔗 Related Issue

Closes #1457

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🧪 Tests

23 new tests in `backend/tests/productSoftDelete.test.js`. The strongest one is
the plainest:

```js
for (const sql of executedSql()) {
    expect(sql).not.toMatch(/DELETE\s+FROM\s+products\b/i);
}
```

Fourteen cascades hang off that statement; none of them can fire if it is not
sent. There is a matching test asserting no statement on the delete path names
`reviews`, `order_items`, `wishlist_items`, `product_questions` or any of the
other history tables.

Also covered: the release only runs after the withdrawal succeeds; a failed
release does not undo the withdrawal or turn a successful one into a 500;
restore's guard, its draft status and that it does not recreate carts; and the
repository split, including that a repository without the option is byte-for-byte
unchanged.

## 🌐 Additional Notes

**Overlaps with #1461.** That PR is the other half of the same story — `status`
is also unread, and `archived` is exactly the value that belongs on a withdrawn
row. They touch different functions in `productController.js` but both add a
line to `module.exports`, so whichever merges second will want a one-line
resolution there. #1461 introduces `ARCHIVED_PRODUCT_STATUS` in
`constants/productVisibility.js`; the `'archived'` literal here should become
that constant once both are in, and there is a comment at the statement saying
so. Neither PR depends on the other to be correct.

**On CI:** `main` is currently red for reasons that predate this branch —
`npm run check:syntax` fails on two frontend files (#1444) and 9 backend suites
fail with it. Checked against a clean `main`: the same 9 suites and same 23
tests fail either way. This branch adds 23 passing tests. #1448 is the fix.
