### PR TITLE
Count returns in units, so a partial one leaves the rest returnable

### DIFF
--- a/backend/controllers/refundController.js
+++ b/backend/controllers/refundController.js
@@ -74,6 +74,190 @@ const createRequest = async (req, res) => {
         });
     }
 
+    // The whole submission runs in one transaction (#1477). The units already
+    // claimed on this line have to be counted and the new request inserted
+    // without anything landing in between -- read on the pool and written on the
+    // pool, two submissions arriving together both saw the same figure, both
+    // passed, and the line went out over its quantity.
+    let connection;
+
+    try {
+        connection = await db.getConnection();
+        await connection.beginTransaction();
+
+        const [orders] = await connection.query(
+            "SELECT user_id, status, delivered_at, created_at FROM orders WHERE id = ? LIMIT 1",
+            [orderId]
+        );
+
+        const order = safeArray(orders)[0];
+
+        if (!order || order.user_id !== userId) {
+            await connection.rollback();
+
+            return res.status(404).json({
+                success: false,
+                message: "Order not found"
+            });
+        }
+
+        if (order.status !== ELIGIBLE_ORDER_STATUS) {
+            await connection.rollback();
+
+            return res.status(400).json({
+                success: false,
+                message: "Only delivered orders are eligible for a return"
+            });
+        }
+
+        if (isReturnWindowExpired(order)) {
+            await connection.rollback();
+
+            return res.status(400).json({
+                success: false,
+                message: `The ${RETURN_WINDOW_DAYS}-day return window for this order has closed`
+            });
+        }
+
+        // `FOR UPDATE` on the order line, not on the requests. The line is the
+        // thing there is exactly one of, so it is what two concurrent
+        // submissions for the same item can serialize on; locking the request
+        // rows would lock nothing when there are none yet, which is precisely
+        // the case that races.
+        const [items] = await connection.query(
+            `SELECT id, product_id, qty
+               FROM order_items
+              WHERE id = ? AND order_id = ?
+              LIMIT 1
+              FOR UPDATE`,
+            [orderItemId, orderId]
+        );
+
+        const item = safeArray(items)[0];
+
+        if (!item) {
+            await connection.rollback();
+
+            return res.status(400).json({
+                success: false,
+                message: "The selected item is not part of this order"
+            });
+        }
+
+        const purchasedQty = safeInteger(item.qty);
+        const claimedQty = await RefundRequest.claimedQuantityForItem(
+            orderItemId,
+            connection
+        );
+        const returnableQty = Math.max(purchasedQty - claimedQty, 0);
+
+        if (returnableQty < 1) {
+            await connection.rollback();
+
+            return res.status(409).json({
+                success: false,
+                message: "Every unit of this item has already been returned",
+                data: {
+                    purchased_quantity: purchasedQty,
+                    claimed_quantity: claimedQty,
+                    returnable_quantity: 0
+                }
+            });
+        }
+
+        // Omitting the quantity means "the rest of it", which is what it always
+        // meant -- it just used to resolve to the quantity purchased rather than
+        // the quantity still returnable.
+        const quantity = requestedQty === null ? returnableQty : requestedQty;
+
+        if (quantity < 1 || quantity > returnableQty) {
+            await connection.rollback();
+
+            return res.status(400).json({
+                success: false,
+                message: claimedQty > 0
+                    ? `You have already returned ${claimedQty} of ${purchasedQty}. `
+                      + `Return quantity must be between 1 and ${returnableQty}`
+                    : `Return quantity must be between 1 and ${returnableQty}`,
+                data: {
+                    purchased_quantity: purchasedQty,
+                    claimed_quantity: claimedQty,
+                    returnable_quantity: returnableQty
+                }
+            });
+        }
+
+        const requestId = await RefundRequest.create(
+            {
+                userId,
+                orderId,
+                orderItemId,
+                productId: item.product_id,
+                reason,
+                quantity
+            },
+            connection
+        );
+
+        const created = await RefundRequest.findById(requestId, { connection });
+
+        await connection.commit();
+
+        return res.status(201).json({
+            success: true,
+            message: "Return request submitted",
+            data: {
+                ...(created ? created.toJSON() : { id: requestId }),
+                purchased_quantity: purchasedQty,
+                returnable_quantity: returnableQty - quantity
+            }
+        });
+    } catch (error) {
+        if (connection) {
+            await connection.rollback();
+        }
+
+        console.error("CREATE REFUND REQUEST ERROR:", error);
+
+        return res.status(500).json({
+            success: false,
+            message: "Failed to submit return request"
+        });
+    } finally {
+        if (connection) {
+            connection.release();
+        }
+    }
+};
+
+/**
+ * What is still returnable on a delivered order.
+ *
+ * There was no way to ask (#1477). A customer looking at a delivered order could
+ * only find out what was left by submitting a request and reading the refusal,
+ * and the refusal did not say how many were left either.
+ *
+ * Every line of the order is listed, including ones that are fully returned, so
+ * the caller can render the whole order rather than only its remainder.
+ */
+const listReturnable = async (req, res) => {
+    const userId = safeUUID(req.user?.id);
+    const orderId = safeUUID(req.params.orderId);
+
+    if (!userId) {
+        return res.status(401).json({
+            success: false,
+            message: "Authentication required"
+        });
+    }
+
+    if (!orderId) {
+        return res.status(400).json({
+            success: false,
+            message: "Invalid order ID"
+        });
+    }
+
     try {
         const [orders] = await db.query(
             "SELECT user_id, status, delivered_at, created_at FROM orders WHERE id = ? LIMIT 1",
@@ -82,6 +266,8 @@ const createRequest = async (req, res) => {
 
         const order = safeArray(orders)[0];
 
+        // Same answer for "no such order" and "not yours". Distinguishing them
+        // tells an unauthenticated guesser which order ids exist.
         if (!order || order.user_id !== userId) {
             return res.status(404).json({
                 success: false,
@@ -89,72 +275,60 @@ const createRequest = async (req, res) => {
             });
         }
 
-        if (order.status !== ELIGIBLE_ORDER_STATUS) {
-            return res.status(400).json({
-                success: false,
-                message: "Only delivered orders are eligible for a return"
-            });
-        }
-
-        if (isReturnWindowExpired(order)) {
-            return res.status(400).json({
-                success: false,
-                message: `The ${RETURN_WINDOW_DAYS}-day return window for this order has closed`
-            });
-        }
-
         const [items] = await db.query(
-            "SELECT id, product_id, qty FROM order_items WHERE id = ? AND order_id = ? LIMIT 1",
-            [orderItemId, orderId]
+            `SELECT id, product_id, variant_id, name, qty
+               FROM order_items
+              WHERE order_id = ?
+              ORDER BY id ASC`,
+            [orderId]
         );
 
-        const item = safeArray(items)[0];
+        const claimed = await RefundRequest.claimedQuantitiesForOrder(orderId);
 
-        if (!item) {
-            return res.status(400).json({
-                success: false,
-                message: "The selected item is not part of this order"
-            });
-        }
+        const eligible = order.status === ELIGIBLE_ORDER_STATUS;
+        const windowExpired = isReturnWindowExpired(order);
+        const orderIsReturnable = eligible && !windowExpired;
 
-        const quantity = requestedQty === null ? item.qty : requestedQty;
+        const lines = safeArray(items).map((item) => {
+            const purchased = safeInteger(item.qty);
+            const claimedForItem = claimed.get(Number(item.id)) || 0;
+            const returnable = Math.max(purchased - claimedForItem, 0);
 
-        if (quantity < 1 || quantity > item.qty) {
-            return res.status(400).json({
-                success: false,
-                message: `Return quantity must be between 1 and ${item.qty}`
-            });
-        }
-
-        if (await RefundRequest.hasOpenRequestForItem(orderItemId)) {
-            return res.status(409).json({
-                success: false,
-                message: "An open return request already exists for this item"
-            });
-        }
-
-        const requestId = await RefundRequest.create({
-            userId,
-            orderId,
-            orderItemId,
-            productId: item.product_id,
-            reason,
-            quantity
+            return {
+                order_item_id: item.id,
+                product_id: item.product_id,
+                variant_id: item.variant_id ?? null,
+                name: item.name,
+                purchased_quantity: purchased,
+                claimed_quantity: claimedForItem,
+                // Gated on the order as well as the line: a line with units left
+                // is not returnable if the window has closed, and saying so here
+                // saves the caller re-deriving it.
+                returnable_quantity: orderIsReturnable ? returnable : 0
+            };
         });
 
-        const created = await RefundRequest.findById(requestId);
-
-        return res.status(201).json({
+        return res.status(200).json({
             success: true,
-            message: "Return request submitted",
-            data: created ? created.toJSON() : { id: requestId }
+            message: "Returnable quantities fetched",
+            data: {
+                order_id: orderId,
+                order_status: order.status,
+                returns_open: orderIsReturnable,
+                reason: orderIsReturnable
+                    ? null
+                    : (!eligible
+                        ? "Only delivered orders are eligible for a return"
+                        : `The ${RETURN_WINDOW_DAYS}-day return window for this order has closed`),
+                items: lines
+            }
         });
     } catch (error) {
-        console.error("CREATE REFUND REQUEST ERROR:", error);
+        console.error("LIST RETURNABLE ITEMS ERROR:", error);
 
         return res.status(500).json({
             success: false,
-            message: "Failed to submit return request"
+            message: "Failed to fetch returnable quantities"
         });
     }
 };
@@ -411,6 +585,7 @@ function normalizeAdminNote(value) {
 
 module.exports = {
     createRequest,
+    listReturnable,
     listMyRequests,
     listAll,
     approveRequest,

--- a/backend/models/RefundRequest.js
+++ b/backend/models/RefundRequest.js
@@ -16,10 +16,20 @@ const REFUND_REQUEST_COLUMNS = `
     updated_at
 `;
 
-// A request is "open" while it is still awaiting an outcome or has been
-// approved but not yet closed out, so a second request for the same line
-// should be blocked in either state.
-const OPEN_STATUSES = ["pending", "approved"];
+// The statuses whose quantity counts against the units bought on a line
+// (#1477).
+//
+// A `pending` request has claimed those units while it is decided; `approved`
+// and `refunded` have consumed them. `rejected` is the only outcome that gives
+// them back, which is what makes re-submitting a refused return work.
+//
+// This replaced a two-member OPEN_STATUSES list used to answer "does this line
+// have a request in flight". That boolean was doing the work of an arithmetic
+// check: it locked the whole line after one partial return, and released the
+// whole line as soon as a request left the pair -- so a rejected request made
+// the full quantity returnable a second time and an approved one made the
+// remainder returnable never.
+const CLAIMED_STATUSES = ["pending", "approved", "refunded"];
 
 class RefundRequest {
     constructor(row) {
@@ -117,19 +127,71 @@ class RefundRequest {
         return rows.map((row) => new RefundRequest(row));
     }
 
-    static async hasOpenRequestForItem(orderItemId, connection = db) {
+    /**
+     * How many units of an order line are already claimed by returns.
+     *
+     * The sum of `quantity` over that line's pending, approved and refunded
+     * requests. Rejected ones are excluded: a refused return releases the units
+     * it asked for, so the customer can submit again.
+     *
+     * Runs on the caller's connection when one is given, so the count can be
+     * taken inside the submission's transaction and under the lock it holds on
+     * the order line. Taken outside, two submissions arriving together both read
+     * the same figure and both pass.
+     *
+     * @param {number} orderItemId
+     * @param {object} [connection]
+     * @returns {Promise<number>}
+     */
+    static async claimedQuantityForItem(orderItemId, connection = db) {
+        const placeholders = CLAIMED_STATUSES.map(() => "?").join(", ");
+
         const [rows] = await connection.query(
             `
-                SELECT id
+                SELECT COALESCE(SUM(quantity), 0) AS claimed
                 FROM refund_requests
                 WHERE order_item_id = ?
-                  AND status IN (?, ?)
-                LIMIT 1
+                  AND status IN (${placeholders})
             `,
-            [orderItemId, OPEN_STATUSES[0], OPEN_STATUSES[1]]
+            [orderItemId, ...CLAIMED_STATUSES]
         );
 
-        return rows.length > 0;
+        return Number(rows[0]?.claimed) || 0;
+    }
+
+    /**
+     * The same figure for every line of an order, as a Map keyed by
+     * `order_item_id`.
+     *
+     * One query rather than one per line: the returnable view over an order
+     * needs all of them, and a loop over `claimedQuantityForItem` is a query per
+     * item for a page a customer is waiting on.
+     *
+     * @param {string} orderId
+     * @param {object} [connection]
+     * @returns {Promise<Map<number, number>>}
+     */
+    static async claimedQuantitiesForOrder(orderId, connection = db) {
+        const placeholders = CLAIMED_STATUSES.map(() => "?").join(", ");
+
+        const [rows] = await connection.query(
+            `
+                SELECT order_item_id, COALESCE(SUM(quantity), 0) AS claimed
+                FROM refund_requests
+                WHERE order_id = ?
+                  AND status IN (${placeholders})
+                GROUP BY order_item_id
+            `,
+            [orderId, ...CLAIMED_STATUSES]
+        );
+
+        const claimed = new Map();
+
+        for (const row of rows) {
+            claimed.set(Number(row.order_item_id), Number(row.claimed) || 0);
+        }
+
+        return claimed;
     }
 
     static async updateStatus(
@@ -149,5 +211,7 @@ class RefundRequest {
         return result.affectedRows > 0;
     }
 }
+
+RefundRequest.CLAIMED_STATUSES = CLAIMED_STATUSES;
 
 module.exports = RefundRequest;

--- a/backend/routes/refundRoutes.js
+++ b/backend/routes/refundRoutes.js
@@ -14,6 +14,11 @@ router.post("/request", authMiddleware, refundController.createRequest);
 // List the authenticated user's own return requests
 router.get("/mine", authMiddleware, refundController.listMyRequests);
 
+// What is still returnable on one of the caller's orders, line by line (#1477).
+// Scoped to the caller in the controller, like /mine -- an order id in the path
+// is not authorisation to see it.
+router.get("/returnable/:orderId", authMiddleware, refundController.listReturnable);
+
 // ==================== ADMIN ROUTES ====================
 
 // List all return requests (optionally filtered by ?status=)

--- a/backend/tests/refundQuantity.test.js
+++ b/backend/tests/refundQuantity.test.js
@@ -1,0 +1,461 @@
+// backend/tests/refundQuantity.test.js
+//
+// Return quantity accounting (#1477).
+//
+// Returns used to be tracked per order line: `hasOpenRequestForItem` answered
+// "does this line have a request that is pending or approved", and the
+// controller treated that boolean as the whole rule. It was wrong in both
+// directions -- it locked a whole line after one partial return, and released a
+// whole line as soon as a request left that pair.
+//
+// These drive the controller directly with mocked `config/db`, which is how
+// every other suite here isolates MySQL. The assertions are about arithmetic and
+// about *which connection* the arithmetic happened on, since taking the count
+// off the pool rather than off the locked transaction is the difference between
+// a rule and a race.
+
+jest.mock("../config/db", () => {
+    const query = jest.fn();
+    const getConnection = jest.fn();
+    return { query, getConnection };
+});
+
+jest.mock("../services/stockCounterService", () => ({
+    restoreStock: jest.fn(async () => undefined)
+}));
+
+const db = require("../config/db");
+const RefundRequest = require("../models/RefundRequest");
+const refundController = require("../controllers/refundController");
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_USER_ID = "22222222-2222-4222-8222-222222222222";
+const ORDER_ID = "33333333-3333-4333-8333-333333333333";
+const PRODUCT_ID = "44444444-4444-4444-8444-444444444444";
+
+/** A delivered order inside the return window. */
+function deliveredOrder(overrides = {}) {
+    return {
+        user_id: USER_ID,
+        status: "delivered",
+        delivered_at: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        created_at: new Date(Date.now() - 48 * 60 * 60 * 1000),
+        ...overrides
+    };
+}
+
+function mockRes() {
+    const res = {
+        statusCode: null,
+        body: null,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        }
+    };
+    return res;
+}
+
+/**
+ * A fake pooled connection routing each SQL string to a canned answer.
+ *
+ * `claimed` is what the SUM over refund_requests returns -- the figure the whole
+ * fix turns on.
+ */
+function fakeConnection({ order = deliveredOrder(), item, claimed = 0, insertId = 7 } = {}) {
+    const calls = [];
+
+    const query = jest.fn(async (sql, params = []) => {
+        calls.push({ sql, params });
+
+        if (/FROM orders/i.test(sql)) {
+            return [order ? [order] : []];
+        }
+        if (/FROM order_items/i.test(sql)) {
+            return [item ? [item] : []];
+        }
+        if (/SUM\(quantity\)/i.test(sql)) {
+            return [[{ claimed }]];
+        }
+        if (/INSERT INTO refund_requests/i.test(sql)) {
+            return [{ insertId, affectedRows: 1 }];
+        }
+        if (/FROM refund_requests/i.test(sql)) {
+            return [[{ id: insertId, quantity: 1, status: "pending" }]];
+        }
+        return [[], { affectedRows: 1 }];
+    });
+
+    const connection = {
+        query,
+        beginTransaction: jest.fn(async () => {}),
+        commit: jest.fn(async () => {}),
+        rollback: jest.fn(async () => {}),
+        release: jest.fn()
+    };
+
+    return { connection, calls };
+}
+
+function sqlsMatching(calls, regex) {
+    return calls.filter(({ sql }) => regex.test(sql));
+}
+
+function makeRequest(body = {}, user = { id: USER_ID }) {
+    return { user, body, params: {} };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+// ============================================================================
+
+describe("RefundRequest.claimedQuantityForItem", () => {
+    it("sums pending, approved and refunded quantities", async () => {
+        db.query.mockResolvedValueOnce([[{ claimed: 4 }]]);
+
+        await expect(RefundRequest.claimedQuantityForItem(9)).resolves.toBe(4);
+
+        const [sql, params] = db.query.mock.calls[0];
+        expect(sql).toMatch(/SUM\(quantity\)/i);
+        expect(params).toEqual([9, "pending", "approved", "refunded"]);
+    });
+
+    it("excludes rejected requests, so a refused return releases its units", async () => {
+        expect(RefundRequest.CLAIMED_STATUSES).not.toContain("rejected");
+    });
+
+    it("counts refunded requests, so a closed-out return does not free the line", async () => {
+        // The old check treated anything outside pending/approved as releasing
+        // the line, so a request marked `refunded` made the whole quantity
+        // returnable from scratch.
+        expect(RefundRequest.CLAIMED_STATUSES).toContain("refunded");
+    });
+
+    it("reads zero rather than null when a line has no requests", async () => {
+        db.query.mockResolvedValueOnce([[{ claimed: null }]]);
+        await expect(RefundRequest.claimedQuantityForItem(9)).resolves.toBe(0);
+    });
+
+    it("runs on the connection it is given", async () => {
+        const connection = { query: jest.fn(async () => [[{ claimed: 2 }]]) };
+
+        await RefundRequest.claimedQuantityForItem(9, connection);
+
+        expect(connection.query).toHaveBeenCalledTimes(1);
+        expect(db.query).not.toHaveBeenCalled();
+    });
+});
+
+describe("createRequest — partial returns", () => {
+    it("accepts a partial return of a line", async () => {
+        const { connection } = fakeConnection({
+            item: { id: 5, product_id: PRODUCT_ID, qty: 5 },
+            claimed: 0
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+        await refundController.createRequest(
+            makeRequest({ orderId: ORDER_ID, orderItemId: 5, quantity: 2, reason: "Too small" }),
+            res
+        );
+
+        expect(res.statusCode).toBe(201);
+        expect(res.body.success).toBe(true);
+        expect(res.body.data.returnable_quantity).toBe(3);
+        expect(connection.commit).toHaveBeenCalledTimes(1);
+    });
+
+    it("still accepts the remainder after an earlier return was approved", async () => {
+        // The bug: two of five returned and approved left the other three
+        // unreturnable forever, because `approved` is where every successful
+        // return stops -- no route moves a request past it.
+        const { connection } = fakeConnection({
+            item: { id: 5, product_id: PRODUCT_ID, qty: 5 },
+            claimed: 2
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+        await refundController.createRequest(
+            makeRequest({ orderId: ORDER_ID, orderItemId: 5, quantity: 3, reason: "Wrong colour" }),
+            res
+        );
+
+        expect(res.statusCode).toBe(201);
+        expect(res.body.data.returnable_quantity).toBe(0);
+    });
+
+    it("refuses a quantity that would take the line past what was bought", async () => {
+        const { connection } = fakeConnection({
+            item: { id: 5, product_id: PRODUCT_ID, qty: 5 },
+            claimed: 3
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+        await refundController.createRequest(
+            makeRequest({ orderId: ORDER_ID, orderItemId: 5, quantity: 3, reason: "Faulty" }),
+            res
+        );
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toContain("already returned 3 of 5");
+        expect(res.body.data.returnable_quantity).toBe(2);
+        expect(connection.commit).not.toHaveBeenCalled();
+        expect(connection.rollback).toHaveBeenCalledTimes(1);
+    });
+
+    it("refuses outright once every unit is claimed", async () => {
+        // This is the path that used to let a rejected or refunded request
+        // release the whole line and be returned a second time -- which
+        // stockCounter.restoreStock would then credit as real inventory.
+        const { connection, calls } = fakeConnection({
+            item: { id: 5, product_id: PRODUCT_ID, qty: 5 },
+            claimed: 5
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+        await refundController.createRequest(
+            makeRequest({ orderId: ORDER_ID, orderItemId: 5, quantity: 5, reason: "All of them" }),
+            res
+        );
+
+        expect(res.statusCode).toBe(409);
+        expect(res.body.data.returnable_quantity).toBe(0);
+        expect(sqlsMatching(calls, /INSERT INTO refund_requests/i)).toHaveLength(0);
+        expect(connection.rollback).toHaveBeenCalledTimes(1);
+    });
+
+    it("defaults an omitted quantity to what is still returnable, not to what was bought", async () => {
+        const { connection, calls } = fakeConnection({
+            item: { id: 5, product_id: PRODUCT_ID, qty: 5 },
+            claimed: 4
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+        await refundController.createRequest(
+            makeRequest({ orderId: ORDER_ID, orderItemId: 5, reason: "The last one" }),
+            res
+        );
+
+        expect(res.statusCode).toBe(201);
+
+        const insert = sqlsMatching(calls, /INSERT INTO refund_requests/i)[0];
+        expect(insert.params[5]).toBe(1);
+    });
+});
+
+describe("createRequest — concurrency", () => {
+    it("locks the order line and counts under that lock", async () => {
+        const { connection, calls } = fakeConnection({
+            item: { id: 5, product_id: PRODUCT_ID, qty: 5 },
+            claimed: 0
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        await refundController.createRequest(
+            makeRequest({ orderId: ORDER_ID, orderItemId: 5, quantity: 1, reason: "Faulty" }),
+            mockRes()
+        );
+
+        // The line is what there is exactly one of, so it is what two concurrent
+        // submissions serialize on. Locking the request rows would lock nothing
+        // when a line has none yet -- the case that actually races.
+        const lineRead = sqlsMatching(calls, /FROM order_items/i)[0];
+        expect(lineRead.sql).toMatch(/FOR UPDATE/i);
+
+        // And every read is on the transaction, not the pool.
+        expect(sqlsMatching(calls, /SUM\(quantity\)/i)).toHaveLength(1);
+        expect(db.query).not.toHaveBeenCalled();
+    });
+
+    it("releases the connection when the insert fails", async () => {
+        const { connection } = fakeConnection({
+            item: { id: 5, product_id: PRODUCT_ID, qty: 5 },
+            claimed: 0
+        });
+        connection.query.mockImplementationOnce(async () => [[deliveredOrder()]]);
+        connection.commit.mockRejectedValueOnce(new Error("deadlock"));
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+        await refundController.createRequest(
+            makeRequest({ orderId: ORDER_ID, orderItemId: 5, quantity: 1, reason: "Faulty" }),
+            res
+        );
+
+        expect(res.statusCode).toBe(500);
+        expect(connection.rollback).toHaveBeenCalled();
+        expect(connection.release).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("createRequest — the checks that were already right", () => {
+    it("rejects an order that belongs to somebody else", async () => {
+        const { connection } = fakeConnection({
+            order: deliveredOrder({ user_id: OTHER_USER_ID }),
+            item: { id: 5, product_id: PRODUCT_ID, qty: 5 }
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+        await refundController.createRequest(
+            makeRequest({ orderId: ORDER_ID, orderItemId: 5, quantity: 1, reason: "Faulty" }),
+            res
+        );
+
+        expect(res.statusCode).toBe(404);
+        expect(connection.rollback).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects an order that has not been delivered", async () => {
+        const { connection } = fakeConnection({
+            order: deliveredOrder({ status: "shipped" }),
+            item: { id: 5, product_id: PRODUCT_ID, qty: 5 }
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+        await refundController.createRequest(
+            makeRequest({ orderId: ORDER_ID, orderItemId: 5, quantity: 1, reason: "Faulty" }),
+            res
+        );
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toContain("delivered");
+    });
+
+    it("rejects an order whose return window has closed", async () => {
+        const longAgo = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+        const { connection } = fakeConnection({
+            order: deliveredOrder({ delivered_at: longAgo }),
+            item: { id: 5, product_id: PRODUCT_ID, qty: 5 }
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+        await refundController.createRequest(
+            makeRequest({ orderId: ORDER_ID, orderItemId: 5, quantity: 1, reason: "Faulty" }),
+            res
+        );
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toContain("return window");
+    });
+
+    it("rejects an item that is not part of the order", async () => {
+        const { connection } = fakeConnection({ item: null });
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+        await refundController.createRequest(
+            makeRequest({ orderId: ORDER_ID, orderItemId: 999, quantity: 1, reason: "Faulty" }),
+            res
+        );
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toContain("not part of this order");
+    });
+
+    it("still requires a reason of a usable length", async () => {
+        const res = mockRes();
+        await refundController.createRequest(
+            makeRequest({ orderId: ORDER_ID, orderItemId: 5, quantity: 1, reason: "no" }),
+            res
+        );
+
+        expect(res.statusCode).toBe(400);
+        // Refused before a connection is taken at all.
+        expect(db.getConnection).not.toHaveBeenCalled();
+    });
+});
+
+describe("listReturnable", () => {
+    function returnableRequest(orderId = ORDER_ID, user = { id: USER_ID }) {
+        return { user, body: {}, params: { orderId } };
+    }
+
+    it("reports purchased, claimed and remaining for every line", async () => {
+        db.query
+            .mockResolvedValueOnce([[deliveredOrder()]])
+            .mockResolvedValueOnce([[
+                { id: 5, product_id: PRODUCT_ID, variant_id: 2, name: "Tee", qty: 5 },
+                { id: 6, product_id: PRODUCT_ID, variant_id: null, name: "Cap", qty: 1 }
+            ]])
+            .mockResolvedValueOnce([[{ order_item_id: 5, claimed: 2 }]]);
+
+        const res = mockRes();
+        await refundController.listReturnable(returnableRequest(), res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.data.returns_open).toBe(true);
+        expect(res.body.data.items).toEqual([
+            expect.objectContaining({
+                order_item_id: 5,
+                purchased_quantity: 5,
+                claimed_quantity: 2,
+                returnable_quantity: 3
+            }),
+            expect.objectContaining({
+                order_item_id: 6,
+                purchased_quantity: 1,
+                claimed_quantity: 0,
+                returnable_quantity: 1
+            })
+        ]);
+    });
+
+    it("reports nothing returnable, with a reason, once the window has closed", async () => {
+        const longAgo = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+        db.query
+            .mockResolvedValueOnce([[deliveredOrder({ delivered_at: longAgo })]])
+            .mockResolvedValueOnce([[{ id: 5, product_id: PRODUCT_ID, variant_id: null, name: "Tee", qty: 5 }]])
+            .mockResolvedValueOnce([[]]);
+
+        const res = mockRes();
+        await refundController.listReturnable(returnableRequest(), res);
+
+        expect(res.body.data.returns_open).toBe(false);
+        expect(res.body.data.reason).toContain("return window");
+        expect(res.body.data.items[0].returnable_quantity).toBe(0);
+        // The line is still listed with its real figures, so the caller can
+        // render the whole order rather than only its remainder.
+        expect(res.body.data.items[0].purchased_quantity).toBe(5);
+    });
+
+    it("does not reveal another customer's order", async () => {
+        db.query.mockResolvedValueOnce([[deliveredOrder({ user_id: OTHER_USER_ID })]]);
+
+        const res = mockRes();
+        await refundController.listReturnable(returnableRequest(), res);
+
+        expect(res.statusCode).toBe(404);
+    });
+
+    it("answers the same way for an order that does not exist", async () => {
+        // Distinguishing "not yours" from "no such order" tells a guesser which
+        // order ids are real.
+        db.query.mockResolvedValueOnce([[]]);
+
+        const res = mockRes();
+        await refundController.listReturnable(returnableRequest(), res);
+
+        expect(res.statusCode).toBe(404);
+    });
+
+    it("requires authentication", async () => {
+        const res = mockRes();
+        await refundController.listReturnable(returnableRequest(ORDER_ID, null), res);
+
+        expect(res.statusCode).toBe(401);
+    });
+});

--- a/migrations/0046_refund_quantity_accounting.sql
+++ b/migrations/0046_refund_quantity_accounting.sql
@@ -1,0 +1,80 @@
+-- ============================================
+-- RETURNS ARE COUNTED IN UNITS, NOT IN LINES
+-- ============================================
+--
+-- `refundController.createRequest` asked one question before accepting a
+-- return: does this order line already have a request that is pending or
+-- approved? A yes/no was doing the work of an arithmetic check, and it was
+-- wrong in both directions (#1477).
+--
+-- Too strict: a line of five units, two returned and approved, and the
+-- remaining three could never be returned -- `approved` is where every
+-- successful return stops, since no route moves a request past it.
+--
+-- Too loose: a request that left that pair released the whole line. Reject one
+-- request for five units and submit another; approve it, and
+-- `stockCounter.restoreStock` credits five units that were never sold. With
+-- `product_variants.stock` authoritative since 0032, that phantom stock is
+-- immediately sellable.
+--
+-- The rule the controller now enforces is a sum: the units claimed by a line's
+-- pending, approved and refunded requests may not exceed the units bought on
+-- it. Rejected requests consume nothing.
+--
+-- Nothing here changes data. `refund_requests` needs no new columns -- quantity
+-- and status were always there and always sufficient; what was missing was
+-- anyone adding them up.
+
+-- ============================================
+-- AN INDEX FOR THE SUM
+-- ============================================
+--
+-- The check runs on every return submission and now reads every request for the
+-- line rather than stopping at the first. `idx_refund_requests_order_item`
+-- covers the lookup but not the status filter, so the engine reads each matching
+-- row to decide whether it counts. Adding status to the key lets the filter be
+-- satisfied from the index.
+--
+-- The count is taken inside the submission's transaction, after the order line
+-- is locked, so it is on the latency path of a request a customer is waiting
+-- on -- which is why it is worth the index rather than a note in review.
+
+DELIMITER //
+
+CREATE PROCEDURE EnforceRefundQuantityAccounting()
+BEGIN
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'refund_requests'
+          AND INDEX_NAME   = 'idx_refund_requests_item_status'
+    ) THEN
+        ALTER TABLE refund_requests
+        ADD INDEX idx_refund_requests_item_status (order_item_id, status, quantity);
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL EnforceRefundQuantityAccounting();
+DROP PROCEDURE EnforceRefundQuantityAccounting;
+
+-- ============================================
+-- WHAT IS NOT DONE HERE, AND WHY
+-- ============================================
+--
+-- Two things a reviewer will reasonably ask about.
+--
+-- No CHECK constraint enforcing the sum. MySQL's CHECK cannot reference another
+-- table, and the quantity a line was bought at lives on `order_items`. A
+-- trigger could, but a trigger that rejects an INSERT is invisible at the call
+-- site and would duplicate the rule the controller states plainly -- and the
+-- controller holds a row lock, so it is not racing anything the trigger would
+-- catch. The invariant stays in one place.
+--
+-- No backfill of over-returned lines. Rows written under the old rule may
+-- already sum past the quantity bought, and the honest correction is a refund
+-- reversal and a stock adjustment, neither of which a migration can decide.
+-- What the new rule does guarantee is that such a line accepts nothing further:
+-- the sum is already at or past the limit, so every subsequent request is
+-- refused. The existing overage is left visible rather than quietly rewritten.


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

Returns were tracked per order line. `hasOpenRequestForItem` answered "does this line have a request that is pending or approved", and `createRequest` treated that yes/no as the whole rule — a boolean doing the work of an arithmetic check. The quantity on a request was validated against the quantity **bought** and never against the quantity **already returned**.

It was wrong in both directions.

**Too strict.** A line of five units, two returned and approved, and the remaining three can never be returned: `409, "An open return request already exists for this item"`. `approved` is where every successful return stops — `refundRoutes.js` mounts `/approve` and `/reject` and nothing else, so nothing moves a request past it.

**Too loose.** Reject a request for five and submit another: `rejected` is not in the pair, so the check passes, and `quantity <= item.qty` passes. Approve it and `stockCounter.restoreStock` credits five units that were never sold. `refunded` has the same shape — the moment a request is closed out the entire line is returnable from scratch. Since #1457 / migration 0032 made `product_variants.stock` authoritative, that phantom stock is immediately sellable.

The rule is now a sum:

> the units claimed by a line's `pending`, `approved` and `refunded` requests may not exceed the units bought on it

Rejected requests consume nothing, which is what makes re-submitting a refused return work.

---

## 🔗 Related Issue

Closes #1477

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] New feature (returnable-quantity endpoint)
- [x] Testing improvement
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix

---

## 🌐 Additional Notes

### Under a lock, because the read is half the fix

`hasOpenRequestForItem` read on the pool and `create` wrote on the pool, so two submissions arriving together both saw "nothing in flight" and both inserted. **Replacing the boolean with a sum does not fix that on its own** — both would read the same total.

The whole submission is one transaction now, and it locks the order line with `FOR UPDATE` before counting:

> The line is what there is exactly one of, so it is what two concurrent submissions can serialize on. Locking the *request* rows would lock nothing when a line has none yet — precisely the case that races.

### Telling the customer what is left

- An omitted `quantity` meant "the rest of it" and resolved to the quantity **purchased**. It now resolves to the quantity still **returnable**, which is what it always meant.
- A refusal says how many are left rather than only that there are not enough, and carries `purchased_quantity` / `claimed_quantity` / `returnable_quantity` in the body.

**`GET /refunds/returnable/:orderId` is new.** There was no way to ask what was still returnable on an order — a customer could only find out by submitting a request and reading the refusal, and the refusal did not say either.

- Every line is listed, fully-returned ones included, so a caller can render the whole order rather than only its remainder.
- The per-line figure is gated on the order as well: units left on a line are not returnable once the window has closed, and saying so here saves the caller re-deriving it.
- It answers `404` identically for "not yours" and "no such order" — distinguishing them tells a guesser which order ids are real. Same reasoning as #1455.

### Migration 0046

Adds `(order_item_id, status, quantity)` to `refund_requests`. The check now reads every request for the line rather than stopping at the first, and it runs *inside* the submission's transaction after the line is locked — so it is on the latency path of a request a customer is waiting on, which is why it is worth the index rather than a note in review.

Two things it deliberately does **not** do, both explained in the file:

- **No CHECK constraint.** MySQL's cannot reference another table, and the quantity a line was bought at lives on `order_items`. A trigger could, but it would be invisible at the call site and would duplicate a rule the controller states plainly — and the controller holds a row lock, so it is not racing anything the trigger would catch.
- **No backfill of over-returned lines.** Rows written under the old rule may already sum past what was bought, and the honest correction is a refund reversal plus a stock adjustment — neither of which a migration can decide. Such a line does accept nothing further under the new rule, since its sum is already at the limit. The existing overage is left visible rather than quietly rewritten.

Takes **0046**. Per `migrations/README.md` please check it is still free before merging — #1476 claims 0045 and #1478 claims 0047, so those three do not collide with each other.

### Tests

New suite, 22 tests, covering both directions of the original bug, the lock and *which connection* each read happens on (taking the count off the pool rather than off the locked transaction is the difference between a rule and a race), and the new endpoint.

---

## ⚠️ CI note

Cut from `main`, which does not currently boot (#1474). Six suites fail here for that reason and that reason only — identical with and without this branch:

```
main alone:      Test Suites: 6 failed, 58 passed   Tests: 13 failed, 1395 passed
main + this PR:  Test Suites: 6 failed, 59 passed   Tests: 13 failed, 1417 passed
```

Merge #1479 first and this goes green — no files in common.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly
