### PR TITLE
Get main green: restore the three things one merge resolution dropped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,12 @@ jobs:
       - name: Require server.js
         working-directory: backend
         run: node ../scripts/check-boot.js
+
+      # The step above covers a module exactly when something on the require
+      # path from server.js reaches it. A module nothing currently imports is
+      # checked by nothing -- it parses, so the syntax gate passes it, and it is
+      # unreachable, so the boot gate never loads it. This imports all of them
+      # (#1474).
+      - name: Require every backend module
+        working-directory: backend
+        run: node ../scripts/check-modules.js

--- a/backend/middleware/rateLimiter.js
+++ b/backend/middleware/rateLimiter.js
@@ -56,6 +56,12 @@ const GUEST_ORDER_LOOKUP_MAX =
     parseInt(process.env.RATE_LIMIT_GUEST_ORDER_LOOKUP_MAX, 10)
     || 10;
 
+// Five messages a quarter of an hour. Nobody with something to say needs a
+// sixth; anybody filling the table does.
+const CONTACT_FORM_MAX =
+    parseInt(process.env.RATE_LIMIT_CONTACT_FORM_MAX, 10)
+    || 5;
+
 const NEWSLETTER_MAX =
     parseInt(process.env.RATE_LIMIT_NEWSLETTER_MAX, 10)
     || 10;

--- a/backend/modules/catalog/index.js
+++ b/backend/modules/catalog/index.js
@@ -1,5 +1,9 @@
 // backend/modules/catalog/index.js
-const { AggregateRoot, DomainEventBus, Repository } = require('../core');
+// `DomainService` belongs in this list: `CatalogService extends DomainService`
+// 200 lines below. It was missing, so importing this module threw
+// `ReferenceError: DomainService is not defined` -- and nothing imports this
+// module, which is why nobody found out (#1474).
+const { AggregateRoot, DomainEventBus, DomainService, Repository } = require('../core');
 
 // ============================================
 // CATALOG MODULE - Bounded Context

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -17,6 +17,8 @@ const courierWebhookRoutes = require("./courierWebhookRoutes");
 const refundRoutes = require("./refundRoutes");
 const addressRoutes = require("./addressRoutes");
 const wishlistNotifyRoutes = require("./wishlistNotifyRoutes");
+const contactRoutes = require("./contactRoutes");
+const interactionRoutes = require("./interactionRoutes");
 const newsletterRoutes = require("./newsletterRoutes");
 
 router.use("/products", productRoutes);
@@ -36,6 +38,12 @@ router.use("/courier-webhooks", courierWebhookRoutes);
 router.use("/refunds", refundRoutes);
 // Saved address book (#1347).
 router.use("/addresses", addressRoutes);
+// Two paths the frontend has always called and nothing has ever served
+// (#1445). The mount names are the ones already in the requests -- singular
+// "contact", plural "interactions" -- because the callers are the contract
+// here, not the other way round.
+router.use("/contact", contactRoutes);
+router.use("/interactions", interactionRoutes);
 // Newsletter sign-up. The form has been on eight pages since long before
 // anything served this path (#1459).
 router.use("/newsletter", newsletterRoutes);

--- a/backend/tests/rateLimiter.test.js
+++ b/backend/tests/rateLimiter.test.js
@@ -1,0 +1,166 @@
+// backend/tests/rateLimiter.test.js
+//
+// The limiter module had no test of its own. `contactFormLimiter` was built
+// from `CONTACT_FORM_MAX`, a merge dropped the declaration and kept the use,
+// and the first thing to notice was the boot gate -- after the merge was on
+// `main` (#1474).
+//
+// A `require` of this module is most of the value here: it evaluates every
+// limiter definition, so an undeclared constant in any of them fails the suite
+// rather than only the boot script. The assertions past that cover the part a
+// require cannot, which is whether each limiter got the numbers it was supposed
+// to get. `max` being `undefined` is not an error to express-rate-limit -- it
+// falls back to the library default of 5 -- so a limiter can be silently
+// mis-tuned without anything throwing.
+//
+// Redis is stubbed: `config/redisRateLimitStore` is what connects, and every
+// assertion here is about configuration, which is decided before a store is
+// ever consulted.
+
+// Env has to be set before the module is required -- the maximums are read into
+// consts at import time, so anything set afterwards is read too late.
+process.env.RATE_LIMIT_CONTACT_FORM_MAX = "7";
+process.env.RATE_LIMIT_NEWSLETTER_MAX = "11";
+process.env.RATE_LIMIT_LOGIN_MAX = "4";
+
+// `name` never reaches express-rate-limit -- createLimiter spends it on the
+// store's Redis namespace (`rl:auth:<name>`) and passes the rest through. So
+// the namespace is what identifies a limiter in the recorded options, and the
+// stub returns a tagged object rather than undefined to carry it.
+jest.mock("../config/redisRateLimitStore", () => ({
+    createRateLimitStore: jest.fn((namespace) => ({ __namespace: namespace }))
+}));
+
+// express-rate-limit is replaced with a recorder. The real one is a well-tested
+// third-party package; what is worth asserting is the options this repo hands
+// it, and the recorder is the only way to see them.
+const recordedOptions = [];
+
+jest.mock("express-rate-limit", () => {
+    const factory = jest.fn((options) => {
+        recordedOptions.push(options);
+
+        const middleware = (req, res, next) => next();
+        middleware.__options = options;
+        return middleware;
+    });
+
+    factory.ipKeyGenerator = jest.fn((address) => `ip:${address}`);
+
+    return factory;
+});
+
+const limiters = require("../middleware/rateLimiter");
+
+// The namespace createLimiter builds, and therefore the only identifier a
+// limiter carries into its recorded options.
+const NAMESPACE_PREFIX = "rl:auth:";
+
+function namespaceOf(options) {
+    return String(options.store?.__namespace || "").replace(NAMESPACE_PREFIX, "");
+}
+
+function optionsFor(name) {
+    return recordedOptions.find((options) => namespaceOf(options) === name);
+}
+
+// Every limiter the module exports, with the express-rate-limit `name` it is
+// registered under. A limiter added to the module without being added here
+// fails the completeness test below, which is the point: the list is the
+// inventory, and an entry missing from it is a limiter nobody is checking.
+const EXPORTED_LIMITERS = [
+    ["loginLimiter", "login"],
+    ["signupLimiter", "signup"],
+    ["refreshTokenLimiter", "refresh-token"],
+    ["forgotPasswordLimiter", "forgot-password"],
+    ["otpVerifyLimiter", "otp-verify"],
+    ["resetPasswordLimiter", "reset-password"],
+    ["otpRequestLimiter", "otp-request"],
+    ["newsletterLimiter", "newsletter"],
+    ["guestOrderLookupLimiter", "guest-order-lookup"],
+    ["contactFormLimiter", "contact-form"],
+    ["suspiciousIpLimiter", "suspicious-ip"]
+];
+
+describe("rateLimiter module", () => {
+    it("imports without throwing", () => {
+        // The regression. `CONTACT_FORM_MAX` was referenced by
+        // `contactFormLimiter` and declared by nothing, so this require threw
+        // `ReferenceError` and took `routes/authRoutes.js` -- and therefore the
+        // whole server -- down with it.
+        expect(() => require("../middleware/rateLimiter")).not.toThrow();
+    });
+
+    it.each(EXPORTED_LIMITERS)("exports %s as middleware", (exportName) => {
+        expect(typeof limiters[exportName]).toBe("function");
+    });
+
+    it("registers exactly the limiters it exports, and no others", () => {
+        const registered = recordedOptions.map(namespaceOf).sort();
+        const expected = EXPORTED_LIMITERS.map(([, name]) => name).sort();
+
+        expect(registered).toEqual(expected);
+    });
+
+    it("gives every limiter its own Redis namespace", () => {
+        // Sharing a bucket means one limiter spends another's budget: five
+        // failed logins would also consume the signup allowance for that client.
+        const namespaces = recordedOptions.map(namespaceOf);
+
+        expect(new Set(namespaces).size).toBe(namespaces.length);
+        for (const options of recordedOptions) {
+            expect(options.store.__namespace).toMatch(/^rl:auth:.+/);
+        }
+    });
+
+    it("gives every limiter a max", () => {
+        // express-rate-limit treats an absent `max` as its own default of 5
+        // rather than as an error, so an undeclared constant reaching this far
+        // would produce a quietly wrong limit instead of a loud failure. That is
+        // the shape of the bug this file exists for -- assert it directly.
+        for (const options of recordedOptions) {
+            expect(Number.isFinite(options.max)).toBe(true);
+            expect(options.max).toBeGreaterThan(0);
+        }
+    });
+
+    it("gives every limiter a positive window", () => {
+        for (const options of recordedOptions) {
+            expect(Number.isFinite(options.windowMs)).toBe(true);
+            expect(options.windowMs).toBeGreaterThan(0);
+        }
+    });
+});
+
+describe("environment overrides", () => {
+    it("reads the contact form maximum from RATE_LIMIT_CONTACT_FORM_MAX", () => {
+        expect(optionsFor("contact-form").max).toBe(7);
+    });
+
+    it("reads the newsletter maximum from RATE_LIMIT_NEWSLETTER_MAX", () => {
+        expect(optionsFor("newsletter").max).toBe(11);
+    });
+
+    it("reads the login maximum from RATE_LIMIT_LOGIN_MAX", () => {
+        expect(optionsFor("login").max).toBe(4);
+    });
+});
+
+describe("limiter namespacing", () => {
+    it("keeps the contact form in its own bucket", () => {
+        // Someone who has just failed a login is exactly the person about to
+        // use the contact form. Sharing a counter would mean the one locks out
+        // the other.
+        const contactForm = optionsFor("contact-form");
+        const login = optionsFor("login");
+
+        expect(contactForm.store.__namespace).not.toBe(login.store.__namespace);
+    });
+
+    it("gives the newsletter a longer window than the credential limiters", () => {
+        // Deliberate: the newsletter limit is about volume of outbound mail
+        // over an hour, not about credential guessing over fifteen minutes.
+        expect(optionsFor("newsletter").windowMs)
+            .toBeGreaterThan(optionsFor("login").windowMs);
+    });
+});

--- a/frontend/newsletter.html
+++ b/frontend/newsletter.html
@@ -11,7 +11,7 @@
     >
 
     <!-- SEO -->
-    <link rel="canonical" href="https://www.bhuvansh.xyz/newsletter.html">
+    <link rel="canonical" href="https://e-commerce-git-main-bhuvanshs-projects.vercel.app/newsletter.html">
     <meta
         name="description"
         content="Confirm or cancel your AnthropicBots E-Commerce newsletter subscription."

--- a/frontend/sitemap.xml
+++ b/frontend/sitemap.xml
@@ -3,97 +3,102 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/Buy1Get1.html</loc>
-    <lastmod>2026-06-20</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/about.html</loc>
-    <lastmod>2026-07-18</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/blog.html</loc>
-    <lastmod>2026-07-18</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/compare.html</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/contact.html</loc>
-    <lastmod>2026-07-18</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/delivery.html</loc>
-    <lastmod>2026-07-18</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/early_summer.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/help.html</loc>
-    <lastmod>2026-07-18</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/index.html</loc>
-    <lastmod>2026-07-18</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/mens.html</loc>
-    <lastmod>2026-06-20</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/newsletter.html</loc>
+    <lastmod>2026-08-04</lastmod>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/privacy.html</loc>
-    <lastmod>2026-07-18</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/product.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/seasonal.html</loc>
-    <lastmod>2026-06-20</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/shop.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/signin.html</loc>
-    <lastmod>2026-07-18</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/signup.html</loc>
-    <lastmod>2026-07-18</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/terms.html</loc>
-    <lastmod>2026-07-18</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/tshirt.html</loc>
-    <lastmod>2026-06-20</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://e-commerce-git-main-bhuvanshs-projects.vercel.app/womens.html</loc>
-    <lastmod>2026-06-20</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.8</priority>
   </url>
 </urlset>

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "scripts": {
     "check:syntax": "node scripts/check-syntax.js",
     "check:boot": "cd backend && node ../scripts/check-boot.js",
+    "check:modules": "cd backend && node ../scripts/check-modules.js",
     "sitemap": "node scripts/generate-sitemap.js",
     "check:sitemap": "node scripts/generate-sitemap.js --check",
     "check:a11y": "node scripts/check-a11y-landmarks.js",
-    "test": "npm run check:syntax && npm run check:boot && npm run test:backend",
+    "test": "npm run check:syntax && npm run check:boot && npm run check:modules && npm run test:backend",
     "test:backend": "npm --prefix backend test",
     "start": "npm --prefix backend start",
     "dev": "npm --prefix backend run dev"

--- a/scripts/check-boot.js
+++ b/scripts/check-boot.js
@@ -32,28 +32,15 @@
 
 const path = require('path');
 
+// Shared with scripts/check-modules.js, which needs the identical set. Applied
+// before the first require of application code -- see the module itself for why
+// the two gates must not keep separate copies of it.
+const { applyPlaceholderEnv } = require('./lib/placeholder-env');
+
+applyPlaceholderEnv();
+
 const REPO_ROOT = path.resolve(__dirname, '..');
 const SERVER_PATH = path.join(REPO_ROOT, 'backend', 'server.js');
-
-// Placeholders, not secrets: nothing here is used to reach a real service.
-// Each is `||`-guarded so a caller that has a real value keeps it.
-const PLACEHOLDER_ENV = {
-    NODE_ENV: 'test',
-    DB_HOST: 'localhost',
-    DB_PORT: '3306',
-    DB_USER: 'boot_check',
-    DB_PASSWORD: 'boot_check',
-    DB_NAME: 'boot_check',
-    JWT_SECRET: 'boot_check_jwt_secret_at_least_32_characters_long',
-    JWT_REFRESH_SECRET: 'boot_check_jwt_refresh_secret_at_least_32_characters',
-    PORT: '5099',
-    FRONTEND_URL: 'http://localhost:5500',
-    STRIPE_SECRET_KEY: 'sk_test_00000000000000000000000000'
-};
-
-for (const [key, value] of Object.entries(PLACEHOLDER_ENV)) {
-    process.env[key] = process.env[key] || value;
-}
 
 function fail(message, error) {
     console.error(`\n❌ backend/server.js failed to boot: ${message}\n`);

--- a/scripts/check-modules.js
+++ b/scripts/check-modules.js
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+//
+// scripts/check-modules.js
+//
+// Require-time gate for every backend module, not just the ones the server
+// happens to reach. Addresses #1474.
+//
+// We already run two gates before this one and neither could see the failure
+// that took `main` down:
+//
+//   check-syntax.js  parses each file. `max: CONTACT_FORM_MAX` where nothing
+//                    declares `CONTACT_FORM_MAX` is a valid identifier in a
+//                    valid expression; it parses cleanly and throws when the
+//                    line runs.
+//   check-boot.js    requires `server.js`, so it covers a module exactly when
+//                    something on the require path from `server.js` reaches it.
+//                    It did catch this one -- after the merge was already on
+//                    `main`, because the merge is what created it.
+//
+// The gap is the second of those. A module nothing currently imports -- a
+// service behind a flag, a route that is written but not yet mounted, a module
+// whose only caller was deleted -- is checked by nothing. It parses, so the
+// parse gate passes it; it is not reachable, so the boot gate never loads it.
+// The first person to import it finds out.
+//
+// This requires each one on its own and reports what threw. It is the same
+// check the boot gate makes, applied to the whole tree instead of one graph,
+// and it catches the class the parse gate structurally cannot: undeclared
+// identifiers, `require` of a package that is used but not in package.json,
+// misspelled relative paths, and top-level throws.
+//
+// Usage:
+//   node scripts/check-modules.js            # check backend/
+//   node scripts/check-modules.js --list      # list what would be checked
+//
+// Exit code 0 when every module loads (or fails only in a way KNOWN_FAILURES
+// documents), 1 otherwise.
+//
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { applyPlaceholderEnv } = require('./lib/placeholder-env');
+
+// Must run before the first require of application code -- config/db.js and
+// config/envValidator.js validate at require time.
+applyPlaceholderEnv();
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const BACKEND_ROOT = path.join(REPO_ROOT, 'backend');
+
+// Directories with nothing to load: third-party code, build output, test
+// files (Jest owns those), and directories that hold no JavaScript at all.
+const IGNORED_DIRS = new Set([
+    'node_modules',
+    '.git',
+    'coverage',
+    'dist',
+    'build',
+    'logs',
+    'tests',
+    'docs',
+    'openapi',
+    'sql'
+]);
+
+// `server.js` binds a listener and starts a renewal cron. check-boot.js owns
+// it, deliberately and on its own.
+const IGNORED_FILES = new Set([
+    path.join(BACKEND_ROOT, 'server.js')
+]);
+
+// ============================================================================
+// KNOWN FAILURES
+// ============================================================================
+//
+// A ratchet, in the spirit of the coverage thresholds in backend/jest.config.js.
+// These modules do not load today. Failing the build on them would mean this
+// gate is red on arrival, which teaches people to ignore it -- the exact
+// dynamic that let eight unparsable files reach `main` in #1297.
+//
+// So each is recorded with the error it currently produces and why it is
+// tolerated. The `match` is part of the contract: a module listed here still
+// fails the gate if it starts failing for a *different* reason, and a module
+// that starts loading correctly also fails the gate, so an entry cannot outlive
+// the problem it describes. Fix one, delete its entry.
+//
+// Every one of these is a real defect. None of them is this PR's.
+//
+const KNOWN_FAILURES = [
+    {
+        file: 'middleware/agenticATOMiddleware.js',
+        match: /Cannot find module '@tensorflow\/tfjs-node'/,
+        reason:
+            '@tensorflow/tfjs-node is required but not in backend/package.json. '
+            + 'It is a large native-build dependency; adding it is a decision '
+            + 'about the deployment, not a build fix.'
+    },
+    {
+        file: 'services/agenticATODetectionService.js',
+        match: /Cannot find module '@tensorflow\/tfjs-node'/,
+        reason: 'Same missing dependency as middleware/agenticATOMiddleware.js.'
+    },
+    {
+        file: 'middleware/refundFraudMiddleware.js',
+        match: /Cannot find module 'multer'/,
+        reason:
+            'multer is required but not in backend/package.json. Cheap to add, '
+            + 'but it changes what the refund upload path does and belongs with '
+            + 'a change that exercises it.'
+    },
+    {
+        file: 'routes/puppeteerRoutes.js',
+        match: /Cannot find module 'puppeteer'/,
+        reason:
+            'puppeteer is required but not in backend/package.json. It ships a '
+            + 'browser; adding it to the API image is a deployment decision.'
+    },
+    {
+        file: 'services/puppeteerPoolService.js',
+        match: /Cannot find module 'puppeteer'/,
+        reason: 'Same missing dependency as routes/puppeteerRoutes.js.'
+    }
+];
+
+function findKnownFailure(relativeFile) {
+    return KNOWN_FAILURES.find((entry) => entry.file === relativeFile) || null;
+}
+
+/**
+ * Recursively collect every `.js` file under `dir`.
+ *
+ * @param {string} dir - Absolute directory path.
+ * @param {string[]} [found] - Accumulator.
+ * @returns {string[]} Absolute file paths, sorted for stable output.
+ */
+function collectModules(dir, found = []) {
+    let entries;
+
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (error) {
+        if (error.code === 'ENOENT') return found;
+        throw error;
+    }
+
+    for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            if (IGNORED_DIRS.has(entry.name)) continue;
+            collectModules(full, found);
+            continue;
+        }
+
+        if (!entry.isFile() || !entry.name.endsWith('.js')) continue;
+        if (IGNORED_FILES.has(full)) continue;
+
+        found.push(full);
+    }
+
+    return found;
+}
+
+/**
+ * Require one module and report what happened.
+ *
+ * Requiring is not free of side effects -- several services open pools and
+ * start intervals on import -- but that is the point. A module that cannot be
+ * imported without throwing is a module that cannot be used, and the only way
+ * to find out is to import it.
+ *
+ * @param {string} filePath - Absolute path.
+ * @returns {Error|null} null when it loads.
+ */
+function loadModule(filePath) {
+    try {
+        require(filePath);
+        return null;
+    } catch (error) {
+        return error instanceof Error ? error : new Error(String(error));
+    }
+}
+
+/**
+ * The first stack frame that points inside the repository.
+ *
+ * Node's own loader frames dominate a MODULE_NOT_FOUND stack, and the frame
+ * that matters is the one naming the file that did the requiring.
+ *
+ * @param {Error} error
+ * @returns {string|null}
+ */
+function originFrame(error) {
+    const frames = String(error.stack || '').split('\n').slice(1);
+
+    for (const frame of frames) {
+        if (!frame.includes(REPO_ROOT)) continue;
+        if (frame.includes(`${path.sep}node_modules${path.sep}`)) continue;
+
+        // Anchor on the repo root rather than on whitespace. A frame reads
+        // `at Object.<anonymous> (/abs/path/file.js:12:3)`, and a checkout
+        // directory is allowed to contain spaces -- so neither "everything
+        // after the last space" nor a space-intolerant character class gets the
+        // path right. Slicing from the known prefix does.
+        const start = frame.indexOf(REPO_ROOT);
+        const location = frame.slice(start).replace(/\)\s*$/, '');
+
+        const match = /^(.+):(\d+):(\d+)$/.exec(location);
+        if (!match) continue;
+
+        return `${path.relative(REPO_ROOT, match[1])}:${match[2]}`;
+    }
+
+    return null;
+}
+
+function explain(error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+        return 'a require could not be resolved. Either the relative path is '
+            + 'misspelled, the file is missing, or the package is used but not '
+            + 'listed in backend/package.json.';
+    }
+
+    if (error instanceof ReferenceError) {
+        return 'the module body referenced a name nothing declares. This is the '
+            + 'shape a conflict resolution leaves behind when it keeps a use and '
+            + 'drops its declaration -- it parses, so the syntax gate passes it.';
+    }
+
+    if (error instanceof TypeError) {
+        return 'the module body threw while evaluating. Commonly a destructure '
+            + 'of something a require did not return, or a call on a value that '
+            + 'is not what it is expected to be.';
+    }
+
+    return 'the module body threw on import.';
+}
+
+// ============================================================================
+// RUN
+// ============================================================================
+
+function main() {
+    const modules = collectModules(BACKEND_ROOT).sort();
+
+    if (process.argv.includes('--list')) {
+        for (const file of modules) {
+            console.log(path.relative(REPO_ROOT, file));
+        }
+        process.exit(0);
+    }
+
+    const failures = [];
+    const tolerated = [];
+    const fixed = [];
+
+    for (const file of modules) {
+        const relativeToBackend = path.relative(BACKEND_ROOT, file);
+        const known = findKnownFailure(relativeToBackend);
+        const error = loadModule(file);
+
+        if (!error) {
+            // A module that used to fail and now loads means KNOWN_FAILURES is
+            // stale. Left alone, the list quietly grows into a permanent
+            // exemption for problems that no longer exist.
+            if (known) fixed.push(relativeToBackend);
+            continue;
+        }
+
+        if (known && known.match.test(error.message || '')) {
+            tolerated.push({ file: relativeToBackend, reason: known.reason });
+            continue;
+        }
+
+        failures.push({ file, error, wasKnown: Boolean(known) });
+    }
+
+    // ---- report ------------------------------------------------------------
+
+    console.log('');
+
+    if (tolerated.length > 0) {
+        console.log(`ℹ️  ${tolerated.length} known failure(s) tolerated:\n`);
+        for (const entry of tolerated) {
+            console.log(`   backend/${entry.file}`);
+            console.log(`      ${entry.reason}\n`);
+        }
+    }
+
+    for (const { file, error, wasKnown } of failures) {
+        const relative = path.relative(REPO_ROOT, file);
+        const origin = originFrame(error);
+
+        console.error(`❌ ${relative}`);
+        console.error(`   ${error.name}: ${(error.message || '').split('\n')[0]}`);
+        if (origin && origin !== relative) console.error(`   thrown from ${origin}`);
+        console.error(`   ${explain(error)}`);
+        if (wasKnown) {
+            console.error(
+                '   NOTE: this file is in KNOWN_FAILURES but is failing for a '
+                + 'different reason than the one recorded there.'
+            );
+        }
+        console.error('');
+    }
+
+    for (const file of fixed) {
+        console.error(`❌ backend/${file}`);
+        console.error(
+            '   This module now loads, but it is still listed in KNOWN_FAILURES '
+            + 'in scripts/check-modules.js. Delete its entry.\n'
+        );
+    }
+
+    const failed = failures.length + fixed.length;
+
+    if (failed > 0) {
+        console.error(
+            `${failed} of ${modules.length} backend module(s) could not be `
+            + 'imported.\n\nRun `node scripts/check-modules.js` locally to '
+            + 'reproduce.\n'
+        );
+        process.exit(1);
+    }
+
+    console.log(
+        `✅ module check passed — ${modules.length} backend modules imported `
+        + `cleanly (${tolerated.length} known failure(s) tolerated)\n`
+    );
+
+    // Imported modules hold pools, sockets and interval timers, so the process
+    // would otherwise sit here with nothing left to do.
+    process.exit(0);
+}
+
+main();

--- a/scripts/lib/placeholder-env.js
+++ b/scripts/lib/placeholder-env.js
@@ -1,0 +1,62 @@
+//
+// scripts/lib/placeholder-env.js
+//
+// The environment the require-time gates run under.
+//
+// `config/db.js` and `config/envValidator.js` both validate at require time, so
+// a gate that loads application code has to have these set before the first
+// `require` or it fails on configuration rather than on the thing it is
+// checking. Nothing here reaches a real service: `NODE_ENV=test` makes
+// `config/db.js` skip its background connect, and every value below exists only
+// to get past a presence check.
+//
+// It lives in its own module because two gates need the identical set and they
+// have to agree. When they were separate copies, a value added to one was a
+// value the other tripped over -- which is a gate failing for a reason that has
+// nothing to do with the code under test, and the fastest way to teach people
+// to ignore it.
+//
+
+'use strict';
+
+// Placeholders, not secrets. Each is applied only when the variable is unset,
+// so a caller with a real value keeps it.
+const PLACEHOLDER_ENV = Object.freeze({
+    NODE_ENV: 'test',
+    DB_HOST: 'localhost',
+    DB_PORT: '3306',
+    DB_USER: 'gate_check',
+    DB_PASSWORD: 'gate_check',
+    DB_NAME: 'gate_check',
+    JWT_SECRET: 'gate_check_jwt_secret_at_least_32_characters_long',
+    JWT_REFRESH_SECRET: 'gate_check_jwt_refresh_secret_at_least_32_characters',
+    PORT: '5099',
+    FRONTEND_URL: 'http://localhost:5500',
+    STRIPE_SECRET_KEY: 'sk_test_00000000000000000000000000'
+});
+
+/**
+ * Apply the placeholders to `process.env`, leaving anything already set alone.
+ *
+ * Must be called before the first `require` of application code.
+ *
+ * @returns {string[]} The names of the variables this call actually set,
+ *   so a caller can report what it had to invent.
+ */
+function applyPlaceholderEnv() {
+    const applied = [];
+
+    for (const [key, value] of Object.entries(PLACEHOLDER_ENV)) {
+        if (!process.env[key]) {
+            process.env[key] = value;
+            applied.push(key);
+        }
+    }
+
+    return applied;
+}
+
+module.exports = {
+    PLACEHOLDER_ENV,
+    applyPlaceholderEnv
+};


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`main` has not booted since 2026-08-06 09:01 UTC. `backend/middleware/rateLimiter.js` builds the contact-form limiter from `CONTACT_FORM_MAX`, nothing declares it, so the module throws on require — and `routes/authRoutes.js` requires it, so *every* endpoint is down, not just the contact form.

`git show -c 4455a09` is the whole story. #1445 added `CONTACT_FORM_MAX` and #1459 added `NEWSLETTER_MAX` at the same point in the constants block. Both PRs were green on their own branch. Merging `main` into `feat/1459-newsletter-subscriptions` hit that conflict, kept the newsletter side and dropped the other — while `contactFormLimiter`, two hundred lines further down and part of no conflict, came through from main's side intact. The declaration went; its only use stayed.

**The same resolution did it twice more.** The two suites that were also failing on `main` are both that:

| File | What was dropped | Effect |
|---|---|---|
| `backend/routes/index.js` | `contactRoutes` and `interactionRoutes` — require and mount, four lines. Only `newsletterRoutes` survived. | `/contact` and `/interactions` are 404 again — the exact state #1445 existed to end. |
| `frontend/newsletter.html` | Never got #1446's host change | `<link rel="canonical">` points at `https://www.bhuvansh.xyz`, the retired host, so the one new page disagrees with the other nineteen. It is also absent from `sitemap.xml`, so it is not submitted at all. |

All three are restored here, `sitemap.xml` regenerated.

---

## 🔗 Related Issue

Closes #1474

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] Testing improvement
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix

---

## 🌐 Additional Notes

### Why no gate caught it

The parse gate structurally cannot. `max: CONTACT_FORM_MAX` is a valid identifier in a valid expression; it compiles cleanly and throws when the line runs. `node scripts/check-syntax.js` passes on the broken file — I checked by re-breaking it.

The boot gate can, and did — one minute after the merge landed on `main`, because the merge is what created it.

### The gap this closes

A different one, and it is worth having regardless of merge timing. `check-boot.js` requires `server.js`, so it covers a module exactly when something on the require path from `server.js` reaches it. **A module nothing currently imports is checked by nothing**: it parses, so the syntax gate passes it; it is unreachable, so the boot gate never loads it.

`scripts/check-modules.js` imports all 420 backend modules and reports what throws. It found one on the first run:

```
❌ backend/modules/catalog/index.js
   ReferenceError: DomainService is not defined
```

`modules/catalog/index.js` destructures `{ AggregateRoot, DomainEventBus, Repository }` from `../core` and then declares `class CatalogService extends DomainService`. Identical bug to the one that took main down, in a file nothing imports — so nobody had found out. `DomainService` was already exported from `../core`; it just was not on the list. Fixed here.

Proof it catches the original, with the constant renamed away again:

```
$ node scripts/check-syntax.js
✅ syntax check passed — 562 JavaScript file(s) parsed cleanly     <- sees nothing

$ node ../scripts/check-modules.js
❌ backend/middleware/rateLimiter.js
   ReferenceError: CONTACT_FORM_MAX is not defined
   thrown from backend/middleware/rateLimiter.js:282
   the module body referenced a name nothing declares. This is the shape a
   conflict resolution leaves behind when it keeps a use and drops its
   declaration -- it parses, so the syntax gate passes it.
```

### KNOWN_FAILURES

Five modules do not load today, all of them requiring a package that is used but not in `backend/package.json` (`puppeteer`, `multer`, `@tensorflow/tfjs-node`). Failing the build on those would mean the gate is red on arrival, which is how you teach people to ignore a gate — the same dynamic that let eight unparsable files reach `main` in #1297.

So each is recorded with the error it currently produces and why it is tolerated. The recorded pattern is part of the contract:

- a listed module still **fails** the gate if it starts failing for a *different* reason;
- a listed module that starts **loading** also fails the gate, so an entry cannot outlive the problem it describes.

Every one of them is a real defect. None of them is this PR's, and adding a browser or a native TensorFlow build to the API image is a deployment decision, not a build fix.

### Tests

The limiter module had no test of its own. `tests/rateLimiter.test.js` requires it — which alone would have failed this — and then asserts the part a require cannot: that every limiter got a finite `max` and `windowMs`, and its own Redis namespace. `max: undefined` is not an error to express-rate-limit; it silently falls back to the library default of 5, so a limiter can be mis-tuned without anything throwing.

`check-boot.js` and `check-modules.js` need the identical placeholder environment and have to agree on it, so it moves to `scripts/lib/placeholder-env.js` rather than living as two copies that drift.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

**Local run, all gates:**

```
✅ syntax check passed — 562 JavaScript file(s) parsed cleanly
✅ boot check passed — backend/server.js loaded with 73 mounted layers
✅ module check passed — 420 backend modules imported cleanly (5 known failure(s) tolerated)
✅ frontend/sitemap.xml covers all 20 public page(s)
✅ landmark check passed — 30 page(s) have a skip link, a main landmark and one h1

Test Suites: 65 passed, 65 total
Tests:       1467 passed, 1467 total
```

Before this branch: 2 suites failing, 6 tests failing, boot gate red.
