### PR TITLE
Pay for an order once, and give the points back when it is returned

### DIFF
--- a/backend/routes/loyaltyRoutes.js
+++ b/backend/routes/loyaltyRoutes.js
@@ -160,4 +160,34 @@ router.post('/admin/adjust', authMiddleware, adminMiddleware, async (req, res) =
     }
 });
 
+/**
+ * POST /api/loyalty/admin/reverse
+ * Admin-only. Take back the points awarded for an order that was cancelled or
+ * returned. Body: { userId, orderId, reason? }.
+ *
+ * Separate from /admin/adjust rather than folded into it (#1476). An adjustment
+ * carries no order id, so a correction made through it cannot be tied back to
+ * the order that caused it and a second refund on the same order looks exactly
+ * like the first. This one is keyed on the order and is idempotent because of
+ * it -- calling it twice claws back once.
+ */
+router.post('/admin/reverse', authMiddleware, adminMiddleware, async (req, res) => {
+    try {
+        const { userId, orderId, reason } = req.body;
+
+        if (userId === undefined || userId === null) {
+            return res.status(400).json({ success: false, error: 'userId is required' });
+        }
+        if (orderId === undefined || orderId === null || orderId === '') {
+            return res.status(400).json({ success: false, error: 'orderId is required' });
+        }
+
+        const result = await loyaltyService.reverse(userId, { orderId, reason });
+        res.json({ success: true, data: result });
+    } catch (error) {
+        console.error('Reverse loyalty points error:', error);
+        res.status(400).json({ success: false, error: error.message || 'Failed to reverse points' });
+    }
+});
+
 module.exports = router;

--- a/backend/services/loyaltyService.js
+++ b/backend/services/loyaltyService.js
@@ -118,13 +118,58 @@ class LoyaltyService extends EventEmitter {
      * the account's CURRENT tier multiplier, then balance/lifetime are updated,
      * the tier is recomputed against the new lifetime total, and an `earn` ledger
      * row is appended — all in one transaction.
+     *
+     * Idempotent per order (#1476). This is driven by an `{ async: true }`
+     * ORDER_CREATED subscriber — fire-and-forget, errors swallowed by design —
+     * so the publisher does not know whether a handler ran, and anything that
+     * republishes the event calls this again. Before, that credited again: a
+     * retry after a transient failure, a backfill over historical orders, or two
+     * app instances both subscribed all paid out twice, in points that are
+     * spendable at REDEEM_RATE.
+     *
+     * A prior credit for the same `orderId` is returned as-is rather than
+     * written a second time, and `uniq_loyalty_award_per_order` (migration 0045)
+     * is the backstop for two callers getting past that check at once.
+     *
+     * An award with no `orderId` has nothing to key on and is not deduplicated.
      */
     async award(userId, { orderId = null, amount = 0, reason = 'order' } = {}, connection = null) {
+        // `redeem` and `adjust` both validate their input and both refuse to
+        // drive a balance negative. `award` did neither, which made it the one
+        // way to get a negative balance into loyalty_accounts: a negative
+        // `amount` produced negative base points and subtracted from the
+        // balance *and* from the lifetime total, recorded as an `earn`.
+        const orderAmount = Number(amount);
+
+        if (!Number.isFinite(orderAmount) || orderAmount < 0) {
+            throw new Error(
+                `Invalid award amount: ${amount}. The order amount must be a non-negative number.`
+            );
+        }
+
         return this._withTransaction(connection, async (conn) => {
             const account = await this._getOrCreateAccountTx(conn, userId);
 
+            // Under the account lock `_getOrCreateAccountTx` just took, so a
+            // concurrent award for the same order waits here instead of reading
+            // "nothing credited yet" alongside us.
+            if (orderId !== null && orderId !== undefined) {
+                const existing = await this._findAwardForOrderTx(conn, userId, orderId);
+
+                if (existing) {
+                    return {
+                        pointsEarned: existing.points,
+                        balance: account.points_balance,
+                        lifetimePoints: account.lifetime_points,
+                        tier: account.tier,
+                        tierUpgraded: false,
+                        alreadyAwarded: true
+                    };
+                }
+            }
+
             const currentTier = this.computeTier(account.lifetime_points);
-            const basePoints = Math.floor(Number(amount) * EARN_RATE);
+            const basePoints = Math.floor(orderAmount * EARN_RATE);
             const earnedPoints = Math.floor(basePoints * currentTier.multiplier);
 
             const newBalance = account.points_balance + earnedPoints;
@@ -146,7 +191,7 @@ class LoyaltyService extends EventEmitter {
                 balanceAfter: newBalance,
                 reason,
                 metadata: {
-                    amount: Number(amount),
+                    amount: orderAmount,
                     basePoints,
                     multiplier: currentTier.multiplier,
                     tierAtEarn: currentTier.name
@@ -158,7 +203,8 @@ class LoyaltyService extends EventEmitter {
                 balance: newBalance,
                 lifetimePoints: newLifetime,
                 tier: newTier.name,
-                tierUpgraded: newTier.name !== currentTier.name
+                tierUpgraded: newTier.name !== currentTier.name,
+                alreadyAwarded: false
             };
             this.emit('loyalty.earned', { userId, ...result });
             return result;
@@ -210,6 +256,113 @@ class LoyaltyService extends EventEmitter {
                 balance: newBalance
             };
             this.emit('loyalty.redeemed', { userId, ...result });
+            return result;
+        });
+    }
+
+    /**
+     * Take back the points awarded for an order that was cancelled or returned.
+     *
+     * There was no way to do this (#1476). `refundController.approveRequest`
+     * already exists and already restocks inventory, but the points paid out for
+     * the order stayed. `adjust()` could be used by hand, except that it takes no
+     * `orderId` — so the correction could not be tied back to the order that
+     * caused it, and a second refund on the same order was indistinguishable
+     * from the first.
+     *
+     * Written as an `adjust` row carrying the order id, which makes it
+     * idempotent through the same unique key that protects the award: a second
+     * call for an order already reversed returns the first result rather than
+     * clawing back twice.
+     *
+     * Lifetime points come down too, and the tier with them. Leaving lifetime
+     * alone would let a customer keep a tier bought with an order they returned,
+     * and the ladder is the whole reason lifetime is tracked separately.
+     *
+     * The balance is clamped at zero rather than going negative. The points may
+     * already have been spent, and an unsettleable debt over a refund the
+     * customer is entitled to is a worse answer than absorbing the difference —
+     * what was actually clawed back is on the returned result and in the ledger
+     * row's metadata, so the shortfall is visible rather than silent.
+     *
+     * @param {string|number} userId
+     * @param {{orderId: string|number, reason?: string}} options
+     * @param {object} [connection]
+     */
+    async reverse(userId, { orderId, reason = 'order reversed' } = {}, connection = null) {
+        if (orderId === null || orderId === undefined) {
+            throw new Error('Cannot reverse loyalty points without an orderId.');
+        }
+
+        return this._withTransaction(connection, async (conn) => {
+            const account = await this._getOrCreateAccountTx(conn, userId);
+
+            const alreadyReversed = await this._findReversalForOrderTx(conn, userId, orderId);
+
+            if (alreadyReversed) {
+                return {
+                    pointsReversed: Math.abs(alreadyReversed.points),
+                    balance: account.points_balance,
+                    lifetimePoints: account.lifetime_points,
+                    tier: account.tier,
+                    alreadyReversed: true
+                };
+            }
+
+            const award = await this._findAwardForOrderTx(conn, userId, orderId);
+
+            // Nothing was ever credited for this order — a cancellation before
+            // the award landed, or an order that predates the program. Not an
+            // error: the caller wanted the points gone and they are.
+            if (!award) {
+                return {
+                    pointsReversed: 0,
+                    balance: account.points_balance,
+                    lifetimePoints: account.lifetime_points,
+                    tier: account.tier,
+                    alreadyReversed: false
+                };
+            }
+
+            const awarded = Number(award.points) || 0;
+            const newBalance = Math.max(account.points_balance - awarded, 0);
+            const newLifetime = Math.max(account.lifetime_points - awarded, 0);
+            const newTier = this.computeTier(newLifetime);
+            const clawedBack = account.points_balance - newBalance;
+
+            await conn.query(
+                `UPDATE loyalty_accounts
+                    SET points_balance = ?, lifetime_points = ?, tier = ?, updated_at = NOW()
+                  WHERE user_id = ?`,
+                [newBalance, newLifetime, newTier.name, userId]
+            );
+
+            await this._appendLedgerRow(conn, {
+                userId,
+                orderId,
+                type: 'adjust',
+                points: -awarded,
+                balanceAfter: newBalance,
+                reason,
+                metadata: {
+                    reversalOf: award.id,
+                    pointsAwarded: awarded,
+                    pointsClawedBack: clawedBack,
+                    shortfall: awarded - clawedBack,
+                    tierBefore: account.tier
+                }
+            });
+
+            const result = {
+                pointsReversed: awarded,
+                pointsClawedBack: clawedBack,
+                balance: newBalance,
+                lifetimePoints: newLifetime,
+                tier: newTier.name,
+                tierDowngraded: newTier.name !== account.tier,
+                alreadyReversed: false
+            };
+            this.emit('loyalty.reversed', { userId, orderId, ...result });
             return result;
         });
     }
@@ -413,6 +566,45 @@ class LoyaltyService extends EventEmitter {
             [userId]
         );
         return created[0];
+    }
+
+    /**
+     * The `earn` row for this order, if one has already been written.
+     *
+     * Runs on the transaction's connection so it is read under the account lock
+     * `_getOrCreateAccountTx` takes. Read outside it, two concurrent awards for
+     * the same order both see nothing and both credit.
+     *
+     * `LIMIT 1` with the lowest id: the unique key makes a second row
+     * impossible from here on, but rows predating migration 0045 may still be
+     * paired, and the earliest is the one the order actually earned.
+     */
+    async _findAwardForOrderTx(conn, userId, orderId) {
+        const [rows] = await conn.query(
+            `SELECT id, points, balance_after, created_at
+               FROM loyalty_transactions
+              WHERE user_id = ? AND order_id = ? AND type = 'earn'
+              ORDER BY id ASC
+              LIMIT 1`,
+            [userId, orderId]
+        );
+        return rows && rows.length > 0 ? rows[0] : null;
+    }
+
+    /**
+     * The reversal row for this order, if the points have already been taken
+     * back. Same locking argument as `_findAwardForOrderTx`.
+     */
+    async _findReversalForOrderTx(conn, userId, orderId) {
+        const [rows] = await conn.query(
+            `SELECT id, points, balance_after, created_at
+               FROM loyalty_transactions
+              WHERE user_id = ? AND order_id = ? AND type = 'adjust'
+              ORDER BY id ASC
+              LIMIT 1`,
+            [userId, orderId]
+        );
+        return rows && rows.length > 0 ? rows[0] : null;
     }
 
     async _appendLedgerRow(conn, { userId, orderId, type, points, balanceAfter, reason, metadata }) {

--- a/backend/tests/loyalty.test.js
+++ b/backend/tests/loyalty.test.js
@@ -255,3 +255,233 @@ describe("auto-earn subscriber (ORDER_CREATED)", () => {
         await expect(entry.handler({ orderId: 99, userId: 5, total: 10 })).resolves.toBeUndefined();
     });
 });
+
+// ============================================================================
+// IDEMPOTENCY AND REVERSAL (#1476)
+// ============================================================================
+//
+// `makeConnection` above answers the account SELECT and returns a generic
+// affected-rows result for everything else, which means it answers the ledger
+// lookups with `[{ affectedRows: 1, insertId: 1 }]` -- truthy, and not a row.
+// These tests need to control what the ledger returns, so they build on it.
+
+/**
+ * A connection whose ledger lookups answer with `ledgerRows`.
+ *
+ * @param {object} account The loyalty_accounts row.
+ * @param {{earn?: object|null, adjust?: object|null}} ledgerRows
+ */
+function makeLedgerConnection(account, { earn = null, adjust = null } = {}) {
+    const calls = [];
+    const query = jest.fn(async (sql, params = []) => {
+        calls.push({ sql, params });
+
+        if (/FROM loyalty_accounts WHERE user_id = \?/i.test(sql)) {
+            return [account ? [account] : []];
+        }
+        if (/FROM loyalty_transactions[\s\S]*type = 'earn'/i.test(sql)) {
+            return [earn ? [earn] : []];
+        }
+        if (/FROM loyalty_transactions[\s\S]*type = 'adjust'/i.test(sql)) {
+            return [adjust ? [adjust] : []];
+        }
+        return [{ affectedRows: 1, insertId: 1 }];
+    });
+
+    const connection = {
+        query,
+        beginTransaction: jest.fn(async () => {}),
+        commit: jest.fn(async () => {}),
+        rollback: jest.fn(async () => {}),
+        release: jest.fn()
+    };
+    return { connection, calls };
+}
+
+const bronzeAccount = (overrides = {}) => ({
+    user_id: 7,
+    points_balance: 500,
+    lifetime_points: 500,
+    tier: "Bronze",
+    ...overrides
+});
+
+describe("award idempotency", () => {
+    test("credits an order that has not been awarded yet", async () => {
+        const { connection, calls } = makeLedgerConnection(bronzeAccount(), { earn: null });
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await loyaltyService.award(7, { orderId: 42, amount: 100 });
+
+        expect(result.pointsEarned).toBe(100);
+        expect(result.alreadyAwarded).toBe(false);
+        expect(ledgerInsert(calls)).toBeDefined();
+    });
+
+    test("does not credit an order twice", async () => {
+        // The bug: ORDER_CREATED is an `{ async: true }` subscriber, so anything
+        // that republishes it -- a retry, a backfill, a second app instance --
+        // called award again and it paid again.
+        const { connection, calls } = makeLedgerConnection(bronzeAccount(), {
+            earn: { id: 11, points: 100, balance_after: 500 }
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await loyaltyService.award(7, { orderId: 42, amount: 100 });
+
+        expect(result.alreadyAwarded).toBe(true);
+        expect(result.pointsEarned).toBe(100);
+        expect(result.balance).toBe(500);
+
+        // Nothing written: no second ledger row, no balance change.
+        expect(ledgerInsert(calls)).toBeUndefined();
+        expect(accountUpdate(calls)).toBeUndefined();
+        expect(connection.commit).toHaveBeenCalledTimes(1);
+    });
+
+    test("checks for a prior award on the transaction's own connection", async () => {
+        // Read outside the account lock, two concurrent awards for the same
+        // order both see nothing and both credit.
+        const { connection, calls } = makeLedgerConnection(bronzeAccount(), { earn: null });
+        db.getConnection.mockResolvedValue(connection);
+
+        await loyaltyService.award(7, { orderId: 42, amount: 100 });
+
+        const lookup = sqlsMatching(calls, /FROM loyalty_transactions[\s\S]*type = 'earn'/i)[0];
+        expect(lookup).toBeDefined();
+        expect(lookup.params).toEqual([7, 42]);
+        expect(db.query).not.toHaveBeenCalled();
+    });
+
+    test("does not deduplicate an award with no orderId", async () => {
+        // There is nothing to key it on, so it is not claimed to be idempotent.
+        const { connection, calls } = makeLedgerConnection(bronzeAccount(), { earn: null });
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await loyaltyService.award(7, { orderId: null, amount: 50 });
+
+        expect(result.pointsEarned).toBe(50);
+        expect(sqlsMatching(calls, /FROM loyalty_transactions[\s\S]*type = 'earn'/i)).toHaveLength(0);
+    });
+});
+
+describe("award input validation", () => {
+    test.each([[-500], [-1], [Number.NaN], [Number.POSITIVE_INFINITY], ["nonsense"]])(
+        "refuses an amount of %p",
+        async (amount) => {
+            const { connection } = makeLedgerConnection(bronzeAccount());
+            db.getConnection.mockResolvedValue(connection);
+
+            await expect(loyaltyService.award(7, { orderId: 1, amount })).rejects.toThrow(
+                /must be a non-negative number/
+            );
+        }
+    );
+
+    test("a negative amount can no longer drive the balance down", async () => {
+        // This was the only way to get a negative balance into loyalty_accounts:
+        // redeem() and adjust() both validate and both refuse to go negative,
+        // award() did neither and wrote the result as an `earn`.
+        const { connection, calls } = makeLedgerConnection(bronzeAccount());
+        db.getConnection.mockResolvedValue(connection);
+
+        await expect(
+            loyaltyService.award(7, { orderId: 1, amount: -500 })
+        ).rejects.toThrow();
+
+        expect(accountUpdate(calls)).toBeUndefined();
+    });
+
+    test("accepts a zero-value order without writing a negative row", async () => {
+        const { connection } = makeLedgerConnection(bronzeAccount(), { earn: null });
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await loyaltyService.award(7, { orderId: 1, amount: 0 });
+
+        expect(result.pointsEarned).toBe(0);
+    });
+});
+
+describe("reverse", () => {
+    test("claws back the points an order earned and lowers the tier with them", async () => {
+        // Silver on 1100 lifetime; the order that earned 200 is returned, so
+        // lifetime falls to 900 and the account is Bronze again. Leaving
+        // lifetime alone would let the customer keep a tier bought with an
+        // order they sent back.
+        const { connection, calls } = makeLedgerConnection(
+            bronzeAccount({ points_balance: 1100, lifetime_points: 1100, tier: "Silver" }),
+            { earn: { id: 11, points: 200, balance_after: 1100 }, adjust: null }
+        );
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await loyaltyService.reverse(7, { orderId: 42, reason: "returned" });
+
+        expect(result.pointsReversed).toBe(200);
+        expect(result.balance).toBe(900);
+        expect(result.lifetimePoints).toBe(900);
+        expect(result.tier).toBe("Bronze");
+        expect(result.tierDowngraded).toBe(true);
+
+        expect(accountUpdate(calls).params).toEqual([900, 900, "Bronze", 7]);
+
+        const ledger = ledgerInsert(calls);
+        expect(ledger.params.slice(0, 5)).toEqual([7, 42, "adjust", -200, 900]);
+    });
+
+    test("is idempotent — a second reversal claws back nothing further", async () => {
+        const { connection, calls } = makeLedgerConnection(
+            bronzeAccount({ points_balance: 900, lifetime_points: 900 }),
+            { earn: { id: 11, points: 200 }, adjust: { id: 12, points: -200 } }
+        );
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await loyaltyService.reverse(7, { orderId: 42 });
+
+        expect(result.alreadyReversed).toBe(true);
+        expect(result.pointsReversed).toBe(200);
+        expect(accountUpdate(calls)).toBeUndefined();
+        expect(ledgerInsert(calls)).toBeUndefined();
+    });
+
+    test("clamps at zero when the points have already been spent", async () => {
+        // An unsettleable debt over a refund the customer is entitled to is a
+        // worse answer than absorbing the difference, so the shortfall is
+        // recorded rather than charged.
+        const { connection, calls } = makeLedgerConnection(
+            bronzeAccount({ points_balance: 50, lifetime_points: 200 }),
+            { earn: { id: 11, points: 200 }, adjust: null }
+        );
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await loyaltyService.reverse(7, { orderId: 42 });
+
+        expect(result.balance).toBe(0);
+        expect(result.pointsReversed).toBe(200);
+        expect(result.pointsClawedBack).toBe(50);
+
+        const metadata = JSON.parse(ledgerInsert(calls).params[6]);
+        expect(metadata.shortfall).toBe(150);
+        expect(metadata.pointsAwarded).toBe(200);
+    });
+
+    test("is a no-op for an order that never earned anything", async () => {
+        // A cancellation before the award landed, or an order predating the
+        // program. The caller wanted the points gone and they are.
+        const { connection, calls } = makeLedgerConnection(bronzeAccount(), {
+            earn: null,
+            adjust: null
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await loyaltyService.reverse(7, { orderId: 999 });
+
+        expect(result.pointsReversed).toBe(0);
+        expect(accountUpdate(calls)).toBeUndefined();
+        expect(ledgerInsert(calls)).toBeUndefined();
+    });
+
+    test("requires an orderId", async () => {
+        await expect(loyaltyService.reverse(7, {})).rejects.toThrow(/without an orderId/);
+        await expect(loyaltyService.reverse(7, { orderId: null })).rejects.toThrow();
+    });
+});

--- a/migrations/0045_loyalty_award_idempotency.sql
+++ b/migrations/0045_loyalty_award_idempotency.sql
@@ -1,0 +1,138 @@
+-- ============================================
+-- ONE ORDER, ONE AWARD
+-- ============================================
+--
+-- `loyaltyService.award()` writes an `earn` row every time it is called, and it
+-- is called by an `{ async: true }` ORDER_CREATED subscriber -- fire-and-forget,
+-- errors swallowed by design. So the number of times a customer is paid for an
+-- order is the number of times that event is delivered for it, and points are
+-- spendable at REDEEM_RATE, which makes a replay a way of printing money
+-- (#1476).
+--
+-- 0004_loyalty_points.sql gave `loyalty_transactions` this:
+--
+--     INDEX idx_order (order_id)
+--
+-- An index, not a constraint. The database will accept as many `earn` rows for
+-- one order as it is sent. The service is being taught to check first, but a
+-- check in application code is a convention; two application instances handling
+-- the same republished event race straight past it. The constraint below is
+-- what makes it impossible.
+--
+-- (user_id, order_id, type) rather than (order_id, type): the ledger has no
+-- foreign key to `orders` and `order_id` is an INT here, so scoping to the
+-- account is the narrower claim and the one that is certainly true.
+--
+-- NULL `order_id` is unaffected. MySQL treats NULLs as distinct in a UNIQUE
+-- index, so the `redeem` and `adjust` rows -- which all carry NULL -- can still
+-- be written without limit. That is the behaviour this constraint needs: only
+-- rows that name an order are being made unique.
+
+-- ============================================
+-- CLEAR THE DUPLICATES ALREADY IN THE TABLE
+-- ============================================
+--
+-- The index cannot be added while any exist, and there is no reason to assume
+-- none do -- the whole point is that nothing has ever stopped them.
+--
+-- A duplicate is every `earn` row for a (user, order) pair except the earliest,
+-- which is the one that corresponds to the order actually being placed. The
+-- surplus is not a bookkeeping artefact: those points were credited to a real
+-- balance and can already have been spent. So the balance is corrected first,
+-- then the rows are removed, then the tier is recomputed from the corrected
+-- lifetime total.
+--
+-- Order matters. Deleting first would lose the amounts needed to correct by.
+
+CREATE TEMPORARY TABLE loyalty_award_surplus AS
+SELECT
+    t.user_id,
+    SUM(t.points) AS surplus_points
+FROM loyalty_transactions t
+JOIN (
+    SELECT user_id, order_id, MIN(id) AS keep_id
+    FROM loyalty_transactions
+    WHERE type = 'earn' AND order_id IS NOT NULL
+    GROUP BY user_id, order_id
+    HAVING COUNT(*) > 1
+) first_award
+  ON  first_award.user_id  = t.user_id
+  AND first_award.order_id = t.order_id
+WHERE t.type = 'earn'
+  AND t.order_id IS NOT NULL
+  AND t.id <> first_award.keep_id
+GROUP BY t.user_id;
+
+-- Balance is clamped at zero. Lifetime is clamped too, and for a different
+-- reason: it is a monotonic total that decides the tier, so letting it go
+-- negative would put an account below Bronze, which is not a state the ladder
+-- has. An account that has already spent the duplicated points lands on zero
+-- rather than in debt -- the alternative is a balance the customer cannot
+-- settle, over an error that was not theirs.
+
+UPDATE loyalty_accounts a
+JOIN loyalty_award_surplus s ON s.user_id = a.user_id
+SET a.points_balance  = GREATEST(a.points_balance  - s.surplus_points, 0),
+    a.lifetime_points = GREATEST(a.lifetime_points - s.surplus_points, 0),
+    a.updated_at      = NOW();
+
+DELETE t
+FROM loyalty_transactions t
+JOIN (
+    SELECT user_id, order_id, MIN(id) AS keep_id
+    FROM loyalty_transactions
+    WHERE type = 'earn' AND order_id IS NOT NULL
+    GROUP BY user_id, order_id
+    HAVING COUNT(*) > 1
+) first_award
+  ON  first_award.user_id  = t.user_id
+  AND first_award.order_id = t.order_id
+WHERE t.type = 'earn'
+  AND t.order_id IS NOT NULL
+  AND t.id <> first_award.keep_id;
+
+-- Tiers, from the corrected lifetime totals. The thresholds are the TIERS
+-- ladder in services/loyaltyService.js; that constant stays authoritative at
+-- runtime and this only brings stored rows back in step with it. An account
+-- that was promoted on duplicated points is demoted here, which is the honest
+-- outcome -- it never reached the threshold.
+
+UPDATE loyalty_accounts a
+JOIN loyalty_award_surplus s ON s.user_id = a.user_id
+SET a.tier = CASE
+        WHEN a.lifetime_points >= 20000 THEN 'Platinum'
+        WHEN a.lifetime_points >=  5000 THEN 'Gold'
+        WHEN a.lifetime_points >=  1000 THEN 'Silver'
+        ELSE 'Bronze'
+    END;
+
+DROP TEMPORARY TABLE loyalty_award_surplus;
+
+-- ============================================
+-- THE CONSTRAINT
+-- ============================================
+--
+-- Guarded so the file is safe to re-run: the runner records a checksum and will
+-- not re-apply an unchanged migration, but a database that adopted the baseline
+-- by hand may already carry the index, and `ADD UNIQUE KEY` on an existing name
+-- is an error rather than a no-op.
+
+DELIMITER //
+
+CREATE PROCEDURE EnforceLoyaltyAwardIdempotency()
+BEGIN
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'loyalty_transactions'
+          AND INDEX_NAME   = 'uniq_loyalty_award_per_order'
+    ) THEN
+        ALTER TABLE loyalty_transactions
+        ADD UNIQUE KEY uniq_loyalty_award_per_order (user_id, order_id, type);
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL EnforceLoyaltyAwardIdempotency();
+DROP PROCEDURE EnforceLoyaltyAwardIdempotency;


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`loyaltyService.award()` writes an `earn` row every time it is called, and it is called by an `{ async: true }` ORDER_CREATED subscriber — fire-and-forget, errors swallowed by design. So the number of times a customer is paid for an order is the number of times that event is delivered for it:

```js
await loyaltyService.award(1, { orderId: 99, amount: 500 });
await loyaltyService.award(1, { orderId: 99, amount: 500 });

await loyaltyService.getBalance(1);
// { pointsBalance: 1000, lifetimePoints: 1000, tier: 'Bronze' }
```

Two `earn` rows against order 99, a thousand points for a five-hundred-unit order, and `getHistory` shows both as legitimate. Points are spendable at `REDEEM_RATE`, so a replay is a way of printing money. A retry after a transient failure, a backfill over historical orders, an admin re-emitting an event, two app instances both subscribed — each pays out again.

---

## 🔗 Related Issue

Closes #1476

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] Security fix
- [x] New feature (reversal path)
- [x] Testing improvement
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

---

## 🌐 Additional Notes

### The constraint — migration 0045

`0004_loyalty_points.sql` gave the ledger `INDEX idx_order (order_id)`. An index, not a constraint; the database will take as many `earn` rows for one order as it is sent.

```sql
ALTER TABLE loyalty_transactions
ADD UNIQUE KEY uniq_loyalty_award_per_order (user_id, order_id, type);
```

MySQL treats NULLs as distinct in a unique index, which is exactly what this needs: `redeem` and `adjust` rows all carry a NULL `order_id` and can still be written without limit. **Only rows that name an order are made unique.**

`(user_id, order_id, type)` rather than `(order_id, type)`: the ledger has no foreign key to `orders` and `order_id` is an `INT` here, so scoping to the account is the narrower claim and the one that is certainly true.

**Existing duplicates are cleared first**, because the index cannot be added while any exist and there is no reason to assume none do — the whole point is that nothing has ever stopped them. Order of operations matters:

1. sum the surplus per user (every `earn` for a (user, order) pair except the earliest);
2. **correct the balances** — those points were credited to real balances and can already have been spent;
3. delete the surplus rows — doing this first would lose the amounts to correct by;
4. recompute tiers from the corrected lifetime totals.

An account promoted on duplicated points is demoted, which is the honest outcome: it never reached the threshold. Balance and lifetime both clamp at zero rather than going negative.

The DDL is guarded by a procedure in the same style as `0032_variant_stock_authority.sql`, so a database that adopted the baseline by hand and already carries the index is not an error.

### The service

`award` looks for an existing credit before writing one, **under the account lock `_getOrCreateAccountTx` already takes** — read outside it, two concurrent awards for the same order both see nothing and both credit. A prior award comes back as-is with `alreadyAwarded: true`.

The unique key is the backstop for two callers getting past the check at once; the check is what stops the common case raising an error nobody is listening for (the subscriber swallows them).

An award with no `orderId` has nothing to key on and is not claimed to be idempotent.

**`amount` is validated.** `redeem` and `adjust` both validate their input and both refuse to drive a balance negative. `award` did neither, which made it the one way to get a negative balance into `loyalty_accounts` — a negative `amount` produced negative base points and subtracted from the balance *and* from the lifetime total, recorded as an `earn`.

### Reversal — the other half of the issue

There was no way to take points back. `refundController.approveRequest` already restocks inventory, but the points paid for the order stayed. `adjust()` could be used by hand, except that it carries no `orderId` — so the correction could not be tied to the order that caused it, and a second refund on the same order was indistinguishable from the first.

`reverse(userId, { orderId })` writes an `adjust` row **that names the order**, which makes it idempotent through the same unique key: call it twice and it claws back once.

- **Lifetime comes down with the balance, and the tier with it.** Leaving lifetime alone would let a customer keep a tier bought with an order they sent back, and the ladder is the whole reason lifetime is tracked separately.
- **The balance clamps at zero.** The points may already have been spent, and an unsettleable debt over a refund the customer is entitled to is a worse answer than absorbing the difference. What was actually clawed back is on the result and in the ledger row's metadata (`pointsAwarded`, `pointsClawedBack`, `shortfall`), so the difference is recorded rather than silent.
- An order that never earned anything is a no-op, not an error — a cancellation before the award landed, or an order predating the program.

`POST /api/loyalty/admin/reverse` exposes it, admin-only, separate from `/admin/adjust` for the reason above.

### Migration numbering

Takes **0045**. Per `migrations/README.md`, please check it is still free before merging — I have two further PRs in flight that claim 0046 (#1477) and 0047 (#1478), so those three do not collide with each other.

The runner splits this file into 8 statements, `DELIMITER` block included — verified against `utils/sqlStatements.js` rather than assumed.

---

## ⚠️ CI note

Cut from `main`, which does not currently boot (#1474). Six suites fail here for that reason and that reason only — identical with and without this branch:

```
main alone:      Test Suites: 6 failed, 58 passed   Tests: 13 failed, 1395 passed
main + this PR:  Test Suites: 6 failed, 58 passed   Tests: 13 failed, 1411 passed
```

`+16` tests, `loyalty.test.js` 26 passed. Merge #1479 first and this goes green — no files in common.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly
