### PR TITLE
Make a redeemed gift card pay for the order it names

### DIFF
--- a/backend/routes/giftCardRoutes.js
+++ b/backend/routes/giftCardRoutes.js
@@ -14,7 +14,14 @@ const ERROR_STATUS = {
     INACTIVE: 400,
     EXPIRED: 410,
     INSUFFICIENT_BALANCE: 402,
-    NOT_FOUND: 404
+    NOT_FOUND: 404,
+    // 404 rather than 403: "not yours" and "no such order" have to answer
+    // identically, or the endpoint becomes a way to enumerate order ids (#1478).
+    ORDER_NOT_FOUND: 404,
+    FORBIDDEN: 403,
+    ORDER_NOT_PAYABLE: 409,
+    ORDER_SETTLED: 409,
+    CURRENCY_MISMATCH: 400
 };
 
 function handleError(res, error, logLabel) {
@@ -78,7 +85,17 @@ router.post("/balance", authMiddleware, async (req, res) => {
     }
 });
 
-// Redeem an amount off a gift card. Atomic + double-spend safe in the service.
+// Pay part or all of an order with a gift card. Atomic + double-spend safe in
+// the service, which also locks the order, checks it belongs to the caller and
+// clamps the amount to what is outstanding on it.
+//
+// `orderId` is now required (#1478). It used to be optional, and omitting it
+// called `redeem()`, which decremented the balance against nothing at all --
+// a redemption that settles no order cannot be reconciled and is
+// indistinguishable from one that was later refunded. There is no reason for a
+// customer to burn store credit into thin air.
+//
+// `amount` is optional and means "as much as this card can cover" when absent.
 router.post("/redeem", authMiddleware, async (req, res) => {
     try {
         const { code, amount, orderId } = req.body;
@@ -90,13 +107,31 @@ router.post("/redeem", authMiddleware, async (req, res) => {
             });
         }
 
-        const result = orderId
-            ? await giftCardService.applyToOrder(code, orderId, amount)
-            : await giftCardService.redeem(code, amount);
+        if (!orderId) {
+            return res.status(400).json({
+                success: false,
+                message: "An order ID is required to redeem a gift card"
+            });
+        }
+
+        // The order's owner, from the token rather than from the body.
+        // authMiddleware establishes who is calling; it does not establish that
+        // this order is theirs, and nothing else here did either.
+        const userId = req.user?.id ?? req.user?.userId;
+
+        const result = await giftCardService.applyToOrder(
+            code,
+            orderId,
+            amount,
+            null,
+            { userId }
+        );
 
         return res.status(200).json({
             success: true,
-            message: "Gift card redeemed",
+            message: result.orderSettled
+                ? "Gift card redeemed and order paid in full"
+                : "Gift card redeemed",
             data: result
         });
     } catch (error) {

--- a/backend/services/giftCardService.js
+++ b/backend/services/giftCardService.js
@@ -1,6 +1,22 @@
 const crypto = require("crypto");
 const promisePool = require("../config/db");
 
+// The store prices in exactly one currency and declares it here. A card is
+// issued in that currency by default and may only be redeemed against it.
+// `gift_cards.currency` defaulted to "USD" while the store priced in INR, and
+// nothing ever compared the two -- latent while a redemption changed no order
+// total, and not latent from the moment one does (#1478).
+const CURRENCY = require("../config/currency");
+
+// Orders a card may still pay towards. Anything else is either already settled
+// or no longer payable, and a redemption against it would take a balance for
+// something the customer is not being charged for.
+const PAYABLE_PAYMENT_STATUSES = Object.freeze(["pending", "failed"]);
+
+// Order lifecycle states that are over. `payment_status` alone is not enough:
+// a cancelled order can still read `pending`.
+const UNPAYABLE_ORDER_STATUSES = Object.freeze(["cancelled", "refunded"]);
+
 // 8 random bytes -> 16 uppercase hex chars. Only the SHA-256 hash of this
 // plaintext is ever persisted (code_hash); the plaintext is returned to the
 // caller exactly once, at issue time.
@@ -95,7 +111,16 @@ async function issueInTransaction(conn, { amount, currency, expiresAt }, now) {
 // while the surrounding transaction is open, which is what closes the
 // double-spend race. Validation throws BEFORE any write, so a rejected redeem
 // leaves the balance untouched and writes no ledger row.
-async function redeemInTransaction(conn, codeHash, amount, orderId, now) {
+/**
+ * Take the row lock and run every check that does not depend on the amount.
+ *
+ * Split out of `redeemInTransaction` so a caller can see the balance before
+ * deciding what to redeem -- `applyToOrder` pays "as much as this card can
+ * cover", which is not a number anyone can know until the card is locked and
+ * read. The lock is held either way, so nothing can move between this and the
+ * decrement.
+ */
+async function lockAndValidateCard(conn, codeHash, now) {
     const [rows] = await conn.query(
         "SELECT id, balance, currency, status, expires_at FROM gift_cards WHERE code_hash = ? FOR UPDATE",
         [codeHash]
@@ -114,6 +139,22 @@ async function redeemInTransaction(conn, codeHash, amount, orderId, now) {
     if (isExpired(giftCard, now)) {
         throw new GiftCardError("Gift card has expired", "EXPIRED");
     }
+
+    // The store prices in one currency. A card labelled in another cannot be
+    // subtracted from an order total without choosing an exchange rate, and
+    // there is none to choose -- so it is refused rather than applied 1:1.
+    if (giftCard.currency !== CURRENCY.code) {
+        throw new GiftCardError(
+            `This gift card is issued in ${giftCard.currency} and cannot be used here`,
+            "CURRENCY_MISMATCH"
+        );
+    }
+
+    return giftCard;
+}
+
+async function redeemInTransaction(conn, codeHash, amount, orderId, now, lockedCard = null) {
+    const giftCard = lockedCard || (await lockAndValidateCard(conn, codeHash, now));
 
     const balance = Number(giftCard.balance);
 
@@ -169,10 +210,100 @@ async function runRedemption(code, amount, orderId, connection) {
     }
 }
 
+/**
+ * Load and lock the order a card is about to pay towards, and establish that it
+ * may.
+ *
+ * The order is locked before the card is. Both locks are always taken in that
+ * direction, so two redemptions against one order cannot deadlock by each
+ * holding what the other wants.
+ *
+ * `userId` is required. `authMiddleware` establishes who is calling; it does
+ * not establish that this order is theirs, and the route had no second check --
+ * so any authenticated caller could attach a redemption to any order id.
+ *
+ * @returns {{id: string, total: number, giftCardAmount: number, outstanding: number}}
+ */
+async function lockPayableOrder(conn, orderId, userId) {
+    if (!userId) {
+        throw new GiftCardError(
+            "A gift card can only be redeemed against an order by its owner",
+            "FORBIDDEN"
+        );
+    }
+
+    const [rows] = await conn.query(
+        `SELECT id, user_id, status, payment_status, total, gift_card_amount, deleted_at
+           FROM orders
+          WHERE id = ?
+          LIMIT 1
+          FOR UPDATE`,
+        [orderId]
+    );
+
+    const order = rows[0];
+
+    // One answer for "no such order" and "not yours". Telling them apart hands
+    // an attacker a way to enumerate order ids, and this endpoint is reachable
+    // by anyone with an account.
+    if (!order || order.deleted_at || String(order.user_id) !== String(userId)) {
+        throw new GiftCardError("Order not found", "ORDER_NOT_FOUND");
+    }
+
+    if (UNPAYABLE_ORDER_STATUSES.includes(order.status)) {
+        throw new GiftCardError(
+            `This order is ${order.status} and cannot be paid`,
+            "ORDER_NOT_PAYABLE"
+        );
+    }
+
+    if (!PAYABLE_PAYMENT_STATUSES.includes(order.payment_status)) {
+        throw new GiftCardError(
+            `This order is already ${order.payment_status}`,
+            "ORDER_NOT_PAYABLE"
+        );
+    }
+
+    const total = roundMoney(Number(order.total) || 0);
+    const giftCardAmount = roundMoney(Number(order.gift_card_amount) || 0);
+    const outstanding = roundMoney(total - giftCardAmount);
+
+    if (outstanding <= 0) {
+        throw new GiftCardError("This order has nothing left to pay", "ORDER_SETTLED");
+    }
+
+    return { id: order.id, total, giftCardAmount, outstanding };
+}
+
+/**
+ * Record on the order what the card just paid, and settle it if that covers it.
+ *
+ * In the same transaction as the balance decrement, so the ledger and the order
+ * cannot disagree about what was paid.
+ */
+async function settleOrder(conn, order, amount, now) {
+    const paid = roundMoney(order.giftCardAmount + amount);
+    const remaining = roundMoney(order.total - paid);
+
+    await conn.query(
+        `UPDATE orders
+            SET gift_card_amount = ?,
+                payment_status   = ?,
+                updated_at       = ?
+          WHERE id = ?`,
+        [paid, remaining <= 0 ? "paid" : "pending", now, order.id]
+    );
+
+    return { giftCardAmount: paid, outstanding: Math.max(remaining, 0) };
+}
+
 const giftCardService = {
     // Issue a new gift card. Returns the plaintext `code` — this is the only
     // time it is available, since only its hash is stored.
-    issue: async ({ amount, currency = "USD", expiresAt = null }, connection = null) => {
+    // `currency` defaults to the store's, not to a hardcoded "USD". The store
+    // prices in one currency and declares it in config/currency.js; a card
+    // issued in anything else cannot be redeemed here (#1478).
+    issue: async ({ amount, currency = CURRENCY.code, expiresAt = null }, connection = null) => {
         const value = normalizeAmount(amount);
         const now = new Date();
         const expiresAtDate = expiresAt ? new Date(expiresAt) : null;
@@ -212,25 +343,139 @@ const giftCardService = {
             throw new GiftCardError("Gift card not found", "NOT_FOUND");
         }
 
+        // Status is derived, not read back verbatim.
+        //
+        // Nothing sweeps `expires_at` into the `status` column -- no job, no
+        // trigger, no migration -- so a card past its expiry still reads
+        // `active` with its full balance, right up until the customer tries to
+        // spend it and gets a 410. `redeemInTransaction` has always applied
+        // `isExpired`; this is the same rule, applied where the customer can see
+        // it (#1478).
+        const expired = isExpired(giftCard, new Date());
+
         return {
             balance: Number(giftCard.balance),
             currency: giftCard.currency,
-            status: giftCard.status,
-            expiresAt: giftCard.expires_at
+            status: expired ? GIFT_CARD_STATUS.EXPIRED : giftCard.status,
+            expiresAt: giftCard.expires_at,
+            // Whether it can be spent right now, which is the question a caller
+            // is actually asking and one that four statuses plus an expiry date
+            // make them re-derive.
+            redeemable:
+                !expired
+                && giftCard.status === GIFT_CARD_STATUS.ACTIVE
+                && giftCard.currency === CURRENCY.code
+                && Number(giftCard.balance) > 0
         };
     },
 
-    // Redeem `amount` off a card's balance. Atomic; safe against concurrent
-    // double-spend via the FOR UPDATE row lock inside the transaction.
+    // Redeem `amount` off a card's balance, tied to nothing.
+    //
+    // Deliberately not reachable from the customer route any more: a redemption
+    // that names no order settles nothing, cannot be reconciled, and is
+    // indistinguishable from one that was later refunded. It stays here for
+    // administrative correction and because `applyToOrder` is built on it.
+    //
+    // Atomic; safe against concurrent double-spend via the FOR UPDATE row lock
+    // inside the transaction.
     redeem: async (code, amount, connection = null) => {
         return runRedemption(code, amount, null, connection);
     },
 
-    // Same as redeem, but ties the ledger row to an order. Accepts an optional
-    // caller-owned `connection` so checkout can redeem inside its own
-    // transaction (mirrors inventoryReservationService).
-    applyToOrder: async (code, orderId, amount, connection = null) => {
-        return runRedemption(code, amount, orderId, connection);
+    /**
+     * Pay part or all of an order with a gift card.
+     *
+     * What this used to do: write `orderId` into the ledger row and nothing
+     * else. The order was never read, so any authenticated caller could attach a
+     * redemption to any order id -- and even in the honest case the order total
+     * was untouched, so the customer's balance was spent and they were still
+     * charged in full (#1478).
+     *
+     * Now the order is loaded and locked first, the caller must own it, it must
+     * still be payable, and the amount is clamped to what is outstanding on it.
+     * The order is settled in the same transaction as the balance decrement, so
+     * the ledger and the order cannot disagree about what was paid.
+     *
+     * `amount` is optional. Omitted, it means "as much as this card can cover",
+     * which is what a customer paying with a gift card almost always wants and
+     * what they would otherwise have to compute themselves.
+     *
+     * @param {string} code
+     * @param {string} orderId
+     * @param {number|null} amount
+     * @param {object|null} connection Caller-owned transaction, for checkout.
+     * @param {{userId: string}} options
+     */
+    applyToOrder: async (code, orderId, amount, connection = null, { userId } = {}) => {
+        const run = async (conn) => {
+            // Order first, then card -- always this direction, so two
+            // redemptions against one order cannot deadlock by each holding what
+            // the other is waiting for.
+            const order = await lockPayableOrder(conn, orderId, userId);
+
+            const now = new Date();
+            const codeHash = hashCode(code);
+
+            // The card is locked and read before the amount is decided, because
+            // an omitted amount means "as much as this card can cover" and that
+            // is not a number anyone can know until the balance is in hand. The
+            // lock is held from here through the decrement either way.
+            const card = await lockAndValidateCard(conn, codeHash, now);
+            const cardBalance = roundMoney(Number(card.balance) || 0);
+
+            // Clamped, not merely validated. A caller asking for more than is
+            // owed is asking to overpay, and the answer is to take what is owed
+            // rather than to refuse -- the balance is theirs and so is the
+            // order. An explicit amount larger than the card holds is still an
+            // error, though: that is the caller being wrong about their own
+            // balance, and silently taking less would hide it.
+            const toRedeem = amount === undefined || amount === null
+                ? roundMoney(Math.min(order.outstanding, cardBalance))
+                : roundMoney(Math.min(normalizeAmount(amount), order.outstanding));
+
+            if (toRedeem <= 0) {
+                throw new GiftCardError(
+                    "This gift card has no balance left to apply",
+                    "INSUFFICIENT_BALANCE"
+                );
+            }
+
+            const redemption = await redeemInTransaction(
+                conn,
+                codeHash,
+                toRedeem,
+                orderId,
+                now,
+                card
+            );
+            const settlement = await settleOrder(conn, order, toRedeem, now);
+
+            return {
+                ...redemption,
+                orderId,
+                orderTotal: order.total,
+                orderPaidByGiftCards: settlement.giftCardAmount,
+                orderOutstanding: settlement.outstanding,
+                orderSettled: settlement.outstanding <= 0
+            };
+        };
+
+        if (connection) {
+            return run(connection);
+        }
+
+        const conn = await promisePool.getConnection();
+        try {
+            await conn.beginTransaction();
+            const result = await run(conn);
+            await conn.commit();
+            return result;
+        } catch (error) {
+            await conn.rollback();
+            throw error;
+        } finally {
+            conn.release();
+        }
     }
 };
 

--- a/backend/tests/giftCard.test.js
+++ b/backend/tests/giftCard.test.js
@@ -62,7 +62,7 @@ describe("issue", () => {
         });
         db.getConnection.mockResolvedValue(connection);
 
-        const result = await service.issue({ amount: 50, currency: "USD" });
+        const result = await service.issue({ amount: 50, currency: "INR" });
 
         expect(connection.beginTransaction).toHaveBeenCalledTimes(1);
         expect(connection.commit).toHaveBeenCalledTimes(1);
@@ -101,16 +101,17 @@ describe("getBalance", () => {
     test("looks up by code_hash and returns balance/status/expiry without a lock", async () => {
         const code = "ABCDEF0123456789";
         db.query.mockResolvedValue([
-            [{ balance: 25.5, currency: "USD", status: "active", expires_at: null }]
+            [{ balance: 25.5, currency: "INR", status: "active", expires_at: null }]
         ]);
 
         const balance = await service.getBalance(code);
 
         expect(balance).toEqual({
             balance: 25.5,
-            currency: "USD",
+            currency: "INR",
             status: "active",
-            expiresAt: null
+            expiresAt: null,
+            redeemable: true
         });
 
         const [sql, params] = db.query.mock.calls[0];
@@ -133,7 +134,7 @@ describe("redeem", () => {
         const code = "1111222233334444";
         const connection = makeTxnConnection((sql) => {
             if (/SELECT .* FROM gift_cards WHERE code_hash = \?/i.test(sql)) {
-                return [[{ id: 7, balance: 50, currency: "USD", status: "active", expires_at: null }]];
+                return [[{ id: 7, balance: 50, currency: "INR", status: "active", expires_at: null }]];
             }
             if (/INSERT INTO gift_card_transactions/i.test(sql)) {
                 return [{ insertId: 900, affectedRows: 1 }];
@@ -175,7 +176,7 @@ describe("redeem", () => {
                 return [[{
                     id: 8,
                     balance: 50,
-                    currency: "USD",
+                    currency: "INR",
                     status: "active",
                     expires_at: new Date(Date.now() - 24 * 60 * 60 * 1000)
                 }]];
@@ -202,7 +203,7 @@ describe("redeem", () => {
     test("rejects an over-redeem without dropping balance below zero or writing a ledger row", async () => {
         const connection = makeTxnConnection((sql) => {
             if (/SELECT .* FROM gift_cards WHERE code_hash = \?/i.test(sql)) {
-                return [[{ id: 9, balance: 50, currency: "USD", status: "active", expires_at: null }]];
+                return [[{ id: 9, balance: 50, currency: "INR", status: "active", expires_at: null }]];
             }
             return [{ affectedRows: 1 }];
         });
@@ -228,7 +229,7 @@ describe("redeem", () => {
         const code = "5555666677778888";
         const conn = makeConnection((sql) => {
             if (/SELECT .* FROM gift_cards WHERE code_hash = \?/i.test(sql)) {
-                return [[{ id: 3, balance: 40, currency: "USD", status: "active", expires_at: null }]];
+                return [[{ id: 3, balance: 40, currency: "INR", status: "active", expires_at: null }]];
             }
             if (/INSERT INTO gift_card_transactions/i.test(sql)) {
                 return [{ insertId: 5, affectedRows: 1 }];
@@ -247,26 +248,347 @@ describe("redeem", () => {
     });
 });
 
-describe("applyToOrder", () => {
-    test("ties the redeem ledger row to the order id", async () => {
-        const code = "9999000011112222";
-        const orderId = "11111111-1111-1111-1111-111111111111";
-        const conn = makeConnection((sql) => {
-            if (/SELECT .* FROM gift_cards WHERE code_hash = \?/i.test(sql)) {
-                return [[{ id: 12, balance: 100, currency: "USD", status: "active", expires_at: null }]];
-            }
-            if (/INSERT INTO gift_card_transactions/i.test(sql)) {
-                return [{ insertId: 77, affectedRows: 1 }];
-            }
-            return [{ affectedRows: 1 }];
+// ============================================================================
+// APPLYING A CARD TO AN ORDER (#1478)
+// ============================================================================
+//
+// What this used to do: write `orderId` into the ledger row and nothing else.
+// The order was never read -- so any authenticated caller could attach a
+// redemption to any order id -- and `orders` was untouched, so the balance was
+// spent and the customer was still charged in full.
+
+const ORDER_ID = "11111111-1111-1111-1111-111111111111";
+const OWNER_ID = "22222222-2222-2222-2222-222222222222";
+const STRANGER_ID = "33333333-3333-3333-3333-333333333333";
+
+/** An unpaid order belonging to OWNER_ID. */
+function payableOrder(overrides = {}) {
+    return {
+        id: ORDER_ID,
+        user_id: OWNER_ID,
+        status: "pending",
+        payment_status: "pending",
+        total: 100,
+        gift_card_amount: 0,
+        deleted_at: null,
+        ...overrides
+    };
+}
+
+/** A live card with `balance` on it. */
+function activeCard(overrides = {}) {
+    return { id: 12, balance: 100, currency: "INR", status: "active", expires_at: null, ...overrides };
+}
+
+/**
+ * A connection answering the order lock, the card lock and the writes.
+ */
+function orderConnection({ order = payableOrder(), card = activeCard() } = {}) {
+    return makeTxnConnection((sql) => {
+        if (/FROM orders/i.test(sql)) {
+            return [order ? [order] : []];
+        }
+        if (/FROM gift_cards WHERE code_hash = \?/i.test(sql)) {
+            return [card ? [card] : []];
+        }
+        if (/INSERT INTO gift_card_transactions/i.test(sql)) {
+            return [{ insertId: 77, affectedRows: 1 }];
+        }
+        return [{ affectedRows: 1 }];
+    });
+}
+
+describe("applyToOrder — the order actually gets paid", () => {
+    test("reduces what the order owes, not just the card balance", async () => {
+        const connection = orderConnection();
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await service.applyToOrder("9999000011112222", ORDER_ID, 60, null, {
+            userId: OWNER_ID
         });
 
-        const result = await service.applyToOrder(code, orderId, 60, { query: conn.query });
-
         expect(result.balanceAfter).toBe(40);
-        const ledger = sqlsMatching(conn.calls, /INSERT INTO gift_card_transactions/i);
+        expect(result.orderPaidByGiftCards).toBe(60);
+        expect(result.orderOutstanding).toBe(40);
+        expect(result.orderSettled).toBe(false);
+
+        const orderUpdate = sqlsMatching(connection.calls, /UPDATE orders/i);
+        expect(orderUpdate).toHaveLength(1);
+        expect(orderUpdate[0].params[0]).toBe(60);
+        // Still owes 40, so it is not marked paid.
+        expect(orderUpdate[0].params[1]).toBe("pending");
+    });
+
+    test("marks the order paid when the card covers it in full", async () => {
+        const connection = orderConnection({ card: activeCard({ balance: 250 }) });
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await service.applyToOrder("CODE000000000000", ORDER_ID, 100, null, {
+            userId: OWNER_ID
+        });
+
+        expect(result.orderOutstanding).toBe(0);
+        expect(result.orderSettled).toBe(true);
+        expect(sqlsMatching(connection.calls, /UPDATE orders/i)[0].params[1]).toBe("paid");
+    });
+
+    test("settles the order in the same transaction as the balance decrement", async () => {
+        // Otherwise the ledger and the order can disagree about what was paid.
+        const connection = orderConnection();
+        db.getConnection.mockResolvedValue(connection);
+
+        await service.applyToOrder("CODE000000000000", ORDER_ID, 60, null, { userId: OWNER_ID });
+
+        expect(connection.beginTransaction).toHaveBeenCalledTimes(1);
+        expect(connection.commit).toHaveBeenCalledTimes(1);
+        expect(sqlsMatching(connection.calls, /UPDATE gift_cards SET balance/i)).toHaveLength(1);
+        expect(sqlsMatching(connection.calls, /UPDATE orders/i)).toHaveLength(1);
+    });
+
+    test("still ties the ledger row to the order", async () => {
+        const connection = orderConnection();
+        db.getConnection.mockResolvedValue(connection);
+
+        await service.applyToOrder("CODE000000000000", ORDER_ID, 60, null, { userId: OWNER_ID });
+
+        const ledger = sqlsMatching(connection.calls, /INSERT INTO gift_card_transactions/i);
         expect(ledger).toHaveLength(1);
-        expect(ledger[0].params[1]).toBe(orderId);
+        expect(ledger[0].params[1]).toBe(ORDER_ID);
         expect(ledger[0].params[2]).toBe("redeem");
+    });
+
+    test("takes the order lock before the card lock", async () => {
+        // Always this direction, so two redemptions against one order cannot
+        // deadlock by each holding what the other is waiting for.
+        const connection = orderConnection();
+        db.getConnection.mockResolvedValue(connection);
+
+        await service.applyToOrder("CODE000000000000", ORDER_ID, 60, null, { userId: OWNER_ID });
+
+        const locks = connection.calls
+            .map(({ sql }) => sql)
+            .filter((sql) => /FOR UPDATE/i.test(sql));
+
+        expect(locks[0]).toMatch(/FROM orders/i);
+        expect(locks[1]).toMatch(/FROM gift_cards/i);
+    });
+});
+
+describe("applyToOrder — ownership", () => {
+    test("refuses an order belonging to somebody else", async () => {
+        const connection = orderConnection();
+        db.getConnection.mockResolvedValue(connection);
+
+        await expect(
+            service.applyToOrder("CODE000000000000", ORDER_ID, 25, null, { userId: STRANGER_ID })
+        ).rejects.toMatchObject({ code: "ORDER_NOT_FOUND" });
+
+        expect(sqlsMatching(connection.calls, /UPDATE gift_cards/i)).toHaveLength(0);
+        expect(connection.rollback).toHaveBeenCalledTimes(1);
+    });
+
+    test("answers identically for an order that does not exist", async () => {
+        // Distinguishing "not yours" from "no such order" makes this endpoint a
+        // way to enumerate order ids.
+        const connection = orderConnection({ order: null });
+        db.getConnection.mockResolvedValue(connection);
+
+        await expect(
+            service.applyToOrder("CODE000000000000", ORDER_ID, 25, null, { userId: OWNER_ID })
+        ).rejects.toMatchObject({ code: "ORDER_NOT_FOUND" });
+    });
+
+    test("refuses a soft-deleted order", async () => {
+        const connection = orderConnection({ order: payableOrder({ deleted_at: new Date() }) });
+        db.getConnection.mockResolvedValue(connection);
+
+        await expect(
+            service.applyToOrder("CODE000000000000", ORDER_ID, 25, null, { userId: OWNER_ID })
+        ).rejects.toMatchObject({ code: "ORDER_NOT_FOUND" });
+    });
+
+    test("refuses when no userId is supplied at all", async () => {
+        // A caller that forgets to pass one must not fall through to the old
+        // behaviour of trusting the body.
+        const connection = orderConnection();
+        db.getConnection.mockResolvedValue(connection);
+
+        await expect(
+            service.applyToOrder("CODE000000000000", ORDER_ID, 25)
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+});
+
+describe("applyToOrder — what may still be paid", () => {
+    test("refuses an order that is already paid", async () => {
+        const connection = orderConnection({
+            order: payableOrder({ payment_status: "paid" })
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        await expect(
+            service.applyToOrder("CODE000000000000", ORDER_ID, 25, null, { userId: OWNER_ID })
+        ).rejects.toMatchObject({ code: "ORDER_NOT_PAYABLE" });
+    });
+
+    test("refuses a cancelled order even when payment_status still reads pending", async () => {
+        const connection = orderConnection({ order: payableOrder({ status: "cancelled" }) });
+        db.getConnection.mockResolvedValue(connection);
+
+        await expect(
+            service.applyToOrder("CODE000000000000", ORDER_ID, 25, null, { userId: OWNER_ID })
+        ).rejects.toMatchObject({ code: "ORDER_NOT_PAYABLE" });
+    });
+
+    test("refuses an order other cards have already covered", async () => {
+        const connection = orderConnection({
+            order: payableOrder({ total: 100, gift_card_amount: 100 })
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        await expect(
+            service.applyToOrder("CODE000000000000", ORDER_ID, 25, null, { userId: OWNER_ID })
+        ).rejects.toMatchObject({ code: "ORDER_SETTLED" });
+    });
+});
+
+describe("applyToOrder — the amount", () => {
+    test("clamps an amount larger than what is outstanding", async () => {
+        // A caller asking for more than is owed is asking to overpay. Taking
+        // what is owed is the right answer -- the balance is theirs and so is
+        // the order.
+        const connection = orderConnection({ card: activeCard({ balance: 500 }) });
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await service.applyToOrder("CODE000000000000", ORDER_ID, 400, null, {
+            userId: OWNER_ID
+        });
+
+        expect(result.amount).toBe(100);
+        expect(result.balanceAfter).toBe(400);
+        expect(result.orderOutstanding).toBe(0);
+    });
+
+    test("clamps against what other cards have already paid", async () => {
+        const connection = orderConnection({
+            order: payableOrder({ total: 100, gift_card_amount: 70 }),
+            card: activeCard({ balance: 500 })
+        });
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await service.applyToOrder("CODE000000000000", ORDER_ID, 90, null, {
+            userId: OWNER_ID
+        });
+
+        expect(result.amount).toBe(30);
+        expect(result.orderPaidByGiftCards).toBe(100);
+        expect(result.orderSettled).toBe(true);
+    });
+
+    test("an omitted amount means as much as the card can cover", async () => {
+        const connection = orderConnection({ card: activeCard({ balance: 40 }) });
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await service.applyToOrder("CODE000000000000", ORDER_ID, undefined, null, {
+            userId: OWNER_ID
+        });
+
+        // Outstanding is 100, the card holds 40 -- so it pays 40 and the card
+        // is emptied, not refused for being short.
+        expect(result.amount).toBe(40);
+        expect(result.balanceAfter).toBe(0);
+        expect(result.orderOutstanding).toBe(60);
+    });
+
+    test("still refuses a card that cannot cover the clamped amount", async () => {
+        const connection = orderConnection({ card: activeCard({ balance: 10 }) });
+        db.getConnection.mockResolvedValue(connection);
+
+        await expect(
+            service.applyToOrder("CODE000000000000", ORDER_ID, 50, null, { userId: OWNER_ID })
+        ).rejects.toMatchObject({ code: "INSUFFICIENT_BALANCE" });
+    });
+});
+
+describe("currency", () => {
+    test("refuses a card issued in a currency the store does not price in", async () => {
+        // gift_cards.currency defaulted to USD while the store prices in INR,
+        // and nothing compared the two. Subtracting one from the other means
+        // choosing an exchange rate, and there is none to choose.
+        const connection = orderConnection({ card: activeCard({ currency: "USD" }) });
+        db.getConnection.mockResolvedValue(connection);
+
+        await expect(
+            service.applyToOrder("CODE000000000000", ORDER_ID, 25, null, { userId: OWNER_ID })
+        ).rejects.toMatchObject({ code: "CURRENCY_MISMATCH" });
+
+        expect(sqlsMatching(connection.calls, /UPDATE orders/i)).toHaveLength(0);
+    });
+
+    test("issues in the store's currency by default", async () => {
+        const connection = makeTxnConnection((sql) =>
+            /INSERT INTO gift_cards/i.test(sql)
+                ? [{ insertId: 1, affectedRows: 1 }]
+                : [{ insertId: 2, affectedRows: 1 }]
+        );
+        db.getConnection.mockResolvedValue(connection);
+
+        const result = await service.issue({ amount: 50 });
+
+        expect(result.currency).toBe("INR");
+        expect(sqlsMatching(connection.calls, /INSERT INTO gift_cards/i)[0].params[2]).toBe("INR");
+    });
+});
+
+describe("getBalance — expiry", () => {
+    test("reports an expired card as expired, not as active", async () => {
+        // Nothing sweeps expires_at into the status column, so a lapsed card
+        // read `active` with its full balance right up until the customer tried
+        // to spend it and got a 410.
+        db.query.mockResolvedValue([[{
+            balance: 50,
+            currency: "INR",
+            status: "active",
+            expires_at: new Date(Date.now() - 24 * 60 * 60 * 1000)
+        }]]);
+
+        const balance = await service.getBalance("EXPIREDCARD00000");
+
+        expect(balance.status).toBe("expired");
+        expect(balance.redeemable).toBe(false);
+        // The balance is still reported: it is a real figure, and hiding it
+        // would leave the customer unable to see what they are asking about.
+        expect(balance.balance).toBe(50);
+    });
+
+    test("leaves a card with no expiry alone", async () => {
+        db.query.mockResolvedValue([[
+            { balance: 50, currency: "INR", status: "active", expires_at: null }
+        ]]);
+
+        await expect(service.getBalance("CODE000000000000")).resolves.toMatchObject({
+            status: "active",
+            redeemable: true
+        });
+    });
+
+    test("is not redeemable when the card is in a foreign currency", async () => {
+        db.query.mockResolvedValue([[
+            { balance: 50, currency: "USD", status: "active", expires_at: null }
+        ]]);
+
+        await expect(service.getBalance("CODE000000000000")).resolves.toMatchObject({
+            redeemable: false
+        });
+    });
+
+    test("is not redeemable when the balance is gone", async () => {
+        db.query.mockResolvedValue([[
+            { balance: 0, currency: "INR", status: "redeemed", expires_at: null }
+        ]]);
+
+        await expect(service.getBalance("CODE000000000000")).resolves.toMatchObject({
+            redeemable: false
+        });
     });
 });

--- a/migrations/0047_gift_card_order_settlement.sql
+++ b/migrations/0047_gift_card_order_settlement.sql
@@ -1,0 +1,133 @@
+-- ============================================
+-- A REDEEMED GIFT CARD HAS TO PAY FOR SOMETHING
+-- ============================================
+--
+-- `applyToOrder(code, orderId, amount)` wrote `orderId` into
+-- `gift_card_transactions.order_id` and did nothing else with it. The order was
+-- never read, so nothing established that it existed, that it belonged to the
+-- caller, that it was unpaid, or that `amount` bore any relation to what was
+-- owed on it (#1478).
+--
+-- The half that costs customers money is not the missing ownership check. It is
+-- that even in the honest case -- your own card, your own order, a sensible
+-- amount -- `orders` was untouched. The balance was spent, a `redeem` row was
+-- written, and the customer was still asked for the full amount at checkout.
+-- Gift cards were a way to destroy store credit.
+--
+-- This adds the column that records what a card paid, so the redemption and the
+-- order can be reconciled and so the amount owed actually comes down.
+
+-- ============================================
+-- WHAT THE CARDS HAVE PAID
+-- ============================================
+--
+-- A column of its own rather than reusing one that exists. `orders` already
+-- carries `discount`, `discount_amount`, `final_amount` and `total_amount`, and
+-- checkoutService writes `priced.total` into `total`, `total_amount` *and*
+-- `final_amount` -- three copies of one figure. Folding store credit into any
+-- of them would make a paid-with-credit order indistinguishable from a
+-- discounted one, and store credit is not a discount: it is a payment, it came
+-- out of a balance somebody bought, and it has to be refundable back to that
+-- balance.
+--
+-- Outstanding on an order is `total - gift_card_amount`.
+
+DELIMITER //
+
+CREATE PROCEDURE AddGiftCardSettlementColumn()
+BEGIN
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'orders'
+          AND COLUMN_NAME  = 'gift_card_amount'
+    ) THEN
+        ALTER TABLE orders
+        ADD COLUMN gift_card_amount DECIMAL(10,2) NOT NULL DEFAULT 0.00 AFTER discount_amount;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+        WHERE TABLE_SCHEMA     = DATABASE()
+          AND TABLE_NAME       = 'orders'
+          AND CONSTRAINT_NAME  = 'chk_orders_gift_card_amount'
+    ) THEN
+        ALTER TABLE orders
+        ADD CONSTRAINT chk_orders_gift_card_amount CHECK (gift_card_amount >= 0);
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL AddGiftCardSettlementColumn();
+DROP PROCEDURE AddGiftCardSettlementColumn;
+
+-- Backfilled to zero by the DEFAULT, which is correct rather than merely
+-- convenient: no redemption has ever reduced what an order owed, so every
+-- existing order has had exactly zero paid for it by a card. The
+-- `gift_card_transactions` rows that name an order are real -- balances were
+-- genuinely spent -- but they settled nothing, and inventing a settlement for
+-- them now would mark orders paid that were, in fact, paid in full by other
+-- means. Those customers are owed their balance back; see the note below.
+
+-- ============================================
+-- THE CURRENCY A CARD IS ISSUED IN
+-- ============================================
+--
+-- `gift_cards.currency` defaults to 'USD'. The store has exactly one currency
+-- and declares it in backend/config/currency.js, where it is INR -- has been
+-- since the fix that stopped the storefront showing rupees while invoices
+-- printed dollars and payment intents were raised in USD.
+--
+-- So every card ever issued through the service's default is labelled in a
+-- currency the store does not price in, and `applyToOrder` never compared the
+-- two. With one currency configured that was latent; the moment a redemption
+-- actually reduces an order total it stops being latent, because the figure
+-- coming off the order is denominated in something else.
+--
+-- The default moves to the store's currency. New cards are labelled correctly.
+
+DELIMITER //
+
+CREATE PROCEDURE AlignGiftCardCurrencyDefault()
+BEGIN
+    IF EXISTS (
+        SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA   = DATABASE()
+          AND TABLE_NAME     = 'gift_cards'
+          AND COLUMN_NAME    = 'currency'
+          AND COLUMN_DEFAULT = 'USD'
+    ) THEN
+        ALTER TABLE gift_cards
+        MODIFY COLUMN currency CHAR(3) NOT NULL DEFAULT 'INR';
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL AlignGiftCardCurrencyDefault();
+DROP PROCEDURE AlignGiftCardCurrencyDefault;
+
+-- Existing rows are deliberately NOT rewritten.
+--
+-- Relabelling a balance from one currency to another is choosing an exchange
+-- rate, and there is no rate a migration can defensibly pick -- 1:1 is a rate
+-- too, and the wrong one by a factor of about eighty. The service now refuses a
+-- redemption whose card currency does not match the store's, so a card in this
+-- state fails loudly at the point of use instead of being applied across
+-- currencies without anyone noticing.
+--
+-- That does strand those balances until somebody decides what they are worth.
+-- Stranded and visible is better than spent at an invented rate. To see them:
+--
+--     SELECT id, balance, currency, created_at
+--       FROM gift_cards
+--      WHERE currency <> 'INR' AND status = 'active' AND balance > 0;
+--
+-- The customers with a `gift_card_transactions` row naming an order are owed
+-- their balance back regardless -- the redemption took their credit and settled
+-- nothing. `giftCardService.issue` can make them whole:
+--
+--     SELECT t.gift_card_id, t.order_id, t.amount, t.created_at
+--       FROM gift_card_transactions t
+--      WHERE t.type = 'redeem' AND t.order_id IS NOT NULL;


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`POST /api/gift-cards/redeem` took `orderId` and `amount` straight from the body and passed both to the service without loading the order:

```js
const result = orderId
    ? await giftCardService.applyToOrder(code, orderId, amount)
    : await giftCardService.redeem(code, amount);
```

`applyToOrder` wrote `orderId` into `gift_card_transactions.order_id` and did nothing else with it. The order was never read — so nothing established that it existed, that it belonged to the caller, that it was unpaid, or that `amount` bore any relation to what was owed. **Any authenticated caller could attach a redemption to any order id.** `authMiddleware` establishes who is calling; nothing here established whose order it was.

**The half that costs customers money is not that one.** Even in the honest case — your own card, your own order, a sensible amount — `orders` was untouched. The balance was spent, a `redeem` row was written, and the customer was still asked for the full amount at checkout. Gift cards were a way to destroy store credit.

---

## 🔗 Related Issue

Closes #1478

---

## 🛠️ Type of Change

- [x] Security fix
- [x] Bug fix
- [x] Testing improvement
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

---

## 🌐 Additional Notes

### What happens now

The order is **loaded and locked first**, and it must belong to the caller, not be cancelled or refunded, and still be awaiting payment.

- "Not yours" and "no such order" answer **identically** (`404`) — telling them apart makes this endpoint a way to enumerate order ids, and anyone with an account can reach it. Same reasoning as #1455.
- **Order lock before card lock**, always in that direction, so two redemptions against one order cannot deadlock by each holding what the other wants.

**The amount is clamped to what is outstanding**, not merely validated. A caller asking for more than is owed is asking to overpay, and taking what is owed is the right answer — the balance is theirs and so is the order.

Omitting `amount` means "as much as this card can cover", which is what someone paying with a gift card almost always wants. That requires the balance, so the card is locked and read **before** the amount is decided rather than after — which is why `lockAndValidateCard` is split out of `redeemInTransaction`. The lock is held from there through the decrement either way, so nothing moves in between.

An *explicit* amount larger than the card holds is still an error: that is the caller being wrong about their own balance, and quietly taking less would hide it.

### The order actually gets paid — migration 0047

`orders.gift_card_amount`, and the order is settled **in the same transaction as the balance decrement**, so the ledger and the order cannot disagree about what was paid. Outstanding is `total - gift_card_amount`; `payment_status` goes to `paid` when a card covers it in full.

A column of its own rather than folding it into `discount` or `final_amount`:

> store credit is not a discount. It is a payment, out of a balance somebody bought, and it has to stay refundable back to that balance — a paid-with-credit order has to stay distinguishable from a discounted one.

(`checkoutService` already writes `priced.total` into `total`, `total_amount` *and* `final_amount` — three copies of one figure. Adding a fourth meaning to one of them would not have helped.)

Backfilled to zero, which is correct rather than merely convenient: no redemption has ever reduced what an order owed, so every existing order has had exactly zero paid for it by a card.

### `orderId` is now required

It used to be optional, and omitting it called `redeem()`, which decremented a balance against nothing at all — a redemption that settles no order cannot be reconciled and is indistinguishable from one that was later refunded. `redeem()` stays in the service for administrative correction; it is just no longer reachable from the customer route.

### Currency

`gift_cards.currency` defaulted to `'USD'` while the store prices in INR and says so in `config/currency.js`. Nothing compared the two. That was latent only for as long as a redemption changed no order total — it stops being latent here, because the figure now coming off an order would be denominated in something else.

New cards are issued in the store's currency; a mismatch is refused at redemption.

**Existing rows are deliberately not rewritten.** Relabelling a balance from one currency to another is choosing an exchange rate, and 1:1 is a rate too — wrong by roughly a factor of eighty. Those cards now fail loudly at the point of use instead of being applied across currencies unnoticed.

⚠️ **This needs an operator decision, and I have not made it for you.** The migration carries both queries — one to find stranded balances, one to find the customers whose credit was taken by a redemption that settled nothing and who are owed a reissue via `giftCardService.issue`.

### Expiry

`getBalance` returned the stored `status` column verbatim, and nothing sweeps `expires_at` into it — no job, no trigger, no migration. A lapsed card read `active` with its full balance right up until the customer tried to spend it and got a `410`.

The status is derived now, using the same `isExpired` the redemption path has always used. The balance is still reported — it is a real figure, and hiding it leaves the customer unable to see what they are asking about — and a `redeemable` flag answers the question they were actually asking rather than making them re-derive it from four statuses plus a date.

### Tests

`giftCard.test.js` goes from 9 to 30. The existing fixtures said `currency: "USD"`, which the new check refuses — they were written against the old default and now say `INR`. The `applyToOrder` test asserted only that the ledger row carried the order id, which was the entire extent of what the function did; it is replaced by suites covering settlement, ownership, payability, clamping, lock ordering, currency and expiry.

### Migration numbering

Takes **0047**. Per `migrations/README.md` please check it is still free before merging — #1476 claims 0045 and #1477 claims 0046, so those three do not collide with each other.

---

## ⚠️ CI note

Cut from `main`, which does not currently boot (#1474). Six suites fail here for that reason and that reason only — identical with and without this branch:

```
main alone:      Test Suites: 6 failed, 58 passed   Tests: 13 failed, 1395 passed
main + this PR:  Test Suites: 6 failed, 58 passed   Tests: 13 failed, 1416 passed
```

Merge #1479 first and this goes green — no files in common.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly
