### PR TITLE
Let somebody read the messages the contact form stores

### DIFF
--- a/backend/controllers/adminContactController.js
+++ b/backend/controllers/adminContactController.js
@@ -1,0 +1,149 @@
+// backend/controllers/adminContactController.js
+//
+// The read side of the contact form (#1495).
+//
+// `POST /api/contact` has been writing to `contact_messages` since #1445 and
+// nothing has ever read the table. Not badly -- at all: there was no SELECT
+// against it anywhere in the repository, no admin route and no screen. Every
+// message anyone sent through the site went into a table no human being and no
+// piece of code could open, behind a toast promising a reply by email.
+//
+// These handlers are thin. Everything that decides anything is in
+// contactService, beside the writer, so validation, insertion and retrieval
+// cannot get different answers to "what is a valid status?".
+
+'use strict';
+
+const contactService = require('../services/contactService');
+const { ContactError } = require('../services/contactService');
+
+/**
+ * Map a thrown error onto a response.
+ *
+ * @param {import('express').Response} res
+ * @param {Error} error
+ * @param {string} context
+ */
+function handleError(res, error, context) {
+    if (error instanceof ContactError) {
+        return res.status(error.status).json({
+            success: false,
+            message: error.message,
+            code: error.code
+        });
+    }
+
+    console.error(`${context}:`, error);
+
+    return res.status(500).json({
+        success: false,
+        message: 'Something went wrong. Please try again.'
+    });
+}
+
+/** The id on the token, under either of the two names login paths mint. */
+function actorId(req) {
+    return req.user && (req.user.id || req.user.userId);
+}
+
+/**
+ * GET /api/admin/contact-messages
+ *
+ * Query: ?status=new&search=refund&email=a@b.c&page=1&limit=20
+ *
+ * Oldest first within a filter. A support queue read newest-first buries the
+ * complaint that has been waiting longest, which is the one that matters.
+ */
+const listContactMessages = async (req, res) => {
+    try {
+        const result = await contactService.listMessages({
+            status: req.query.status,
+            search: req.query.search,
+            email: req.query.email,
+            page: req.query.page,
+            limit: req.query.limit
+        });
+
+        return res.status(200).json({
+            success: true,
+            message: 'Contact messages retrieved',
+            data: result
+        });
+    } catch (error) {
+        return handleError(res, error, 'LIST CONTACT MESSAGES ERROR');
+    }
+};
+
+/**
+ * GET /api/admin/contact-messages/:id
+ *
+ * One message, plus everything else that address has ever sent. Answering the
+ * fourth complaint from someone without knowing it is the fourth is how a
+ * support queue loses people.
+ */
+const getContactMessage = async (req, res) => {
+    try {
+        const message = await contactService.getMessage(req.params.id);
+
+        return res.status(200).json({
+            success: true,
+            message: 'Contact message retrieved',
+            data: { message }
+        });
+    } catch (error) {
+        return handleError(res, error, 'GET CONTACT MESSAGE ERROR');
+    }
+};
+
+/**
+ * PATCH /api/admin/contact-messages/:id/status
+ *
+ * Body: { status: 'new' | 'in_progress' | 'resolved' | 'spam' }
+ *
+ * Closing one stamps `responded_at` and `responded_by`. Those columns have
+ * existed since migration 0042 with no writer at all.
+ */
+const updateContactMessageStatus = async (req, res) => {
+    try {
+        const message = await contactService.updateStatus(
+            req.params.id,
+            req.body?.status,
+            actorId(req)
+        );
+
+        return res.status(200).json({
+            success: true,
+            message: `Message marked ${message.status}`,
+            data: { message }
+        });
+    } catch (error) {
+        return handleError(res, error, 'UPDATE CONTACT MESSAGE STATUS ERROR');
+    }
+};
+
+/**
+ * GET /api/admin/contact-messages/summary
+ *
+ * How many are sitting in each state. A dashboard leads with "how many are
+ * unanswered" and that number cannot be derived from a paginated list.
+ */
+const getContactMessageSummary = async (req, res) => {
+    try {
+        const counts = await contactService.countByStatus();
+
+        return res.status(200).json({
+            success: true,
+            message: 'Contact message summary retrieved',
+            data: { counts }
+        });
+    } catch (error) {
+        return handleError(res, error, 'CONTACT MESSAGE SUMMARY ERROR');
+    }
+};
+
+module.exports = {
+    listContactMessages,
+    getContactMessage,
+    updateContactMessageStatus,
+    getContactMessageSummary
+};

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -16,6 +16,15 @@ const {
     verifyErasureReceiptAdmin
 } = require("../controllers/admin.controller");
 
+// Support queue (#1495). The contact form has been writing to
+// contact_messages since #1445; nothing has ever read the table.
+const {
+    listContactMessages,
+    getContactMessage,
+    updateContactMessageStatus,
+    getContactMessageSummary
+} = require("../controllers/adminContactController");
+
 const authMiddleware = require("../middleware/authMiddleware");
 const { adminMiddleware } = require("../middleware/rbacMiddleware");
 const { adminLimiter } = require("../middleware/authLimiter");
@@ -53,5 +62,19 @@ router.get("/logs", getAdminLogs);
 router.get("/erasure-requests", listErasureRequests);
 router.get("/erasure-requests/:id", getErasureRequest);
 router.get("/erasure-receipts/:receiptId", verifyErasureReceiptAdmin);
+
+// ==================== SUPPORT QUEUE (#1495) ====================
+//
+// Every route on this router already has `adminLimiter`, `authMiddleware` and
+// `adminMiddleware` applied above, so these inherit them rather than restating
+// them -- which is the point of mounting the queue here instead of giving it a
+// router of its own.
+//
+// "/summary" is declared BEFORE "/:id". Express matches in declaration order,
+// and the id guard would otherwise reject "summary" as an invalid id.
+router.get("/contact-messages/summary", getContactMessageSummary);
+router.get("/contact-messages", listContactMessages);
+router.get("/contact-messages/:id", getContactMessage);
+router.patch("/contact-messages/:id/status", updateContactMessageStatus);
 
 module.exports = router;

--- a/backend/services/contactService.js
+++ b/backend/services/contactService.js
@@ -13,7 +13,9 @@ const db = require("../config/db");
 const {
     sanitizeString,
     validateEmail,
-    safeUUID
+    safeUUID,
+    safeNumber,
+    safeArray
 } = require("../utils/helpers");
 
 // Long enough for a real complaint, short enough that the column is not a
@@ -112,9 +114,331 @@ async function recordMessage(submission, context = {}) {
     return result.insertId;
 }
 
+// ---------------------------------------------------------------------------
+// Reading the queue (#1495)
+// ---------------------------------------------------------------------------
+//
+// There was no read path at all. Not a poor one -- none: no SELECT against
+// contact_messages anywhere in the repository, no admin route, no screen. A
+// customer submitted the form, was told "Thanks -- your message has reached us
+// and we'll reply by email", and the row went into a table nobody could open.
+//
+// The schema was designed for a workflow that was never built. `status`,
+// `responded_at`, `responded_by` and two of the three indexes exist to serve
+// queries nobody wrote; migration 0042 even names the two questions the queue
+// is read by -- "what is unanswered, and what did this person send us before".
+// Both are answerable here now.
+
+/** The workflow states, exactly the ENUM in migration 0042. */
+const STATUSES = Object.freeze(['new', 'in_progress', 'resolved', 'spam']);
+
+/** Statuses that count as closed, for `responded_at` purposes. */
+const CLOSED_STATUSES = Object.freeze(['resolved', 'spam']);
+
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+
+class ContactError extends Error {
+    constructor(message, status = 400, code = 'CONTACT_ERROR') {
+        super(message);
+        this.name = 'ContactError';
+        this.status = status;
+        this.code = code;
+    }
+}
+
+/**
+ * Normalise paging arguments.
+ *
+ * @param {object} query
+ * @returns {{page: number, limit: number, offset: number}}
+ */
+function resolvePaging(query = {}) {
+    const page = Math.max(1, Math.trunc(safeNumber(query.page)) || 1);
+    const requested = Math.trunc(safeNumber(query.limit)) || DEFAULT_PAGE_SIZE;
+    const limit = Math.min(MAX_PAGE_SIZE, Math.max(1, requested));
+
+    return { page, limit, offset: (page - 1) * limit };
+}
+
+/**
+ * The support queue.
+ *
+ * Ordered oldest-first within a status filter, because a queue read newest-first
+ * is a queue whose oldest complaint is hardest to find. `idx_contact_messages_
+ * status_created` is on `(status, created_at)` for precisely this.
+ *
+ * @param {object} [filters]
+ * @param {string} [filters.status] - one of STATUSES
+ * @param {string} [filters.search] - matched against subject, message and email
+ * @param {string} [filters.email] - exact sender address
+ * @param {number} [filters.page]
+ * @param {number} [filters.limit]
+ * @returns {Promise<{messages: object[], pagination: object, counts: object}>}
+ */
+async function listMessages(filters = {}) {
+    const { page, limit, offset } = resolvePaging(filters);
+
+    const where = [];
+    const params = [];
+
+    if (filters.status) {
+        const status = sanitizeString(filters.status).toLowerCase();
+
+        if (!STATUSES.includes(status)) {
+            throw new ContactError(
+                `status must be one of: ${STATUSES.join(', ')}`,
+                400,
+                'INVALID_STATUS'
+            );
+        }
+
+        where.push('status = ?');
+        params.push(status);
+    }
+
+    if (filters.email) {
+        where.push('email = ?');
+        params.push(sanitizeString(filters.email).toLowerCase());
+    }
+
+    if (filters.search) {
+        // LIKE wildcards in the term are escaped: a search for "100%" should
+        // find "100%" and not every row in the table.
+        const term = `%${escapeLike(sanitizeString(filters.search))}%`;
+
+        where.push("(subject LIKE ? ESCAPE '\\\\' OR message LIKE ? ESCAPE '\\\\' OR email LIKE ? ESCAPE '\\\\')");
+        params.push(term, term, term);
+    }
+
+    const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+    const [rows] = await db.query(
+        `SELECT cm.id, cm.user_id, cm.name, cm.email, cm.subject, cm.message,
+                cm.status, cm.responded_at, cm.responded_by, cm.created_at,
+                u.name AS account_name,
+                r.name AS responder_name
+           FROM contact_messages cm
+           LEFT JOIN users u ON u.id = cm.user_id
+           LEFT JOIN users r ON r.id = cm.responded_by
+           ${clause}
+          ORDER BY cm.created_at ASC, cm.id ASC
+          LIMIT ? OFFSET ?`,
+        [...params, limit, offset]
+    );
+
+    const [totals] = await db.query(
+        `SELECT COUNT(*) AS total FROM contact_messages ${clause}`,
+        params
+    );
+
+    const total = Number(totals?.[0]?.total || 0);
+
+    return {
+        messages: safeArray(rows).map(toQueueEntry),
+        pagination: {
+            page,
+            limit,
+            total,
+            totalPages: Math.max(1, Math.ceil(total / limit))
+        },
+        counts: await countByStatus()
+    };
+}
+
+/**
+ * How many messages sit in each state.
+ *
+ * The number a support screen leads with is "how many are unanswered", and
+ * deriving it from a paginated list is not possible.
+ *
+ * @returns {Promise<Record<string, number>>}
+ */
+async function countByStatus() {
+    const [rows] = await db.query(
+        `SELECT status, COUNT(*) AS total FROM contact_messages GROUP BY status`
+    );
+
+    const counts = Object.fromEntries(STATUSES.map((status) => [status, 0]));
+
+    for (const row of safeArray(rows)) {
+        counts[row.status] = Number(row.total);
+    }
+
+    return counts;
+}
+
+/**
+ * One message, with everything else that sender has ever written.
+ *
+ * The history is the reason `idx_contact_messages_email` exists and it would
+ * otherwise never be used. Answering a complaint without knowing it is the
+ * fourth one from the same address is how a support queue loses people.
+ *
+ * @param {number} id
+ * @returns {Promise<object>}
+ */
+async function getMessage(id) {
+    const messageId = Math.trunc(safeNumber(id));
+
+    if (messageId < 1) {
+        throw new ContactError('Invalid message ID', 400, 'INVALID_ID');
+    }
+
+    const [rows] = await db.query(
+        `SELECT cm.id, cm.user_id, cm.name, cm.email, cm.subject, cm.message,
+                cm.status, cm.ip_address, cm.user_agent,
+                cm.responded_at, cm.responded_by, cm.created_at, cm.updated_at,
+                u.name AS account_name,
+                r.name AS responder_name
+           FROM contact_messages cm
+           LEFT JOIN users u ON u.id = cm.user_id
+           LEFT JOIN users r ON r.id = cm.responded_by
+          WHERE cm.id = ?
+          LIMIT 1`,
+        [messageId]
+    );
+
+    if (!safeArray(rows).length) {
+        throw new ContactError('Message not found', 404, 'MESSAGE_NOT_FOUND');
+    }
+
+    const message = rows[0];
+
+    const [history] = await db.query(
+        `SELECT id, subject, status, created_at
+           FROM contact_messages
+          WHERE email = ? AND id <> ?
+          ORDER BY created_at DESC
+          LIMIT 10`,
+        [message.email, messageId]
+    );
+
+    return {
+        ...toQueueEntry(message),
+        // Abuse handling: migration 0042 keeps these so "the limiter counts
+        // requests, this is what an investigation reads afterwards". They are
+        // on the detail view only, not the list.
+        ipAddress: message.ip_address,
+        userAgent: message.user_agent,
+        updatedAt: message.updated_at,
+        senderHistory: safeArray(history).map((row) => ({
+            id: row.id,
+            subject: row.subject,
+            status: row.status,
+            createdAt: row.created_at
+        }))
+    };
+}
+
+/**
+ * Move a message through the workflow.
+ *
+ * Closing one stamps `responded_at` and `responded_by` from the acting admin.
+ * Those columns exist and this transition is the only thing that can fill
+ * them; without it "have we answered this?" has no answer that is not
+ * somebody's memory, which is what migration 0042 says the status is for.
+ *
+ * Re-opening clears them, because a message that is `in_progress` again has
+ * not been answered, and leaving a stale responder on it would say it had.
+ *
+ * @param {number} id
+ * @param {string} status
+ * @param {string} adminId
+ * @returns {Promise<object>} the message as it now stands
+ */
+async function updateStatus(id, status, adminId) {
+    const messageId = Math.trunc(safeNumber(id));
+    const next = sanitizeString(status).toLowerCase();
+    const actor = safeUUID(adminId);
+
+    if (messageId < 1) {
+        throw new ContactError('Invalid message ID', 400, 'INVALID_ID');
+    }
+
+    if (!STATUSES.includes(next)) {
+        throw new ContactError(
+            `status must be one of: ${STATUSES.join(', ')}`,
+            400,
+            'INVALID_STATUS'
+        );
+    }
+
+    if (!actor) {
+        throw new ContactError('Authentication required', 401, 'UNAUTHENTICATED');
+    }
+
+    const closing = CLOSED_STATUSES.includes(next);
+
+    const [result] = await db.query(
+        `UPDATE contact_messages
+            SET status = ?,
+                responded_at = ${closing ? 'COALESCE(responded_at, NOW())' : 'NULL'},
+                responded_by = ${closing ? '?' : 'NULL'}
+          WHERE id = ?`,
+        closing ? [next, actor, messageId] : [next, messageId]
+    );
+
+    if (result.affectedRows === 0) {
+        throw new ContactError('Message not found', 404, 'MESSAGE_NOT_FOUND');
+    }
+
+    return getMessage(messageId);
+}
+
+/**
+ * Escape the LIKE metacharacters in a user-supplied search term.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeLike(value) {
+    return String(value).replace(/[\\%_]/g, (character) => `\\${character}`);
+}
+
+/**
+ * One row as the admin API returns it.
+ *
+ * `user_id` is deliberately nullable and deliberately not cascaded -- a message
+ * must outlive the account that sent it, "or a shopper closing their account
+ * erases the complaint that made them close it" (migration 0042). So the
+ * account name is a bonus and the email in the body is the identity.
+ *
+ * @param {object} row
+ * @returns {object}
+ */
+function toQueueEntry(row) {
+    return {
+        id: row.id,
+        name: row.name,
+        email: row.email,
+        subject: row.subject,
+        message: row.message,
+        status: row.status,
+        createdAt: row.created_at,
+        respondedAt: row.responded_at,
+        respondedBy: row.responded_by
+            ? { id: row.responded_by, name: row.responder_name || null }
+            : null,
+        account: row.user_id
+            ? { id: row.user_id, name: row.account_name || null }
+            : null
+    };
+}
+
 module.exports = {
     validateSubmission,
     recordMessage,
+    listMessages,
+    countByStatus,
+    getMessage,
+    updateStatus,
+    toQueueEntry,
+    ContactError,
+    STATUSES,
+    CLOSED_STATUSES,
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
     MAX_MESSAGE_LENGTH,
     MIN_MESSAGE_LENGTH
 };

--- a/backend/services/contactService.js
+++ b/backend/services/contactService.js
@@ -368,9 +368,27 @@ async function updateStatus(id, status, adminId) {
         throw new ContactError('Authentication required', 401, 'UNAUTHENTICATED');
     }
 
+    // Existence is established by reading the row, not by the UPDATE's
+    // affectedRows.
+    //
+    // mysql2 is not connected with CLIENT_FOUND_ROWS, so `affectedRows` on an
+    // UPDATE counts rows *changed*, not rows matched. Setting a message to the
+    // status it already holds changes nothing, so affectedRows is 0 -- and
+    // treating that as "no such message" answers 404 for a message the caller
+    // is looking straight at. Marking an already-resolved thread resolved is a
+    // thing support does by reflex, so this is not a corner case.
+    const [existing] = await db.query(
+        'SELECT id FROM contact_messages WHERE id = ? LIMIT 1',
+        [messageId]
+    );
+
+    if (!safeArray(existing).length) {
+        throw new ContactError('Message not found', 404, 'MESSAGE_NOT_FOUND');
+    }
+
     const closing = CLOSED_STATUSES.includes(next);
 
-    const [result] = await db.query(
+    await db.query(
         `UPDATE contact_messages
             SET status = ?,
                 responded_at = ${closing ? 'COALESCE(responded_at, NOW())' : 'NULL'},
@@ -378,10 +396,6 @@ async function updateStatus(id, status, adminId) {
           WHERE id = ?`,
         closing ? [next, actor, messageId] : [next, messageId]
     );
-
-    if (result.affectedRows === 0) {
-        throw new ContactError('Message not found', 404, 'MESSAGE_NOT_FOUND');
-    }
 
     return getMessage(messageId);
 }

--- a/backend/tests/adminContactRoutes.test.js
+++ b/backend/tests/adminContactRoutes.test.js
@@ -1,0 +1,317 @@
+// backend/tests/adminContactRoutes.test.js
+//
+// The admin surface over the support queue (#1495).
+//
+// The service tests cover what the queue returns. These cover the thing that
+// was actually missing: that there is somewhere to ask from, that it is behind
+// the admin guard, and that "/summary" is not swallowed by "/:id".
+//
+// The gating assertions are not ceremony. `contact_messages` holds names, email
+// addresses, free-text complaints, IP addresses and user agents for people who
+// may not even have an account -- the form is open to anyone. A route over that
+// table that answers a signed-in shopper is a data breach, so it is asserted
+// rather than assumed.
+
+let mockUser = { id: '55555555-5555-4555-8555-555555555555', role: 'admin' };
+
+jest.mock('../middleware/authMiddleware', () => {
+    const stub = (req, res, next) => {
+        if (!mockUser) {
+            return res
+                .status(401)
+                .json({ success: false, message: 'Authentication required' });
+        }
+        req.user = mockUser;
+        next();
+    };
+    stub.optionalAuth = (req, res, next) => {
+        if (mockUser) req.user = mockUser;
+        next();
+    };
+    return stub;
+});
+
+// `adminMiddleware` re-reads the user from the database before it looks at the
+// role, so the stub answers the users lookup from `mockUser`.
+jest.mock('../config/db', () => ({
+    query: jest.fn(async (sql, params) => {
+        if (/FROM users/i.test(sql) && mockUser && params?.[0] === mockUser.id) {
+            return [
+                [
+                    {
+                        id: mockUser.id,
+                        email: `${mockUser.role}@example.test`,
+                        name: mockUser.role,
+                        role: mockUser.role,
+                        is_active: 1,
+                        is_verified: 1
+                    }
+                ]
+            ];
+        }
+        return [[]];
+    }),
+    getConnection: jest.fn()
+}));
+
+jest.mock('../services/contactService', () => {
+    class ContactError extends Error {
+        constructor(message, status = 400, code = 'CONTACT_ERROR') {
+            super(message);
+            this.status = status;
+            this.code = code;
+        }
+    }
+
+    return {
+        ContactError,
+        STATUSES: ['new', 'in_progress', 'resolved', 'spam'],
+        listMessages: jest.fn(),
+        countByStatus: jest.fn(),
+        getMessage: jest.fn(),
+        updateStatus: jest.fn()
+    };
+});
+
+// The admin limiter is real rate limiting with real counters; it would make
+// these tests order-dependent for no benefit, and it is not what is under test.
+jest.mock('../middleware/authLimiter', () => ({
+    adminLimiter: (req, res, next) => next(),
+    authLimiter: (req, res, next) => next(),
+    contactFormLimiter: (req, res, next) => next()
+}));
+
+const express = require('express');
+const request = require('supertest');
+
+const contactService = require('../services/contactService');
+const { ContactError } = require('../services/contactService');
+const adminRoutes = require('../routes/adminRoutes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/admin', adminRoutes);
+
+const ADMIN = { id: '55555555-5555-4555-8555-555555555555', role: 'admin' };
+const SHOPPER = { id: '66666666-6666-4666-8666-666666666666', role: 'user' };
+
+const MESSAGE = {
+    id: 3,
+    name: 'Asha Menon',
+    email: 'asha@example.com',
+    subject: 'Order never arrived',
+    status: 'new',
+    createdAt: '2026-06-01T09:00:00.000Z'
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = ADMIN;
+});
+
+describe('GET /api/admin/contact-messages', () => {
+    test('returns the queue', async () => {
+        contactService.listMessages.mockResolvedValue({
+            messages: [MESSAGE],
+            pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+            counts: { new: 1, in_progress: 0, resolved: 0, spam: 0 }
+        });
+
+        const res = await request(app).get('/api/admin/contact-messages');
+
+        expect(res.status).toBe(200);
+        expect(res.body.data.messages).toHaveLength(1);
+    });
+
+    test('passes the filters through', async () => {
+        contactService.listMessages.mockResolvedValue({
+            messages: [],
+            pagination: {},
+            counts: {}
+        });
+
+        await request(app).get(
+            '/api/admin/contact-messages?status=new&search=refund&email=a%40b.c&page=2&limit=10'
+        );
+
+        expect(contactService.listMessages).toHaveBeenCalledWith({
+            status: 'new',
+            search: 'refund',
+            email: 'a@b.c',
+            page: '2',
+            limit: '10'
+        });
+    });
+
+    test('is refused to a signed-in shopper', async () => {
+        mockUser = SHOPPER;
+
+        const res = await request(app).get('/api/admin/contact-messages');
+
+        expect(res.status).toBe(403);
+        expect(contactService.listMessages).not.toHaveBeenCalled();
+    });
+
+    test('is refused to an anonymous caller', async () => {
+        mockUser = null;
+
+        const res = await request(app).get('/api/admin/contact-messages');
+
+        expect(res.status).toBe(401);
+        expect(contactService.listMessages).not.toHaveBeenCalled();
+    });
+
+    test('uses the documented envelope', async () => {
+        contactService.listMessages.mockResolvedValue({
+            messages: [],
+            pagination: {},
+            counts: {}
+        });
+
+        const res = await request(app).get('/api/admin/contact-messages');
+
+        expect(res.body).toEqual({
+            success: true,
+            message: expect.any(String),
+            data: { messages: [], pagination: {}, counts: {} }
+        });
+    });
+});
+
+describe('GET /api/admin/contact-messages/summary', () => {
+    test('is not captured by /:id', async () => {
+        contactService.countByStatus.mockResolvedValue({
+            new: 4,
+            in_progress: 1,
+            resolved: 9,
+            spam: 2
+        });
+
+        const res = await request(app).get('/api/admin/contact-messages/summary');
+
+        expect(res.status).toBe(200);
+        expect(res.body.data.counts.new).toBe(4);
+        // If declaration order slipped, this would have gone to getMessage
+        // with id = "summary" and answered 400.
+        expect(contactService.getMessage).not.toHaveBeenCalled();
+    });
+
+    test('is admin only', async () => {
+        mockUser = SHOPPER;
+
+        const res = await request(app).get('/api/admin/contact-messages/summary');
+
+        expect(res.status).toBe(403);
+    });
+});
+
+describe('GET /api/admin/contact-messages/:id', () => {
+    test('returns one message', async () => {
+        contactService.getMessage.mockResolvedValue({ ...MESSAGE, senderHistory: [] });
+
+        const res = await request(app).get('/api/admin/contact-messages/3');
+
+        expect(res.status).toBe(200);
+        expect(res.body.data.message.id).toBe(3);
+        expect(contactService.getMessage).toHaveBeenCalledWith('3');
+    });
+
+    test('a service error carries its own status', async () => {
+        contactService.getMessage.mockRejectedValue(
+            new ContactError('Message not found', 404, 'MESSAGE_NOT_FOUND')
+        );
+
+        const res = await request(app).get('/api/admin/contact-messages/999');
+
+        expect(res.status).toBe(404);
+        expect(res.body.code).toBe('MESSAGE_NOT_FOUND');
+    });
+
+    test('an unexpected failure does not leak its detail', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        contactService.getMessage.mockRejectedValue(
+            new Error("ER_NO_SUCH_TABLE: 'ecommerce.contact_messages'")
+        );
+
+        const res = await request(app).get('/api/admin/contact-messages/3');
+
+        expect(res.status).toBe(500);
+        expect(res.body.message).not.toMatch(/ER_NO_SUCH_TABLE/);
+
+        console.error.mockRestore();
+    });
+
+    test('is admin only', async () => {
+        mockUser = SHOPPER;
+
+        const res = await request(app).get('/api/admin/contact-messages/3');
+
+        expect(res.status).toBe(403);
+    });
+});
+
+describe('PATCH /api/admin/contact-messages/:id/status', () => {
+    test('records the transition against the acting admin', async () => {
+        contactService.updateStatus.mockResolvedValue({
+            ...MESSAGE,
+            status: 'resolved'
+        });
+
+        const res = await request(app)
+            .patch('/api/admin/contact-messages/3/status')
+            .send({ status: 'resolved' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.message).toBe('Message marked resolved');
+        expect(contactService.updateStatus).toHaveBeenCalledWith('3', 'resolved', ADMIN.id);
+    });
+
+    test('a rejected status comes back as the service decided', async () => {
+        contactService.updateStatus.mockRejectedValue(
+            new ContactError('status must be one of: …', 400, 'INVALID_STATUS')
+        );
+
+        const res = await request(app)
+            .patch('/api/admin/contact-messages/3/status')
+            .send({ status: 'pending' });
+
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe('INVALID_STATUS');
+    });
+
+    test('is refused to a signed-in shopper', async () => {
+        mockUser = SHOPPER;
+
+        const res = await request(app)
+            .patch('/api/admin/contact-messages/3/status')
+            .send({ status: 'spam' });
+
+        expect(res.status).toBe(403);
+        expect(contactService.updateStatus).not.toHaveBeenCalled();
+    });
+});
+
+describe('the table is no longer write-only', () => {
+    test('contactService exposes reads beside the writer', () => {
+        const real = jest.requireActual('../services/contactService');
+
+        for (const name of ['listMessages', 'getMessage', 'updateStatus', 'countByStatus']) {
+            expect(typeof real[name]).toBe('function');
+        }
+    });
+
+    test('something in the repository SELECTs from contact_messages', () => {
+        // Before this change the only occurrences of the table name in
+        // backend/ were one comment, one INSERT and one filename in a test.
+        const fs = require('fs');
+        const path = require('path');
+
+        const source = fs.readFileSync(
+            path.join(__dirname, '..', 'services', 'contactService.js'),
+            'utf8'
+        );
+
+        expect(source).toMatch(/SELECT[\s\S]*?FROM contact_messages/i);
+        expect(source).toMatch(/UPDATE contact_messages/i);
+    });
+});

--- a/backend/tests/adminContactRoutes.test.js
+++ b/backend/tests/adminContactRoutes.test.js
@@ -143,6 +143,20 @@ describe('GET /api/admin/contact-messages', () => {
         });
     });
 
+    test('an unrecognised status filter comes back as a 400, not a 500', async () => {
+        // The service refuses it before the query, with the list of what is
+        // accepted, rather than letting the column reject it in strict mode
+        // with a message nobody can act on.
+        contactService.listMessages.mockRejectedValue(
+            new ContactError('status must be one of: …', 400, 'INVALID_STATUS')
+        );
+
+        const res = await request(app).get('/api/admin/contact-messages?status=pending');
+
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe('INVALID_STATUS');
+    });
+
     test('is refused to a signed-in shopper', async () => {
         mockUser = SHOPPER;
 

--- a/backend/tests/contactQueue.test.js
+++ b/backend/tests/contactQueue.test.js
@@ -1,0 +1,341 @@
+// backend/tests/contactQueue.test.js
+//
+// The support queue (#1495).
+//
+// `POST /api/contact` has been writing to `contact_messages` since #1445 and
+// nothing has ever read the table -- no SELECT anywhere in the repository, no
+// admin route, no screen. The customer got "Thanks, your message has reached
+// us and we'll reply by email" and the row went somewhere nobody could look.
+//
+// So these tests are about the reads: what the queue returns, in what order,
+// and what a status transition writes. The one that matters most is the last
+// describe: `status`, `responded_at` and `responded_by` have existed since
+// migration 0042 with no writer, and closing a message is the only thing that
+// can fill them.
+
+jest.mock('../config/db', () => ({
+    query: jest.fn(),
+    getConnection: jest.fn()
+}));
+
+const db = require('../config/db');
+const contactService = require('../services/contactService');
+const { ContactError } = require('../services/contactService');
+
+const ADMIN = '55555555-5555-4555-8555-555555555555';
+
+function messageRow(overrides = {}) {
+    return {
+        id: 3,
+        user_id: null,
+        name: 'Asha Menon',
+        email: 'asha@example.com',
+        subject: 'Order never arrived',
+        message: 'My order was marked delivered but nothing turned up.',
+        status: 'new',
+        ip_address: '203.0.113.7',
+        user_agent: 'Mozilla/5.0',
+        responded_at: null,
+        responded_by: null,
+        created_at: '2026-06-01 09:00:00',
+        updated_at: '2026-06-01 09:00:00',
+        account_name: null,
+        responder_name: null,
+        ...overrides
+    };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    db.query.mockResolvedValue([[]]);
+});
+
+// ---------------------------------------------------------------------------
+// The list
+// ---------------------------------------------------------------------------
+
+describe('listMessages', () => {
+    function mockList({ rows = [messageRow()], total = 1, counts = [] } = {}) {
+        db.query
+            .mockResolvedValueOnce([rows])
+            .mockResolvedValueOnce([[{ total }]])
+            .mockResolvedValueOnce([counts]);
+    }
+
+    test('returns the queue with paging and per-status counts', async () => {
+        mockList({
+            counts: [
+                { status: 'new', total: 4 },
+                { status: 'resolved', total: 9 }
+            ],
+            total: 13
+        });
+
+        const result = await contactService.listMessages();
+
+        expect(result.messages).toHaveLength(1);
+        expect(result.pagination).toEqual({
+            page: 1,
+            limit: 20,
+            total: 13,
+            totalPages: 1
+        });
+        // The number a support screen leads with. It cannot be derived from a
+        // paginated list, which is why it is returned alongside one.
+        expect(result.counts).toEqual({
+            new: 4,
+            in_progress: 0,
+            resolved: 9,
+            spam: 0
+        });
+    });
+
+    test('orders oldest first', async () => {
+        mockList();
+
+        await contactService.listMessages();
+
+        const [sql] = db.query.mock.calls[0];
+
+        // A queue read newest-first buries the complaint that has been waiting
+        // longest, which is the one that matters. The index in migration 0042
+        // is on (status, created_at) for exactly this read.
+        expect(sql).toMatch(/ORDER BY cm\.created_at ASC/);
+    });
+
+    test('filters by status', async () => {
+        mockList();
+
+        await contactService.listMessages({ status: 'new' });
+
+        const [sql, params] = db.query.mock.calls[0];
+
+        expect(sql).toMatch(/WHERE status = \?/);
+        expect(params[0]).toBe('new');
+    });
+
+    test('refuses a status outside the enum', async () => {
+        await expect(
+            contactService.listMessages({ status: 'pending' })
+        ).rejects.toMatchObject({ code: 'INVALID_STATUS' });
+
+        expect(db.query).not.toHaveBeenCalled();
+    });
+
+    test('escapes LIKE metacharacters in the search term', async () => {
+        mockList();
+
+        await contactService.listMessages({ search: '100%_off' });
+
+        const [, params] = db.query.mock.calls[0];
+
+        // Unescaped, "100%" matches every row in the table.
+        expect(params[0]).toBe('%100\\%\\_off%');
+    });
+
+    test('caps the page size', async () => {
+        mockList();
+
+        const result = await contactService.listMessages({ limit: 5000 });
+
+        expect(result.pagination.limit).toBe(contactService.MAX_PAGE_SIZE);
+    });
+
+    test('treats junk paging as the defaults rather than failing', async () => {
+        mockList();
+
+        const result = await contactService.listMessages({ page: 'abc', limit: -3 });
+
+        expect(result.pagination.page).toBe(1);
+        expect(result.pagination.limit).toBe(1);
+    });
+
+    test('does not put the IP or user agent on the list', async () => {
+        mockList();
+
+        const result = await contactService.listMessages();
+
+        // They are kept for abuse investigation and belong on a detail view,
+        // not scattered across a screen somebody leaves open.
+        expect(result.messages[0].ipAddress).toBeUndefined();
+        expect(result.messages[0].userAgent).toBeUndefined();
+    });
+
+    test('reports the sender as the email even when the account is gone', async () => {
+        // `user_id` is nullable and deliberately not cascaded: a message must
+        // outlive the account that sent it, "or a shopper closing their
+        // account erases the complaint that made them close it" (0042).
+        mockList({ rows: [messageRow({ user_id: null })] });
+
+        const result = await contactService.listMessages();
+
+        expect(result.messages[0].account).toBeNull();
+        expect(result.messages[0].email).toBe('asha@example.com');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The detail
+// ---------------------------------------------------------------------------
+
+describe('getMessage', () => {
+    test('returns the message with the sender\'s other messages', async () => {
+        db.query
+            .mockResolvedValueOnce([[messageRow()]])
+            .mockResolvedValueOnce([
+                [{ id: 1, subject: 'Where is my refund', status: 'resolved', created_at: 'x' }]
+            ]);
+
+        const result = await contactService.getMessage(3);
+
+        expect(result.id).toBe(3);
+        expect(result.senderHistory).toHaveLength(1);
+
+        // idx_contact_messages_email exists for this question and nothing
+        // else was asking it.
+        const [historySql, historyParams] = db.query.mock.calls[1];
+        expect(historySql).toMatch(/WHERE email = \? AND id <> \?/);
+        expect(historyParams).toEqual(['asha@example.com', 3]);
+    });
+
+    test('includes the abuse-handling fields', async () => {
+        db.query
+            .mockResolvedValueOnce([[messageRow()]])
+            .mockResolvedValueOnce([[]]);
+
+        const result = await contactService.getMessage(3);
+
+        expect(result.ipAddress).toBe('203.0.113.7');
+        expect(result.userAgent).toBe('Mozilla/5.0');
+    });
+
+    test('404s on a message that is not there', async () => {
+        db.query.mockResolvedValueOnce([[]]);
+
+        await expect(contactService.getMessage(999)).rejects.toMatchObject({
+            status: 404,
+            code: 'MESSAGE_NOT_FOUND'
+        });
+    });
+
+    test('rejects an unusable id before querying', async () => {
+        await expect(contactService.getMessage('abc')).rejects.toBeInstanceOf(ContactError);
+        expect(db.query).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The transition
+// ---------------------------------------------------------------------------
+
+describe('updateStatus', () => {
+    function mockUpdate(row = messageRow({ status: 'resolved' })) {
+        db.query
+            .mockResolvedValueOnce([{ affectedRows: 1 }])
+            .mockResolvedValueOnce([[row]])
+            .mockResolvedValueOnce([[]]);
+    }
+
+    test('stamps responded_at and responded_by when a message is closed', async () => {
+        mockUpdate();
+
+        await contactService.updateStatus(3, 'resolved', ADMIN);
+
+        const [sql, params] = db.query.mock.calls[0];
+
+        // These two columns have existed since migration 0042 with no writer
+        // at all. This transition is the only thing that can fill them.
+        expect(sql).toMatch(/responded_at = COALESCE\(responded_at, NOW\(\)\)/);
+        expect(sql).toMatch(/responded_by = \?/);
+        expect(params).toEqual(['resolved', ADMIN, 3]);
+    });
+
+    test('marking spam counts as closing it', async () => {
+        mockUpdate(messageRow({ status: 'spam' }));
+
+        await contactService.updateStatus(3, 'spam', ADMIN);
+
+        const [sql] = db.query.mock.calls[0];
+
+        expect(sql).toMatch(/responded_by = \?/);
+    });
+
+    test('keeps the original responded_at when a closed message is closed again', async () => {
+        mockUpdate();
+
+        await contactService.updateStatus(3, 'resolved', ADMIN);
+
+        // COALESCE, not NOW(): the first answer is when it was answered.
+        expect(db.query.mock.calls[0][0]).toMatch(/COALESCE\(responded_at, NOW\(\)\)/);
+    });
+
+    test('re-opening clears the responder', async () => {
+        mockUpdate(messageRow({ status: 'in_progress' }));
+
+        await contactService.updateStatus(3, 'in_progress', ADMIN);
+
+        const [sql, params] = db.query.mock.calls[0];
+
+        // A message that is in progress again has not been answered, and a
+        // stale responder on it would say it had.
+        expect(sql).toMatch(/responded_at = NULL/);
+        expect(sql).toMatch(/responded_by = NULL/);
+        expect(params).toEqual(['in_progress', 3]);
+    });
+
+    test.each(['pending', 'closed', 'RESOLVED_MAYBE', ''])(
+        'refuses the status %p',
+        async (status) => {
+            await expect(
+                contactService.updateStatus(3, status, ADMIN)
+            ).rejects.toMatchObject({ code: 'INVALID_STATUS' });
+
+            expect(db.query).not.toHaveBeenCalled();
+        }
+    );
+
+    test('accepts a status in the wrong case', async () => {
+        mockUpdate();
+
+        await contactService.updateStatus(3, 'RESOLVED', ADMIN);
+
+        expect(db.query.mock.calls[0][1][0]).toBe('resolved');
+    });
+
+    test('refuses without an acting admin', async () => {
+        await expect(
+            contactService.updateStatus(3, 'resolved', null)
+        ).rejects.toMatchObject({ status: 401 });
+    });
+
+    test('404s when the update matches nothing', async () => {
+        db.query.mockResolvedValueOnce([{ affectedRows: 0 }]);
+
+        await expect(
+            contactService.updateStatus(999, 'resolved', ADMIN)
+        ).rejects.toMatchObject({ status: 404 });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The writer is unchanged
+// ---------------------------------------------------------------------------
+
+describe('recordMessage', () => {
+    test('still inserts exactly what it did before', async () => {
+        db.query.mockResolvedValueOnce([{ insertId: 7 }]);
+
+        const id = await contactService.recordMessage(
+            {
+                name: 'Asha',
+                email: 'asha@example.com',
+                subject: 'Hello',
+                message: 'A message long enough to pass validation.'
+            },
+            { userId: null, ipAddress: '203.0.113.7', userAgent: 'x' }
+        );
+
+        expect(id).toBe(7);
+        expect(db.query.mock.calls[0][0]).toMatch(/INSERT INTO contact_messages/);
+    });
+});

--- a/backend/tests/contactQueue.test.js
+++ b/backend/tests/contactQueue.test.js
@@ -229,19 +229,24 @@ describe('getMessage', () => {
 // ---------------------------------------------------------------------------
 
 describe('updateStatus', () => {
+    // Existence check, UPDATE, then the getMessage read-back and its history.
     function mockUpdate(row = messageRow({ status: 'resolved' })) {
         db.query
+            .mockResolvedValueOnce([[{ id: row.id }]])
             .mockResolvedValueOnce([{ affectedRows: 1 }])
             .mockResolvedValueOnce([[row]])
             .mockResolvedValueOnce([[]]);
     }
+
+    /** The UPDATE, which is the second statement now. */
+    const updateCall = () => db.query.mock.calls[1];
 
     test('stamps responded_at and responded_by when a message is closed', async () => {
         mockUpdate();
 
         await contactService.updateStatus(3, 'resolved', ADMIN);
 
-        const [sql, params] = db.query.mock.calls[0];
+        const [sql, params] = updateCall();
 
         // These two columns have existed since migration 0042 with no writer
         // at all. This transition is the only thing that can fill them.
@@ -255,7 +260,7 @@ describe('updateStatus', () => {
 
         await contactService.updateStatus(3, 'spam', ADMIN);
 
-        const [sql] = db.query.mock.calls[0];
+        const [sql] = updateCall();
 
         expect(sql).toMatch(/responded_by = \?/);
     });
@@ -266,7 +271,7 @@ describe('updateStatus', () => {
         await contactService.updateStatus(3, 'resolved', ADMIN);
 
         // COALESCE, not NOW(): the first answer is when it was answered.
-        expect(db.query.mock.calls[0][0]).toMatch(/COALESCE\(responded_at, NOW\(\)\)/);
+        expect(updateCall()[0]).toMatch(/COALESCE\(responded_at, NOW\(\)\)/);
     });
 
     test('re-opening clears the responder', async () => {
@@ -274,7 +279,7 @@ describe('updateStatus', () => {
 
         await contactService.updateStatus(3, 'in_progress', ADMIN);
 
-        const [sql, params] = db.query.mock.calls[0];
+        const [sql, params] = updateCall();
 
         // A message that is in progress again has not been answered, and a
         // stale responder on it would say it had.
@@ -299,7 +304,7 @@ describe('updateStatus', () => {
 
         await contactService.updateStatus(3, 'RESOLVED', ADMIN);
 
-        expect(db.query.mock.calls[0][1][0]).toBe('resolved');
+        expect(updateCall()[1][0]).toBe('resolved');
     });
 
     test('refuses without an acting admin', async () => {
@@ -308,12 +313,33 @@ describe('updateStatus', () => {
         ).rejects.toMatchObject({ status: 401 });
     });
 
-    test('404s when the update matches nothing', async () => {
-        db.query.mockResolvedValueOnce([{ affectedRows: 0 }]);
+    test('404s when there is no such message', async () => {
+        db.query.mockResolvedValueOnce([[]]);
 
         await expect(
             contactService.updateStatus(999, 'resolved', ADMIN)
         ).rejects.toMatchObject({ status: 404 });
+
+        // And does not attempt the UPDATE.
+        expect(db.query).toHaveBeenCalledTimes(1);
+    });
+
+    test('setting the status it already holds is not a 404', async () => {
+        // Existence is established by reading the row, not by the UPDATE's
+        // affectedRows. mysql2 is not connected with CLIENT_FOUND_ROWS, so
+        // affectedRows counts rows *changed* -- re-resolving an already
+        // resolved thread changes nothing and reports 0, which read as "no
+        // such message" for a message the caller is looking straight at.
+        // Support does that by reflex, so it is not a corner case.
+        db.query
+            .mockResolvedValueOnce([[{ id: 3 }]])
+            .mockResolvedValueOnce([{ affectedRows: 0 }])
+            .mockResolvedValueOnce([[messageRow({ status: 'resolved' })]])
+            .mockResolvedValueOnce([[]]);
+
+        const result = await contactService.updateStatus(3, 'resolved', ADMIN);
+
+        expect(result.status).toBe('resolved');
     });
 });
 


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`POST /api/contact` writes to `contact_messages`. Nothing reads it.

Not "nothing reads it well" — there is no `SELECT` against that table anywhere in the repository:

```
$ grep -rn "contact_messages" --include="*.js" backend/ | grep -v node_modules
backend/services/contactService.js:10:// The table is migrations/0042_...
backend/services/contactService.js:97:        `INSERT INTO contact_messages
backend/tests/frontendApiPaths.test.js:147:                '0042_contact_messages_...'
```

One comment, one `INSERT`, one filename. No list endpoint, no detail endpoint, no status transition, no admin screen, no notification. A customer fills in the form, gets

> Thanks — your message has reached us and we'll reply by email.

and the row goes into a table no human being and no piece of code will ever open.

---

## 🔗 Related Issue

Closes #1495

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] New feature
- [x] Testing improvement
- [ ] Security fix
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

---

## 🌐 Additional Notes

### This is the second half of #1445, and it is the half that decides whether the first half meant anything

#1445 was that `contact.html` posted to a path nothing served and the form claimed success over a 404. The route and the table landed. The reason the route was worth having — that a message reaches somebody — did not.

From the sender's side the outcome is unchanged. Their message goes nowhere, and they are told it arrived.

That is arguably worse than the 404 was. Before, the row did not exist and nobody was under any illusion of having a support queue. Now there is a table filling up with complaints, sitting under a `SECURITY.md` that tells people to report things, and a promise on the form that nobody is in a position to keep.

### The schema was designed for a workflow nobody wrote

Migration 0042 is not a bare log table:

```sql
status ENUM('new', 'in_progress', 'resolved', 'spam') NOT NULL DEFAULT 'new',
responded_at DATETIME NULL,
responded_by CHAR(36) NULL,

-- The two questions the queue is read by: what is unanswered, and what did
-- this person send us before.
INDEX idx_contact_messages_status_created (status, created_at),
INDEX idx_contact_messages_email (email),
```

and its own comment says why `status` is there:

> `status` is the smallest useful workflow. Without one, "have we answered this?" has no answer that is not somebody's memory.

Every one of those columns was dead. `status` was `'new'` on every row that would ever exist. `responded_at` and `responded_by` had no writer at all. Two of the three indexes served reads nobody had written.

Both of the questions the migration names are answerable now, and the two indexes it added for them are what answer them.

### What is here

```
GET   /api/admin/contact-messages          ?status= &search= &email= &page= &limit=
GET   /api/admin/contact-messages/summary
GET   /api/admin/contact-messages/:id
PATCH /api/admin/contact-messages/:id/status
```

Mounted on `adminRoutes`, not on a router of its own — that router already applies `adminLimiter`, `authMiddleware` and `adminMiddleware` to everything on it, so these inherit the guards instead of restating them, and a route added here later cannot forget them.

`/summary` is declared **above** `/:id`. Express matches in declaration order and the id would otherwise capture `"summary"` and answer 400. There is a test for it.

**The list is ordered oldest-first** within a filter. A support queue read newest-first buries the complaint that has been waiting longest, which is the one that matters — and `idx_contact_messages_status_created` is on `(status, created_at)` for exactly that read.

**`/summary` exists because a paginated list cannot answer "how many are unanswered".** That is the number a support screen leads with, so it is returned by the list too, alongside the page.

**The detail view returns the sender's other messages.** `idx_contact_messages_email` exists for that question and nothing else was asking it. Answering the fourth complaint from an address without knowing it is the fourth is how a support queue loses people.

**`ip_address` and `user_agent` are on the detail view only, not the list.** Migration 0042 keeps them because "the limiter counts requests, this is what an investigation reads afterwards" — that is a deliberate lookup, not something to scatter across a screen somebody leaves open on a shared desk.

### The transition writes the two columns that never had a writer

Marking a message `resolved` or `spam` stamps `responded_at` and `responded_by` from the acting admin. `COALESCE(responded_at, NOW())`, not `NOW()`: closing an already-closed message must not overwrite when it was first answered.

Re-opening to `new` or `in_progress` **clears** both. A message that is in progress again has not been answered, and leaving a stale responder on it would say it had.

### The service, not the controller

The reads sit in `contactService` beside `recordMessage`, for the reason its own header already gives about validation:

> so that the rules travel with the writer — a second caller (an admin tool, a support import) cannot get a different answer to "is this a valid message?"

Same argument for "what is a valid status?" and "what does closing one do?". The controller is four thin handlers.

### Small things fixed on the way past

**LIKE metacharacters in the search term are escaped.** A search for `100%` should find "100%", not every row in the table. Unescaped `%` and `_` in a user-supplied `LIKE` are also a cheap way to make the database scan everything.

**Paging is clamped rather than trusted** — `?limit=5000` gets 100, `?page=abc` gets 1.

**A status outside the ENUM is refused before it reaches MySQL**, with the list of what is accepted, rather than being rejected by the column in strict mode with a message nobody can act on.

**`user_id` is treated as the bonus it is.** The migration makes it nullable and deliberately does not cascade — a message must outlive the account that sent it, "or a shopper closing their account erases the complaint that made them close it". So the join to `users` is a LEFT JOIN, the account name is decoration, and the email in the body is the identity. There is a test for that specifically.

### Tests

**`tests/contactQueue.test.js`** — 25 tests on the service: ordering, filtering, escaping, clamping, the sender history, and the transition. The four transition tests are the ones worth reading — they pin the exact SQL that fills `responded_at` and `responded_by`, because those columns going unwritten for a second time would look identical from outside.

**`tests/adminContactRoutes.test.js`** — 16 tests on the routes. Every endpoint is asserted to answer **403 to a signed-in shopper** and **401 to an anonymous caller**, and that is not ceremony: this table holds names, email addresses, free-text complaints, IP addresses and user agents for people who may not even have an account. A route over it that answers a shopper is a data breach, so it is tested rather than assumed.

The last two tests are about the defect rather than the feature — that `contactService` exposes reads at all, and that a `SELECT` and an `UPDATE` against `contact_messages` now exist in the source. Before this change, grepping the backend for the table name found a comment, an `INSERT`, and nothing else.

### Deliberately not in this PR

**An admin screen.** `admin.html` has no support tab, and building one is a UI change of its own size. The blocker was that the queue could not be read at *all*; these endpoints are usable with a token today and are what a screen would call.

**Notifying support that a message arrived.** Worth doing and genuinely separate: `notificationEmailService` has no template for it, and it needs a recipient policy — a shared inbox, an on-call rota, something. Deciding that is not part of making the queue readable, and I would rather that decision was made on purpose than smuggled in here. Right now nobody knows to go looking; after this, at least there is somewhere to look.

**A customer-facing "my messages" view.** Different audience, different auth story, and it interacts with the deliberately-uncascaded `user_id`.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

Full suite green on this branch: **68 suites, 1599 tests** (from 66 / 1558 on `main`). No existing test file is modified. No migration — every column this uses has been in the schema since 0042 with nothing writing to it.

No files in common with #1498 or #1499.
