### PR TITLE
Enforce the per-user promo limits the columns have always claimed

### DIFF
--- a/backend/controllers/promo.controller.js
+++ b/backend/controllers/promo.controller.js
@@ -1,5 +1,11 @@
 
-const { validatePromo, calculateDiscount, getPromoByCode, applyPromoTransaction } = require("../services/promo.service");
+const {
+    validatePromo,
+    calculateDiscount,
+    getPromoByCode,
+    applyPromoTransaction,
+    checkEligibilityForRow
+} = require("../services/promo.service");
 const cartLifecycle = require("../services/cartLifecycleService");
 const { safeNumber, sanitizeString } = require("../utils/helpers");
 const { PERMISSIONS, hasPermission } = require("../config/policy");
@@ -250,6 +256,22 @@ const validatePromoCode = async (req, res) => {
             });
         }
 
+        // Per-user eligibility (#1475). Advisory -- applyPromoTransaction runs
+        // the authoritative version under the promo row lock -- but this is the
+        // call that lets the shopper find out at the cart rather than at the
+        // moment they try to pay.
+        //
+        // `promo` may have come from promoCache, which is keyed on the code
+        // alone and so is shared across users. That is fine: nothing cached
+        // here is per-user; the usage count is read fresh below.
+        const eligibility = await checkEligibilityForRow(promo, userId);
+        if (!eligibility.eligible) {
+            return res.status(400).json({
+                success: false,
+                message: eligibility.reason
+            });
+        }
+
         // Calculate discount
         const discount = calculateDiscount(promo, cartTotal);
         const maxAllowedDiscount = calculateMaxDiscount(
@@ -344,7 +366,11 @@ const validateMultiplePromos = async (req, res) => {
                     continue;
                 }
 
-                const validation = await validatePromo(normalizedCode, total);
+                // `userId` is passed so a code the caller is not eligible for
+                // comes back as an invalid entry with a reason, alongside the
+                // codes that did validate, rather than as a blanket failure
+                // (#1475).
+                const validation = await validatePromo(normalizedCode, total, userId);
                 if (!validation.valid) {
                     promoResults.push({ promoCode: code, valid: false, message: validation.message });
                     continue;
@@ -481,8 +507,12 @@ const applyMultiplePromos = async (req, res) => {
                     continue;
                 }
 
-                // Validate promo against current remaining total
-                const validation = await validatePromo(promo.code, remainingTotal);
+                // Validate promo against current remaining total. Passing
+                // `userId` turns "not eligible" into a per-code result here
+                // instead of an exception out of applyPromoTransaction below,
+                // which would abandon the codes that were still to be applied
+                // (#1475).
+                const validation = await validatePromo(promo.code, remainingTotal, userId);
                 if (!validation.valid) {
                     results.push({
                         promoCode: promo.code,

--- a/backend/services/promo.service.js
+++ b/backend/services/promo.service.js
@@ -47,7 +47,159 @@ const getPromoByCode = async (code) => {
     return safeArray(results)[0];
 };
 
-const validatePromo = async (code, cartTotal) => {
+// ============================================================================
+// PER-USER ELIGIBILITY
+// ============================================================================
+//
+// `per_user_limit` and `user_eligibility` were columns nothing read (#1475).
+// The helpers below are what reads them, and they are shared by the pre-flight
+// check and the one inside the apply transaction so the two cannot disagree
+// about what a value means.
+
+// The controllers hand a guest the literal string "guest" rather than an id, so
+// every anonymous caller shares one identity. Counting per-user usage against
+// that is meaningless -- it would let the first guest exhaust the allowance for
+// all of them -- so a per-user rule needs a real account behind it.
+const GUEST_USER_ID = "guest";
+
+const isIdentifiedUser = (userId) =>
+    userId !== null
+    && userId !== undefined
+    && userId !== ""
+    && userId !== GUEST_USER_ID;
+
+/**
+ * How many times one user may use this code.
+ *
+ * NULL means unlimited; a number, including zero, is a limit. The distinction
+ * matters: `0` is legal (`CHECK (per_user_limit >= 0)` in
+ * migrations/0002_promo_schema.sql) and reads as "nobody may use this", but a
+ * truthiness test folds it into "unlimited" -- the exact opposite of what it
+ * says.
+ *
+ * @param {unknown} value
+ * @returns {number|null} null when unlimited.
+ */
+const parsePerUserLimit = (value) => {
+    if (value === null || value === undefined || value === "") {
+        return null;
+    }
+
+    const limit = Number(value);
+
+    return Number.isFinite(limit) && limit >= 0 ? limit : null;
+};
+
+/**
+ * The account allow-list, if the promo carries one.
+ *
+ * Stored as JSON text. A malformed value is treated as "no allow-list" rather
+ * than being allowed to throw: a bad column should not take down validation for
+ * a code that is otherwise fine, and the surrounding checks still apply.
+ *
+ * An empty array means the same as no list at all -- that is the reading the
+ * original helper had, and rows exist that rely on it.
+ *
+ * @param {unknown} raw
+ * @returns {string[]|null} null when the promo is open to everybody.
+ */
+const parseEligibleUsers = (raw) => {
+    if (!raw) return null;
+
+    let parsed;
+
+    try {
+        parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+    } catch (error) {
+        console.error("Promo user_eligibility is not valid JSON, ignoring it:", error.message);
+        return null;
+    }
+
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+        return null;
+    }
+
+    return parsed.map((id) => String(id));
+};
+
+/**
+ * How many times this user has already used this code.
+ *
+ * Runs on the caller's connection when one is given, so the count can be taken
+ * inside the apply transaction and under the same row lock as the global
+ * counter. Taken outside it, two concurrent requests both read "0 so far" and
+ * both proceed.
+ *
+ * @param {string} promoCode
+ * @param {string} userId
+ * @param {object} [connection]
+ * @returns {Promise<number>}
+ */
+const countUserUsage = async (promoCode, userId, connection = db) => {
+    const [rows] = await connection.query(
+        "SELECT COUNT(*) AS count FROM promo_usage_logs WHERE promo_code = ? AND user_id = ?",
+        [promoCode, userId]
+    );
+
+    return safeNumber(safeArray(rows)[0]?.count) || 0;
+};
+
+/**
+ * Is this user allowed to use this code?
+ *
+ * Split out from the row fetch so the transaction can call it with a row it has
+ * already locked instead of reading the same row a second time.
+ *
+ * @param {object} promo
+ * @param {string} userId
+ * @param {object} [connection]
+ * @returns {Promise<{eligible: boolean, reason?: string}>}
+ */
+const checkEligibilityForRow = async (promo, userId, connection = db) => {
+    const eligibleUsers = parseEligibleUsers(promo.user_eligibility);
+    const perUserLimit = parsePerUserLimit(promo.per_user_limit);
+
+    // A promo with no per-user rule is open to anyone, signed in or not.
+    if (eligibleUsers === null && perUserLimit === null) {
+        return { eligible: true };
+    }
+
+    if (!isIdentifiedUser(userId)) {
+        return {
+            eligible: false,
+            reason: "Sign in to use this promo code"
+        };
+    }
+
+    if (eligibleUsers !== null && !eligibleUsers.includes(String(userId))) {
+        return {
+            eligible: false,
+            reason: "This promo is not available for your account"
+        };
+    }
+
+    if (perUserLimit !== null) {
+        if (perUserLimit === 0) {
+            return {
+                eligible: false,
+                reason: "This promo is not available for your account"
+            };
+        }
+
+        const used = await countUserUsage(promo.code, userId, connection);
+
+        if (used >= perUserLimit) {
+            return {
+                eligible: false,
+                reason: "You have already used this promo the maximum number of times"
+            };
+        }
+    }
+
+    return { eligible: true };
+};
+
+const validatePromo = async (code, cartTotal, userId = null) => {
     const promo = await getPromoByCode(code);
     if (!promo) {
         return { valid: false, message: "Invalid promo code" };
@@ -73,6 +225,21 @@ const validatePromo = async (code, cartTotal) => {
         return { valid: false, message: "Promo code usage limit has been reached" };
     }
 
+    // Per-user eligibility. Advisory here and re-checked under the row lock in
+    // `applyPromoTransaction` -- this call exists so the shopper is turned away
+    // at the cart with a reason, rather than at the moment they try to pay.
+    //
+    // `userId` is optional so existing callers keep working; when it is absent
+    // a per-user rule cannot be evaluated and the code passes this stage, which
+    // is why the authoritative check is the one in the transaction.
+    if (userId !== null && userId !== undefined) {
+        const eligibility = await checkEligibilityForRow(promo, userId);
+
+        if (!eligibility.eligible) {
+            return { valid: false, message: eligibility.reason };
+        }
+    }
+
     return { valid: true, promo };
 };
 
@@ -95,8 +262,51 @@ const calculateDiscount = (promo, cartTotal) => {
     return Number(discount.toFixed(2));
 };
 
+/**
+ * Bring the Redis counter back in line with the durable value.
+ *
+ * Called *after* the transaction commits, with the number that was committed.
+ * Redis is a cache in front of `promo_codes.usage_count`, not the system of
+ * record, so it is written from the record rather than incremented alongside
+ * it -- an increment that happens inside a transaction survives that
+ * transaction rolling back, and `getUsedCount` prefers Redis, so the drift is
+ * permanent and always upward (#1475).
+ *
+ * Failing to write the cache is not a failure of the redemption: the durable
+ * count is already committed and `getUsedCount` falls back to it.
+ *
+ * @param {string} promoCode
+ * @param {number} usageCount The committed `usage_count`.
+ * @param {Date|string|null} expiryDate Used to expire the key with the promo.
+ */
+const refreshUsageCounter = async (promoCode, usageCount, expiryDate) => {
+    const usageKey = getPromoUsageKey(promoCode);
+
+    try {
+        await redis.set(usageKey, String(usageCount));
+
+        const ttlSeconds = expiryDate
+            ? Math.floor((new Date(expiryDate).getTime() - Date.now()) / 1000)
+            : 0;
+
+        if (ttlSeconds > 0) {
+            await redis.expire(usageKey, ttlSeconds);
+        }
+    } catch (error) {
+        console.error(
+            `Could not refresh the promo usage counter for ${promoCode}; `
+            + `usage_count is committed at ${usageCount} and remains authoritative:`,
+            error.message
+        );
+    }
+};
+
 const applyPromoTransaction = async (promoCode, userId, discountAmount) => {
     try {
+        // Captured inside the transaction, used after it commits.
+        let committedUsageCount = null;
+        let promoExpiryDate = null;
+
         await withTransaction(async (connection) => {
             // Lock the promo row for update (prevents concurrent usage)
             const [promoResults] = await connection.query(
@@ -123,28 +333,35 @@ const applyPromoTransaction = async (promoCode, userId, discountAmount) => {
                 throw new Error(`Promo code ${promoCode} has expired`);
             }
 
-            // Check usage limit with Redis counter for atomic increment
-            const usageKey = getPromoUsageKey(promoCode);
-            const usedCount = await getUsedCount(promoCode, promo);
+            // The global usage limit, read from the row this transaction has
+            // locked. `usage_count` is the durable counter and it is what the
+            // lock protects, so it is the value the limit has to be tested
+            // against -- consulting the Redis cache here means testing a number
+            // that another transaction may already have moved.
+            const usedCount = safeNumber(promo.usage_count) || 0;
 
             if (promo.usage_limit && usedCount >= promo.usage_limit) {
                 throw new Error(`Promo code ${promoCode} usage limit reached`);
             }
 
-            // Increment usage counter atomically in Redis
-            const newCount = await redis.incr(usageKey);
+            // The per-user rule, under that same lock.
+            //
+            // This is the authoritative check -- `validatePromo` runs one too,
+            // but it runs unlocked and possibly minutes earlier, so it can only
+            // ever be advice. Taking the count here, against a row no other
+            // transaction can touch until this one ends, is what makes two
+            // simultaneous redemptions of a one-per-customer code impossible
+            // rather than merely unlikely.
+            const eligibility = await checkEligibilityForRow(promo, userId, connection);
 
-            // If usage limit exceeded, rollback Redis counter
-            if (promo.usage_limit && newCount > promo.usage_limit) {
-                await redis.decr(usageKey);
-                throw new Error(`Promo code ${promoCode} usage limit reached`);
+            if (!eligibility.eligible) {
+                throw new Error(
+                    `Promo code ${promoCode} is not available for user ${userId}: ${eligibility.reason}`
+                );
             }
 
-            const expiryDate = new Date(promo.expiry_date);
-            const ttlSeconds = Math.floor((expiryDate - now) / 1000);
-            if (ttlSeconds > 0) {
-                await redis.expire(usageKey, ttlSeconds);
-            }
+            committedUsageCount = usedCount + 1;
+            promoExpiryDate = promo.expiry_date;
 
             // Update database usage count
             await connection.query(
@@ -164,6 +381,11 @@ const applyPromoTransaction = async (promoCode, userId, discountAmount) => {
             );
         });
 
+        // Only now, and from the value that was actually committed. Nothing
+        // above this line touches Redis, so a rollback anywhere in the
+        // transaction leaves the counter exactly as it found it.
+        await refreshUsageCounter(promoCode, committedUsageCount, promoExpiryDate);
+
         console.log(`[AUDIT] Promo ${promoCode} applied by user ${userId} - Discount: ${discountAmount}`);
         return true;
 
@@ -173,34 +395,37 @@ const applyPromoTransaction = async (promoCode, userId, discountAmount) => {
     }
 };
 
-const checkPromoEligibility = async (promoCode, userId) => {
+/**
+ * Is this user allowed to use this code, by code rather than by row?
+ *
+ * The public entry point, kept for callers that have a code and not a row. The
+ * rules themselves live in `checkEligibilityForRow` so that this and the check
+ * inside `applyPromoTransaction` cannot drift apart -- when they were separate,
+ * one of them was simply never called.
+ *
+ * Two behaviours here changed with #1475, both of them bugs:
+ *
+ *   * `per_user_limit = 0` used to mean unlimited, because the guard was a
+ *     truthiness test. Zero is a legal value with an obvious meaning and it is
+ *     now honoured; NULL is what means unlimited.
+ *   * `count > 0 && per_user_limit` short-circuited before comparing, so the
+ *     comparison only ran for a user who had already used the code -- which is
+ *     harmless but was doing no work, and hid how little the function was
+ *     consulted.
+ *
+ * @param {string} promoCode
+ * @param {string} userId
+ * @param {object} [connection] Runs on the caller's transaction when supplied.
+ * @returns {Promise<{eligible: boolean, reason?: string}>}
+ */
+const checkPromoEligibility = async (promoCode, userId, connection = db) => {
     try {
         const promo = await getPromoByCode(promoCode);
         if (!promo) {
             return { eligible: false, reason: "Promo code not found" };
         }
 
-        // Check user-specific eligibility
-        if (promo.user_eligibility) {
-            const eligibleUsers = JSON.parse(promo.user_eligibility);
-            if (eligibleUsers.length > 0 && !eligibleUsers.includes(userId)) {
-                return { eligible: false, reason: "This promo is not available for your account" };
-            }
-        }
-
-        // Check if user has already used this promo
-        const [usageResults] = await db.query(
-            "SELECT COUNT(*) as count FROM promo_usage_logs WHERE promo_code = ? AND user_id = ?",
-            [promoCode, userId]
-        );
-        
-        if (usageResults[0].count > 0 && promo.per_user_limit) {
-            if (usageResults[0].count >= promo.per_user_limit) {
-                return { eligible: false, reason: "You have already used this promo the maximum number of times" };
-            }
-        }
-
-        return { eligible: true };
+        return await checkEligibilityForRow(promo, userId, connection);
     } catch (error) {
         console.error("Promo eligibility check error:", error);
         return { eligible: false, reason: "Failed to check eligibility" };
@@ -254,7 +479,13 @@ module.exports = {
     calculateDiscount,
     applyPromoTransaction,
     checkPromoEligibility,
+    checkEligibilityForRow,
+    countUserUsage,
+    parsePerUserLimit,
+    parseEligibleUsers,
+    refreshUsageCounter,
     getPromoUsageStats,
     resetPromoUsage,
-    getPromoUsageKey
+    getPromoUsageKey,
+    GUEST_USER_ID
 };

--- a/backend/tests/promo.test.js
+++ b/backend/tests/promo.test.js
@@ -297,8 +297,8 @@ describe("calculateDiscount", () => {
 });
 
 describe("applyPromoTransaction", () => {
-    it("locks the row, increments the counter, writes the log and commits", async () => {
-        const promo = activePromo({ usage_limit: 10 });
+    it("locks the row, writes the log, commits, then refreshes the counter", async () => {
+        const promo = activePromo({ usage_limit: 10, usage_count: 3 });
         const connection = fakeConnection([promo]);
         useTransaction(connection);
 
@@ -311,7 +311,10 @@ describe("applyPromoTransaction", () => {
             expect.stringContaining("FOR UPDATE"),
             ["TEST100"]
         );
-        expect(redis.incr).toHaveBeenCalledTimes(1);
+        // The counter is written after the commit, from the value that was
+        // committed -- never incremented inside the transaction (#1475).
+        expect(redis.incr).not.toHaveBeenCalled();
+        expect(redis.set).toHaveBeenCalledWith("promo:usage:TEST100", "4");
         expect(connection.query).toHaveBeenCalledWith(
             expect.stringContaining("usage_count = usage_count + 1"),
             ["TEST100"]
@@ -348,21 +351,56 @@ describe("applyPromoTransaction", () => {
         ).rejects.toThrow("has expired");
 
         expect(redis.incr).not.toHaveBeenCalled();
+        expect(redis.set).not.toHaveBeenCalled();
         expect(connection.rollback).toHaveBeenCalledTimes(1);
     });
 
-    it("gives the counter back when the increment overshoots the limit", async () => {
-        const connection = fakeConnection([activePromo({ usage_limit: 1, usage_count: 0 })]);
+    it("refuses a promo whose committed usage_count has reached the limit", async () => {
+        // The limit is tested against `usage_count` on the locked row, not
+        // against the Redis cache: the lock is what makes the durable counter
+        // safe to read, and a cached number may already have moved under
+        // another transaction (#1475).
+        const connection = fakeConnection([activePromo({ usage_limit: 1, usage_count: 1 })]);
         useTransaction(connection);
-        redis.incr.mockResolvedValueOnce(2);
 
         await expect(
             promoService.applyPromoTransaction("TEST100", "user123", 50)
         ).rejects.toThrow("usage limit reached");
 
-        expect(redis.decr).toHaveBeenCalledTimes(1);
         expect(connection.rollback).toHaveBeenCalledTimes(1);
         expect(connection.commit).not.toHaveBeenCalled();
+    });
+
+    it("leaves the counter alone when the transaction rolls back", async () => {
+        // The bug this replaced: the increment happened inside the transaction
+        // and was compensated on exactly one failure path, so any other failure
+        // -- a deadlock, a constraint violation, a dropped connection -- rolled
+        // the database back and left Redis one higher, permanently, because
+        // getUsedCount prefers Redis over usage_count.
+        const connection = fakeConnection([activePromo({ usage_limit: 10 })]);
+        connection.commit.mockRejectedValueOnce(new Error("deadlock"));
+        useTransaction(connection);
+
+        await expect(
+            promoService.applyPromoTransaction("TEST100", "user123", 50)
+        ).rejects.toThrow("deadlock");
+
+        expect(redis.incr).not.toHaveBeenCalled();
+        expect(redis.set).not.toHaveBeenCalled();
+    });
+
+    it("still succeeds when refreshing the counter fails", async () => {
+        // The durable count is committed by then; Redis is a cache in front of
+        // it and getUsedCount falls back to usage_count when it is missing.
+        const connection = fakeConnection([activePromo({ usage_limit: 10 })]);
+        useTransaction(connection);
+        redis.set.mockRejectedValueOnce(new Error("Redis is down"));
+
+        await expect(
+            promoService.applyPromoTransaction("TEST100", "user123", 50)
+        ).resolves.toBe(true);
+
+        expect(connection.commit).toHaveBeenCalledTimes(1);
     });
 
     it("releases the connection even when the commit itself fails", async () => {
@@ -397,6 +435,14 @@ describe("checkPromoEligibility", () => {
         expect(result.reason).toContain("not available for your account");
     });
 
+    it("accepts a user named in the eligibility list", async () => {
+        stubPromoRow(activePromo({ user_eligibility: JSON.stringify(["u1", "u2"]) }));
+
+        await expect(
+            promoService.checkPromoEligibility("TEST100", "u1")
+        ).resolves.toEqual({ eligible: true });
+    });
+
     it("rejects a user who has hit their per-user limit", async () => {
         stubPromoRow(activePromo({ per_user_limit: 1 }));
         db.query.mockResolvedValueOnce([[{ count: 1 }]]);
@@ -416,6 +462,75 @@ describe("checkPromoEligibility", () => {
         ).resolves.toEqual({ eligible: true });
     });
 
+    it("accepts a user still under a per-user limit above one", async () => {
+        stubPromoRow(activePromo({ per_user_limit: 3 }));
+        db.query.mockResolvedValueOnce([[{ count: 2 }]]);
+
+        await expect(
+            promoService.checkPromoEligibility("TEST100", "u1")
+        ).resolves.toEqual({ eligible: true });
+    });
+
+    it("treats per_user_limit = 0 as blocked, not unlimited", async () => {
+        // `CHECK (per_user_limit >= 0)` makes zero legal, and it reads as
+        // "nobody may use this". The guard used to be a truthiness test, which
+        // folded zero into unlimited -- the exact opposite (#1475).
+        stubPromoRow(activePromo({ per_user_limit: 0 }));
+
+        const result = await promoService.checkPromoEligibility("TEST100", "u1");
+
+        expect(result.eligible).toBe(false);
+    });
+
+    it("treats a NULL per_user_limit as unlimited", async () => {
+        stubPromoRow(activePromo({ per_user_limit: null }));
+
+        await expect(
+            promoService.checkPromoEligibility("TEST100", "u1")
+        ).resolves.toEqual({ eligible: true });
+
+        // No count is taken: there is no limit to compare one against.
+        expect(db.query).toHaveBeenCalledTimes(1);
+    });
+
+    it("treats an empty eligibility list as open to everybody", async () => {
+        stubPromoRow(activePromo({ user_eligibility: "[]" }));
+
+        await expect(
+            promoService.checkPromoEligibility("TEST100", "u1")
+        ).resolves.toEqual({ eligible: true });
+    });
+
+    it("ignores an unparsable eligibility list rather than failing the code", async () => {
+        // A bad column should not take down validation for a code that is
+        // otherwise fine; the remaining checks still apply.
+        stubPromoRow(activePromo({ user_eligibility: "{not json" }));
+
+        await expect(
+            promoService.checkPromoEligibility("TEST100", "u1")
+        ).resolves.toEqual({ eligible: true });
+    });
+
+    it("asks a guest to sign in when the promo carries a per-user rule", async () => {
+        // Controllers hand every anonymous caller the literal string "guest",
+        // so counting per-user usage against it would let the first guest
+        // exhaust the allowance for all of them.
+        stubPromoRow(activePromo({ per_user_limit: 1 }));
+
+        const result = await promoService.checkPromoEligibility("TEST100", "guest");
+
+        expect(result.eligible).toBe(false);
+        expect(result.reason).toContain("Sign in");
+    });
+
+    it("lets a guest use a promo with no per-user rule", async () => {
+        stubPromoRow(activePromo({ per_user_limit: null, user_eligibility: null }));
+
+        await expect(
+            promoService.checkPromoEligibility("TEST100", "guest")
+        ).resolves.toEqual({ eligible: true });
+    });
+
     it("reports a lookup failure rather than throwing at the caller", async () => {
         db.query.mockRejectedValueOnce(new Error("DB connection failed"));
 
@@ -424,6 +539,121 @@ describe("checkPromoEligibility", () => {
         expect(result.eligible).toBe(false);
         expect(result.reason).toBe("Failed to check eligibility");
     });
+});
+
+describe("per-user limits are enforced where it counts", () => {
+    // The bug in #1475 was not that the rules were wrong. It was that the only
+    // function containing them was never called from any write path, so both
+    // columns were inert. These assert the wiring, which is the part that was
+    // missing.
+
+    it("validatePromo consults eligibility when given a userId", async () => {
+        stubPromoRow(activePromo({ per_user_limit: 1 }));
+        db.query.mockResolvedValueOnce([[{ count: 1 }]]);
+
+        const result = await promoService.validatePromo("TEST100", 500, "u1");
+
+        expect(result.valid).toBe(false);
+        expect(result.message).toContain("maximum number of times");
+    });
+
+    it("validatePromo without a userId still validates everything else", async () => {
+        // Backwards compatible: the third argument is optional, and its absence
+        // means "no user to check", not "check nobody". The authoritative check
+        // is the one under the row lock.
+        stubPromoRow(activePromo({ per_user_limit: 1 }));
+
+        const result = await promoService.validatePromo("TEST100", 500);
+
+        expect(result.valid).toBe(true);
+    });
+
+    it("applyPromoTransaction refuses a user who has exhausted the code", async () => {
+        const connection = fakeConnection([activePromo({ per_user_limit: 1 })]);
+        useTransaction(connection);
+
+        // Row lock first, then the per-user count on that same connection.
+        connection.query
+            .mockResolvedValueOnce([[activePromo({ per_user_limit: 1 })]])
+            .mockResolvedValueOnce([[{ count: 1 }]]);
+
+        await expect(
+            promoService.applyPromoTransaction("TEST100", "u1", 50)
+        ).rejects.toThrow("not available for user");
+
+        expect(connection.rollback).toHaveBeenCalledTimes(1);
+        expect(connection.commit).not.toHaveBeenCalled();
+        // Nothing was written: no usage row, no counter.
+        expect(connection.query).not.toHaveBeenCalledWith(
+            expect.stringContaining("INSERT INTO promo_usage_logs"),
+            expect.anything()
+        );
+        expect(redis.set).not.toHaveBeenCalled();
+    });
+
+    it("applyPromoTransaction counts usage on its own connection, not the pool", async () => {
+        // Taken outside the transaction, two concurrent redemptions of a
+        // one-per-customer code both read "0 so far" and both proceed. The
+        // count has to happen under the lock this transaction already holds.
+        const connection = fakeConnection([activePromo({ per_user_limit: 2 })]);
+        useTransaction(connection);
+
+        connection.query
+            .mockResolvedValueOnce([[activePromo({ per_user_limit: 2 })]])
+            .mockResolvedValueOnce([[{ count: 0 }]])
+            .mockResolvedValue([[], { affectedRows: 1 }]);
+
+        await expect(
+            promoService.applyPromoTransaction("TEST100", "u1", 50)
+        ).resolves.toBe(true);
+
+        expect(connection.query).toHaveBeenCalledWith(
+            expect.stringContaining("FROM promo_usage_logs"),
+            ["TEST100", "u1"]
+        );
+        // Never on the pool -- that connection is outside the transaction.
+        expect(db.query).not.toHaveBeenCalledWith(
+            expect.stringContaining("FROM promo_usage_logs"),
+            expect.anything()
+        );
+    });
+});
+
+describe("parsePerUserLimit", () => {
+    it.each([
+        [null, null],
+        [undefined, null],
+        ["", null],
+        [0, 0],
+        ["0", 0],
+        [1, 1],
+        ["3", 3],
+        [-1, null],
+        ["nonsense", null]
+    ])("maps %p to %p", (input, expected) => {
+        expect(promoService.parsePerUserLimit(input)).toBe(expected);
+    });
+});
+
+describe("parseEligibleUsers", () => {
+    it("parses a JSON array of ids", () => {
+        expect(promoService.parseEligibleUsers('["a","b"]')).toEqual(["a", "b"]);
+    });
+
+    it("accepts an array that has already been parsed", () => {
+        expect(promoService.parseEligibleUsers(["a"])).toEqual(["a"]);
+    });
+
+    it("coerces ids to strings so a numeric column still matches", () => {
+        expect(promoService.parseEligibleUsers("[1,2]")).toEqual(["1", "2"]);
+    });
+
+    it.each([[null], [undefined], [""], ["[]"], ["{not json"], ['"a string"']])(
+        "returns null for %p",
+        (input) => {
+            expect(promoService.parseEligibleUsers(input)).toBeNull();
+        }
+    );
 });
 
 describe("getPromoUsageKey", () => {


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`promo_codes.per_user_limit` and `promo_codes.user_eligibility` were inert. A code marked one-per-customer could be redeemed by the same customer without limit, and a code restricted to a named list of accounts could be redeemed by anybody.

The check was written. It was just never called:

```
$ grep -rn "checkPromoEligibility" backend --include="*.js" | grep -v node_modules
backend/services/promo.service.js:176:const checkPromoEligibility = async (promoCode, userId) => {
backend/services/promo.service.js:256:    checkPromoEligibility,
backend/tests/promo.test.js:381:describe("checkPromoEligibility", () => {
```

Declared, exported, unit-tested, and reached by no controller, route or service. `validatePromo` checked active / dates / minimum order / global usage limit and stopped there; `applyPromoTransaction` re-checked the same four inside its transaction. Neither looked at *who was asking* — `applyPromoTransaction` takes a `userId` and spent it only on the audit row.

The stored procedure in `migrations/0002_promo_schema.sql:254` does contain the rule. Nothing calls that procedure either; the service issues its own `SELECT ... FOR UPDATE` and its own `UPDATE`. It was dead in the same way the function was.

---

## 🔗 Related Issue

Closes #1475

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] Security fix
- [x] Testing improvement
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

---

## 🌐 Additional Notes

### Where the check now runs — twice, and the distinction matters

`validatePromo(code, cartTotal, userId)` runs it **unlocked**, so the shopper is turned away at the cart with a reason rather than at the moment they try to pay. The third argument is optional; existing callers keep working.

`applyPromoTransaction` runs it **again inside the transaction**, on the connection already holding the promo row lock. That one is authoritative:

> Taken outside the lock, two simultaneous redemptions of a one-per-customer code both read "none used so far" and both proceed. Taken under it, the second waits for the first to commit and then sees it.

Both call the same `checkEligibilityForRow`. That is the point — when the rules lived in one function nobody called, nobody noticed they were unreachable.

### Two readings corrected

**`per_user_limit = 0` meant unlimited.** The guard was `count > 0 && promo.per_user_limit`, a truthiness test. Zero is legal (`CHECK (per_user_limit >= 0)`) and reads as "nobody may use this" — the opposite of what it did. `NULL` is what means unlimited, and now it is the only thing that does.

**Guests.** The controllers hand every anonymous caller the literal string `'guest'`, so they all share one identity. Counting per-user usage against that would let the first guest exhaust the allowance for all of them, so a promo carrying a per-user rule now asks for a sign-in. A promo with no such rule is unaffected — guests keep using it exactly as before.

### The Redis counter no longer outlives a rollback

This was the second bug in the issue. `applyPromoTransaction` incremented the Redis counter *inside* the database transaction and compensated it on exactly one path — overshooting the limit:

```js
const newCount = await redis.incr(usageKey);
if (promo.usage_limit && newCount > promo.usage_limit) {
    await redis.decr(usageKey);      // the only compensated path
    throw ...
}
// ... UPDATE promo_codes ...        <- anything that throws below here
// ... INSERT promo_usage_logs ...      rolls back the DB and leaves Redis +1
```

Since `getUsedCount` prefers Redis over the durable `usage_count`, that drift was permanent and always upward: a limited promo retires early with no redemption to show for it.

Nothing touches Redis inside the transaction now:

- the limit is tested against `usage_count` **on the locked row** — the value the lock exists to protect, rather than a cached number another transaction may already have moved;
- the cache is written **after the commit**, from the number that was committed;
- a Redis failure during that refresh is logged, not fatal — the durable count is committed and `getUsedCount` falls back to it.

### Tests

Two existing tests asserted the increment-inside-the-transaction behaviour and its single compensation path. They were describing the bug, so they now describe what replaced it. `parsePerUserLimit` and `parseEligibleUsers` are exported and table-tested because their edge cases (`0` vs `NULL`, `[]`, unparsable JSON, numeric ids) are exactly where the original reading went wrong.

`+32` tests on this suite, `65 passed`.

---

## ⚠️ CI note

This branch is cut from `main`, which **does not currently boot** — `rateLimiter.js` references an undeclared `CONTACT_FORM_MAX` (#1474). Six suites fail here for that reason and that reason only; the count is identical with and without this branch's changes:

```
main alone:        Test Suites: 6 failed, 58 passed   Tests: 13 failed, 1395 passed
main + this PR:    Test Suites: 6 failed, 58 passed   Tests: 13 failed, 1427 passed
```

Rebased onto #1479 (the boot fix) it is fully green:

```
Test Suites: 65 passed, 65 total
Tests:       1499 passed, 1499 total
```

**Merge #1479 first** and this goes green with no rebase needed — the two touch no files in common.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly
