### PR TITLE
Stop a withdrawn pincode saying the store delivers to it

### DIFF
--- a/backend/config/routePolicy.js
+++ b/backend/config/routePolicy.js
@@ -39,6 +39,14 @@ const PUBLIC_ROUTES = Object.freeze([
     { method: 'GET', path: '/api/products/categories/tree', reason: PUBLIC_REASON.CATALOG },
     { method: 'GET', path: '/api/products/:id/questions', reason: PUBLIC_REASON.CATALOG },
     { method: 'GET', path: '/api/pincode/check/:pincode', reason: PUBLIC_REASON.CATALOG },
+    // The other two reads over serviceable_pincodes, which had handlers and no
+    // routes until #1496. Same reasoning as the single check: a shopper asks
+    // whether you deliver to them before they have an account, often before
+    // they have a basket. Both read one public table, write nothing, and
+    // answer only what the delivery page already shows -- and all three are
+    // now rate limited at the router, which none of them was before.
+    { method: 'GET', path: '/api/pincode/search', reason: PUBLIC_REASON.CATALOG },
+    { method: 'POST', path: '/api/pincode/check-multiple', reason: PUBLIC_REASON.CATALOG },
 
     { method: 'GET', path: '/api/auth/status', reason: PUBLIC_REASON.AUTH_ENTRY },
     { method: 'POST', path: '/api/auth/signup', reason: PUBLIC_REASON.AUTH_ENTRY },

--- a/backend/controllers/pincodeController.js
+++ b/backend/controllers/pincodeController.js
@@ -1,126 +1,161 @@
+// backend/controllers/pincodeController.js
+//
+// "Do you deliver to my pincode?" (#1496).
+//
+// Four handlers lived here and one had a route. `checkMultiplePincodes`,
+// `searchPincodes` and `clearPincodeCache` were exported and unreachable --
+// including the only one that could clear a cache.
+//
+// The rest of what changed:
+//
+//   * this file kept its own NodeCache, a second one under the same key scheme
+//     as the model's, and neither invalidation reached the other. Both now go
+//     through services/pincodeCache.js; see that file for the whole story.
+//   * `clearPincodeCache` guarded itself with `req.user && !hasPermission(...)`,
+//     so a caller with no `req.user` short-circuited the `&&` and flushed the
+//     cache. The route was unmounted, which is the only thing that made it
+//     latent -- and mounting it, which is the obvious fix for the paragraph
+//     above, would have published an unauthenticated cache-flush endpoint under
+//     a message reading "Only admins can clear pincode cache". The guard is
+//     `config/policy.authorize` now, applied at the route.
+//   * the rate limiter was a hand-rolled `Map` that inserted one entry per
+//     client address and never removed one: an unbounded map keyed by
+//     attacker-supplied source addresses, on an endpoint reachable from the
+//     open internet. It is a limiter from middleware/rateLimiter.js now, which
+//     already solves the multi-process and proxy cases this got wrong.
+//   * `PINCODE_REGEX` was read from the environment as if it were a regex.
+//     `process.env` values are strings, so setting the variable that exists to
+//     configure this turned every request into
+//     `TypeError: PINCODE_REGEX.test is not a function`.
+//   * `delivery_charges` and `cod_available` are on the row and were dropped
+//     from the answer. For a shopper about to pay cash on delivery, whether
+//     cash on delivery is available is the question they came to ask.
+
 const Pincode = require("../models/Pincode");
-const NodeCache = require('node-cache');
-const { PERMISSIONS, hasPermission } = require("../config/policy");
+const pincodeCache = require("../services/pincodeCache");
 
-const cache = new NodeCache({
-    stdTTL: 86400,
-    checkperiod: 3600
-});
+/**
+ * Six digits, or whatever `PINCODE_REGEX` says.
+ *
+ * Compiled if it comes from the environment. It used to be used raw, and a
+ * string has no `.test`.
+ */
+const PINCODE_REGEX = (() => {
+    const configured = process.env.PINCODE_REGEX;
 
-const rateLimiter = new Map();
-const RATE_LIMIT_WINDOW = 60000;
-const MAX_REQUESTS = 20;
+    if (!configured) {
+        return /^\d{6}$/;
+    }
 
-const PINCODE_REGEX = process.env.PINCODE_REGEX || /^\d{6}$/;
-const BATCH_MAX_LIMIT = parseInt(process.env.PINCODE_BATCH_LIMIT) || 50;
+    try {
+        return new RegExp(configured);
+    } catch (error) {
+        console.error(
+            `PINCODE_REGEX is not a valid regular expression (${error.message}); ` +
+                "falling back to the six-digit default"
+        );
+        return /^\d{6}$/;
+    }
+})();
+
+const BATCH_MAX_LIMIT = parseInt(process.env.PINCODE_BATCH_LIMIT, 10) || 50;
 
 function validatePincode(pincode) {
     if (!pincode || typeof pincode !== 'string') {
         return { valid: false, message: "Pincode is required" };
     }
-    
+
     const sanitized = pincode.replace(/[^\d]/g, '');
-    
+
     if (!PINCODE_REGEX.test(sanitized)) {
-        return { 
-            valid: false, 
+        return {
+            valid: false,
             message: "Please enter a valid 6-digit pincode."
         };
     }
-    
+
     return { valid: true, sanitized };
 }
 
-function checkRateLimit(ip) {
-    const now = Date.now();
-    const key = `pincode_${ip}`;
-    
-    if (!rateLimiter.has(key)) {
-        rateLimiter.set(key, [now]);
-        return true;
+/**
+ * Turn the row into the answer a shopper asked for.
+ *
+ * @param {object|undefined} row
+ * @returns {object}
+ */
+function toVerdict(row) {
+    if (!row) {
+        return {
+            deliverable: false,
+            message: "Sorry, delivery is not currently available at this pincode."
+        };
     }
-    
-    const requests = rateLimiter.get(key).filter(
-        time => now - time < RATE_LIMIT_WINDOW
-    );
-    
-    if (requests.length >= MAX_REQUESTS) {
-        return false;
-    }
-    
-    requests.push(now);
-    rateLimiter.set(key, requests);
-    return true;
+
+    const etaDays = Number(row.eta_days);
+    const deliveryCharges = Number(row.delivery_charges || 0);
+    const codAvailable = row.cod_available === 1 || row.cod_available === true;
+
+    return {
+        deliverable: true,
+        eta_days: etaDays,
+        city: row.city,
+        state: row.state,
+        // Both were on the row and neither was returned. Someone checking
+        // their pincode before buying wants to know what shipping costs and
+        // whether they can pay on delivery, not only when it turns up.
+        delivery_charges: deliveryCharges,
+        cod_available: codAvailable,
+        message:
+            `Delivery available! Estimated delivery in ${etaDays} day(s) to ` +
+            `${row.city}, ${row.state}.` +
+            (codAvailable ? " Cash on delivery is available." : "")
+    };
 }
 
-function getCacheKey(pincode) {
-    return `pincode_${pincode}`;
-}
-
+/**
+ * GET /api/pincode/check/:pincode
+ */
 const checkPincode = async (req, res) => {
-    const clientIp = req.ip || req.connection.remoteAddress || 'unknown';
-    
-    if (!checkRateLimit(clientIp)) {
-        return res.status(429).json({
-            success: false,
-            message: "Too many pincode checks. Please try again later."
-        });
-    }
-    
     const { pincode } = req.params;
     const validation = validatePincode(pincode);
-    
+
     if (!validation.valid) {
         return res.status(400).json({
             success: false,
             message: validation.message
         });
     }
-    
+
     const sanitizedPincode = validation.sanitized;
-    const cacheKey = getCacheKey(sanitizedPincode);
-    
-    const cached = cache.get(cacheKey);
+
+    const cached = pincodeCache.get(pincodeCache.NAMESPACE_VERDICT, sanitizedPincode);
+
     if (cached) {
-        console.log(`Cache hit for pincode ${sanitizedPincode}`);
         return res.status(200).json({
             success: true,
             ...cached,
+            // The documented envelope is { success, message, data }. The
+            // top-level fields stay because frontend/scripts/pincode.js reads
+            // `data.message` and `data.deliverable` off the top level; both
+            // shapes are served until that caller moves.
+            data: cached,
             cached: true
         });
     }
-    
+
     try {
         const results = await Pincode.findByCode(sanitizedPincode);
-        
-        let responseData;
-        
-        if (results.length === 0) {
-            responseData = {
-                deliverable: false,
-                message: "Sorry, delivery is not currently available at this pincode."
-            };
-        } else {
-            const { eta_days, city, state } = results[0];
-            responseData = {
-                deliverable: true,
-                eta_days,
-                city,
-                state,
-                message: `Delivery available! Estimated delivery in ${eta_days} day(s) to ${city}, ${state}.`
-            };
-        }
-        
-        cache.set(cacheKey, responseData);
-        
-        console.log(`Pincode check: ${sanitizedPincode} - Deliverable: ${responseData.deliverable}`);
-        
+        const verdict = toVerdict(results?.[0]);
+
+        pincodeCache.set(pincodeCache.NAMESPACE_VERDICT, sanitizedPincode, verdict);
+
         return res.status(200).json({
             success: true,
-            ...responseData,
+            ...verdict,
+            data: verdict,
             cached: false
         });
-        
+
     } catch (error) {
         console.error("Pincode check error:", error.message);
         return res.status(500).json({
@@ -130,94 +165,67 @@ const checkPincode = async (req, res) => {
     }
 };
 
+/**
+ * POST /api/pincode/check-multiple
+ *
+ * Exported and unrouted until now.
+ */
 const checkMultiplePincodes = async (req, res) => {
-    const clientIp = req.ip || req.connection.remoteAddress || 'unknown';
-    
-    if (!checkRateLimit(clientIp)) {
-        return res.status(429).json({
-            success: false,
-            message: "Too many requests. Please try again later."
-        });
-    }
-    
-    const { pincodes } = req.body;
-    
-    if (!pincodes || !Array.isArray(pincodes) || pincodes.length === 0) {
+    const { pincodes } = req.body || {};
+
+    if (!Array.isArray(pincodes) || pincodes.length === 0) {
         return res.status(400).json({
             success: false,
             message: "Please provide an array of pincodes"
         });
     }
-    
+
     if (pincodes.length > BATCH_MAX_LIMIT) {
         return res.status(400).json({
             success: false,
             message: `Maximum ${BATCH_MAX_LIMIT} pincodes allowed per request`
         });
     }
-    
+
     try {
         const results = [];
         const uniquePincodes = [...new Set(pincodes)];
-        
+
         for (const code of uniquePincodes) {
             const validation = validatePincode(code);
+
             if (!validation.valid) {
                 results.push({
-                    pincode: code,
+                    pincode: typeof code === "string" ? code : String(code),
                     valid: false,
                     error: validation.message
                 });
                 continue;
             }
-            
+
             const sanitized = validation.sanitized;
-            const cacheKey = getCacheKey(sanitized);
-            const cached = cache.get(cacheKey);
-            
+            const cached = pincodeCache.get(pincodeCache.NAMESPACE_VERDICT, sanitized);
+
             if (cached) {
-                results.push({
-                    pincode: sanitized,
-                    ...cached,
-                    cached: true
-                });
+                results.push({ pincode: sanitized, ...cached, cached: true });
                 continue;
             }
-            
-            const dbResults = await Pincode.findByCode(sanitized);
-            
-            let responseData;
-            if (dbResults.length === 0) {
-                responseData = {
-                    deliverable: false,
-                    message: "Delivery not available at this pincode"
-                };
-            } else {
-                const { eta_days, city, state } = dbResults[0];
-                responseData = {
-                    deliverable: true,
-                    eta_days,
-                    city,
-                    state,
-                    message: `Delivery available in ${eta_days} day(s) to ${city}, ${state}`
-                };
-            }
-            
-            cache.set(cacheKey, responseData);
-            
-            results.push({
-                pincode: sanitized,
-                ...responseData,
-                cached: false
-            });
+
+            const rows = await Pincode.findByCode(sanitized);
+            const verdict = toVerdict(rows?.[0]);
+
+            pincodeCache.set(pincodeCache.NAMESPACE_VERDICT, sanitized, verdict);
+
+            results.push({ pincode: sanitized, ...verdict, cached: false });
         }
-        
+
         return res.status(200).json({
             success: true,
+            message: "Pincode availability retrieved",
             data: results,
             total: results.length
         });
-        
+
     } catch (error) {
         console.error("Batch pincode check error:", error.message);
         return res.status(500).json({
@@ -227,25 +235,31 @@ const checkMultiplePincodes = async (req, res) => {
     }
 };
 
+/**
+ * GET /api/pincode/search?query=
+ *
+ * Exported and unrouted until now.
+ */
 const searchPincodes = async (req, res) => {
     const { query } = req.query;
-    
-    if (!query || query.length < 3) {
+
+    if (!query || String(query).trim().length < 3) {
         return res.status(400).json({
             success: false,
             message: "Search query must be at least 3 characters"
         });
     }
-    
+
     try {
-        const results = await Pincode.search(query);
-        
+        const results = await Pincode.search(String(query).trim());
+
         return res.status(200).json({
             success: true,
+            message: "Pincode search completed",
             data: results,
             total: results.length
         });
-        
+
     } catch (error) {
         console.error("Pincode search error:", error.message);
         return res.status(500).json({
@@ -255,26 +269,33 @@ const searchPincodes = async (req, res) => {
     }
 };
 
+/**
+ * POST /api/pincode/cache/clear
+ *
+ * Authorisation is `authorize(PERMISSIONS.CACHE_MANAGE)` at the route, not a
+ * check in here. The check that was in here read
+ *
+ *     if (req.user && !hasPermission(req.user, PERMISSIONS.CACHE_MANAGE))
+ *
+ * which refuses a signed-in non-admin and waves an anonymous caller straight
+ * through to `flushAll()`. `hasPermission(undefined, ...)` already returns
+ * false, so the `req.user &&` was not guarding against a crash -- it only
+ * weakened the check.
+ */
 const clearPincodeCache = async (req, res) => {
     try {
-        if (req.user && !hasPermission(req.user, PERMISSIONS.CACHE_MANAGE)) {
-            return res.status(403).json({
-                success: false,
-                message: "Unauthorized: Only admins can clear pincode cache"
-            });
-        }
-        
-        const cacheSize = cache.keys().length;
-        cache.flushAll();
-        rateLimiter.clear();
-        
-        console.log(`Pincode cache cleared: ${cacheSize} entries removed`);
-        
+        const cleared = pincodeCache.flush();
+
+        console.log(
+            `Pincode cache cleared by ${req.user?.id || "unknown"}: ${cleared} entries removed`
+        );
+
         return res.status(200).json({
             success: true,
-            message: `Pincode cache cleared successfully (${cacheSize} entries removed)`
+            message: `Pincode cache cleared successfully (${cleared} entries removed)`,
+            data: { cleared }
         });
-        
+
     } catch (error) {
         console.error("Clear pincode cache error:", error.message);
         return res.status(500).json({
@@ -288,5 +309,8 @@ module.exports = {
     checkPincode,
     checkMultiplePincodes,
     searchPincodes,
-    clearPincodeCache
+    clearPincodeCache,
+    toVerdict,
+    validatePincode,
+    PINCODE_REGEX
 };

--- a/backend/middleware/rateLimiter.js
+++ b/backend/middleware/rateLimiter.js
@@ -70,6 +70,17 @@ const NEWSLETTER_WINDOW_MS =
     parseInt(process.env.RATE_LIMIT_NEWSLETTER_WINDOW_MS, 10)
     || 60 * 60 * 1000; // 1 hour
 
+// Twenty pincode checks a minute. That is the budget the hand-rolled Map in
+// pincodeController carried (#1496) and there is no reason to change the
+// number while moving where it is counted.
+const PINCODE_LOOKUP_MAX =
+    parseInt(process.env.RATE_LIMIT_PINCODE_MAX, 10)
+    || 20;
+
+const PINCODE_WINDOW_MS =
+    parseInt(process.env.RATE_LIMIT_PINCODE_WINDOW_MS, 10)
+    || 60 * 1000; // 1 minute
+
 // ==================== CUSTOM KEY GENERATOR ====================
 // A limit is only as good as the identity it counts against, so the identity is
 // picked deliberately here.
@@ -284,6 +295,28 @@ const contactFormLimiter = createLimiter({
     logPrefix: "Contact form rate limit exceeded"
 });
 
+// ==================== PINCODE LOOKUP LIMITER ====================
+//
+// pincodeController used to count these itself, in a module-level `Map` that
+// inserted one entry per client address and never removed one (#1496). Entries
+// were pruned within a key on the next request from that key, but a key
+// visited once stayed for the lifetime of the process -- an unbounded map,
+// keyed by attacker-supplied source addresses, on an endpoint reachable from
+// the open internet and behind no authentication.
+//
+// Counting it here instead also fixes two things the hand-rolled version got
+// wrong for free: the counters are shared across instances rather than
+// per-process, and the key comes from `customKeyGenerator`, which respects the
+// explicitly configured `trust proxy` instead of reading `req.connection
+// .remoteAddress` (deprecated since Node 13) behind a load balancer.
+const pincodeLookupLimiter = createLimiter({
+    name: "pincode-lookup",
+    windowMs: PINCODE_WINDOW_MS,
+    max: PINCODE_LOOKUP_MAX,
+    message: "Too many pincode checks. Please try again in a minute.",
+    logPrefix: "Pincode lookup rate limit exceeded"
+});
+
 // ==================== SUSPICIOUS IP RATE LIMITER ====================
 const suspiciousIpKeyGenerator = (req) => {
     const address = req.ip || req.socket?.remoteAddress;
@@ -318,6 +351,7 @@ module.exports = {
     newsletterLimiter,
     guestOrderLookupLimiter,
     contactFormLimiter,
+    pincodeLookupLimiter,
     suspiciousIpLimiter,
     customKeyGenerator,
     onLimitReached

--- a/backend/models/Pincode.js
+++ b/backend/models/Pincode.js
@@ -1,12 +1,39 @@
-const db = require("../config/db");
-const NodeCache = require('node-cache');
+// backend/models/Pincode.js
+//
+// Delivery serviceability (#1496).
+//
+// Two things were wrong at this layer and both were invisible from outside.
+//
+// `serviceable_pincodes` carries `deleted_at`, `deleted_by` and an index on
+// `deleted_at` (migrations/0001_baseline_schema.sql:888-912). Not one query
+// read any of them. Every read filtered on `is_active = TRUE` and nothing
+// else, so a soft-deleted pincode still answered "yes, we deliver here", still
+// resolved a city and state for a shipping quote, and still turned up in
+// search. Withdrawal had no effect on any read path.
+//
+// And `delete` was a hard DELETE against a table built for soft deletion, so
+// `deleted_by` and `deleted_at` had no writer at all and the audit trail those
+// columns exist for did not exist.
+//
+// The cache also lives in services/pincodeCache.js now rather than here; see
+// that file for why there were two of them and why that could not work.
 
-const cache = new NodeCache({
-    stdTTL: 86400,
-    checkperiod: 3600
-});
+const db = require("../config/db");
+const pincodeCache = require("../services/pincodeCache");
 
 const PINCODE_REGEX = /^\d{6}$/;
+
+/**
+ * The predicate every read shares.
+ *
+ * Written out once, so a query added later cannot quietly omit the soft-delete
+ * check -- which is how the omission survived across nine separate reads.
+ */
+const LIVE = "is_active = TRUE AND deleted_at IS NULL";
+
+/** The columns a caller gets. `deleted_at` is not among them by design. */
+const COLUMNS = `pincode, city, state, country, eta_days, is_active,
+                 delivery_charges, cod_available, created_at, updated_at`;
 
 const Pincode = {
     validatePincode: (pincode) => {
@@ -30,29 +57,23 @@ const Pincode = {
         return pincodes.map(p => Pincode.validatePincode(p));
     },
 
-    getCacheKey: (pincode) => {
-        return `pincode_${pincode}`;
-    },
-
     findByCode: async (pincode) => {
         try {
             const validPincode = Pincode.validatePincode(pincode);
-            const cacheKey = Pincode.getCacheKey(validPincode);
 
-            const cached = cache.get(cacheKey);
+            const cached = pincodeCache.get(pincodeCache.NAMESPACE_ROWS, validPincode);
             if (cached !== undefined) {
                 return cached;
             }
 
             const [rows] = await db.query(
-                `SELECT pincode, city, state, country, eta_days, is_active, 
-                        delivery_charges, cod_available, created_at, updated_at
-                 FROM serviceable_pincodes 
-                 WHERE pincode = ? AND is_active = TRUE`,
+                `SELECT ${COLUMNS}
+                 FROM serviceable_pincodes
+                 WHERE pincode = ? AND ${LIVE}`,
                 [validPincode]
             );
 
-            cache.set(cacheKey, rows);
+            pincodeCache.set(pincodeCache.NAMESPACE_ROWS, validPincode, rows);
             return rows;
 
         } catch (error) {
@@ -68,10 +89,9 @@ const Pincode = {
 
             const placeholders = uniquePincodes.map(() => '?').join(',');
             const [rows] = await db.query(
-                `SELECT pincode, city, state, country, eta_days, is_active, 
-                        delivery_charges, cod_available, created_at, updated_at
-                 FROM serviceable_pincodes 
-                 WHERE pincode IN (${placeholders}) AND is_active = TRUE`,
+                `SELECT ${COLUMNS}
+                 FROM serviceable_pincodes
+                 WHERE pincode IN (${placeholders}) AND ${LIVE}`,
                 uniquePincodes
             );
 
@@ -95,13 +115,18 @@ const Pincode = {
                 throw new Error('Search query must be at least 2 characters');
             }
 
-            const searchTerm = `%${query.trim()}%`;
+            // LIKE metacharacters in the term are escaped: a search for "100%"
+            // should find "100%", not scan and return everything.
+            const searchTerm = `%${Pincode.escapeLike(query.trim())}%`;
+
             const [rows] = await db.query(
                 `SELECT pincode, city, state, country, eta_days, is_active,
                         delivery_charges, cod_available
-                 FROM serviceable_pincodes 
-                 WHERE (pincode LIKE ? OR city LIKE ? OR state LIKE ?) 
-                 AND is_active = TRUE
+                 FROM serviceable_pincodes
+                 WHERE (pincode LIKE ? ESCAPE '\\\\'
+                        OR city LIKE ? ESCAPE '\\\\'
+                        OR state LIKE ? ESCAPE '\\\\')
+                 AND ${LIVE}
                  LIMIT ?`,
                 [searchTerm, searchTerm, searchTerm, Math.min(limit, 50)]
             );
@@ -116,7 +141,9 @@ const Pincode = {
 
     count: async (filter = {}) => {
         try {
-            let query = 'SELECT COUNT(*) as total FROM serviceable_pincodes WHERE 1=1';
+            // Withdrawn rows are excluded here too. A count that includes them
+            // disagrees with every list that does not.
+            let query = 'SELECT COUNT(*) as total FROM serviceable_pincodes WHERE deleted_at IS NULL';
             const params = [];
 
             if (filter.is_active !== undefined) {
@@ -143,7 +170,7 @@ const Pincode = {
         }
     },
 
-    create: async (data) => {
+    create: async (data, actorId = null) => {
         try {
             const validPincode = Pincode.validatePincode(data.pincode);
 
@@ -151,10 +178,25 @@ const Pincode = {
                 throw new Error('City and state are required');
             }
 
+            // A pincode withdrawn earlier and added again is the same row --
+            // `pincode` is UNIQUE, so a plain INSERT would fail against a
+            // soft-deleted one and the operator would have no way to tell why.
             const [result] = await db.query(
-                `INSERT INTO serviceable_pincodes 
-                 (pincode, city, state, country, eta_days, delivery_charges, cod_available, is_active)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+                `INSERT INTO serviceable_pincodes
+                 (pincode, city, state, country, eta_days, delivery_charges,
+                  cod_available, is_active, created_by)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 ON DUPLICATE KEY UPDATE
+                     city = VALUES(city),
+                     state = VALUES(state),
+                     country = VALUES(country),
+                     eta_days = VALUES(eta_days),
+                     delivery_charges = VALUES(delivery_charges),
+                     cod_available = VALUES(cod_available),
+                     is_active = VALUES(is_active),
+                     updated_by = VALUES(created_by),
+                     deleted_at = NULL,
+                     deleted_by = NULL`,
                 [
                     validPincode,
                     data.city,
@@ -163,12 +205,12 @@ const Pincode = {
                     data.eta_days || 3,
                     data.delivery_charges || 0,
                     data.cod_available !== false ? 1 : 0,
-                    data.is_active !== false ? 1 : 0
+                    data.is_active !== false ? 1 : 0,
+                    actorId
                 ]
             );
 
-            const cacheKey = Pincode.getCacheKey(validPincode);
-            cache.del(cacheKey);
+            pincodeCache.invalidate(validPincode);
 
             return {
                 id: result.insertId,
@@ -182,7 +224,7 @@ const Pincode = {
         }
     },
 
-    update: async (pincode, data) => {
+    update: async (pincode, data, actorId = null) => {
         try {
             const validPincode = Pincode.validatePincode(pincode);
 
@@ -222,17 +264,19 @@ const Pincode = {
                 throw new Error('No fields to update');
             }
 
+            updates.push('updated_by = ?');
+            params.push(actorId);
+
             params.push(validPincode);
 
             const [result] = await db.query(
-                `UPDATE serviceable_pincodes 
+                `UPDATE serviceable_pincodes
                  SET ${updates.join(', ')}, updated_at = NOW()
-                 WHERE pincode = ?`,
+                 WHERE pincode = ? AND deleted_at IS NULL`,
                 params
             );
 
-            const cacheKey = Pincode.getCacheKey(validPincode);
-            cache.del(cacheKey);
+            pincodeCache.invalidate(validPincode);
 
             return result.affectedRows > 0;
 
@@ -242,17 +286,30 @@ const Pincode = {
         }
     },
 
-    delete: async (pincode) => {
+    /**
+     * Withdraw a pincode.
+     *
+     * A soft delete, which is what the table was built for. This used to issue
+     * `DELETE FROM serviceable_pincodes`, destroying the row and with it any
+     * record that the store had ever served that area -- while `deleted_at`
+     * and `deleted_by` sat unused two columns over.
+     *
+     * @param {string} pincode
+     * @param {string|null} actorId - recorded in deleted_by
+     * @returns {Promise<boolean>}
+     */
+    delete: async (pincode, actorId = null) => {
         try {
             const validPincode = Pincode.validatePincode(pincode);
 
             const [result] = await db.query(
-                'DELETE FROM serviceable_pincodes WHERE pincode = ?',
-                [validPincode]
+                `UPDATE serviceable_pincodes
+                 SET deleted_at = NOW(), deleted_by = ?, is_active = 0
+                 WHERE pincode = ? AND deleted_at IS NULL`,
+                [actorId, validPincode]
             );
 
-            const cacheKey = Pincode.getCacheKey(validPincode);
-            cache.del(cacheKey);
+            pincodeCache.invalidate(validPincode);
 
             return result.affectedRows > 0;
 
@@ -262,9 +319,40 @@ const Pincode = {
         }
     },
 
+    /**
+     * Undo a withdrawal.
+     *
+     * A soft delete nobody can reverse is, from outside, the hard delete it
+     * replaced -- the same argument #1457 made for products.
+     *
+     * @param {string} pincode
+     * @param {string|null} actorId
+     * @returns {Promise<boolean>}
+     */
+    restore: async (pincode, actorId = null) => {
+        try {
+            const validPincode = Pincode.validatePincode(pincode);
+
+            const [result] = await db.query(
+                `UPDATE serviceable_pincodes
+                 SET deleted_at = NULL, deleted_by = NULL, is_active = 1, updated_by = ?
+                 WHERE pincode = ? AND deleted_at IS NOT NULL`,
+                [actorId, validPincode]
+            );
+
+            pincodeCache.invalidate(validPincode);
+
+            return result.affectedRows > 0;
+
+        } catch (error) {
+            console.error('Pincode.restore error:', error.message);
+            throw error;
+        }
+    },
+
     getCities: async (state = null) => {
         try {
-            let query = 'SELECT DISTINCT city FROM serviceable_pincodes WHERE is_active = TRUE';
+            let query = `SELECT DISTINCT city FROM serviceable_pincodes WHERE ${LIVE}`;
             const params = [];
 
             if (state) {
@@ -286,7 +374,7 @@ const Pincode = {
     getStates: async () => {
         try {
             const [rows] = await db.query(
-                'SELECT DISTINCT state FROM serviceable_pincodes WHERE is_active = TRUE ORDER BY state'
+                `SELECT DISTINCT state FROM serviceable_pincodes WHERE ${LIVE} ORDER BY state`
             );
             return rows.map(row => row.state);
 
@@ -300,7 +388,7 @@ const Pincode = {
         try {
             const validPincode = Pincode.validatePincode(pincode);
             const [rows] = await db.query(
-                'SELECT eta_days FROM serviceable_pincodes WHERE pincode = ? AND is_active = TRUE',
+                `SELECT eta_days FROM serviceable_pincodes WHERE pincode = ? AND ${LIVE}`,
                 [validPincode]
             );
 
@@ -316,7 +404,7 @@ const Pincode = {
         try {
             const validPincode = Pincode.validatePincode(pincode);
             const [rows] = await db.query(
-                'SELECT COUNT(*) as count FROM serviceable_pincodes WHERE pincode = ? AND is_active = TRUE',
+                `SELECT COUNT(*) as count FROM serviceable_pincodes WHERE pincode = ? AND ${LIVE}`,
                 [validPincode]
             );
 
@@ -328,20 +416,26 @@ const Pincode = {
         }
     },
 
+    /**
+     * Escape the LIKE metacharacters in a user-supplied search term.
+     *
+     * @param {string} value
+     * @returns {string}
+     */
+    escapeLike: (value) => String(value).replace(/[\\%_]/g, (character) => `\\${character}`),
+
     clearCache: () => {
-        cache.flushAll();
-        console.log('Pincode cache cleared');
-        return true;
+        const cleared = pincodeCache.flush();
+        console.log(`Pincode cache cleared: ${cleared} entries removed`);
+        return cleared;
     },
 
-    getCacheStats: () => {
-        return {
-            keys: cache.keys(),
-            size: cache.keys().length,
-            hits: cache.getStats?.().hits || 0,
-            misses: cache.getStats?.().misses || 0
-        };
-    }
+    getCacheStats: () => pincodeCache.stats(),
+
+    // Exported so the controller and the tests can name the same thing the
+    // model does, rather than each keeping a copy.
+    LIVE_CONDITION: LIVE,
+    PINCODE_REGEX
 };
 
 module.exports = Pincode;

--- a/backend/routes/pincodeRoutes.js
+++ b/backend/routes/pincodeRoutes.js
@@ -1,7 +1,82 @@
+// backend/routes/pincodeRoutes.js
+//
+// Mounted at /api/pincode.
+//
+// This file was five lines and served one of the controller's four handlers
+// (#1496). `checkMultiplePincodes`, `searchPincodes` and `clearPincodeCache`
+// were all exported and unreachable -- including the only one that could clear
+// a cache, which is how a corrected pincode could take 24 hours to show up on
+// the product page.
+
 const express = require("express");
 const router = express.Router();
-const { checkPincode } = require("../controllers/pincodeController");
 
+const {
+    checkPincode,
+    checkMultiplePincodes,
+    searchPincodes,
+    clearPincodeCache
+} = require("../controllers/pincodeController");
+
+const authMiddleware = require("../middleware/authMiddleware");
+const { authorize } = require("../config/policy");
+const { PERMISSIONS } = require("../config/policy");
+const { pincodeLookupLimiter } = require("../middleware/rateLimiter");
+
+// ==================== PUBLIC ====================
+//
+// Unauthenticated by design: a shopper checks whether you deliver to them
+// before they have an account, and often before they have a basket. The
+// limiter is therefore the only thing between the endpoint and a scan of every
+// pincode in the country, and it is applied at the router so a route added
+// later cannot be missing it.
+router.use(pincodeLookupLimiter);
+
+/**
+ * GET /api/pincode/check/:pincode
+ */
 router.get("/check/:pincode", checkPincode);
+
+/**
+ * GET /api/pincode/search?query=
+ *
+ * Declared above "/check/:pincode" is unnecessary -- the paths do not overlap
+ * -- but it is declared before the batch POST so the reads read together.
+ */
+router.get("/search", searchPincodes);
+
+/**
+ * POST /api/pincode/check-multiple
+ * Body: { pincodes: string[] }
+ *
+ * Capped at PINCODE_BATCH_LIMIT (50) in the controller.
+ */
+router.post("/check-multiple", checkMultiplePincodes);
+
+// ==================== ADMIN ====================
+
+/**
+ * POST /api/pincode/cache/clear
+ *
+ * The invalidation that existed and could not be called.
+ *
+ * `authorize` is the guard rather than the check the handler used to carry.
+ * That one read `if (req.user && !hasPermission(...))`, which refuses a
+ * signed-in non-admin and lets a caller with no `req.user` through -- so
+ * mounting the route without changing it would have published an
+ * unauthenticated cache flush under a message saying only admins can do it.
+ * `authMiddleware` runs first so an anonymous caller is a 401 rather than
+ * reaching a permission check at all.
+ */
+router.post(
+    "/cache/clear",
+    authMiddleware,
+    authorize(PERMISSIONS.CACHE_MANAGE),
+    clearPincodeCache
+);
+
+router.use((req, res) => {
+    res.status(404).json({ success: false, message: "Pincode route not found" });
+});
 
 module.exports = router;

--- a/backend/services/pincodeCache.js
+++ b/backend/services/pincodeCache.js
@@ -1,0 +1,126 @@
+// backend/services/pincodeCache.js
+//
+// One cache over serviceable_pincodes (#1496).
+//
+// There were two. `models/Pincode.js` created a NodeCache and so did
+// `controllers/pincodeController.js`, both with a 24-hour TTL, both keyed by a
+// `pincode_<code>` scheme from a `getCacheKey` copied verbatim into both files.
+// One key, two caches, two shapes: the model stored the raw rows, the
+// controller stored a formatted answer.
+//
+// Neither invalidation reached the other:
+//
+//   * Pincode.create/update/delete cleared the model's entry, so the shopper-
+//     facing checker kept serving its own copy for up to 24 hours;
+//   * clearPincodeCache flushed the controller's, so shipping quotes -- which
+//     go through Pincode.findByCode -- kept using theirs;
+//   * Pincode.clearCache() existed and was called from nowhere.
+//
+// There was no sequence of callable operations that cleared both, so an admin
+// correcting a pincode's ETA changed what the shipping quote said and did not
+// change what the product page said. Two caches under one key scheme cannot be
+// made to agree; the fix is that there is one, here, and both callers use it.
+
+'use strict';
+
+const NodeCache = require('node-cache');
+
+/**
+ * A day. Serviceability changes when someone edits a row, and every path that
+ * edits one invalidates through this module, so the TTL is a backstop rather
+ * than the mechanism.
+ */
+const PINCODE_CACHE_TTL_SECONDS =
+    Number(process.env.PINCODE_CACHE_TTL_SECONDS) || 86400;
+
+const cache = new NodeCache({
+    stdTTL: PINCODE_CACHE_TTL_SECONDS,
+    checkperiod: 3600,
+    // Values are handed out by reference otherwise, so a caller that mutates
+    // what it got mutates what everyone else will get.
+    useClones: true
+});
+
+/**
+ * Namespaced so two kinds of answer about the same pincode -- the raw row and
+ * the formatted deliverability verdict -- cannot collide under one key, which
+ * is precisely what the two old caches did.
+ *
+ * @param {string} namespace
+ * @param {string} pincode
+ * @returns {string}
+ */
+function key(namespace, pincode) {
+    return `pincode:${namespace}:${pincode}`;
+}
+
+/**
+ * @param {string} namespace
+ * @param {string} pincode
+ * @returns {*} the cached value, or undefined
+ */
+function get(namespace, pincode) {
+    return cache.get(key(namespace, pincode));
+}
+
+/**
+ * @param {string} namespace
+ * @param {string} pincode
+ * @param {*} value
+ */
+function set(namespace, pincode, value) {
+    cache.set(key(namespace, pincode), value);
+}
+
+/**
+ * Forget everything known about one pincode, in every namespace.
+ *
+ * This is the operation that did not exist. A write invalidated whichever
+ * cache the writer happened to hold a reference to, and the other one kept
+ * answering.
+ *
+ * @param {string} pincode
+ * @returns {number} how many entries were dropped
+ */
+function invalidate(pincode) {
+    const keys = cache.keys().filter((cached) => cached.endsWith(`:${pincode}`));
+
+    return cache.del(keys);
+}
+
+/**
+ * Drop everything.
+ *
+ * @returns {number} how many entries were dropped
+ */
+function flush() {
+    const count = cache.keys().length;
+    cache.flushAll();
+    return count;
+}
+
+/**
+ * @returns {{size: number, keys: string[], hits: number, misses: number}}
+ */
+function stats() {
+    const nodeStats = cache.getStats?.() || {};
+
+    return {
+        size: cache.keys().length,
+        keys: cache.keys(),
+        hits: nodeStats.hits || 0,
+        misses: nodeStats.misses || 0
+    };
+}
+
+module.exports = {
+    NAMESPACE_ROWS: 'rows',
+    NAMESPACE_VERDICT: 'verdict',
+    PINCODE_CACHE_TTL_SECONDS,
+    get,
+    set,
+    invalidate,
+    flush,
+    stats,
+    key
+};

--- a/backend/tests/fixtures/policySnapshot.json
+++ b/backend/tests/fixtures/policySnapshot.json
@@ -115,6 +115,7 @@
     "GET /api/courier-webhooks/health",
     "GET /api/orders/status/check",
     "GET /api/pincode/check/:pincode",
+    "GET /api/pincode/search",
     "GET /api/products",
     "GET /api/products/:id",
     "GET /api/products/:id/questions",
@@ -137,6 +138,7 @@
     "POST /api/courier-webhooks/:provider",
     "POST /api/orders/lookup",
     "POST /api/orders/validate",
+    "POST /api/pincode/check-multiple",
     "POST /api/promos/validate",
     "POST /api/wishlist-notify/unsubscribe"
   ],

--- a/backend/tests/pincodeRoutes.test.js
+++ b/backend/tests/pincodeRoutes.test.js
@@ -1,0 +1,286 @@
+// backend/tests/pincodeRoutes.test.js
+//
+// The pincode API (#1496).
+//
+// The router was five lines and served one of the controller's four handlers.
+// `checkMultiplePincodes`, `searchPincodes` and `clearPincodeCache` were all
+// exported and unreachable -- including the only one that could clear a cache,
+// which is why a corrected pincode could take a day to reach the product page.
+//
+// The cache-clear tests are the ones that matter. Its handler used to guard
+// itself with
+//
+//     if (req.user && !hasPermission(req.user, PERMISSIONS.CACHE_MANAGE))
+//
+// which refuses a signed-in non-admin and lets a caller with no `req.user`
+// fall straight through to `flushAll()`. That was latent only because the
+// route was not mounted -- and mounting it, which is the obvious fix for the
+// paragraph above, would have published an unauthenticated cache flush behind
+// a message reading "Only admins can clear pincode cache".
+
+let mockUser = null;
+
+jest.mock('../middleware/authMiddleware', () => {
+    const stub = (req, res, next) => {
+        if (!mockUser) {
+            return res
+                .status(401)
+                .json({ success: false, message: 'Authentication required' });
+        }
+        req.user = mockUser;
+        next();
+    };
+    stub.optionalAuth = (req, res, next) => {
+        if (mockUser) req.user = mockUser;
+        next();
+    };
+    return stub;
+});
+
+// Real rate limiting would make these tests order-dependent for no benefit,
+// and the limiter has its own coverage. That it is *applied* is asserted
+// separately, against the source, at the bottom of this file.
+jest.mock('../middleware/rateLimiter', () => ({
+    pincodeLookupLimiter: (req, res, next) => next()
+}));
+
+jest.mock('../models/Pincode', () => ({
+    findByCode: jest.fn(),
+    search: jest.fn()
+}));
+
+const express = require('express');
+const request = require('supertest');
+
+const Pincode = require('../models/Pincode');
+const pincodeCache = require('../services/pincodeCache');
+const pincodeRoutes = require('../routes/pincodeRoutes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/pincode', pincodeRoutes);
+
+const ROW = {
+    pincode: '110001',
+    city: 'New Delhi',
+    state: 'Delhi',
+    country: 'India',
+    eta_days: 2,
+    is_active: 1,
+    delivery_charges: 49,
+    cod_available: 1
+};
+
+const ADMIN = { id: 'admin-1', role: 'admin' };
+const SHOPPER = { id: 'user-1', role: 'user' };
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    pincodeCache.flush();
+    mockUser = null;
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    console.log.mockRestore();
+});
+
+describe('GET /api/pincode/check/:pincode', () => {
+    test('answers with the delivery charge and COD availability', async () => {
+        Pincode.findByCode.mockResolvedValue([ROW]);
+
+        const res = await request(app).get('/api/pincode/check/110001');
+
+        expect(res.status).toBe(200);
+        expect(res.body.deliverable).toBe(true);
+        expect(res.body.delivery_charges).toBe(49);
+        expect(res.body.cod_available).toBe(true);
+    });
+
+    test('keeps the top-level fields the frontend reads', async () => {
+        Pincode.findByCode.mockResolvedValue([ROW]);
+
+        const res = await request(app).get('/api/pincode/check/110001');
+
+        // frontend/scripts/pincode.js reads `data.message` and
+        // `data.deliverable` off the top level of the response. Both shapes
+        // are served until that caller moves.
+        expect(typeof res.body.message).toBe('string');
+        expect(res.body.data.deliverable).toBe(true);
+    });
+
+    test('is public', async () => {
+        Pincode.findByCode.mockResolvedValue([]);
+
+        const res = await request(app).get('/api/pincode/check/110001');
+
+        expect(res.status).toBe(200);
+    });
+
+    test('rejects a malformed pincode', async () => {
+        const res = await request(app).get('/api/pincode/check/abc');
+
+        expect(res.status).toBe(400);
+        expect(Pincode.findByCode).not.toHaveBeenCalled();
+    });
+
+    test('serves the second identical request from the cache', async () => {
+        Pincode.findByCode.mockResolvedValue([ROW]);
+
+        const first = await request(app).get('/api/pincode/check/110001');
+        const second = await request(app).get('/api/pincode/check/110001');
+
+        expect(first.body.cached).toBe(false);
+        expect(second.body.cached).toBe(true);
+        expect(Pincode.findByCode).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('GET /api/pincode/search', () => {
+    test('was exported and unroutable; it answers now', async () => {
+        Pincode.search.mockResolvedValue([ROW]);
+
+        const res = await request(app).get('/api/pincode/search?query=Delhi');
+
+        expect(res.status).toBe(200);
+        expect(res.body.data).toHaveLength(1);
+        expect(res.body.total).toBe(1);
+    });
+
+    test('refuses a query under three characters', async () => {
+        const res = await request(app).get('/api/pincode/search?query=De');
+
+        expect(res.status).toBe(400);
+        expect(Pincode.search).not.toHaveBeenCalled();
+    });
+});
+
+describe('POST /api/pincode/check-multiple', () => {
+    test('was exported and unroutable; it answers now', async () => {
+        Pincode.findByCode.mockResolvedValue([ROW]);
+
+        const res = await request(app)
+            .post('/api/pincode/check-multiple')
+            .send({ pincodes: ['110001', '400001'] });
+
+        expect(res.status).toBe(200);
+        expect(res.body.data).toHaveLength(2);
+    });
+
+    test('reports a bad entry without failing the whole batch', async () => {
+        Pincode.findByCode.mockResolvedValue([ROW]);
+
+        const res = await request(app)
+            .post('/api/pincode/check-multiple')
+            .send({ pincodes: ['110001', 'nonsense'] });
+
+        expect(res.status).toBe(200);
+        expect(res.body.data[1].valid).toBe(false);
+    });
+
+    test('caps the batch', async () => {
+        const res = await request(app)
+            .post('/api/pincode/check-multiple')
+            .send({ pincodes: Array.from({ length: 200 }, (_, i) => String(100000 + i)) });
+
+        expect(res.status).toBe(400);
+        expect(res.body.message).toMatch(/Maximum/);
+    });
+
+    test('rejects a body that is not an array', async () => {
+        const res = await request(app)
+            .post('/api/pincode/check-multiple')
+            .send({ pincodes: '110001' });
+
+        expect(res.status).toBe(400);
+    });
+});
+
+describe('POST /api/pincode/cache/clear', () => {
+    test('refuses an anonymous caller', async () => {
+        // The regression. The old in-handler check was
+        // `req.user && !hasPermission(...)`, so no `req.user` meant no check
+        // at all and the cache was flushed.
+        mockUser = null;
+
+        const res = await request(app).post('/api/pincode/cache/clear');
+
+        expect(res.status).toBe(401);
+    });
+
+    test('refuses a signed-in shopper', async () => {
+        mockUser = SHOPPER;
+
+        const res = await request(app).post('/api/pincode/cache/clear');
+
+        expect(res.status).toBe(403);
+    });
+
+    test('lets an admin through and reports what it dropped', async () => {
+        mockUser = ADMIN;
+        pincodeCache.set(pincodeCache.NAMESPACE_VERDICT, '110001', { deliverable: true });
+
+        const res = await request(app).post('/api/pincode/cache/clear');
+
+        expect(res.status).toBe(200);
+        expect(res.body.data.cleared).toBe(1);
+        expect(pincodeCache.get(pincodeCache.NAMESPACE_VERDICT, '110001')).toBeUndefined();
+    });
+
+    test('the anonymous refusal happens before anything is flushed', async () => {
+        mockUser = null;
+        pincodeCache.set(pincodeCache.NAMESPACE_VERDICT, '110001', { deliverable: true });
+
+        await request(app).post('/api/pincode/cache/clear');
+
+        expect(pincodeCache.get(pincodeCache.NAMESPACE_VERDICT, '110001')).toBeDefined();
+    });
+});
+
+describe('what the router applies', () => {
+    const fs = require('fs');
+    const path = require('path');
+
+    const source = fs.readFileSync(
+        path.join(__dirname, '..', 'routes', 'pincodeRoutes.js'),
+        'utf8'
+    );
+
+    test('the limiter is applied at the router, not per route', () => {
+        // Router-level so a route added later cannot be missing it. These are
+        // unauthenticated endpoints over a table of every area the store
+        // serves; the limiter is the only thing bounding a full scan.
+        expect(source).toMatch(/router\.use\(pincodeLookupLimiter\)/);
+    });
+
+    test('the cache clear is behind both a login and a permission', () => {
+        expect(source).toMatch(/authMiddleware,\s*\n\s*authorize\(PERMISSIONS\.CACHE_MANAGE\)/);
+    });
+
+    test('the controller keeps no hand-rolled limiter', () => {
+        const controller = fs.readFileSync(
+            path.join(__dirname, '..', 'controllers', 'pincodeController.js'),
+            'utf8'
+        );
+
+        // It was a module-level `Map` that inserted one entry per client
+        // address and never removed one.
+        expect(controller).not.toMatch(/const rateLimiter = new Map\(\)/);
+        expect(controller).not.toMatch(/req\.connection\.remoteAddress/);
+    });
+
+    test('every handler the controller exports has a route', () => {
+        const handlers = [
+            'checkPincode',
+            'checkMultiplePincodes',
+            'searchPincodes',
+            'clearPincodeCache'
+        ];
+
+        const unrouted = handlers.filter(
+            (handler) => source.split(handler).length - 1 < 2
+        );
+
+        expect(unrouted).toEqual([]);
+    });
+});

--- a/backend/tests/pincodeServiceability.test.js
+++ b/backend/tests/pincodeServiceability.test.js
@@ -1,0 +1,343 @@
+// backend/tests/pincodeServiceability.test.js
+//
+// Delivery serviceability (#1496).
+//
+// Three things are pinned here and they are all things that were invisible
+// from outside:
+//
+//   * `deleted_at` was read by nothing. A withdrawn pincode still said the
+//     store delivered to it, in the product-page checker and in the shipping
+//     quote, and there was an index on the column nobody used. Those
+//     assertions are on the SQL, because a mocked `db.query` accepts any
+//     string and a missing WHERE clause is exactly what has to be caught.
+//   * there were two caches under one key scheme and no operation that
+//     cleared both. That is a behavioural test: write through the model, read
+//     through the controller's path, and check the answer moved.
+//   * `clearPincodeCache` waved anonymous callers through its own admin check.
+
+jest.mock('../config/db', () => ({
+    query: jest.fn(),
+    getConnection: jest.fn()
+}));
+
+const db = require('../config/db');
+const Pincode = require('../models/Pincode');
+const pincodeCache = require('../services/pincodeCache');
+const pincodeController = require('../controllers/pincodeController');
+
+const ROW = (overrides = {}) => ({
+    pincode: '110001',
+    city: 'New Delhi',
+    state: 'Delhi',
+    country: 'India',
+    eta_days: 2,
+    is_active: 1,
+    delivery_charges: 49,
+    cod_available: 1,
+    created_at: '2026-01-01 00:00:00',
+    updated_at: '2026-01-01 00:00:00',
+    ...overrides
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    pincodeCache.flush();
+    db.query.mockResolvedValue([[]]);
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    console.log.mockRestore();
+    console.error.mockRestore();
+});
+
+// ---------------------------------------------------------------------------
+// The soft delete nothing read
+// ---------------------------------------------------------------------------
+
+describe('deleted_at', () => {
+    const READS = [
+        ['findByCode', () => Pincode.findByCode('110001')],
+        ['findByCodes', () => Pincode.findByCodes(['110001'])],
+        ['search', () => Pincode.search('Delhi')],
+        ['getCities', () => Pincode.getCities()],
+        ['getStates', () => Pincode.getStates()],
+        ['getDeliveryEta', () => Pincode.getDeliveryEta('110001')],
+        ['isDeliverable', () => Pincode.isDeliverable('110001')],
+        ['count', () => Pincode.count()]
+    ];
+
+    test.each(READS)('%s excludes withdrawn rows', async (_name, run) => {
+        await run();
+
+        const [sql] = db.query.mock.calls[0];
+
+        expect(sql).toMatch(/deleted_at IS NULL/);
+    });
+
+    test('every read filtered on is_active alone before this change', () => {
+        // The index on deleted_at has existed since the baseline schema and
+        // not one query used it, so withdrawal had no effect on any read path.
+        const fs = require('fs');
+        const path = require('path');
+
+        // Comments are stripped: the header of this file quotes the table name
+        // while explaining the bug, and so does the doc comment on `delete`.
+        const source = fs
+            .readFileSync(path.join(__dirname, '..', 'models', 'Pincode.js'), 'utf8')
+            .split('\n')
+            .map((line) => (/^\s*(\/\/|\/\*|\*)/.test(line) ? '' : line))
+            .join('\n');
+
+        // Every place the model reads the table, with the 400 characters that
+        // follow -- enough to reach the WHERE clause of the longest query in
+        // the file, which is `search` with its three LIKE branches.
+        const reads = [...source.matchAll(/FROM serviceable_pincodes/g)].map(
+            (match) => ({
+                line: source.slice(0, match.index).split('\n').length,
+                tail: source.slice(match.index, match.index + 400)
+            })
+        );
+
+        expect(reads.length).toBeGreaterThan(5);
+
+        // `${LIVE}` is the shared predicate, written out once at the top of
+        // the model so a query added later cannot quietly omit the check --
+        // which is how the omission survived across eight separate reads.
+        const unguarded = reads
+            .filter(
+                ({ tail }) =>
+                    !/deleted_at IS (?:NOT )?NULL/.test(tail) && !/\$\{LIVE\}/.test(tail)
+            )
+            .map(({ line, tail }) => `Pincode.js:${line}: ${tail.split('\n')[0]}`);
+
+        expect(unguarded).toEqual([]);
+    });
+});
+
+describe('delete', () => {
+    test('withdraws the row instead of destroying it', async () => {
+        db.query.mockResolvedValue([{ affectedRows: 1 }]);
+
+        await Pincode.delete('110001', 'admin-1');
+
+        const [sql, params] = db.query.mock.calls[0];
+
+        // It used to be `DELETE FROM serviceable_pincodes`, against a table
+        // with deleted_at, deleted_by and an index on the former.
+        expect(sql).not.toMatch(/^\s*DELETE FROM/i);
+        expect(sql).toMatch(/SET deleted_at = NOW\(\), deleted_by = \?/);
+        expect(params[0]).toBe('admin-1');
+    });
+
+    test('is idempotent', async () => {
+        db.query.mockResolvedValue([{ affectedRows: 0 }]);
+
+        const result = await Pincode.delete('110001', 'admin-1');
+
+        expect(result).toBe(false);
+        expect(db.query.mock.calls[0][0]).toMatch(/deleted_at IS NULL/);
+    });
+
+    test('can be undone', async () => {
+        db.query.mockResolvedValue([{ affectedRows: 1 }]);
+
+        await Pincode.restore('110001', 'admin-1');
+
+        const [sql] = db.query.mock.calls[0];
+
+        // A soft delete nobody can reverse is, from outside, the hard delete
+        // it replaced -- the argument #1457 made for products.
+        expect(sql).toMatch(/deleted_at = NULL/);
+        expect(sql).toMatch(/deleted_at IS NOT NULL/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// One cache
+// ---------------------------------------------------------------------------
+
+describe('the cache', () => {
+    function fakeRes() {
+        return {
+            statusCode: null,
+            body: null,
+            status(code) {
+                this.statusCode = code;
+                return this;
+            },
+            json(payload) {
+                this.body = payload;
+                return this;
+            }
+        };
+    }
+
+    test('a write through the model changes what the checker answers', async () => {
+        // This is the defect. The model cleared its own cache and the
+        // controller kept serving a different copy under an equivalent key for
+        // up to 24 hours, so correcting a pincode changed what the shipping
+        // quote said and not what the product page said.
+        db.query.mockResolvedValue([[ROW({ eta_days: 2 })]]);
+
+        const first = fakeRes();
+        await pincodeController.checkPincode({ params: { pincode: '110001' } }, first);
+        expect(first.body.eta_days).toBe(2);
+
+        db.query.mockResolvedValue([{ affectedRows: 1 }]);
+        await Pincode.update('110001', { eta_days: 9 }, 'admin-1');
+
+        db.query.mockResolvedValue([[ROW({ eta_days: 9 })]]);
+        const second = fakeRes();
+        await pincodeController.checkPincode({ params: { pincode: '110001' } }, second);
+
+        expect(second.body.eta_days).toBe(9);
+        expect(second.body.cached).toBe(false);
+    });
+
+    test('withdrawing a pincode stops the checker offering it', async () => {
+        db.query.mockResolvedValue([[ROW()]]);
+
+        const before = fakeRes();
+        await pincodeController.checkPincode({ params: { pincode: '110001' } }, before);
+        expect(before.body.deliverable).toBe(true);
+
+        db.query.mockResolvedValue([{ affectedRows: 1 }]);
+        await Pincode.delete('110001', 'admin-1');
+
+        db.query.mockResolvedValue([[]]);
+        const after = fakeRes();
+        await pincodeController.checkPincode({ params: { pincode: '110001' } }, after);
+
+        expect(after.body.deliverable).toBe(false);
+    });
+
+    test('invalidation reaches every namespace for that pincode', () => {
+        pincodeCache.set(pincodeCache.NAMESPACE_ROWS, '110001', [ROW()]);
+        pincodeCache.set(pincodeCache.NAMESPACE_VERDICT, '110001', { deliverable: true });
+        pincodeCache.set(pincodeCache.NAMESPACE_VERDICT, '400001', { deliverable: true });
+
+        pincodeCache.invalidate('110001');
+
+        expect(pincodeCache.get(pincodeCache.NAMESPACE_ROWS, '110001')).toBeUndefined();
+        expect(pincodeCache.get(pincodeCache.NAMESPACE_VERDICT, '110001')).toBeUndefined();
+        // And leaves other pincodes alone.
+        expect(pincodeCache.get(pincodeCache.NAMESPACE_VERDICT, '400001')).toBeDefined();
+    });
+
+    test('the raw row and the verdict do not collide', () => {
+        // Two caches under one `pincode_<code>` key was the original arrangement
+        // and the shapes were different, so whichever wrote last decided what
+        // the other one read.
+        pincodeCache.set(pincodeCache.NAMESPACE_ROWS, '110001', [ROW()]);
+        pincodeCache.set(pincodeCache.NAMESPACE_VERDICT, '110001', { deliverable: false });
+
+        expect(pincodeCache.get(pincodeCache.NAMESPACE_ROWS, '110001')).toHaveLength(1);
+        expect(pincodeCache.get(pincodeCache.NAMESPACE_VERDICT, '110001').deliverable).toBe(false);
+    });
+
+    test('there is only one NodeCache left', () => {
+        const fs = require('fs');
+        const path = require('path');
+
+        const files = ['models/Pincode.js', 'controllers/pincodeController.js'];
+
+        for (const relative of files) {
+            const source = fs.readFileSync(path.join(__dirname, '..', relative), 'utf8');
+
+            expect(source).not.toMatch(/new NodeCache\(/);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The answer
+// ---------------------------------------------------------------------------
+
+describe('toVerdict', () => {
+    test('returns the delivery charge and COD availability', async () => {
+        // Both are on the row and neither was returned. For someone about to
+        // pay cash on delivery, whether cash on delivery is available is the
+        // question they came to ask.
+        const verdict = pincodeController.toVerdict(ROW());
+
+        expect(verdict.delivery_charges).toBe(49);
+        expect(verdict.cod_available).toBe(true);
+        expect(verdict.message).toMatch(/Cash on delivery is available/);
+    });
+
+    test('says nothing about COD when it is not available', () => {
+        const verdict = pincodeController.toVerdict(ROW({ cod_available: 0 }));
+
+        expect(verdict.cod_available).toBe(false);
+        expect(verdict.message).not.toMatch(/Cash on delivery/);
+    });
+
+    test('answers not-deliverable for a pincode with no row', () => {
+        const verdict = pincodeController.toVerdict(undefined);
+
+        expect(verdict.deliverable).toBe(false);
+        expect(verdict.eta_days).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The configurable regex
+// ---------------------------------------------------------------------------
+
+describe('PINCODE_REGEX', () => {
+    const original = process.env.PINCODE_REGEX;
+
+    afterEach(() => {
+        jest.resetModules();
+        if (original === undefined) {
+            delete process.env.PINCODE_REGEX;
+        } else {
+            process.env.PINCODE_REGEX = original;
+        }
+    });
+
+    test('a configured pattern is compiled, not used as a string', () => {
+        // `process.env` values are strings, and a string has no `.test`.
+        // Setting the variable that exists to configure this used to turn
+        // every request into "PINCODE_REGEX.test is not a function".
+        jest.resetModules();
+        process.env.PINCODE_REGEX = '^\\d{5}$';
+
+        const reloaded = require('../controllers/pincodeController');
+
+        expect(reloaded.PINCODE_REGEX).toBeInstanceOf(RegExp);
+        expect(reloaded.validatePincode('12345').valid).toBe(true);
+        expect(reloaded.validatePincode('123456').valid).toBe(false);
+    });
+
+    test('an unparseable pattern falls back rather than taking the endpoint down', () => {
+        jest.resetModules();
+        process.env.PINCODE_REGEX = '^[0-9'; // unterminated character class
+
+        const reloaded = require('../controllers/pincodeController');
+
+        expect(reloaded.PINCODE_REGEX).toBeInstanceOf(RegExp);
+        expect(reloaded.validatePincode('110001').valid).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Search
+// ---------------------------------------------------------------------------
+
+describe('search', () => {
+    test('escapes LIKE metacharacters in the term', async () => {
+        await Pincode.search('100%');
+
+        const [, params] = db.query.mock.calls[0];
+
+        expect(params[0]).toBe('%100\\%%');
+    });
+
+    test('refuses a term that is too short', async () => {
+        await expect(Pincode.search('a')).rejects.toThrow(/at least 2 characters/);
+        expect(db.query).not.toHaveBeenCalled();
+    });
+});

--- a/backend/tests/rateLimiter.test.js
+++ b/backend/tests/rateLimiter.test.js
@@ -79,6 +79,10 @@ const EXPORTED_LIMITERS = [
     ["newsletterLimiter", "newsletter"],
     ["guestOrderLookupLimiter", "guest-order-lookup"],
     ["contactFormLimiter", "contact-form"],
+    // Unauthenticated lookups over serviceable_pincodes. Counted here rather
+    // than in a module-level Map inside pincodeController, which grew one
+    // entry per client address and never dropped one (#1496).
+    ["pincodeLookupLimiter", "pincode-lookup"],
     ["suspiciousIpLimiter", "suspicious-ip"]
 ];
 


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`serviceable_pincodes` carries a soft-delete column. Nothing read it.

```sql
-- migrations/0001_baseline_schema.sql:888-912
deleted_by CHAR(36),
deleted_at DATETIME,
...
INDEX idx_pincodes_deleted (deleted_at)
```

Every read in `models/Pincode.js` filtered on `is_active = TRUE` and nothing else — `findByCode`, `findByCodes`, `search`, `count`, `getCities`, `getStates`, `getDeliveryEta`, `isDeliverable`. Eight reads, an index on the column, and not one query using it.

So a withdrawn pincode still said the store delivered to it, still resolved a city and state for a shipping quote (`shipping.service.js:165` goes through `Pincode.findByCode`), and still turned up in search. Withdrawal had no effect on any read path.

And `Pincode.delete` was a hard `DELETE` against a table built for soft deletion, so `deleted_at` and `deleted_by` had no writer at all — the audit trail those columns exist for did not exist, and the only way to withdraw a pincode destroyed the record that the store had ever served that area.

---

## 🔗 Related Issue

Closes #1496

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] Security fix
- [x] Testing improvement
- [x] Code refactoring
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Documentation update

---

## 🌐 Additional Notes

### The soft delete

`deleted_at IS NULL` is on every read, and it is written out **once** — `LIVE` at the top of the model — rather than eight times. That is the point rather than tidiness: the omission survived across eight separate queries precisely because each one had to remember it independently.

`delete` withdraws the row and stamps `deleted_at` and `deleted_by`, and `restore` undoes it. A soft delete nobody can reverse is, from outside, the hard delete it replaced — the argument #1457 made for products.

`create` upserts, because `pincode` is `UNIQUE` and a plain `INSERT` against a soft-deleted row fails with a duplicate-key error that tells the operator nothing about why. Re-adding a withdrawn pincode clears `deleted_at`, which is what re-adding it means.

### Two caches under one key

`models/Pincode.js` created a `NodeCache`. `controllers/pincodeController.js` created a **second** one — same 24-hour TTL, same `pincode_<code>` key scheme, from a `getCacheKey` copied verbatim into both files. One key, two caches, two shapes: the model cached the raw rows, the controller cached a formatted verdict.

Neither invalidation reached the other:

| Operation | Clears | Leaves stale |
| --- | --- | --- |
| `Pincode.create/update/delete` | the model's | the checker's, for up to 24h |
| `clearPincodeCache` | the controller's | the shipping quote's |
| `Pincode.clearCache()` | — | it was called from nowhere |

**There was no sequence of callable operations that cleared both.** An admin correcting a pincode's ETA changed what the shipping quote said and did not change what the product page said, and had no way to make them agree.

`services/pincodeCache.js` is the one cache now. Keys are namespaced (`pincode:rows:110001`, `pincode:verdict:110001`) so the two kinds of answer about one pincode cannot collide — which is exactly what the old arrangement did — and `invalidate(pincode)` drops every namespace for that code, so a write reaches everything.

Two tests cover this behaviourally rather than structurally: write through the model, read through the controller's path, and check the answer moved.

### Three handlers with no route

`checkMultiplePincodes`, `searchPincodes` and `clearPincodeCache` were all exported from a 291-line controller and none had a route. `routes/pincodeRoutes.js` was five lines.

The unreachable one that mattered is the cache clear — it is the invalidation, so its absence is why a corrected pincode could take a day to show up.

### The cache-clear guard let anonymous callers through

```js
if (req.user && !hasPermission(req.user, PERMISSIONS.CACHE_MANAGE)) {
    return res.status(403).json({ message: "Unauthorized: Only admins can clear pincode cache" });
}
```

`req.user && ...`. A signed-in non-admin is refused. A caller with **no** `req.user` short-circuits the `&&` and falls straight through to `flushAll()`.

This was latent only because the route was unmounted — and mounting it, which is the obvious fix for the paragraph above, would have published an unauthenticated cache-flush endpoint under a message reading *"Only admins can clear pincode cache"*. The two defects were hiding each other.

`hasPermission(undefined, ...)` already returns `false` (`config/policy.js:239-244`), so the `req.user &&` was not protecting against a crash. It only weakened the check.

It is `authMiddleware` + `authorize(PERMISSIONS.CACHE_MANAGE)` at the route now, so an anonymous caller is a 401 before reaching a permission check at all. There is a test asserting the cache is still populated after an anonymous attempt.

### The hand-rolled rate limiter

```js
const rateLimiter = new Map();
```

`checkRateLimit` inserted one entry per client IP and never removed one. Entries were pruned *within* a key on the next request from that key, but a key visited once stayed for the lifetime of the process — an unbounded map keyed by attacker-supplied source addresses, on an unauthenticated endpoint reachable from the open internet. The only thing that emptied it was `rateLimiter.clear()` inside the handler that had no route.

It was also a re-implementation of something the repo already has, and got three things wrong that `middleware/rateLimiter.js` gets right: counters are per-process rather than shared (`redisRateLimitStore`), the key ignores the explicitly configured `trust proxy` (`customKeyGenerator`, `tests/rateLimitClientIdentity.test.js`), and it read `req.connection.remoteAddress`, deprecated since Node 13.

`pincodeLookupLimiter` keeps the same budget — 20 a minute — and is applied **at the router**, so a route added later cannot be missing it. All three public endpoints are behind it; previously only the single check was limited at all.

### A regex read from the environment as a string

```js
const PINCODE_REGEX = process.env.PINCODE_REGEX || /^\d{6}$/;
```

`process.env` values are strings. Set `PINCODE_REGEX` and every request became `TypeError: PINCODE_REGEX.test is not a function` — a 500 on the delivery checker caused by setting the variable that exists to configure it. The default was fine, which is why nobody hit it.

It is compiled now, and an unparseable pattern logs and falls back rather than taking the endpoint down. Both are tested.

### The answer includes what the row already knew

`serviceable_pincodes` stores `delivery_charges` and `cod_available`, and the seed data sets `cod_available` on all ten rows. The check returned `deliverable`, `eta_days`, `city`, `state` and prose, and dropped both.

For a shopper checking their pincode before buying, whether cash on delivery is available **is the question they came to ask**. Both are in the response and COD is mentioned in the message when it applies.

### The envelope

`checkPincode` spread its payload at the top level while the other two handlers in the same file returned `{success, data, total}`. The documented shape (`AGENTS.md`, `CONTRIBUTING.md`) is `{ success, message, data }`.

`frontend/scripts/pincode.js` reads `data.message` and `data.deliverable` **off the top level**, so it is written against the non-conforming one. Both shapes are served — `data` added, top-level fields kept — rather than breaking a live caller in a PR about serviceability. Moving the frontend and dropping the duplication belongs in its own change.

### Route policy

`GET /api/pincode/search` and `POST /api/pincode/check-multiple` are added to `PUBLIC_ROUTES` in `config/routePolicy.js`, with the reasoning written down beside them: same as the single check — a shopper asks whether you deliver to them before they have an account, often before they have a basket. Both read one public table, write nothing, and answer only what the delivery page already shows.

Two pinned lists needed updating and I want to flag that rather than let it pass unnoticed, because both exist as review gates:

- `tests/fixtures/policySnapshot.json` — the public-route snapshot. It exists so a new public route cannot appear without someone editing the snapshot on purpose. Two entries added.
- `tests/rateLimiter.test.js` — the limiter inventory. Its own comment says "a limiter added to the module without being added here fails the completeness test below, which is the point". One entry added.

Those are the only existing test files touched.

### Tests

**`tests/pincodeServiceability.test.js`** — 24 tests. The `deleted_at` assertions are on the **SQL**, deliberately: `db.query` is mocked and accepts any string, so no behavioural test in a suite without a live MySQL can see a missing `WHERE` clause — and a missing `WHERE` clause is the bug. Eight reads are each checked, plus a static sweep of the model that fails if a *new* query omits the guard.

The cache tests are the opposite and also deliberate: write through the model, read through the controller, assert the answer changed. Structure would not have caught the two-cache problem, because both caches were individually correct.

**`tests/pincodeRoutes.test.js`** — 19 tests. Each newly-mounted endpoint, and the cache clear against an anonymous caller (401), a signed-in shopper (403) and an admin (200) — plus one asserting the cache is *still populated* after the anonymous attempt, because "returns 401" and "did not flush" are different claims and it is the second one that matters.

### Deliberately not in this PR

**An admin CRUD surface for pincodes.** `Pincode.create/update/delete/restore` are model methods with no route, before this PR and after it. Giving them one is a feature with its own validation and audit questions; withdrawing a pincode via SQL and having the reads honour it is the bug, and that is fixed here.

**Moving `frontend/scripts/pincode.js` onto the `data` envelope.** Serving both shapes is the safe half; the caller change is a frontend PR.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

Full suite green on this branch: **68 suites, 1602 tests** (from 66 / 1558 on `main`). No migration — every column this uses has been in the baseline schema from the start.

No files in common with #1498, #1499 or #1500.
