### PR TITLE
Make the subscription renewal job run at all

### DIFF
--- a/backend/controllers/subscriptionController.js
+++ b/backend/controllers/subscriptionController.js
@@ -1,110 +1,170 @@
-const promisePool = require("../config/db");
-const { safeNumber } = require("../utils/helpers");
+// backend/controllers/subscriptionController.js
+//
+// Thin handlers over subscriptionService (#1494).
+//
+// This file used to hold the rules: a hand-taken pool connection, an existence
+// check and an insert issued outside any transaction, and its own copy of the
+// four-branch period arithmetic that the renewal job also carried. Both copies
+// fell through their `else if` chain on an unrecognised interval and produced a
+// period of zero length. The rules are in the service now, so there is one of
+// each, and the job and these handlers are both callers.
+//
+// There were also no reads. Four routes, all writes: a shopper could subscribe,
+// pause, resume and cancel, and had no way to see what they were subscribed to,
+// when the period ended, or that a cancellation was pending. `GET /me` and
+// `GET /plans` are the missing half.
+
+'use strict';
+
+const subscriptionService = require('../services/subscriptionService');
+const { SubscriptionError } = require('../services/subscriptionService');
+
+/**
+ * Map a thrown error onto a response.
+ *
+ * SubscriptionError carries the status it wants. Anything else is unexpected,
+ * so the detail goes to the log and the caller gets a generic message.
+ *
+ * @param {import('express').Response} res
+ * @param {Error} error
+ * @param {string} context
+ */
+function handleError(res, error, context) {
+    if (error instanceof SubscriptionError) {
+        return res.status(error.status).json({
+            success: false,
+            message: error.message,
+            code: error.code
+        });
+    }
+
+    console.error(`${context}:`, error);
+
+    return res.status(500).json({
+        success: false,
+        message: 'Something went wrong. Please try again.'
+    });
+}
+
+/** The id on the token, under either of the two names login paths mint. */
+function callerId(req) {
+    return req.user && (req.user.id || req.user.userId);
+}
 
 const subscriptionController = {
-    // Subscribe user to a plan
-    subscribe: async (req, res) => {
-        let connection;
+    /**
+     * GET /api/subscriptions/plans
+     *
+     * Public: you cannot choose a plan you cannot see, and choosing one is the
+     * step before having an account is required.
+     */
+    listPlans: async (req, res) => {
         try {
-            connection = await promisePool.getConnection();
-            const userId = req.user.id;
-            const planId = safeNumber(req.body.planId);
+            const plans = await subscriptionService.listPlans();
 
-            if (planId < 1) {
-                return res.status(400).json({ success: false, message: "Invalid plan ID" });
-            }
-
-            const [plans] = await connection.query("SELECT * FROM billing_plans WHERE id = ? AND is_active = 1", [planId]);
-            if (plans.length === 0) {
-                return res.status(404).json({ success: false, message: "Billing plan not found" });
-            }
-            const plan = plans[0];
-
-            // Check if already subscribed
-            const [existing] = await connection.query("SELECT id FROM subscriptions WHERE user_id = ? AND status IN ('active', 'past_due', 'paused')", [userId]);
-            if (existing.length > 0) {
-                return res.status(400).json({ success: false, message: "User already has an active subscription" });
-            }
-
-            // Calculate period end
-            const start = new Date();
-            const end = new Date();
-            if (plan.interval === 'monthly') end.setMonth(end.getMonth() + plan.interval_count);
-            else if (plan.interval === 'yearly') end.setFullYear(end.getFullYear() + plan.interval_count);
-            else if (plan.interval === 'weekly') end.setDate(end.getDate() + 7 * plan.interval_count);
-            else if (plan.interval === 'daily') end.setDate(end.getDate() + plan.interval_count);
-
-            await connection.query(
-                "INSERT INTO subscriptions (user_id, plan_id, status, current_period_start, current_period_end) VALUES (?, ?, 'active', ?, ?)",
-                [userId, planId, start, end]
-            );
-
-            return res.status(200).json({ success: true, message: "Subscribed successfully", periodEnd: end });
+            return res.status(200).json({
+                success: true,
+                message: 'Billing plans retrieved',
+                data: { plans }
+            });
         } catch (error) {
-            console.error("SUBSCRIBE ERROR:", error);
-            return res.status(500).json({ success: false, message: "Failed to subscribe" });
-        } finally {
-            if (connection) connection.release();
+            return handleError(res, error, 'LIST BILLING PLANS ERROR');
         }
     },
 
-    // Pause subscription
+    /**
+     * GET /api/subscriptions/me
+     *
+     * The caller's own subscription, or null. 200 with null rather than 404:
+     * "you have no subscription" is a successful answer to "what am I
+     * subscribed to", and a 404 here would be indistinguishable from a route
+     * that does not exist -- which is what this endpoint is fixing.
+     */
+    getMine: async (req, res) => {
+        try {
+            const subscription = await subscriptionService.getForUser(callerId(req));
+
+            return res.status(200).json({
+                success: true,
+                message: subscription
+                    ? 'Subscription retrieved'
+                    : 'No active subscription',
+                data: { subscription }
+            });
+        } catch (error) {
+            return handleError(res, error, 'GET SUBSCRIPTION ERROR');
+        }
+    },
+
+    /** POST /api/subscriptions/subscribe */
+    subscribe: async (req, res) => {
+        try {
+            const subscription = await subscriptionService.subscribe(
+                callerId(req),
+                req.body?.planId
+            );
+
+            return res.status(201).json({
+                success: true,
+                message: 'Subscribed successfully',
+                data: { subscription },
+                // The old handler answered with a bare `periodEnd` at the top
+                // level. Kept so an existing caller does not break.
+                periodEnd: subscription.currentPeriodEnd
+            });
+        } catch (error) {
+            return handleError(res, error, 'SUBSCRIBE ERROR');
+        }
+    },
+
+    /** POST /api/subscriptions/pause */
     pause: async (req, res) => {
         try {
-            const userId = req.user.id;
-            const [result] = await promisePool.query(
-                "UPDATE subscriptions SET status = 'paused' WHERE user_id = ? AND status = 'active'",
-                [userId]
-            );
+            const subscription = await subscriptionService.pause(callerId(req));
 
-            if (result.affectedRows === 0) {
-                return res.status(404).json({ success: false, message: "No active subscription found to pause" });
-            }
-
-            return res.status(200).json({ success: true, message: "Subscription paused" });
+            return res.status(200).json({
+                success: true,
+                message: 'Subscription paused',
+                data: { subscription }
+            });
         } catch (error) {
-            console.error("PAUSE SUBSCRIPTION ERROR:", error);
-            return res.status(500).json({ success: false, message: "Failed to pause subscription" });
+            return handleError(res, error, 'PAUSE SUBSCRIPTION ERROR');
         }
     },
 
-    // Resume subscription
+    /** POST /api/subscriptions/resume */
     resume: async (req, res) => {
         try {
-            const userId = req.user.id;
-            const [result] = await promisePool.query(
-                "UPDATE subscriptions SET status = 'active' WHERE user_id = ? AND status = 'paused'",
-                [userId]
-            );
+            const subscription = await subscriptionService.resume(callerId(req));
 
-            if (result.affectedRows === 0) {
-                return res.status(404).json({ success: false, message: "No paused subscription found to resume" });
-            }
-
-            return res.status(200).json({ success: true, message: "Subscription resumed" });
+            return res.status(200).json({
+                success: true,
+                message: subscription.withdrewCancellation
+                    ? 'Subscription resumed and the pending cancellation withdrawn'
+                    : 'Subscription resumed',
+                data: { subscription }
+            });
         } catch (error) {
-            console.error("RESUME SUBSCRIPTION ERROR:", error);
-            return res.status(500).json({ success: false, message: "Failed to resume subscription" });
+            return handleError(res, error, 'RESUME SUBSCRIPTION ERROR');
         }
     },
 
-    // Cancel subscription
+    /** POST /api/subscriptions/cancel */
     cancel: async (req, res) => {
         try {
-            const userId = req.user.id;
-            const [result] = await promisePool.query(
-                "UPDATE subscriptions SET cancel_at_period_end = 1 WHERE user_id = ? AND status IN ('active', 'paused')",
-                [userId]
-            );
+            const subscription = await subscriptionService.cancel(callerId(req));
 
-            if (result.affectedRows === 0) {
-                return res.status(404).json({ success: false, message: "No active subscription found to cancel" });
-            }
-
-            return res.status(200).json({ success: true, message: "Subscription will be canceled at the end of the billing period" });
+            return res.status(200).json({
+                success: true,
+                // Says when, which the old message did not -- and until the
+                // renewal job was fixed there was no "end of the billing
+                // period" at all, because nothing ever ended one.
+                message:
+                    'Subscription will end at the close of the current billing period',
+                data: { subscription }
+            });
         } catch (error) {
-            console.error("CANCEL SUBSCRIPTION ERROR:", error);
-            return res.status(500).json({ success: false, message: "Failed to cancel subscription" });
+            return handleError(res, error, 'CANCEL SUBSCRIPTION ERROR');
         }
     }
 };

--- a/backend/jobs/subscriptionRenewalJob.js
+++ b/backend/jobs/subscriptionRenewalJob.js
@@ -1,78 +1,242 @@
-const promisePool = require("../config/db");
-const { performMockPayment } = require("../utils/helpers"); // Assume this exists or we mock it here
+/**
+ * Subscription renewal worker (#1494).
+ *
+ * This job has never renewed a subscription. Its one query selected
+ * `p.interval` unquoted; INTERVAL is a reserved word, so MySQL read it as the
+ * start of an interval literal and refused the statement. The parse error
+ * landed in the function's own catch, which logged one line and returned, so
+ * the job "ran" daily and did nothing, and every subscription ever created is
+ * still `active` with a period end in the past. A monthly plan was a lifetime
+ * plan.
+ *
+ * Four other things had to change with it, because each would have been a bug
+ * of its own the moment the query started working:
+ *
+ *   * the charge was `Math.random() > 0.2`, not behind any flag, so fixing the
+ *     SQL alone would have started cancelling roughly one customer in 125
+ *     every three days for no reason connected to anything they did;
+ *   * a successful renewal advanced the period and took no money, with a
+ *     comment saying a saga would handle it -- there is no subscription step
+ *     in sagaOrchestratorService;
+ *   * a failed renewal left `current_period_end` alone, so the retry cadence
+ *     was whatever the sweep interval happened to be;
+ *   * the schedule was a bare top-level `setInterval` in server.js, outside
+ *     the NODE_ENV guard the other three jobs sit behind, with no unref, and
+ *     with the first run 24 hours after boot.
+ *
+ * What is here now is the clock and the decision about each row. The rules
+ * live in subscriptionService, which the controller also uses, so the period
+ * arithmetic exists once instead of twice.
+ */
+
+'use strict';
+
+const cron = require('node-cron');
+const logger = require('../utils/logger');
+const subscriptionService = require('../services/subscriptionService');
+
+// Hourly. The periods are measured in days at the shortest, so the interval
+// only decides how late a renewal can be; an hourly sweep also means a service
+// that restarts twice a day still renews, which a 24-hour timer reset on every
+// boot did not.
+const SUBSCRIPTION_RENEWAL_CRON =
+    process.env.SUBSCRIPTION_RENEWAL_CRON || '0 * * * *';
+
+/** How many lapsed subscriptions one sweep will look at. */
+const RENEWAL_BATCH_SIZE = Number(process.env.SUBSCRIPTION_RENEWAL_BATCH) || 500;
+
+let scheduledTask = null;
 
 /**
- * Daily cron job to process subscription renewals
+ * Charge a subscription's renewal.
+ *
+ * There is no off-session charge available here and it is worth being plain
+ * about why rather than papering over it: `payment.service.js` wraps Stripe's
+ * PaymentIntents, which need a client to confirm them. Recurring billing needs
+ * a saved payment method and an off-session confirmation, and neither exists
+ * in this codebase yet.
+ *
+ * So this returns `configured: false` unless a stand-in is explicitly switched
+ * on, and the sweep treats an unconfigured provider as "leave it alone" rather
+ * than as a failure. That distinction is the whole point. The previous code
+ * had no provider either, and expressed that as a coin flip that cancelled
+ * real subscriptions -- a missing integration must not look like a customer
+ * whose card was declined.
+ *
+ * `SUBSCRIPTION_MOCK_PAYMENTS=true` turns on a stand-in that always succeeds.
+ * Always, not usually: a development stub that fails at random makes local
+ * behaviour unreproducible, and randomness is what this is replacing.
+ *
+ * @param {object} subscription
+ * @returns {Promise<{configured: boolean, success?: boolean, reason?: string}>}
  */
-async function processRenewals() {
-    console.log("🔄 Starting subscription renewal job...");
-    let connection;
+async function chargeRenewal(subscription) {
+    if (process.env.SUBSCRIPTION_MOCK_PAYMENTS === 'true') {
+        logger.debug(
+            `Subscription ${subscription.id}: mock payment accepted ` +
+                `(${subscription.currency} ${subscription.price})`
+        );
+        return { configured: true, success: true };
+    }
+
+    return {
+        configured: false,
+        reason:
+            'No recurring payment provider is configured. Set SUBSCRIPTION_MOCK_PAYMENTS=true ' +
+            'in development, or wire an off-session charge in before enabling this in production.'
+    };
+}
+
+/**
+ * One pass over everything whose period has lapsed.
+ *
+ * Each subscription is handled on its own: a row that throws is logged and the
+ * sweep continues, because one bad plan must not stop everyone else renewing.
+ *
+ * @param {object} [options]
+ * @param {Date} [options.now] - injectable so tests do not depend on the clock
+ * @param {Function} [options.charge] - injectable payment step
+ * @returns {Promise<{due: number, renewed: number, canceled: number, pastDue: number, skipped: number, failed: number}>}
+ */
+async function processRenewals({ now = new Date(), charge = chargeRenewal } = {}) {
+    const summary = {
+        due: 0,
+        renewed: 0,
+        canceled: 0,
+        pastDue: 0,
+        skipped: 0,
+        failed: 0
+    };
+
+    let due;
+
     try {
-        connection = await promisePool.getConnection();
-        const now = new Date();
-        
-        // Find subscriptions due for renewal today (active or past_due)
-        const [dueSubscriptions] = await connection.query(`
-            SELECT s.*, p.price, p.interval, p.interval_count 
-            FROM subscriptions s
-            JOIN billing_plans p ON s.plan_id = p.id
-            WHERE s.current_period_end <= ?
-            AND s.status IN ('active', 'past_due')
-        `, [now]);
-
-        console.log(`Found ${dueSubscriptions.length} subscriptions due for renewal.`);
-
-        for (const sub of dueSubscriptions) {
-            await connection.beginTransaction();
-
-            try {
-                if (sub.cancel_at_period_end) {
-                    await connection.query("UPDATE subscriptions SET status = 'canceled', canceled_at = ? WHERE id = ?", [now, sub.id]);
-                    await connection.commit();
-                    continue;
-                }
-
-                // Mock payment
-                const paymentSuccess = Math.random() > 0.2; // 80% success rate
-                
-                if (paymentSuccess) {
-                    // Update period end
-                    const end = new Date(sub.current_period_end);
-                    if (sub.interval === 'monthly') end.setMonth(end.getMonth() + sub.interval_count);
-                    else if (sub.interval === 'yearly') end.setFullYear(end.getFullYear() + sub.interval_count);
-                    else if (sub.interval === 'weekly') end.setDate(end.getDate() + 7 * sub.interval_count);
-                    else if (sub.interval === 'daily') end.setDate(end.getDate() + sub.interval_count);
-
-                    await connection.query(
-                        "UPDATE subscriptions SET status = 'active', current_period_start = current_period_end, current_period_end = ?, dunning_retry_count = 0 WHERE id = ?",
-                        [end, sub.id]
-                    );
-                    
-                    // Create order (omitted for brevity, assume saga handles this later)
-                    // ...
-                    
-                } else {
-                    // Dunning management
-                    const retries = sub.dunning_retry_count + 1;
-                    if (retries >= 3) {
-                        await connection.query("UPDATE subscriptions SET status = 'canceled', canceled_at = ?, dunning_retry_count = ? WHERE id = ?", [now, retries, sub.id]);
-                    } else {
-                        // Extend period by a bit or keep same but set past_due
-                        await connection.query("UPDATE subscriptions SET status = 'past_due', dunning_retry_count = ? WHERE id = ?", [retries, sub.id]);
-                    }
-                }
-                
-                await connection.commit();
-            } catch (err) {
-                await connection.rollback();
-                console.error(`Error processing subscription ${sub.id}:`, err);
-            }
-        }
+        due = await subscriptionService.findDueForRenewal(now, RENEWAL_BATCH_SIZE);
     } catch (error) {
-        console.error("RENEWAL JOB ERROR:", error);
-    } finally {
-        if (connection) connection.release();
+        // This is where the parse error used to land, silently.
+        logger.error(`Subscription renewal sweep could not read due rows: ${error.message}`);
+        throw error;
+    }
+
+    summary.due = due.length;
+
+    if (!due.length) {
+        logger.debug('Subscription renewal sweep: nothing due');
+        return summary;
+    }
+
+    logger.info(`Subscription renewal sweep: ${due.length} due`);
+
+    let warnedUnconfigured = false;
+
+    for (const subscription of due) {
+        try {
+            // Asked to end, and the period it was to end at has passed.
+            if (subscription.cancel_at_period_end) {
+                await subscriptionService.completeCancellation(subscription, now);
+                summary.canceled += 1;
+                continue;
+            }
+
+            const payment = await charge(subscription);
+
+            if (!payment.configured) {
+                // Leave the row exactly as it is. It stays due, and the next
+                // sweep will pick it up once a provider exists. Cancelling
+                // somebody because *we* have not built billing is not a
+                // customer outcome anyone would defend.
+                summary.skipped += 1;
+
+                if (!warnedUnconfigured) {
+                    logger.warn(`Subscription renewal skipped: ${payment.reason}`);
+                    warnedUnconfigured = true;
+                }
+                continue;
+            }
+
+            if (payment.success) {
+                const result = await subscriptionService.recordRenewal(subscription, now);
+                summary.renewed += 1;
+
+                logger.info(
+                    `Subscription ${subscription.id} renewed to ` +
+                        `${result.periodEnd.toISOString()} (${result.periodsBilled} period(s))`
+                );
+                continue;
+            }
+
+            const result = await subscriptionService.recordDunningFailure(subscription, now);
+
+            if (result.outcome === 'canceled') {
+                summary.canceled += 1;
+            } else {
+                summary.pastDue += 1;
+            }
+        } catch (error) {
+            summary.failed += 1;
+            logger.error(
+                `Subscription ${subscription.id} could not be processed: ${error.message}`
+            );
+        }
+    }
+
+    logger.info(
+        `Subscription renewal sweep finished: renewed=${summary.renewed} ` +
+            `canceled=${summary.canceled} pastDue=${summary.pastDue} ` +
+            `skipped=${summary.skipped} failed=${summary.failed}`
+    );
+
+    return summary;
+}
+
+/**
+ * Put the sweep on a schedule.
+ *
+ * Shaped like startCartRecoveryJob: a no-op under test, disableable by
+ * environment, and idempotent so a double call does not schedule twice.
+ *
+ * @returns {object|null} the scheduled task, or null if it was not scheduled
+ */
+function startSubscriptionRenewalJob() {
+    if (process.env.NODE_ENV === 'test') {
+        return null;
+    }
+
+    if (process.env.SUBSCRIPTION_RENEWAL_JOB_ENABLED === 'false') {
+        logger.info(
+            'Subscription renewal job disabled via SUBSCRIPTION_RENEWAL_JOB_ENABLED=false'
+        );
+        return null;
+    }
+
+    if (scheduledTask) {
+        return scheduledTask;
+    }
+
+    scheduledTask = cron.schedule(SUBSCRIPTION_RENEWAL_CRON, () => {
+        processRenewals().catch((error) => {
+            logger.error(`Subscription renewal job failed: ${error.message}`);
+        });
+    });
+
+    logger.info(`Subscription renewal job scheduled (${SUBSCRIPTION_RENEWAL_CRON})`);
+
+    return scheduledTask;
+}
+
+function stopSubscriptionRenewalJob() {
+    if (scheduledTask) {
+        scheduledTask.stop();
+        scheduledTask = null;
     }
 }
 
+// `processRenewals` stays the default export: server.js and anything else that
+// required this file got the function directly, and changing that shape is not
+// part of fixing the query.
 module.exports = processRenewals;
+module.exports.processRenewals = processRenewals;
+module.exports.chargeRenewal = chargeRenewal;
+module.exports.startSubscriptionRenewalJob = startSubscriptionRenewalJob;
+module.exports.stopSubscriptionRenewalJob = stopSubscriptionRenewalJob;
+module.exports.SUBSCRIPTION_RENEWAL_CRON = SUBSCRIPTION_RENEWAL_CRON;

--- a/backend/routes/subscriptionRoutes.js
+++ b/backend/routes/subscriptionRoutes.js
@@ -1,12 +1,54 @@
+// backend/routes/subscriptionRoutes.js
+//
+// Mounted at /api/subscriptions.
+//
+// This router had four routes and all four were writes (#1494). A shopper
+// could subscribe, pause, resume and cancel, and had no way to find out what
+// they were subscribed to, when the period ended, or that a cancellation was
+// pending -- and no way to see the plans before choosing one. The two reads
+// below are the missing half.
+
 const express = require("express");
 const router = express.Router();
 const authMiddleware = require("../middleware/authMiddleware");
 const subscriptionController = require("../controllers/subscriptionController");
 
-// User endpoints
+// ==================== PUBLIC ====================
+
+/**
+ * GET /api/subscriptions/plans
+ *
+ * Public, because choosing a plan comes before having an account, and a
+ * pricing page behind a login is a pricing page nobody reads.
+ *
+ * Declared above the authenticated routes rather than after them so the
+ * router-level guard question never arises for it.
+ */
+router.get("/plans", subscriptionController.listPlans);
+
+// ==================== USER ====================
+
+/**
+ * GET /api/subscriptions/me
+ *
+ * The caller's own subscription, or null. Answers 200 either way: "you have no
+ * subscription" is a successful answer to the question, and a 404 would be
+ * indistinguishable from a route that does not exist -- which is exactly the
+ * confusion this endpoint is fixing.
+ */
+router.get("/me", authMiddleware, subscriptionController.getMine);
+
 router.post("/subscribe", authMiddleware, subscriptionController.subscribe);
 router.post("/pause", authMiddleware, subscriptionController.pause);
+
+// Resume covers both un-pausing and withdrawing a pending cancellation. A
+// shopper who presses Cancel and changes their mind means the second one, and
+// used to be told "No paused subscription found to resume".
 router.post("/resume", authMiddleware, subscriptionController.resume);
 router.post("/cancel", authMiddleware, subscriptionController.cancel);
+
+router.use((req, res) => {
+    res.status(404).json({ success: false, message: "Subscription route not found" });
+});
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -132,7 +132,8 @@ const recentlyViewedRoutes = require('./routes/recentlyViewedRoutes');
 const complexityRoutes = require('./routes/complexityRoutes');
 const { architectureComplexityService } = require('./services/architectureComplexityService');
 
-const processRenewals = require('./jobs/subscriptionRenewalJob');
+// The subscription renewal job is required where it is started, in bootstrap()
+// alongside the other three background jobs, rather than at module load.
 const flagRoutes = require('./routes/flagRoutes');
 const { featureFlagService } = require('./services/featureFlagService');
 
@@ -459,8 +460,17 @@ process.on('SIGINT', async () => {
     }
 });
 
-// Start Subscription Renewals Cron Job
-setInterval(processRenewals, 24 * 60 * 60 * 1000); // run daily
+// The subscription renewal sweep used to be scheduled here, as a bare
+// top-level `setInterval(processRenewals, 24 * 60 * 60 * 1000)` (#1494). It is
+// scheduled with the other three background jobs in bootstrap() now, for the
+// three reasons it should always have been:
+//
+//   * it sat outside the `NODE_ENV !== "test"` guard the others are behind and
+//     had no unref, so it armed itself during `npm test` and held the event
+//     loop open -- part of why the suite ends with "Force exiting Jest";
+//   * the first run was 24 hours after boot and the timer reset on every
+//     restart, so a service deploying more than once a day never swept;
+//   * it had no try/catch of its own, unlike the three below it.
 
 // 11. Application Bootstrap Function
 async function bootstrap() {
@@ -527,6 +537,17 @@ async function bootstrap() {
             startCartRecoveryJob();
         } catch (err) {
             console.error("Warning: Failed to start cart recovery job:", err.message);
+        }
+
+        // Subscription renewals (#1494). Moved here from a bare top-level
+        // setInterval so it is guarded, caught and stoppable like the rest.
+        try {
+            const {
+                startSubscriptionRenewalJob
+            } = require("./jobs/subscriptionRenewalJob");
+            startSubscriptionRenewalJob();
+        } catch (err) {
+            console.error("Warning: Failed to start subscription renewal job:", err.message);
         }
     }
 

--- a/backend/services/subscriptionService.js
+++ b/backend/services/subscriptionService.js
@@ -1,0 +1,622 @@
+// backend/services/subscriptionService.js
+//
+// Billing plans and subscriptions (#1494).
+//
+// The rules used to live in two places that agreed by coincidence: the
+// four-branch period arithmetic was written out once in subscriptionController
+// and again in subscriptionRenewalJob, neither with a fallback, so an interval
+// outside the enum produced a period of zero length in both. They are here
+// once now, and the job and the controller are both callers.
+//
+// `interval` is a reserved word in MySQL. Every statement below that names it
+// quotes it. The migration that created the column says so explicitly
+// (migrations/0024_reconcile_commerce_tables.sql:14-16) and the renewal query
+// did not, which is why the job has never run.
+
+'use strict';
+
+const db = require('../config/db');
+const { withTransaction } = require('../config/db');
+const logger = require('../utils/logger');
+const { safeNumber, safeUUID } = require('../utils/helpers');
+
+/**
+ * Statuses that mean "this account already has a subscription".
+ *
+ * `canceled` is absent deliberately: a subscription that has ended is not in
+ * the way of a new one.
+ */
+const LIVE_STATUSES = Object.freeze(['active', 'past_due', 'paused']);
+
+/** Every status the column accepts, matching the ENUM in migration 0024. */
+const STATUSES = Object.freeze(['active', 'past_due', 'paused', 'canceled']);
+
+/**
+ * How many failed renewals a subscription survives before it is cancelled.
+ *
+ * A count rather than a duration, because the retry cadence belongs to the
+ * scheduler and the tolerance belongs here. The two used to be the same number
+ * by accident -- the job left `current_period_end` where it was on failure, so
+ * "three retries" meant "three sweeps", and changing the sweep interval
+ * silently changed the dunning policy.
+ */
+const MAX_DUNNING_RETRIES = safeNumber(process.env.SUBSCRIPTION_MAX_DUNNING_RETRIES) || 3;
+
+/** How long a failed renewal waits before the next attempt, in hours. */
+const DUNNING_RETRY_HOURS = safeNumber(process.env.SUBSCRIPTION_DUNNING_RETRY_HOURS) || 24;
+
+class SubscriptionError extends Error {
+    constructor(message, status = 400, code = 'SUBSCRIPTION_ERROR') {
+        super(message);
+        this.name = 'SubscriptionError';
+        this.status = status;
+        this.code = code;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Period arithmetic
+// ---------------------------------------------------------------------------
+
+/**
+ * Advance a date by one billing period.
+ *
+ * Throws on an interval it does not recognise rather than returning the date
+ * unchanged. Both previous copies of this fell through their `else if` chain
+ * and produced `end === start`: a subscription whose period had already
+ * expired the moment it was created, and which the renewal sweep would then
+ * pick up on every single run.
+ *
+ * @param {Date} from
+ * @param {string} interval - one of daily / weekly / monthly / yearly
+ * @param {number} [count=1] - how many of them
+ * @returns {Date} a new Date; `from` is not mutated
+ */
+function advancePeriod(from, interval, count = 1) {
+    const start = from instanceof Date ? new Date(from.getTime()) : new Date(from);
+
+    if (Number.isNaN(start.getTime())) {
+        throw new SubscriptionError('Cannot advance an invalid date', 500, 'INVALID_PERIOD_START');
+    }
+
+    const steps = Math.trunc(safeNumber(count));
+
+    if (steps < 1) {
+        throw new SubscriptionError(
+            `interval_count must be at least 1, got ${count}`,
+            500,
+            'INVALID_INTERVAL_COUNT'
+        );
+    }
+
+    const end = new Date(start.getTime());
+
+    switch (interval) {
+        case 'daily':
+            end.setDate(end.getDate() + steps);
+            break;
+        case 'weekly':
+            end.setDate(end.getDate() + 7 * steps);
+            break;
+        case 'monthly':
+            end.setMonth(end.getMonth() + steps);
+            break;
+        case 'yearly':
+            end.setFullYear(end.getFullYear() + steps);
+            break;
+        default:
+            throw new SubscriptionError(
+                `Unsupported billing interval: ${interval}`,
+                500,
+                'UNSUPPORTED_INTERVAL'
+            );
+    }
+
+    return end;
+}
+
+/**
+ * Advance a period past `now`, however many periods that takes.
+ *
+ * A subscription whose renewal has been missed for four months should end up
+ * with a period that ends in the future, not one that ends three months ago
+ * and gets swept again on the next run. The loop is bounded so a plan with a
+ * pathological interval cannot spin.
+ *
+ * @param {Date} periodEnd - the period that just lapsed
+ * @param {string} interval
+ * @param {number} count
+ * @param {Date} [now]
+ * @returns {{start: Date, end: Date, periodsBilled: number}}
+ */
+function nextPeriod(periodEnd, interval, count = 1, now = new Date()) {
+    const MAX_CATCH_UP = 120;
+
+    let start = periodEnd instanceof Date ? new Date(periodEnd.getTime()) : new Date(periodEnd);
+    let end = advancePeriod(start, interval, count);
+    let periodsBilled = 1;
+
+    while (end <= now && periodsBilled < MAX_CATCH_UP) {
+        start = end;
+        end = advancePeriod(start, interval, count);
+        periodsBilled += 1;
+    }
+
+    return { start, end, periodsBilled };
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+/**
+ * Every plan a shopper may subscribe to.
+ *
+ * @returns {Promise<object[]>}
+ */
+async function listPlans() {
+    const [rows] = await db.query(
+        `SELECT id, name, description, price, currency,
+                \`interval\`, interval_count, trial_days
+           FROM billing_plans
+          WHERE is_active = 1
+          ORDER BY price ASC, id ASC`
+    );
+
+    return (rows || []).map(toPublicPlan);
+}
+
+/**
+ * The caller's own subscription, plan included, or null.
+ *
+ * "Own" means the one that is not cancelled. A user who has cancelled and
+ * resubscribed has two rows and only one of them is current.
+ *
+ * @param {string} userId
+ * @returns {Promise<object|null>}
+ */
+async function getForUser(userId) {
+    const id = safeUUID(userId);
+
+    if (!id) {
+        throw new SubscriptionError('Authentication required', 401, 'UNAUTHENTICATED');
+    }
+
+    const [rows] = await db.query(
+        `SELECT s.id, s.status, s.current_period_start, s.current_period_end,
+                s.cancel_at_period_end, s.canceled_at, s.dunning_retry_count,
+                s.created_at,
+                p.id AS plan_id, p.name AS plan_name, p.description AS plan_description,
+                p.price, p.currency, p.\`interval\`, p.interval_count, p.trial_days
+           FROM subscriptions s
+           JOIN billing_plans p ON p.id = s.plan_id
+          WHERE s.user_id = ?
+            AND s.status IN (?, ?, ?)
+          ORDER BY s.created_at DESC
+          LIMIT 1`,
+        [id, ...LIVE_STATUSES]
+    );
+
+    if (!rows || rows.length === 0) {
+        return null;
+    }
+
+    return toPublicSubscription(rows[0]);
+}
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+/**
+ * Subscribe the caller to a plan.
+ *
+ * The existence check and the insert are one transaction, and the check takes
+ * the row lock. Previously they were two statements on a hand-taken pool
+ * connection with no transaction at all, so two concurrent requests both saw
+ * zero rows and both inserted -- which CONTRIBUTING.md warns about in as many
+ * words.
+ *
+ * @param {string} userId
+ * @param {number} planId
+ * @returns {Promise<object>} the new subscription
+ */
+async function subscribe(userId, planId) {
+    const id = safeUUID(userId);
+    const plan = Math.trunc(safeNumber(planId));
+
+    if (!id) {
+        throw new SubscriptionError('Authentication required', 401, 'UNAUTHENTICATED');
+    }
+
+    if (plan < 1) {
+        throw new SubscriptionError('Invalid plan ID', 400, 'INVALID_PLAN');
+    }
+
+    return withTransaction(async (connection) => {
+        const [plans] = await connection.query(
+            `SELECT id, name, price, currency, \`interval\`, interval_count, trial_days
+               FROM billing_plans
+              WHERE id = ? AND is_active = 1
+              LIMIT 1`,
+            [plan]
+        );
+
+        if (!plans.length) {
+            throw new SubscriptionError('Billing plan not found', 404, 'PLAN_NOT_FOUND');
+        }
+
+        const billingPlan = plans[0];
+
+        // FOR UPDATE so a second concurrent subscribe waits here rather than
+        // reading the same empty result and inserting alongside this one.
+        const [existing] = await connection.query(
+            `SELECT id, status, cancel_at_period_end
+               FROM subscriptions
+              WHERE user_id = ? AND status IN (?, ?, ?)
+              FOR UPDATE`,
+            [id, ...LIVE_STATUSES]
+        );
+
+        if (existing.length) {
+            // A subscription already scheduled to end is not a reason to
+            // refuse: the shopper is changing their mind, and the honest
+            // answer is to clear the cancellation rather than tell them they
+            // already have something they have asked to be rid of.
+            if (existing[0].cancel_at_period_end) {
+                throw new SubscriptionError(
+                    'This subscription is set to end at the close of the period. ' +
+                        'Resume it instead of subscribing again.',
+                    409,
+                    'CANCELLATION_PENDING'
+                );
+            }
+
+            throw new SubscriptionError(
+                'You already have an active subscription',
+                409,
+                'ALREADY_SUBSCRIBED'
+            );
+        }
+
+        const start = new Date();
+        const trialDays = Math.trunc(safeNumber(billingPlan.trial_days));
+
+        // A trial is a first period of its own length, not a discount on the
+        // first billing period.
+        const end = trialDays > 0
+            ? advancePeriod(start, 'daily', trialDays)
+            : advancePeriod(start, billingPlan.interval, billingPlan.interval_count);
+
+        const [result] = await connection.query(
+            `INSERT INTO subscriptions
+                (user_id, plan_id, status, current_period_start, current_period_end)
+             VALUES (?, ?, 'active', ?, ?)`,
+            [id, billingPlan.id, start, end]
+        );
+
+        return {
+            id: result.insertId,
+            status: 'active',
+            planId: billingPlan.id,
+            planName: billingPlan.name,
+            currentPeriodStart: start,
+            currentPeriodEnd: end,
+            trialDays,
+            cancelAtPeriodEnd: false
+        };
+    });
+}
+
+/**
+ * Pause an active subscription.
+ *
+ * @param {string} userId
+ * @returns {Promise<object>}
+ */
+async function pause(userId) {
+    return transition(userId, {
+        from: ['active'],
+        set: "status = 'paused'",
+        notFound: 'No active subscription found to pause'
+    });
+}
+
+/**
+ * Resume a subscription.
+ *
+ * Two things are called "resume" by a shopper and they are not the same:
+ * un-pausing, and withdrawing a cancellation. Both are handled, because a
+ * customer who presses Resume after pressing Cancel means the second one and
+ * used to get "No paused subscription found to resume".
+ *
+ * @param {string} userId
+ * @returns {Promise<object>}
+ */
+async function resume(userId) {
+    return transition(userId, {
+        from: ['paused', 'active', 'past_due'],
+        // Clearing the flag is the point of the second case; setting status to
+        // 'active' is a no-op for a subscription that already is.
+        set: "status = 'active', cancel_at_period_end = 0, canceled_at = NULL",
+        notFound: 'No subscription found to resume',
+        requireChange: (row) => row.status === 'paused' || row.cancel_at_period_end === 1,
+        unchanged: 'This subscription is already running',
+        // Which of the two happened, decided from the row as it was *before*
+        // the update. Afterwards both look identical, and the caller wants to
+        // tell the shopper which thing they just did.
+        annotate: (row) => ({ withdrewCancellation: row.cancel_at_period_end === 1 })
+    });
+}
+
+/**
+ * Schedule a cancellation for the end of the current period.
+ *
+ * @param {string} userId
+ * @returns {Promise<object>}
+ */
+async function cancel(userId) {
+    return transition(userId, {
+        from: LIVE_STATUSES,
+        set: 'cancel_at_period_end = 1',
+        notFound: 'No active subscription found to cancel',
+        requireChange: (row) => row.cancel_at_period_end !== 1,
+        unchanged: 'This subscription is already set to end at the close of the period'
+    });
+}
+
+/**
+ * Shared shape for the three state changes above.
+ *
+ * Each one reads the row under a lock, decides, writes, and returns the
+ * subscription as the caller should now see it -- so the client does not have
+ * to issue a second request to find out what happened.
+ *
+ * @param {string} userId
+ * @param {object} options
+ * @returns {Promise<object>}
+ */
+async function transition(userId, options) {
+    const id = safeUUID(userId);
+
+    if (!id) {
+        throw new SubscriptionError('Authentication required', 401, 'UNAUTHENTICATED');
+    }
+
+    return withTransaction(async (connection) => {
+        const placeholders = options.from.map(() => '?').join(', ');
+
+        const [rows] = await connection.query(
+            `SELECT id, status, cancel_at_period_end, current_period_end
+               FROM subscriptions
+              WHERE user_id = ? AND status IN (${placeholders})
+              ORDER BY created_at DESC
+              LIMIT 1
+              FOR UPDATE`,
+            [id, ...options.from]
+        );
+
+        if (!rows.length) {
+            throw new SubscriptionError(options.notFound, 404, 'SUBSCRIPTION_NOT_FOUND');
+        }
+
+        const row = rows[0];
+
+        if (options.requireChange && !options.requireChange(row)) {
+            throw new SubscriptionError(options.unchanged, 409, 'NO_CHANGE');
+        }
+
+        await connection.query(
+            `UPDATE subscriptions SET ${options.set} WHERE id = ?`,
+            [row.id]
+        );
+
+        const [updated] = await connection.query(
+            `SELECT s.id, s.status, s.current_period_start, s.current_period_end,
+                    s.cancel_at_period_end, s.canceled_at, s.dunning_retry_count,
+                    s.created_at,
+                    p.id AS plan_id, p.name AS plan_name, p.description AS plan_description,
+                    p.price, p.currency, p.\`interval\`, p.interval_count, p.trial_days
+               FROM subscriptions s
+               JOIN billing_plans p ON p.id = s.plan_id
+              WHERE s.id = ?`,
+            [row.id]
+        );
+
+        return {
+            ...toPublicSubscription(updated[0]),
+            ...(options.annotate ? options.annotate(row) : {})
+        };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Renewal
+// ---------------------------------------------------------------------------
+
+/**
+ * Subscriptions whose period has lapsed.
+ *
+ * `p.\`interval\`` is quoted. It was not, which made this query a syntax error
+ * and is the reason no subscription has ever renewed.
+ *
+ * @param {Date} now
+ * @param {number} [limit]
+ * @returns {Promise<object[]>}
+ */
+async function findDueForRenewal(now = new Date(), limit = 500) {
+    const [rows] = await db.query(
+        `SELECT s.id, s.user_id, s.plan_id, s.status, s.cancel_at_period_end,
+                s.current_period_start, s.current_period_end, s.dunning_retry_count,
+                p.price, p.currency, p.\`interval\`, p.interval_count
+           FROM subscriptions s
+           JOIN billing_plans p ON p.id = s.plan_id
+          WHERE s.current_period_end <= ?
+            AND s.status IN ('active', 'past_due')
+          ORDER BY s.current_period_end ASC
+          LIMIT ?`,
+        [now, Math.trunc(safeNumber(limit)) || 500]
+    );
+
+    return rows || [];
+}
+
+/**
+ * End a subscription whose owner asked for it to end.
+ *
+ * @param {object} subscription
+ * @param {Date} now
+ * @returns {Promise<{outcome: string}>}
+ */
+async function completeCancellation(subscription, now = new Date()) {
+    await withTransaction(async (connection) => {
+        await connection.query(
+            `UPDATE subscriptions
+                SET status = 'canceled', canceled_at = ?
+              WHERE id = ? AND status IN ('active', 'past_due')`,
+            [now, subscription.id]
+        );
+    });
+
+    return { outcome: 'canceled' };
+}
+
+/**
+ * Move a subscription into its next period after a successful charge.
+ *
+ * @param {object} subscription
+ * @param {Date} now
+ * @returns {Promise<{outcome: string, periodEnd: Date, periodsBilled: number}>}
+ */
+async function recordRenewal(subscription, now = new Date()) {
+    const { start, end, periodsBilled } = nextPeriod(
+        subscription.current_period_end,
+        subscription.interval,
+        subscription.interval_count,
+        now
+    );
+
+    await withTransaction(async (connection) => {
+        await connection.query(
+            `UPDATE subscriptions
+                SET status = 'active',
+                    current_period_start = ?,
+                    current_period_end = ?,
+                    dunning_retry_count = 0
+              WHERE id = ?`,
+            [start, end, subscription.id]
+        );
+    });
+
+    return { outcome: 'renewed', periodStart: start, periodEnd: end, periodsBilled };
+}
+
+/**
+ * Record a failed charge.
+ *
+ * The retry is scheduled by moving `current_period_end` forward, so the next
+ * attempt is a fixed interval away rather than "whenever the sweep next runs".
+ * The old code left the column alone, which tied the dunning policy to the
+ * scheduler's interval without saying so.
+ *
+ * @param {object} subscription
+ * @param {Date} now
+ * @returns {Promise<{outcome: string, retries: number}>}
+ */
+async function recordDunningFailure(subscription, now = new Date()) {
+    const retries = Math.trunc(safeNumber(subscription.dunning_retry_count)) + 1;
+    const exhausted = retries >= MAX_DUNNING_RETRIES;
+
+    await withTransaction(async (connection) => {
+        if (exhausted) {
+            await connection.query(
+                `UPDATE subscriptions
+                    SET status = 'canceled', canceled_at = ?, dunning_retry_count = ?
+                  WHERE id = ?`,
+                [now, retries, subscription.id]
+            );
+            return;
+        }
+
+        const retryAt = new Date(now.getTime() + DUNNING_RETRY_HOURS * 60 * 60 * 1000);
+
+        await connection.query(
+            `UPDATE subscriptions
+                SET status = 'past_due', dunning_retry_count = ?, current_period_end = ?
+              WHERE id = ?`,
+            [retries, retryAt, subscription.id]
+        );
+    });
+
+    if (exhausted) {
+        logger.warn(
+            `Subscription ${subscription.id} cancelled after ${retries} failed renewals`
+        );
+    }
+
+    return { outcome: exhausted ? 'canceled' : 'past_due', retries };
+}
+
+// ---------------------------------------------------------------------------
+// Shaping
+// ---------------------------------------------------------------------------
+
+function toPublicPlan(row) {
+    return {
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        price: Number(row.price),
+        currency: row.currency,
+        interval: row.interval,
+        intervalCount: Number(row.interval_count),
+        trialDays: Number(row.trial_days)
+    };
+}
+
+function toPublicSubscription(row) {
+    return {
+        id: row.id,
+        status: row.status,
+        currentPeriodStart: row.current_period_start,
+        currentPeriodEnd: row.current_period_end,
+        // A boolean, not the TINYINT the column stores. A client checking
+        // truthiness on 0 and 1 works by accident and reads badly.
+        cancelAtPeriodEnd: row.cancel_at_period_end === 1,
+        canceledAt: row.canceled_at,
+        dunningRetryCount: Number(row.dunning_retry_count || 0),
+        createdAt: row.created_at,
+        plan: {
+            id: row.plan_id,
+            name: row.plan_name,
+            description: row.plan_description,
+            price: Number(row.price),
+            currency: row.currency,
+            interval: row.interval,
+            intervalCount: Number(row.interval_count),
+            trialDays: Number(row.trial_days)
+        }
+    };
+}
+
+module.exports = {
+    SubscriptionError,
+    LIVE_STATUSES,
+    STATUSES,
+    MAX_DUNNING_RETRIES,
+    DUNNING_RETRY_HOURS,
+    advancePeriod,
+    nextPeriod,
+    listPlans,
+    getForUser,
+    subscribe,
+    pause,
+    resume,
+    cancel,
+    findDueForRenewal,
+    completeCancellation,
+    recordRenewal,
+    recordDunningFailure,
+    toPublicPlan,
+    toPublicSubscription
+};

--- a/backend/tests/serverBootstrap.test.js
+++ b/backend/tests/serverBootstrap.test.js
@@ -12,10 +12,14 @@
 // module loads offline without a live MySQL.
 //
 // Requiring ../server has bootstrap side effects that keep the event loop
-// alive: server.listen() and a daily setInterval renewal cron. The tests all
-// run supertest against the exported `app` (no live listener needed), so they
-// complete on their own -- but the leaked handles mean this suite must run
-// with jest's `--forceExit` to let the process terminate.
+// alive, chiefly server.listen(). It used to also arm a daily setInterval
+// renewal cron at module scope, outside the `NODE_ENV !== "test"` guard the
+// other background jobs sit behind and with no unref; that is scheduled in
+// bootstrap() with the rest now and is a no-op under test (#1494). The tests
+// all run supertest against the exported `app` (no live listener needed), so
+// they complete on their own -- but the remaining leaked handles mean this
+// suite must still run with jest's `--forceExit` to let the process
+// terminate.
 process.env.NODE_ENV = 'test';
 process.env.DB_HOST = process.env.DB_HOST || 'localhost';
 process.env.DB_PORT = process.env.DB_PORT || '3306';

--- a/backend/tests/subscriptionRenewal.test.js
+++ b/backend/tests/subscriptionRenewal.test.js
@@ -1,0 +1,463 @@
+// backend/tests/subscriptionRenewal.test.js
+//
+// Subscription renewal (#1494).
+//
+// The job had never run. `SELECT s.*, p.price, p.interval, p.interval_count`
+// names a reserved word unquoted, so MySQL refused the statement, the parse
+// error landed in the job's own catch, and the sweep logged one line and
+// returned. Every subscription ever created is still `active` with a period
+// end in the past.
+//
+// The first describe below is the regression that matters most and it is a
+// static one: assert on the SQL text. A mocked `db.query` accepts any string,
+// so no behavioural test in a suite without a live MySQL can tell a quoted
+// identifier from an unquoted one -- and an unquoted one is the entire bug.
+// Everything after that is behaviour.
+
+jest.mock('../config/db', () => {
+    const query = jest.fn();
+    const withTransaction = jest.fn(async (fn) => fn({ query: mockConnectionQuery }));
+
+    return Object.assign({ query, getConnection: jest.fn() }, { withTransaction });
+});
+
+// Declared with a `mock` prefix so the factory above may close over it.
+const mockConnectionQuery = jest.fn();
+
+const fs = require('fs');
+const path = require('path');
+
+const db = require('../config/db');
+const subscriptionService = require('../services/subscriptionService');
+const { SubscriptionError } = require('../services/subscriptionService');
+
+const USER = '44444444-4444-4444-8444-444444444444';
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    db.query.mockResolvedValue([[]]);
+    mockConnectionQuery.mockResolvedValue([[]]);
+});
+
+// ---------------------------------------------------------------------------
+// The bug itself
+// ---------------------------------------------------------------------------
+
+describe('the reserved word', () => {
+    const SOURCES = [
+        'services/subscriptionService.js',
+        'jobs/subscriptionRenewalJob.js',
+        'controllers/subscriptionController.js'
+    ];
+
+    test.each(SOURCES)('%s never names `interval` unquoted in SQL', (relative) => {
+        const source = fs.readFileSync(path.join(__dirname, '..', relative), 'utf8');
+
+        // `p.interval` / `billing_plans.interval` / a bare `, interval` in a
+        // select list. The backticked form is what MySQL requires and is what
+        // migration 0024 uses in the DDL.
+        const unquoted = [
+            /\b[a-z_]+\.interval\b(?!`)/gi,
+            /(?:SELECT|,)\s+interval\s*(?:,|\s+FROM)/gi
+        ];
+
+        const offenders = [];
+
+        for (const pattern of unquoted) {
+            for (const match of source.matchAll(pattern)) {
+                // `p.\`interval\`` matches nothing here; a JS property access
+                // like `subscription.interval` is not SQL and is fine.
+                const line = source.slice(0, match.index).split('\n').length;
+                const text = source.split('\n')[line - 1];
+
+                if (/`interval`/.test(text)) continue;
+
+                // Only flag it if the line looks like SQL. The keyword check
+                // is deliberately case-sensitive: this repo writes SQL
+                // keywords in caps, and a lowercase `from` is a JavaScript
+                // parameter name -- `advancePeriod(from, interval, ...)`
+                // otherwise reads as a select list.
+                if (!/\b(SELECT|FROM|JOIN|SET|WHERE)\b/.test(text)) continue;
+
+                offenders.push(`${relative}:${line}: ${text.trim()}`);
+            }
+        }
+
+        expect(offenders).toEqual([]);
+    });
+
+    test('the due-rows query quotes it', async () => {
+        await subscriptionService.findDueForRenewal(new Date('2026-06-01T00:00:00Z'));
+
+        const [sql] = db.query.mock.calls[0];
+
+        expect(sql).toMatch(/p\.`interval`/);
+        expect(sql).not.toMatch(/p\.interval\b(?!`)/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Period arithmetic
+// ---------------------------------------------------------------------------
+
+describe('advancePeriod', () => {
+    const START = new Date('2026-01-31T10:00:00Z');
+
+    test.each([
+        ['daily', 1, '2026-02-01'],
+        ['daily', 10, '2026-02-10'],
+        ['weekly', 1, '2026-02-07'],
+        ['weekly', 2, '2026-02-14'],
+        ['yearly', 1, '2027-01-31']
+    ])('%s x%i advances to %s', (interval, count, expected) => {
+        const end = subscriptionService.advancePeriod(START, interval, count);
+
+        expect(end.toISOString().slice(0, 10)).toBe(expected);
+    });
+
+    test('does not mutate the date it is given', () => {
+        const before = START.getTime();
+
+        subscriptionService.advancePeriod(START, 'monthly', 1);
+
+        expect(START.getTime()).toBe(before);
+    });
+
+    test('throws on an interval outside the enum instead of returning the start', () => {
+        // Both previous copies of this fell through their else-if chain and
+        // left `end === start`, producing a subscription whose period had
+        // already expired at the moment it was created.
+        expect(() => subscriptionService.advancePeriod(START, 'fortnightly', 1)).toThrow(
+            SubscriptionError
+        );
+    });
+
+    test('throws on an interval_count below one', () => {
+        expect(() => subscriptionService.advancePeriod(START, 'monthly', 0)).toThrow(
+            /at least 1/
+        );
+    });
+
+    test('throws on an unusable start date', () => {
+        expect(() => subscriptionService.advancePeriod('not a date', 'monthly', 1)).toThrow(
+            SubscriptionError
+        );
+    });
+});
+
+describe('nextPeriod', () => {
+    test('advances one period when only one has lapsed', () => {
+        const result = subscriptionService.nextPeriod(
+            new Date('2026-05-01T00:00:00Z'),
+            'monthly',
+            1,
+            new Date('2026-05-02T00:00:00Z')
+        );
+
+        expect(result.periodsBilled).toBe(1);
+        expect(result.end.toISOString().slice(0, 10)).toBe('2026-06-01');
+    });
+
+    test('catches up so the new period ends in the future', () => {
+        // A subscription missed for four months should not come back with a
+        // period that ended three months ago and get swept again next run.
+        const result = subscriptionService.nextPeriod(
+            new Date('2026-01-01T00:00:00Z'),
+            'monthly',
+            1,
+            new Date('2026-05-15T00:00:00Z')
+        );
+
+        expect(result.periodsBilled).toBe(5);
+        expect(result.end > new Date('2026-05-15T00:00:00Z')).toBe(true);
+    });
+
+    test('the catch-up loop is bounded', () => {
+        // A daily plan abandoned for a decade must not spin.
+        const result = subscriptionService.nextPeriod(
+            new Date('2016-01-01T00:00:00Z'),
+            'daily',
+            1,
+            new Date('2026-01-01T00:00:00Z')
+        );
+
+        expect(result.periodsBilled).toBeLessThanOrEqual(120);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Subscribing
+// ---------------------------------------------------------------------------
+
+describe('subscribe', () => {
+    const PLAN = {
+        id: 2,
+        name: 'Monthly',
+        price: 499,
+        currency: 'INR',
+        interval: 'monthly',
+        interval_count: 1,
+        trial_days: 0
+    };
+
+    test('locks the existence check inside the transaction', async () => {
+        mockConnectionQuery
+            .mockResolvedValueOnce([[PLAN]])
+            .mockResolvedValueOnce([[]])
+            .mockResolvedValueOnce([{ insertId: 11 }]);
+
+        await subscriptionService.subscribe(USER, 2);
+
+        const existenceCheck = mockConnectionQuery.mock.calls[1][0];
+
+        // Without FOR UPDATE two concurrent requests both read zero rows and
+        // both insert -- which is what the previous handler did, on a pool
+        // connection with no transaction at all.
+        expect(existenceCheck).toMatch(/FOR UPDATE/);
+        expect(db.withTransaction).toHaveBeenCalled();
+    });
+
+    test('refuses a plan that does not exist', async () => {
+        mockConnectionQuery.mockResolvedValueOnce([[]]);
+
+        await expect(subscriptionService.subscribe(USER, 99)).rejects.toMatchObject({
+            status: 404,
+            code: 'PLAN_NOT_FOUND'
+        });
+    });
+
+    test('refuses a second subscription', async () => {
+        mockConnectionQuery
+            .mockResolvedValueOnce([[PLAN]])
+            .mockResolvedValueOnce([[{ id: 5, status: 'active', cancel_at_period_end: 0 }]]);
+
+        await expect(subscriptionService.subscribe(USER, 2)).rejects.toMatchObject({
+            status: 409,
+            code: 'ALREADY_SUBSCRIBED'
+        });
+    });
+
+    test('points a cancelling subscriber at resume rather than refusing flatly', async () => {
+        // The old message was "User already has an active subscription", which
+        // is technically true and useless: they had asked for it to end and
+        // could neither un-cancel nor re-subscribe.
+        mockConnectionQuery
+            .mockResolvedValueOnce([[PLAN]])
+            .mockResolvedValueOnce([[{ id: 5, status: 'active', cancel_at_period_end: 1 }]]);
+
+        await expect(subscriptionService.subscribe(USER, 2)).rejects.toMatchObject({
+            code: 'CANCELLATION_PENDING'
+        });
+    });
+
+    test('a trial is a first period of its own length', async () => {
+        mockConnectionQuery
+            .mockResolvedValueOnce([[{ ...PLAN, trial_days: 14 }]])
+            .mockResolvedValueOnce([[]])
+            .mockResolvedValueOnce([{ insertId: 12 }]);
+
+        const result = await subscriptionService.subscribe(USER, 2);
+        const days = Math.round(
+            (result.currentPeriodEnd - result.currentPeriodStart) / 86400000
+        );
+
+        expect(days).toBe(14);
+    });
+
+    test('rejects an unusable plan id before touching the database', async () => {
+        await expect(subscriptionService.subscribe(USER, 'abc')).rejects.toMatchObject({
+            code: 'INVALID_PLAN'
+        });
+        expect(db.withTransaction).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// State changes
+// ---------------------------------------------------------------------------
+
+describe('resume', () => {
+    const ROW = (overrides = {}) => ({
+        id: 5,
+        status: 'paused',
+        cancel_at_period_end: 0,
+        current_period_end: new Date('2026-07-01T00:00:00Z'),
+        ...overrides
+    });
+
+    const READBACK = (overrides = {}) => [
+        {
+            id: 5,
+            status: 'active',
+            current_period_start: new Date('2026-06-01T00:00:00Z'),
+            current_period_end: new Date('2026-07-01T00:00:00Z'),
+            cancel_at_period_end: 0,
+            canceled_at: null,
+            dunning_retry_count: 0,
+            created_at: new Date('2026-01-01T00:00:00Z'),
+            plan_id: 2,
+            plan_name: 'Monthly',
+            plan_description: null,
+            price: 499,
+            currency: 'INR',
+            interval: 'monthly',
+            interval_count: 1,
+            trial_days: 0,
+            ...overrides
+        }
+    ];
+
+    test('un-pauses a paused subscription', async () => {
+        mockConnectionQuery
+            .mockResolvedValueOnce([[ROW()]])
+            .mockResolvedValueOnce([{}])
+            .mockResolvedValueOnce([READBACK()]);
+
+        const result = await subscriptionService.resume(USER);
+
+        expect(result.status).toBe('active');
+        expect(result.withdrewCancellation).toBe(false);
+    });
+
+    test('withdraws a pending cancellation on an active subscription', async () => {
+        // This is the case that used to answer "No paused subscription found
+        // to resume": the shopper pressed Cancel, changed their mind, and had
+        // nothing to press.
+        mockConnectionQuery
+            .mockResolvedValueOnce([[ROW({ status: 'active', cancel_at_period_end: 1 })]])
+            .mockResolvedValueOnce([{}])
+            .mockResolvedValueOnce([READBACK()]);
+
+        const result = await subscriptionService.resume(USER);
+
+        expect(result.withdrewCancellation).toBe(true);
+        expect(result.cancelAtPeriodEnd).toBe(false);
+
+        const update = mockConnectionQuery.mock.calls[1][0];
+        expect(update).toMatch(/cancel_at_period_end = 0/);
+    });
+
+    test('refuses when there is nothing to resume', async () => {
+        mockConnectionQuery.mockResolvedValueOnce([
+            [ROW({ status: 'active', cancel_at_period_end: 0 })]
+        ]);
+
+        await expect(subscriptionService.resume(USER)).rejects.toMatchObject({
+            code: 'NO_CHANGE'
+        });
+    });
+
+    test('404s when the account has no subscription at all', async () => {
+        mockConnectionQuery.mockResolvedValueOnce([[]]);
+
+        await expect(subscriptionService.resume(USER)).rejects.toMatchObject({
+            status: 404
+        });
+    });
+});
+
+describe('cancel', () => {
+    test('sets the flag rather than ending the subscription immediately', async () => {
+        mockConnectionQuery
+            .mockResolvedValueOnce([[{ id: 5, status: 'active', cancel_at_period_end: 0 }]])
+            .mockResolvedValueOnce([{}])
+            .mockResolvedValueOnce([
+                [
+                    {
+                        id: 5,
+                        status: 'active',
+                        current_period_start: new Date(),
+                        current_period_end: new Date(),
+                        cancel_at_period_end: 1,
+                        canceled_at: null,
+                        dunning_retry_count: 0,
+                        created_at: new Date(),
+                        plan_id: 2,
+                        plan_name: 'Monthly',
+                        plan_description: null,
+                        price: 499,
+                        currency: 'INR',
+                        interval: 'monthly',
+                        interval_count: 1,
+                        trial_days: 0
+                    }
+                ]
+            ]);
+
+        const result = await subscriptionService.cancel(USER);
+
+        expect(result.status).toBe('active');
+        expect(result.cancelAtPeriodEnd).toBe(true);
+    });
+
+    test('is idempotent-refusing rather than silently repeating', async () => {
+        mockConnectionQuery.mockResolvedValueOnce([
+            [{ id: 5, status: 'active', cancel_at_period_end: 1 }]
+        ]);
+
+        await expect(subscriptionService.cancel(USER)).rejects.toMatchObject({
+            code: 'NO_CHANGE'
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Renewal outcomes
+// ---------------------------------------------------------------------------
+
+describe('recordRenewal', () => {
+    test('advances the period and clears the dunning counter', async () => {
+        const subscription = {
+            id: 5,
+            current_period_start: new Date('2026-05-01T00:00:00Z'),
+            current_period_end: new Date('2026-06-01T00:00:00Z'),
+            interval: 'monthly',
+            interval_count: 1
+        };
+
+        const result = await subscriptionService.recordRenewal(
+            subscription,
+            new Date('2026-06-02T00:00:00Z')
+        );
+
+        expect(result.outcome).toBe('renewed');
+        expect(result.periodEnd.toISOString().slice(0, 10)).toBe('2026-07-01');
+
+        const [sql, params] = mockConnectionQuery.mock.calls[0];
+        expect(sql).toMatch(/dunning_retry_count = 0/);
+        expect(params[0]).toEqual(subscription.current_period_end);
+    });
+});
+
+describe('recordDunningFailure', () => {
+    test('schedules the retry by moving the period end forward', async () => {
+        // The old code left current_period_end alone, so the retry cadence was
+        // whatever the sweep interval happened to be -- changing the schedule
+        // silently changed the dunning policy.
+        const now = new Date('2026-06-02T00:00:00Z');
+
+        const result = await subscriptionService.recordDunningFailure(
+            { id: 5, dunning_retry_count: 0 },
+            now
+        );
+
+        expect(result.outcome).toBe('past_due');
+        expect(result.retries).toBe(1);
+
+        const [sql, params] = mockConnectionQuery.mock.calls[0];
+        expect(sql).toMatch(/status = 'past_due'/);
+        expect(params[1] > now).toBe(true);
+    });
+
+    test('cancels once the retries are exhausted', async () => {
+        const result = await subscriptionService.recordDunningFailure(
+            { id: 5, dunning_retry_count: subscriptionService.MAX_DUNNING_RETRIES - 1 },
+            new Date()
+        );
+
+        expect(result.outcome).toBe('canceled');
+
+        const [sql] = mockConnectionQuery.mock.calls[0];
+        expect(sql).toMatch(/status = 'canceled'/);
+    });
+});

--- a/backend/tests/subscriptionRoutes.test.js
+++ b/backend/tests/subscriptionRoutes.test.js
@@ -1,0 +1,450 @@
+// backend/tests/subscriptionRoutes.test.js
+//
+// The subscription API and the renewal sweep (#1494).
+//
+// Two things are covered here that the service tests cannot be:
+//
+//   * the router had four routes and all four were writes. A shopper could
+//     subscribe, pause, resume and cancel and had no way to see what they were
+//     subscribed to. `GET /me` and `GET /plans` are asserted to exist and to
+//     be scoped the way they should be.
+//   * the sweep's decision table. The old job's payment step was
+//     `Math.random() > 0.2`, so what happened to a customer's subscription
+//     depended on a coin flip; the tests below pin each outcome to a cause.
+
+let mockUser = { id: "44444444-4444-4444-8444-444444444444" };
+
+jest.mock("../middleware/authMiddleware", () => {
+    const stub = (req, res, next) => {
+        if (!mockUser) {
+            return res
+                .status(401)
+                .json({ success: false, message: "Authentication required" });
+        }
+        req.user = mockUser;
+        next();
+    };
+    stub.optionalAuth = (req, res, next) => {
+        if (mockUser) req.user = mockUser;
+        next();
+    };
+    return stub;
+});
+
+jest.mock("../services/subscriptionService", () => {
+    class SubscriptionError extends Error {
+        constructor(message, status = 400, code = "SUBSCRIPTION_ERROR") {
+            super(message);
+            this.status = status;
+            this.code = code;
+        }
+    }
+
+    return {
+        SubscriptionError,
+        MAX_DUNNING_RETRIES: 3,
+        listPlans: jest.fn(),
+        getForUser: jest.fn(),
+        subscribe: jest.fn(),
+        pause: jest.fn(),
+        resume: jest.fn(),
+        cancel: jest.fn(),
+        findDueForRenewal: jest.fn(),
+        completeCancellation: jest.fn(),
+        recordRenewal: jest.fn(),
+        recordDunningFailure: jest.fn()
+    };
+});
+
+const express = require("express");
+const request = require("supertest");
+
+const subscriptionService = require("../services/subscriptionService");
+const { SubscriptionError } = require("../services/subscriptionService");
+const subscriptionRoutes = require("../routes/subscriptionRoutes");
+const renewalJob = require("../jobs/subscriptionRenewalJob");
+
+const app = express();
+app.use(express.json());
+app.use("/api/subscriptions", subscriptionRoutes);
+
+const SUBSCRIPTION = {
+    id: 5,
+    status: "active",
+    currentPeriodStart: "2026-06-01T00:00:00.000Z",
+    currentPeriodEnd: "2026-07-01T00:00:00.000Z",
+    cancelAtPeriodEnd: false,
+    plan: { id: 2, name: "Monthly", price: 499, currency: "INR", interval: "monthly" }
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = { id: "44444444-4444-4444-8444-444444444444" };
+});
+
+// ---------------------------------------------------------------------------
+// The reads that did not exist
+// ---------------------------------------------------------------------------
+
+describe("GET /api/subscriptions/plans", () => {
+    test("is public", async () => {
+        mockUser = null;
+        subscriptionService.listPlans.mockResolvedValue([
+            { id: 2, name: "Monthly", price: 499 }
+        ]);
+
+        const res = await request(app).get("/api/subscriptions/plans");
+
+        expect(res.status).toBe(200);
+        expect(res.body.data.plans).toHaveLength(1);
+    });
+
+    test("uses the documented envelope", async () => {
+        subscriptionService.listPlans.mockResolvedValue([]);
+
+        const res = await request(app).get("/api/subscriptions/plans");
+
+        expect(res.body).toEqual({
+            success: true,
+            message: expect.any(String),
+            data: { plans: [] }
+        });
+    });
+});
+
+describe("GET /api/subscriptions/me", () => {
+    test("returns the caller's subscription", async () => {
+        subscriptionService.getForUser.mockResolvedValue(SUBSCRIPTION);
+
+        const res = await request(app).get("/api/subscriptions/me");
+
+        expect(res.status).toBe(200);
+        expect(res.body.data.subscription.id).toBe(5);
+        expect(subscriptionService.getForUser).toHaveBeenCalledWith(mockUser.id);
+    });
+
+    test("answers 200 with null rather than 404 when there is none", async () => {
+        // A 404 here is indistinguishable from a route that does not exist,
+        // which is the confusion this endpoint is fixing.
+        subscriptionService.getForUser.mockResolvedValue(null);
+
+        const res = await request(app).get("/api/subscriptions/me");
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.data.subscription).toBeNull();
+    });
+
+    test("requires authentication", async () => {
+        mockUser = null;
+
+        const res = await request(app).get("/api/subscriptions/me");
+
+        expect(res.status).toBe(401);
+    });
+
+    test("is not captured by another route", async () => {
+        subscriptionService.getForUser.mockResolvedValue(null);
+
+        const res = await request(app).get("/api/subscriptions/me");
+
+        expect(res.body.message).not.toBe("Subscription route not found");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The writes
+// ---------------------------------------------------------------------------
+
+describe("POST /api/subscriptions/subscribe", () => {
+    test("answers 201 and returns the subscription", async () => {
+        subscriptionService.subscribe.mockResolvedValue(SUBSCRIPTION);
+
+        const res = await request(app)
+            .post("/api/subscriptions/subscribe")
+            .send({ planId: 2 });
+
+        expect(res.status).toBe(201);
+        expect(res.body.data.subscription.id).toBe(5);
+        expect(subscriptionService.subscribe).toHaveBeenCalledWith(mockUser.id, 2);
+    });
+
+    test("keeps the top-level periodEnd the old handler returned", async () => {
+        subscriptionService.subscribe.mockResolvedValue(SUBSCRIPTION);
+
+        const res = await request(app)
+            .post("/api/subscriptions/subscribe")
+            .send({ planId: 2 });
+
+        expect(res.body.periodEnd).toBe(SUBSCRIPTION.currentPeriodEnd);
+    });
+
+    test("a service error carries its own status and code", async () => {
+        subscriptionService.subscribe.mockRejectedValue(
+            new SubscriptionError("Billing plan not found", 404, "PLAN_NOT_FOUND")
+        );
+
+        const res = await request(app)
+            .post("/api/subscriptions/subscribe")
+            .send({ planId: 99 });
+
+        expect(res.status).toBe(404);
+        expect(res.body.code).toBe("PLAN_NOT_FOUND");
+    });
+
+    test("an unexpected failure does not leak its detail", async () => {
+        jest.spyOn(console, "error").mockImplementation(() => {});
+        subscriptionService.subscribe.mockRejectedValue(
+            new Error("ER_PARSE_ERROR near 'interval'")
+        );
+
+        const res = await request(app)
+            .post("/api/subscriptions/subscribe")
+            .send({ planId: 2 });
+
+        expect(res.status).toBe(500);
+        expect(res.body.message).not.toMatch(/ER_PARSE_ERROR/);
+
+        console.error.mockRestore();
+    });
+});
+
+describe("POST /api/subscriptions/resume", () => {
+    test("says which of the two things it did", async () => {
+        subscriptionService.resume.mockResolvedValue({
+            ...SUBSCRIPTION,
+            withdrewCancellation: true
+        });
+
+        const res = await request(app).post("/api/subscriptions/resume");
+
+        expect(res.body.message).toMatch(/cancellation withdrawn/i);
+    });
+
+    test("and says the other one when that is what happened", async () => {
+        subscriptionService.resume.mockResolvedValue({
+            ...SUBSCRIPTION,
+            withdrewCancellation: false
+        });
+
+        const res = await request(app).post("/api/subscriptions/resume");
+
+        expect(res.body.message).toBe("Subscription resumed");
+    });
+});
+
+describe("POST /api/subscriptions/cancel", () => {
+    test("reports the pending cancellation back to the caller", async () => {
+        subscriptionService.cancel.mockResolvedValue({
+            ...SUBSCRIPTION,
+            cancelAtPeriodEnd: true
+        });
+
+        const res = await request(app).post("/api/subscriptions/cancel");
+
+        expect(res.status).toBe(200);
+        // The old handler answered with a message and nothing else, so the
+        // shopper had no way to find out when "the end of the billing period"
+        // was -- there was no endpoint that would tell them.
+        expect(res.body.data.subscription.currentPeriodEnd).toBeDefined();
+        expect(res.body.data.subscription.cancelAtPeriodEnd).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The sweep
+// ---------------------------------------------------------------------------
+
+describe("processRenewals", () => {
+    const DUE = (overrides = {}) => ({
+        id: 5,
+        user_id: "44444444-4444-4444-8444-444444444444",
+        plan_id: 2,
+        status: "active",
+        cancel_at_period_end: 0,
+        current_period_start: new Date("2026-05-01T00:00:00Z"),
+        current_period_end: new Date("2026-06-01T00:00:00Z"),
+        dunning_retry_count: 0,
+        price: 499,
+        currency: "INR",
+        interval: "monthly",
+        interval_count: 1,
+        ...overrides
+    });
+
+    const NOW = new Date("2026-06-02T00:00:00Z");
+
+    test("does nothing when nothing is due", async () => {
+        subscriptionService.findDueForRenewal.mockResolvedValue([]);
+
+        const summary = await renewalJob.processRenewals({ now: NOW });
+
+        expect(summary.due).toBe(0);
+        expect(subscriptionService.recordRenewal).not.toHaveBeenCalled();
+    });
+
+    test("renews on a successful charge", async () => {
+        subscriptionService.findDueForRenewal.mockResolvedValue([DUE()]);
+        subscriptionService.recordRenewal.mockResolvedValue({
+            outcome: "renewed",
+            periodEnd: new Date("2026-07-01T00:00:00Z"),
+            periodsBilled: 1
+        });
+
+        const summary = await renewalJob.processRenewals({
+            now: NOW,
+            charge: async () => ({ configured: true, success: true })
+        });
+
+        expect(summary.renewed).toBe(1);
+        expect(subscriptionService.recordRenewal).toHaveBeenCalled();
+    });
+
+    test("ends a subscription the customer asked to end", async () => {
+        subscriptionService.findDueForRenewal.mockResolvedValue([
+            DUE({ cancel_at_period_end: 1 })
+        ]);
+        subscriptionService.completeCancellation.mockResolvedValue({ outcome: "canceled" });
+
+        const summary = await renewalJob.processRenewals({
+            now: NOW,
+            charge: async () => ({ configured: true, success: true })
+        });
+
+        expect(summary.canceled).toBe(1);
+        // Not charged. Taking money for a period the customer cancelled is the
+        // one outcome nobody would defend.
+        expect(subscriptionService.recordRenewal).not.toHaveBeenCalled();
+    });
+
+    test("a declined charge goes to dunning, not straight to cancellation", async () => {
+        subscriptionService.findDueForRenewal.mockResolvedValue([DUE()]);
+        subscriptionService.recordDunningFailure.mockResolvedValue({
+            outcome: "past_due",
+            retries: 1
+        });
+
+        const summary = await renewalJob.processRenewals({
+            now: NOW,
+            charge: async () => ({ configured: true, success: false })
+        });
+
+        expect(summary.pastDue).toBe(1);
+        expect(summary.canceled).toBe(0);
+    });
+
+    test("leaves the row alone when no payment provider is configured", async () => {
+        // The distinction this whole change turns on. A missing integration is
+        // not a customer whose card was declined, and the old code expressed
+        // "we have not built billing" as `Math.random() > 0.2` -- which
+        // cancelled real subscriptions after three unlucky sweeps.
+        subscriptionService.findDueForRenewal.mockResolvedValue([DUE(), DUE({ id: 6 })]);
+
+        const summary = await renewalJob.processRenewals({
+            now: NOW,
+            charge: async () => ({ configured: false, reason: "not wired up" })
+        });
+
+        expect(summary.skipped).toBe(2);
+        expect(summary.canceled).toBe(0);
+        expect(subscriptionService.recordDunningFailure).not.toHaveBeenCalled();
+        expect(subscriptionService.recordRenewal).not.toHaveBeenCalled();
+    });
+
+    test("one bad row does not stop the sweep", async () => {
+        subscriptionService.findDueForRenewal.mockResolvedValue([
+            DUE({ id: 5 }),
+            DUE({ id: 6 })
+        ]);
+        subscriptionService.recordRenewal
+            .mockRejectedValueOnce(new Error("deadlock"))
+            .mockResolvedValueOnce({
+                outcome: "renewed",
+                periodEnd: new Date("2026-07-01T00:00:00Z"),
+                periodsBilled: 1
+            });
+
+        const summary = await renewalJob.processRenewals({
+            now: NOW,
+            charge: async () => ({ configured: true, success: true })
+        });
+
+        expect(summary.failed).toBe(1);
+        expect(summary.renewed).toBe(1);
+    });
+
+    test("a failure reading the due rows is raised, not swallowed", async () => {
+        // This is where the parse error used to land. It was caught, logged as
+        // one line, and the function returned normally, so the job looked
+        // healthy for as long as nobody read stderr.
+        subscriptionService.findDueForRenewal.mockRejectedValue(
+            new Error("ER_PARSE_ERROR near 'interval'")
+        );
+
+        await expect(renewalJob.processRenewals({ now: NOW })).rejects.toThrow(
+            /ER_PARSE_ERROR/
+        );
+    });
+});
+
+describe("chargeRenewal", () => {
+    const original = process.env.SUBSCRIPTION_MOCK_PAYMENTS;
+
+    afterEach(() => {
+        if (original === undefined) {
+            delete process.env.SUBSCRIPTION_MOCK_PAYMENTS;
+        } else {
+            process.env.SUBSCRIPTION_MOCK_PAYMENTS = original;
+        }
+    });
+
+    test("reports itself unconfigured by default", async () => {
+        delete process.env.SUBSCRIPTION_MOCK_PAYMENTS;
+
+        const result = await renewalJob.chargeRenewal({ id: 5, price: 499, currency: "INR" });
+
+        expect(result.configured).toBe(false);
+        expect(result.reason).toMatch(/SUBSCRIPTION_MOCK_PAYMENTS/);
+    });
+
+    test("the development stand-in always succeeds", async () => {
+        process.env.SUBSCRIPTION_MOCK_PAYMENTS = "true";
+
+        // Always, not usually. A stub that fails at random makes local
+        // behaviour unreproducible, and randomness is what it replaces.
+        for (let i = 0; i < 25; i += 1) {
+            const result = await renewalJob.chargeRenewal({
+                id: 5,
+                price: 499,
+                currency: "INR"
+            });
+            expect(result).toEqual({ configured: true, success: true });
+        }
+    });
+});
+
+describe("scheduling", () => {
+    test("does not schedule under test", () => {
+        // The old schedule was a bare top-level setInterval in server.js with
+        // no NODE_ENV guard and no unref, so it armed itself during the suite
+        // and held the event loop open.
+        expect(process.env.NODE_ENV).toBe("test");
+        expect(renewalJob.startSubscriptionRenewalJob()).toBeNull();
+    });
+
+    test("server.js no longer arms a timer at module scope", () => {
+        const fs = require("fs");
+        const path = require("path");
+
+        // Comments are stripped first: the note left where the timer used to
+        // be quotes the line it replaced, and quoting it is the point.
+        const source = fs
+            .readFileSync(path.join(__dirname, "..", "server.js"), "utf8")
+            .split("\n")
+            .filter((line) => !line.trim().startsWith("//"))
+            .join("\n");
+
+        expect(source).not.toMatch(/setInterval\(\s*processRenewals/);
+        expect(source).toMatch(/startSubscriptionRenewalJob/);
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

The subscription renewal job has never renewed a subscription. Its one query was a syntax error:

```js
SELECT s.*, p.price, p.interval, p.interval_count
```

`INTERVAL` is a reserved word. Unquoted, `p.interval` is not a column reference — it is the start of an interval literal, and MySQL refuses the statement. The migration that created the column says so in as many words:

```sql
-- migrations/0024_reconcile_commerce_tables.sql:14-16
-- `interval` is a reserved word, so it is quoted here and must be quoted in any
-- statement that names it explicitly. Subscription renewal reads it to decide
-- how far to advance the period.
```

Quoted in the DDL. Not quoted in the only statement that read it.

The throw landed in the job's own outer catch, which logged one line and returned, so the job "ran" daily and did nothing. **Every subscription ever created is still `active` with a `current_period_end` in the past.** A monthly plan was a lifetime plan, and `cancel_at_period_end` — written by the cancel endpoint, read only by this job — meant nothing at all.

---

## 🔗 Related Issue

Closes #1494

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] Testing improvement
- [x] Code refactoring
- [x] New feature
- [ ] Security fix
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Documentation update

---

## 🌐 Additional Notes

### Why this is more than a pair of backticks

Fixing the SQL alone would have been actively worse than leaving it broken. Four things downstream of that query were written against a job that could not run, and each becomes live the moment it can.

**1. The charge was a coin flip.**

```js
const paymentSuccess = Math.random() > 0.2; // 80% success rate
```

Not behind a flag, an environment check, or a `NODE_ENV` guard. Backtick the query and this starts failing one renewal in five at random, incrementing `dunning_retry_count`, and cancelling any subscription that loses the toss three sweeps running — about one customer in 125 every three days, for a reason unconnected to anything they did or any card they hold.

**2. A successful renewal charged nothing and recorded nothing.**

```js
// Create order (omitted for brevity, assume saga handles this later)
```

There is no subscription step in `sagaOrchestratorService`. The intended happy path was: advance the period, take no money, write no order. Nothing to reconcile and no evidence a renewal occurred.

**3. Dunning did not advance the period**, so the retry clock *was* the sweep clock. "Three retries" meant "three sweeps", which meant three days only because the timer was 24 hours. Changing the schedule silently changed the dunning policy.

**4. `performMockPayment` was imported from `utils/helpers` and does not exist there.** The destructure yields `undefined` rather than throwing, so it was silent — but the `// Assume this exists or we mock it here` beside it records that nobody checked, and the coin flip is what stood in for it.

### The payment step, and being straight about it

There is no off-session charge available in this codebase and I have not pretended otherwise. `payment.service.js` wraps Stripe PaymentIntents, which need a client to confirm. Recurring billing needs a saved payment method and an off-session confirmation, and neither exists here yet.

So `chargeRenewal` returns `{ configured: false }` by default, and the sweep treats an unconfigured provider as **leave the row alone** — not as a decline. That distinction is the entire point of the change:

> A missing integration is not a customer whose card was declined.

The row stays due and the next sweep picks it up once a provider exists. Nobody is cancelled because *we* have not built billing yet. The old code had no provider either and expressed that as `Math.random()`.

`SUBSCRIPTION_MOCK_PAYMENTS=true` turns on a development stand-in that **always** succeeds. Always, not usually — a stub that fails at random makes local behaviour unreproducible, and randomness is precisely what is being removed. There is a test that calls it 25 times and asserts 25 successes.

### One copy of the period arithmetic

The same four-branch `if / else if` chain over `interval` appeared in `subscriptionController.js:31-34` and again in the job at `:39-42`. Neither had a fallback, so an interval outside the enum left `end === start` — a subscription whose period expired the instant it was created, and which the sweep would then re-select on every run, forever.

It is now `advancePeriod()` in `services/subscriptionService.js`, it covers every enum member, and it **throws** on anything else rather than returning the start date. It also refuses an `interval_count` below 1.

`nextPeriod()` sits on top of it and catches up: a subscription missed for four months comes back with a period that ends in the *future*, rather than one that ended three months ago and gets swept again next run. The catch-up loop is bounded at 120 periods so a daily plan abandoned for a decade cannot spin.

### Scheduling

```js
// removed from server.js:463
setInterval(processRenewals, 24 * 60 * 60 * 1000); // run daily
```

Compare the three jobs 45 lines below it, every one of which is inside `if (process.env.NODE_ENV !== "test")` and wrapped in its own try/catch. This one was in none of that: no guard, no catch, no `.unref()`.

`tests/serverBootstrap.test.js` already documented the consequence in its own header — *"bootstrap side effects that keep the event loop alive: server.listen() and a daily setInterval renewal cron"* — and that comment is updated here.

It is now `startSubscriptionRenewalJob()`, shaped like `startCartRecoveryJob`: a no-op under test, disableable with `SUBSCRIPTION_RENEWAL_JOB_ENABLED=false`, idempotent, and scheduled in `bootstrap()` with the others. Hourly via `node-cron` rather than a 24-hour `setInterval`, because the interval was resetting on every restart — a service deploying more than once a day would never have swept even with the SQL fixed.

`module.exports` is still `processRenewals` itself, so anything that required this file keeps the shape it had.

### Reads for a customer

`subscriptionRoutes.js` mounted four routes and all four were writes. A shopper could subscribe, pause, resume and cancel, and had no way to see what they were subscribed to, when the period ended, or that a cancellation was pending. They could not see the plans either.

```
GET /api/subscriptions/plans   public
GET /api/subscriptions/me      the caller's own, or null
```

`/me` answers **200 with null** rather than 404 when there is no subscription. "You have no subscription" is a successful answer to "what am I subscribed to", and a 404 here is indistinguishable from a route that does not exist — which is the exact confusion this endpoint is fixing.

### Three states a customer could get stuck in

**Resume could not withdraw a cancellation.** It moved `paused → active` only, so a shopper who pressed Cancel and changed their mind got *"No paused subscription found to resume"*. `resume` now covers both meanings and reports which one it did.

**Subscribe refused them too.** A cancelled-at-period-end subscription is still `active`, so `subscribe` answered *"User already has an active subscription"* — technically true and useless. It now answers `409 CANCELLATION_PENDING` and names `resume` as the thing to do. Between the two, a customer who cancelled was locked out of their own account state until a job that could not run ran.

**The cancel confirmation said "at the end of the billing period" and there was no way to find out when that was.** It returns the subscription now, period end included.

### Transactions

`subscribe` took a pool connection by hand and issued the existence check and the insert as two separate statements outside any transaction — which `AGENTS.md` and `CONTRIBUTING.md` both explicitly warn against. Two concurrent requests both saw zero rows and both inserted.

Every write is `withTransaction` now, and the existence check takes `FOR UPDATE`, so the second request waits rather than reading the same empty result.

### Tests

**`tests/subscriptionRenewal.test.js`** — 31 tests on the service.

The first describe is deliberately a *static* one, asserting on SQL text, and it is the regression that matters most: a mocked `db.query` accepts any string, so **no behavioural test in a suite without a live MySQL can tell a quoted identifier from an unquoted one** — and an unquoted one is the whole bug. It scans the three subscription source files for `x.interval` appearing on a line that looks like SQL. The keyword check is case-sensitive on purpose: this repo writes SQL keywords in caps, and a lowercase `from` is a JavaScript parameter name — `advancePeriod(from, interval, ...)` otherwise reads as a select list.

**`tests/subscriptionRoutes.test.js`** — 24 tests over the routes and the sweep's decision table. Each renewal outcome is pinned to a cause: cancelled-at-period-end ends and is *not* charged, a decline goes to dunning rather than straight to cancellation, an unconfigured provider changes nothing, one bad row does not stop the sweep, and a failure reading the due rows is raised rather than swallowed — which is exactly what used to happen to the parse error.

### Deliberately not in this PR

- **An actual recurring charge.** It needs a saved-payment-method flow and off-session confirmation, which is a feature, not a bug fix. The seam is `chargeRenewal`, it is injectable, and until something is wired into it nobody gets cancelled.
- **A renewal order or invoice.** Same reason, and it should follow whatever the charge produces rather than being invented ahead of it.
- **A frontend for any of this.** There is no subscriptions screen in the site today; `GET /me` and `GET /plans` are what one would need, and it can have its own PR.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

Full suite green on this branch: **68 suites, 1613 tests** (from 66 / 1558 on `main`). One existing test file is touched and only in a comment — `serverBootstrap.test.js`, whose header described the timer this PR removes.

No files in common with #1498.
