### PR TITLE
Give the recentlyViewed key one owner, and make its reader load

### DIFF
--- a/backend/routes/recentlyViewedRoutes.js
+++ b/backend/routes/recentlyViewedRoutes.js
@@ -1,8 +1,33 @@
 // backend/routes/recentlyViewedRoutes.js
+//
+// Mounted at /api/recently-viewed.
+//
+// These two routes, `services/recentlyViewedService.js` (453 lines) and the
+// `recently_viewed` table have all existed for some time and no frontend file
+// has ever referenced the path (#1497). The site kept its history in
+// localStorage instead, so a signed-in shopper's history was per-browser, was
+// lost when they cleared site data, and did not follow them to another device
+// -- while the server-side store built for exactly that sat empty.
+//
+// frontend/scripts/recently-viewed-store.js is the first caller. Two things
+// were fixed on the way to giving them one:
+//
+//   * the failure envelope used `error` where the rest of the API uses
+//     `message` (AGENTS.md), so a client reading `response.message` on a
+//     failure got undefined;
+//   * `productId` was checked for presence and nothing else, so a malformed id
+//     reached the service and came back as a 500.
+
 const express = require('express');
 const router = express.Router();
 const authMiddleware = require('../middleware/authMiddleware');
 const recentlyViewedService = require('../services/recentlyViewedService');
+const { safeUUID } = require('../utils/helpers');
+
+/** The id on the token, under either of the two names login paths mint. */
+function callerId(req) {
+    return req.user && (req.user.id || req.user.userId);
+}
 
 /**
  * GET /api/recently-viewed
@@ -10,18 +35,18 @@ const recentlyViewedService = require('../services/recentlyViewedService');
  */
 router.get('/', authMiddleware, async (req, res) => {
     try {
-        const userId = req.user.id;
-        const viewed = await recentlyViewedService.getRecentlyViewed(userId);
+        const viewed = await recentlyViewedService.getRecentlyViewed(callerId(req));
 
         res.json({
             success: true,
+            message: 'Recently viewed products retrieved',
             data: viewed
         });
     } catch (error) {
         console.error('Get recently viewed error:', error);
         res.status(500).json({
             success: false,
-            error: 'Failed to get recently viewed'
+            message: 'Failed to get recently viewed'
         });
     }
 });
@@ -32,27 +57,31 @@ router.get('/', authMiddleware, async (req, res) => {
  */
 router.post('/', authMiddleware, async (req, res) => {
     try {
-        const { productId } = req.body;
-        const userId = req.user.id;
+        const productId = safeUUID(req.body?.productId);
 
         if (!productId) {
+            // `products.id` is a CHAR(36) UUID. This used to check only that
+            // the field was present, so anything else went to the service and
+            // came back as a 500 -- a client mistake reported as a server
+            // fault.
             return res.status(400).json({
                 success: false,
-                error: 'Product ID is required'
+                message: 'A valid product ID is required'
             });
         }
 
-        const viewed = await recentlyViewedService.addViewed(userId, productId);
+        const viewed = await recentlyViewedService.addViewed(callerId(req), productId);
 
         res.json({
             success: true,
+            message: 'Recently viewed updated',
             data: viewed
         });
     } catch (error) {
         console.error('Add recently viewed error:', error);
         res.status(500).json({
             success: false,
-            error: 'Failed to add recently viewed'
+            message: 'Failed to add recently viewed'
         });
     }
 });

--- a/backend/tests/recentlyViewed.test.js
+++ b/backend/tests/recentlyViewed.test.js
@@ -1,0 +1,572 @@
+// backend/tests/recentlyViewed.test.js
+//
+// Recently Viewed (#1497), driven for real in jsdom.
+//
+// The defects here cannot be asserted by reading the source, so they are not:
+// what matters is what ends up in localStorage and what ends up in the DOM.
+//
+//   1. `frontend/scripts/recentlyViewed.js` was a `type="module"` script that
+//      imported nine named bindings from `utils.js`. utils.js has no `export`
+//      statement anywhere -- it is a classic script assigning
+//      `window.AppUtils` -- and two of the nine, `safeText` and `safePrice`,
+//      do not exist in it under any spelling. The import failed at module
+//      resolution, so the file never ran and the homepage section never
+//      rendered. home-init.js calls `loadRecentlyViewed` behind a
+//      `typeof === "function"` guard, which is why it was silent.
+//   2. Three writers, two shapes. The reader expected a third.
+//   3. Both object writers deduplicated with `Number(item.id) !==
+//      Number(product.id)`. `products.id` is a UUID, `Number(uuid)` is NaN,
+//      `NaN !== NaN` is true -- so the filter never removed anything, for any
+//      product. Combined with product.js calling its writer twice from
+//      adjacent lines and product-render.js writing on render, one page view
+//      stored three copies.
+//
+// (3) is the one worth reading the tests for. It is not "sometimes wrong": no
+// UUID converts to a number, so deduplication was off for 100% of products.
+
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SCRIPTS = path.join(REPO_ROOT, 'frontend', 'scripts');
+
+const STORE_JS = fs.readFileSync(
+    path.join(SCRIPTS, 'recently-viewed-store.js'),
+    'utf8'
+);
+
+const UUID_A = '3f2a4c10-1111-4b22-8c33-0123456789ab';
+const UUID_B = 'a1b2c3d4-2222-4e55-9f66-fedcba987654';
+const UUID_C = 'deadbeef-3333-4777-8888-0f0f0f0f0f0f';
+
+/**
+ * A page with the store loaded and nothing else.
+ *
+ * @param {object} [options]
+ * @param {*} [options.seed] - what is already in localStorage
+ * @param {string|null} [options.token] - a signed-in shopper's token
+ * @param {Function} [options.apiRequest]
+ * @returns {object}
+ */
+function mountStore({ seed, token = null, apiRequest } = {}) {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+        url: 'https://shop.example/index.html',
+        runScripts: 'outside-only'
+    });
+
+    const { window } = dom;
+
+    if (seed !== undefined) {
+        window.localStorage.setItem('recentlyViewed', JSON.stringify(seed));
+    }
+
+    const requests = [];
+
+    window.AppUtils = {
+        getJSON: (key, fallback) => {
+            try {
+                const raw = window.localStorage.getItem(key);
+                return raw === null ? fallback : JSON.parse(raw);
+            } catch (error) {
+                return fallback;
+            }
+        },
+        setJSON: (key, value) => {
+            window.localStorage.setItem(key, JSON.stringify(value));
+        },
+        getToken: () => token,
+        apiRequest: (url, options) => {
+            requests.push({ url, options });
+            return apiRequest
+                ? apiRequest(url, options)
+                : Promise.resolve({ success: true, data: [] });
+        }
+    };
+
+    window.eval(STORE_JS);
+
+    return {
+        window,
+        store: window.RecentlyViewed,
+        requests,
+        stored: () => JSON.parse(window.localStorage.getItem('recentlyViewed') || '[]')
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Deduplication
+// ---------------------------------------------------------------------------
+
+describe('the dedupe that never fired', () => {
+    test('Number() on a UUID is why', () => {
+        // Not a claim about the store -- a claim about the predicate the two
+        // writers used. It is here so the reason is pinned, not only the fix.
+        expect(Number(UUID_A)).toBeNaN();
+        expect(Number(UUID_A) !== Number(UUID_A)).toBe(true);
+    });
+
+    test('recording the same product twice leaves one entry', () => {
+        const { store, stored } = mountStore();
+
+        store.record({ id: UUID_A, name: 'Classic Tee', price: 799 });
+        store.record({ id: UUID_A, name: 'Classic Tee', price: 799 });
+
+        expect(stored()).toHaveLength(1);
+    });
+
+    test('recording it three times still leaves one', () => {
+        // product.js called its writer twice from adjacent lines and
+        // product-render.js wrote again during render, so this was the real
+        // sequence for one page view.
+        const { store, stored } = mountStore();
+
+        store.record({ id: UUID_A, name: 'Classic Tee' });
+        store.record({ id: UUID_A, name: 'Classic Tee' });
+        store.record({ id: UUID_A, name: 'Classic Tee' });
+
+        expect(stored()).toHaveLength(1);
+    });
+
+    test('a repeat view moves the product to the front', () => {
+        const { store, stored } = mountStore();
+
+        store.record({ id: UUID_A, name: 'A' });
+        store.record({ id: UUID_B, name: 'B' });
+        store.record({ id: UUID_A, name: 'A' });
+
+        expect(stored().map((entry) => entry.id)).toEqual([UUID_A, UUID_B]);
+    });
+
+    test('ids are compared as strings, so a numeric id still dedupes', () => {
+        const { store, stored } = mountStore();
+
+        store.record({ id: 42, name: 'A' });
+        store.record({ id: '42', name: 'A' });
+
+        expect(stored()).toHaveLength(1);
+    });
+
+    test('three views of three products keep all three', () => {
+        // With the broken dedupe and three writes per view, the list held
+        // three copies of the most recent product and nothing else.
+        const { store, stored } = mountStore();
+
+        store.record({ id: UUID_A, name: 'A' });
+        store.record({ id: UUID_B, name: 'B' });
+        store.record({ id: UUID_C, name: 'C' });
+
+        expect(stored().map((entry) => entry.id)).toEqual([UUID_C, UUID_B, UUID_A]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// One shape, whatever is already there
+// ---------------------------------------------------------------------------
+
+describe('reading what older builds left behind', () => {
+    test('bare id strings are kept rather than discarded', () => {
+        // That is what trackRecentlyViewed wrote and what the homepage reader
+        // expected. A browser may still hold it, and a bare id is still a
+        // product somebody looked at -- it just cannot render a card on its
+        // own, so it is marked partial and the reader fills it in.
+        const { store } = mountStore({ seed: [UUID_A, UUID_B] });
+
+        const entries = store.list();
+
+        expect(entries).toHaveLength(2);
+        expect(entries[0].id).toBe(UUID_A);
+        expect(entries[0].partial).toBe(true);
+    });
+
+    test('a mixed array is normalised, not rejected', () => {
+        const { store } = mountStore({
+            seed: [UUID_A, { id: UUID_B, name: 'B', price: 10 }]
+        });
+
+        const entries = store.list();
+
+        expect(entries.map((entry) => entry.id)).toEqual([UUID_A, UUID_B]);
+        expect(entries[1].partial).toBe(false);
+    });
+
+    test('duplicates left by the broken dedupe are collapsed on read', () => {
+        const { store } = mountStore({
+            seed: [
+                { id: UUID_A, name: 'A' },
+                { id: UUID_A, name: 'A' },
+                { id: UUID_A, name: 'A' }
+            ]
+        });
+
+        expect(store.list()).toHaveLength(1);
+    });
+
+    test('junk in the key reads as empty rather than throwing', () => {
+        const { window, store } = mountStore();
+
+        window.localStorage.setItem('recentlyViewed', 'not json');
+
+        expect(store.list()).toEqual([]);
+    });
+
+    test('a non-array value reads as empty', () => {
+        const { store } = mountStore({ seed: { id: UUID_A } });
+
+        expect(store.list()).toEqual([]);
+    });
+
+    test('entries with no usable id are dropped', () => {
+        const { store } = mountStore({
+            seed: [{ name: 'no id' }, null, '', { id: '   ' }, { id: UUID_A, name: 'A' }]
+        });
+
+        expect(store.list().map((entry) => entry.id)).toEqual([UUID_A]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// One cap
+// ---------------------------------------------------------------------------
+
+describe('the cap', () => {
+    test('is one number, not 8 in one file and 10 in another', () => {
+        const { store, stored } = mountStore();
+
+        for (let i = 0; i < 20; i += 1) {
+            store.record({ id: `${UUID_A.slice(0, -2)}${String(i).padStart(2, '0')}`, name: `P${i}` });
+        }
+
+        expect(stored()).toHaveLength(store.MAX_ENTRIES);
+    });
+
+    test('keeps the most recent', () => {
+        const { store } = mountStore();
+
+        for (let i = 0; i < 12; i += 1) {
+            store.record({ id: `id-${i}`, name: `P${i}` });
+        }
+
+        expect(store.list()[0].id).toBe('id-11');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The server side that had no caller
+// ---------------------------------------------------------------------------
+
+describe('syncing to the account', () => {
+    test('a signed-out shopper touches no endpoint', () => {
+        const { store, requests } = mountStore({ token: null });
+
+        store.record({ id: UUID_A, name: 'A' });
+
+        expect(requests).toEqual([]);
+    });
+
+    test('a signed-in shopper records the view server-side', () => {
+        const { store, requests } = mountStore({ token: 'jwt' });
+
+        store.record({ id: UUID_A, name: 'A' });
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0].url).toBe('/recently-viewed');
+        expect(JSON.parse(requests[0].options.body)).toEqual({ productId: UUID_A });
+    });
+
+    test('a failed sync does not lose the local entry', () => {
+        // Recently-viewed is a convenience. A sync failure must never surface
+        // to a shopper or undo what the browser already knows.
+        const { store, stored } = mountStore({
+            token: 'jwt',
+            apiRequest: () => Promise.reject(new Error('offline'))
+        });
+
+        store.record({ id: UUID_A, name: 'A' });
+
+        expect(stored()).toHaveLength(1);
+    });
+
+    test('hydrate merges the account history with what this browser has', async () => {
+        const now = Date.now();
+
+        const { store } = mountStore({
+            token: 'jwt',
+            seed: [{ id: UUID_A, name: 'Local', viewedAt: now - 1000 }],
+            apiRequest: () =>
+                Promise.resolve({
+                    success: true,
+                    data: [{ id: UUID_B, name: 'Remote', viewedAt: now - 5000 }]
+                })
+        });
+
+        const merged = await store.hydrate();
+
+        // A shopper who browsed signed out and then signed in should not lose
+        // what they were looking at, so this merges rather than replacing.
+        expect(merged.map((entry) => entry.id)).toEqual([UUID_A, UUID_B]);
+    });
+
+    test('an entry older than the retention window is dropped on read', async () => {
+        // Thirty days. A product somebody looked at last spring is not
+        // "recently viewed", and without this the list is only ever trimmed by
+        // the cap.
+        const { store } = mountStore({
+            seed: [
+                { id: UUID_A, name: 'Old', viewedAt: 1000 },
+                { id: UUID_B, name: 'New', viewedAt: Date.now() }
+            ]
+        });
+
+        expect(store.list().map((entry) => entry.id)).toEqual([UUID_B]);
+    });
+
+    test('hydrate does nothing when signed out', async () => {
+        const { store, requests } = mountStore({
+            token: null,
+            seed: [{ id: UUID_A, name: 'Local' }]
+        });
+
+        const result = await store.hydrate();
+
+        expect(requests).toEqual([]);
+        expect(result).toHaveLength(1);
+    });
+
+    test('hydrate survives a failing endpoint', async () => {
+        const { store } = mountStore({
+            token: 'jwt',
+            seed: [{ id: UUID_A, name: 'Local' }],
+            apiRequest: () => Promise.reject(new Error('500'))
+        });
+
+        await expect(store.hydrate()).resolves.toHaveLength(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The reader
+// ---------------------------------------------------------------------------
+
+describe('the homepage carousel', () => {
+    const RECENTLY_VIEWED_JS = fs.readFileSync(
+        path.join(SCRIPTS, 'recentlyViewed.js'),
+        'utf8'
+    );
+
+    /**
+     * The homepage section, with the store and the renderer loaded.
+     */
+    function mountCarousel({ seed, token = null, apiRequest } = {}) {
+        const harness = mountStore({ seed, token, apiRequest });
+
+        harness.window.document.body.innerHTML =
+            '<div id="recently-viewed-container"></div>';
+
+        harness.window.AppUtils.escapeHTML = (value) =>
+            String(value)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;');
+        harness.window.AppUtils.formatPrice = (value) => `₹${value}`;
+        harness.window.AppUtils.defaultImage = (value) => value || '/placeholder.png';
+        harness.window.AppUtils.renderSkeletonState = () => {};
+
+        harness.window.eval(RECENTLY_VIEWED_JS);
+
+        harness.container = harness.window.document.getElementById(
+            'recently-viewed-container'
+        );
+
+        return harness;
+    }
+
+    test('it loads at all', () => {
+        // The regression. As a module importing from a file with no exports,
+        // this script never executed and never assigned the global -- and the
+        // only caller checks `typeof === "function"` first, so nothing failed
+        // loudly.
+        const { window } = mountCarousel();
+
+        expect(typeof window.loadRecentlyViewed).toBe('function');
+    });
+
+    test('it renders the products the writers stored', async () => {
+        const { window, container } = mountCarousel({
+            seed: [
+                { id: UUID_A, name: 'Classic Tee', price: 799, image: '/a.png' },
+                { id: UUID_B, name: 'Denim Jacket', price: 2499, image: '/b.png' }
+            ]
+        });
+
+        await window.loadRecentlyViewed();
+
+        expect(container.querySelectorAll('.pro')).toHaveLength(2);
+        expect(container.textContent).toContain('Classic Tee');
+        expect(container.textContent).toContain('Denim Jacket');
+    });
+
+    test('it issues no request when the entries already carry their fields', async () => {
+        // It used to fetch every entry by id on every homepage load, to
+        // recover data the writers had already stored.
+        const { window, requests } = mountCarousel({
+            seed: [{ id: UUID_A, name: 'Classic Tee', price: 799 }]
+        });
+
+        await window.loadRecentlyViewed();
+
+        expect(requests).toEqual([]);
+    });
+
+    test('it fetches only the id-only entries an older build left', async () => {
+        const { window, requests, container } = mountCarousel({
+            seed: [UUID_A, { id: UUID_B, name: 'Denim Jacket', price: 2499 }],
+            apiRequest: (url) =>
+                Promise.resolve({
+                    success: true,
+                    product: { id: UUID_A, name: 'Fetched Tee', price: 799 }
+                })
+        });
+
+        await window.loadRecentlyViewed();
+
+        const productRequests = requests.filter((request) =>
+            request.url.startsWith('/products/')
+        );
+
+        expect(productRequests).toHaveLength(1);
+        expect(productRequests[0].url).toContain(UUID_A);
+        expect(container.textContent).toContain('Fetched Tee');
+        expect(container.textContent).toContain('Denim Jacket');
+    });
+
+    test('an object in the key never reaches a URL', async () => {
+        // The reader read the key as ids and interpolated each into
+        // `/products/${id}`. With objects in there that was
+        // `/products/[object Object]`, which the uuid guard answers 400 to --
+        // so every card failed and the section said "No recently viewed
+        // products available."
+        const { window, requests } = mountCarousel({
+            seed: [{ id: UUID_A, name: 'Classic Tee', price: 799 }]
+        });
+
+        await window.loadRecentlyViewed();
+
+        for (const request of requests) {
+            expect(request.url).not.toContain('[object');
+        }
+    });
+
+    test('it says so when there is nothing to show', async () => {
+        const { window, container } = mountCarousel({ seed: [] });
+
+        await window.loadRecentlyViewed();
+
+        expect(container.textContent).toContain('No recently viewed products yet');
+    });
+
+    test('a product name is escaped before it reaches the DOM', async () => {
+        const { window, container } = mountCarousel({
+            seed: [{ id: UUID_A, name: '<img src=x onerror=alert(1)>', price: 1 }]
+        });
+
+        await window.loadRecentlyViewed();
+
+        expect(container.querySelector('img[onerror]')).toBeNull();
+    });
+
+    test('an entry with no stock figure is not rendered as sold out', async () => {
+        // The old check was `Number(stock) === 0`, which reads a missing
+        // figure as in stock and a null one as sold out. A stored entry may
+        // carry no stock at all, and unknown is not sold out.
+        const { window, container } = mountCarousel({
+            seed: [{ id: UUID_A, name: 'Classic Tee', price: 799 }]
+        });
+
+        await window.loadRecentlyViewed();
+
+        expect(container.querySelector('.out-of-stock-overlay')).toBeNull();
+        expect(container.querySelector('.stock-badge')).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// One writer
+// ---------------------------------------------------------------------------
+
+describe('the key has one owner', () => {
+    const WRITERS = [
+        'product.js',
+        'product-render.js',
+        'related-products.js',
+        'recentlyViewed.js'
+    ];
+
+    test.each(WRITERS)('%s does not write the key directly', (name) => {
+        const source = fs.readFileSync(path.join(SCRIPTS, name), 'utf8');
+
+        // Comments in these files quote the old code while explaining it.
+        const code = source
+            .split('\n')
+            .map((line) => (/^\s*(\/\/|\/\*|\*)/.test(line) ? '' : line))
+            .join('\n');
+
+        expect(code).not.toMatch(/setJSON\(\s*["']recentlyViewed["']/);
+        expect(code).not.toMatch(/localStorage\.setItem\(\s*["']recentlyViewed["']/);
+    });
+
+    test.each(WRITERS)('%s compares no id with Number()', (name) => {
+        const source = fs.readFileSync(path.join(SCRIPTS, name), 'utf8');
+
+        const code = source
+            .split('\n')
+            .map((line) => (/^\s*(\/\/|\/\*|\*)/.test(line) ? '' : line))
+            .join('\n')
+            // Collapse whitespace: product-render.js puts every argument on
+            // its own line, so the comparison spans eight of them.
+            .replace(/\s+/g, ' ');
+
+        expect(code).not.toMatch(/Number\(\s*item\.id\s*\)/);
+    });
+
+    test('no page loads recentlyViewed.js as a module', () => {
+        // utils.js has no exports, so a module importing from it is discarded
+        // before it runs.
+        const pages = fs
+            .readdirSync(path.join(REPO_ROOT, 'frontend'))
+            .filter((name) => name.endsWith('.html'));
+
+        const offenders = [];
+
+        for (const page of pages) {
+            const html = fs.readFileSync(path.join(REPO_ROOT, 'frontend', page), 'utf8');
+
+            for (const tag of html.match(/<script[^>]*>/g) || []) {
+                if (/type\s*=\s*["']module["']/.test(tag) && /scripts\//.test(tag)) {
+                    offenders.push(`${page}: ${tag.replace(/\s+/g, ' ')}`);
+                }
+            }
+        }
+
+        expect(offenders).toEqual([]);
+    });
+
+    test('every page that reads or writes the key loads the store first', () => {
+        const pages = ['index.html', 'product.html'];
+
+        for (const page of pages) {
+            const html = fs.readFileSync(path.join(REPO_ROOT, 'frontend', page), 'utf8');
+
+            const storeAt = html.indexOf('recently-viewed-store.js');
+            expect(storeAt).toBeGreaterThan(-1);
+
+            for (const consumer of ['recentlyViewed.js', 'product-render.js', 'product.js']) {
+                const at = html.indexOf(`scripts/${consumer}`);
+                if (at === -1) continue;
+
+                expect(storeAt).toBeLessThan(at);
+            }
+        }
+    });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -536,8 +536,18 @@
         defer
         src="scripts/recommendations.js"
     ></script>
+    <!-- The single owner of the recentlyViewed key (#1497). Must load before
+         any script that records or reads a view. -->
     <script
-        type="module"
+        defer
+        src="scripts/recently-viewed-store.js"
+    ></script>
+
+    <!-- Was type="module", importing named bindings from utils.js, which
+         exports nothing. The import failed at module resolution and the whole
+         file was discarded, so this section never rendered (#1497). -->
+    <script
+        defer
         src="scripts/recentlyViewed.js"
     ></script>
   </body>

--- a/frontend/product.html
+++ b/frontend/product.html
@@ -923,6 +923,13 @@
     ></script>
 
     <!-- Product Modules -->
+    <!-- The single owner of the recentlyViewed key (#1497). Must load before
+         product-render.js and product.js, both of which record a view. -->
+    <script
+        defer
+        src="scripts/recently-viewed-store.js"
+    ></script>
+
     <script
         defer
         src="scripts/product-render.js"

--- a/frontend/scripts/product-render.js
+++ b/frontend/scripts/product-render.js
@@ -368,65 +368,27 @@ function renderProductRating(
 }
 
 // recently viewed
+//
+// This wrote the `recentlyViewed` key directly, deduplicating with
+// `Number(item.id) !== Number(product.id)` -- and `products.id` is a CHAR(36)
+// UUID, so `Number(uuid)` is NaN, `NaN !== NaN` is true, and the filter
+// removed nothing for any product, ever (#1497). It also capped at 8 while
+// product.js capped the same key at 10 in the same page load.
+//
+// Both are window.RecentlyViewed's business now, and it is the only writer.
 function updateRecentlyViewed(
     product
 ) {
 
-    let viewed =
-        AppUtils.getJSON(
-            "recentlyViewed",
-            []
-        );
+    if (
+        !product
+        || !window.RecentlyViewed
+    ) {
+        return;
+    }
 
-    viewed =
-        AppUtils.safeArray(
-            viewed
-        ).filter(
-            (
-                item
-            ) => {
-
-                return (
-                    Number(
-                        item.id
-                    ) !==
-                    Number(
-                        product.id
-                    )
-                );
-            }
-        );
-
-    viewed.unshift({
-
-        id:
-            product.id,
-
-        name:
-            product.name,
-
-        brand:
-            product.brand,
-
-        category:
-            product.category,
-
-        price:
-            product.price,
-
-        image:
-            product.image
-    });
-
-    viewed =
-        viewed.slice(
-            0,
-            8
-        );
-
-    AppUtils.setJSON(
-        "recentlyViewed",
-        viewed
+    window.RecentlyViewed.record(
+        product
     );
 }
 
@@ -589,9 +551,14 @@ function renderProduct(
         product
     );
 
-    updateRecentlyViewed(
-        product
-    );
+    // `updateRecentlyViewed(product)` was called here. Recording a view is not
+    // rendering, and this was the third write of the same product to the same
+    // key in one page load (#1497) -- product.js already records it when the
+    // product is fetched, which is where the view actually happens.
+    //
+    // The function is kept and still exported: it delegates to the store now,
+    // so an external caller that has always had `window.updateRecentlyViewed`
+    // keeps working and gets the deduplicated behaviour.
 }
 
 

--- a/frontend/scripts/product.js
+++ b/frontend/scripts/product.js
@@ -156,26 +156,15 @@ function cacheProduct(
 // TRACK RECENTLY VIEWED PRODUCTS (Issue #1126)
 // ========================================
 
-function trackRecentlyViewed(productId) {
-    if (!productId) return;
-    
-    // Get existing recently viewed IDs from localStorage
-    let recentlyViewed = AppUtils.getJSON('recentlyViewed', []);
-    
-    // Remove if already exists (to move to front)
-    recentlyViewed = recentlyViewed.filter(id => id !== productId);
-    
-    // Add to front
-    recentlyViewed.unshift(productId);
-    
-    // Keep only last 10
-    if (recentlyViewed.length > 10) {
-        recentlyViewed = recentlyViewed.slice(0, 10);
-    }
-    
-    // Save to localStorage
-    AppUtils.setJSON('recentlyViewed', recentlyViewed);
-}
+// `trackRecentlyViewed` used to live here. It wrote the `recentlyViewed` key
+// as an array of bare id strings, capped at 10, and nothing in the frontend
+// ever called it -- grepping the whole directory for the name returned one
+// hit, its own declaration (#1497). It also disagreed with the two writers
+// that *were* live, both of which stored objects, so leaving it in place meant
+// a fourth shape sitting there waiting for its first caller.
+//
+// Recording a view is `window.RecentlyViewed.record()` now, which owns the key
+// and is the only thing that writes it. See recently-viewed-store.js.
 
 // ========================================
 // Breadcrumb Navigation (Issue #344)
@@ -296,20 +285,25 @@ async function toggleWishlist(productId) {
     // ============================================
     // RECENTLY VIEWED
     // ============================================
+    //
+    // This wrote localStorage directly and deduplicated with
+    // `Number(item.id) !== Number(product.id)`. `products.id` is a CHAR(36)
+    // UUID, `Number(uuid)` is NaN, and `NaN !== NaN` is true -- so the
+    // predicate held for every element and the filter removed nothing, ever,
+    // for any product (#1497). Same defect as #1443, where router.param ran
+    // UUIDs through parseInt.
+    //
+    // It also disagreed with product-render.js on the cap (10 against 8) while
+    // both wrote the same key in the same page load.
     function saveRecentlyViewed(product) {
         if (!product) return;
 
-        const recentlyViewed = JSON.parse(localStorage.getItem("recentlyViewed")) || [];
-        const filtered = recentlyViewed.filter((item) => Number(item.id) !== Number(product.id));
+        if (!window.RecentlyViewed) {
+            console.warn("recently-viewed-store.js is not loaded; view not recorded");
+            return;
+        }
 
-        filtered.unshift({
-            id: product.id,
-            name: product.name,
-            price: product.price,
-            image: product.image
-        });
-
-        localStorage.setItem("recentlyViewed", JSON.stringify(filtered.slice(0, 10)));
+        window.RecentlyViewed.record(product);
     }
 
     // ============================================
@@ -536,13 +530,14 @@ async function toggleWishlist(productId) {
 
             if (response && response.success && response.product) {
                 currentProductData = response.product;
-
-                saveRecentlyViewed(currentProductData);
-
                 window.currentProductData = currentProductData;
-                if (typeof saveRecentlyViewed === "function") {
-                    saveRecentlyViewed(currentProductData);
-                }
+
+                // Once. This was two calls from adjacent lines -- one bare,
+                // one behind a `typeof === "function"` guard on the function
+                // declared six lines above it -- and product-render.js wrote
+                // the same key again during render, so a single page view put
+                // three copies of the product in the list (#1497).
+                saveRecentlyViewed(currentProductData);
 
                 cacheProduct(currentProductData);
             } else {

--- a/frontend/scripts/recently-viewed-store.js
+++ b/frontend/scripts/recently-viewed-store.js
@@ -1,0 +1,307 @@
+// frontend/scripts/recently-viewed-store.js
+//
+// The single owner of the `recentlyViewed` localStorage key (#1497).
+//
+// There were three writers and two readers, in two incompatible shapes:
+//
+//   product.js       trackRecentlyViewed()  array of id strings, cap 10 -- and
+//                                           never called by anything
+//   product.js       saveRecentlyViewed()   array of objects, cap 10
+//   product-render.js updateRecentlyViewed() array of objects, cap 8
+//   recentlyViewed.js loadRecentlyViewed()  read as id strings
+//   related-products.js                     read as objects
+//
+// product.html loads two of the writers and one of the readers; index.html
+// loads the other reader. So the page that writes and the page that reads did
+// not agree on what was in the key.
+//
+// Both object writers deduplicated with `Number(item.id) !== Number(product.id)`.
+// `products.id` is a CHAR(36) UUID, `Number(uuid)` is NaN, and `NaN !== NaN` is
+// true -- so the predicate held for every element and the filter removed
+// nothing, ever, for any product. Combined with saveRecentlyViewed being called
+// twice from adjacent lines plus updateRecentlyViewed on render, one page view
+// wrote three copies of the same product.
+//
+// One module, one shape, one cap, dedupe on the id as a string.
+
+(function () {
+    "use strict";
+
+    const STORAGE_KEY =
+        (window.CONFIG && window.CONFIG.STORAGE_KEYS
+            && window.CONFIG.STORAGE_KEYS.RECENTLY_VIEWED)
+        || "recentlyViewed";
+
+    /**
+     * How many products are kept.
+     *
+     * One number. It was 10 in one writer and 8 in another, on the same key in
+     * the same page load, so the length depended on which ran last.
+     */
+    const MAX_ENTRIES = 8;
+
+    /** Entries older than this are dropped on read. */
+    const MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+    /**
+     * Read the key, tolerating whatever is in it.
+     *
+     * Existing browsers hold the old mixed contents: bare id strings from one
+     * writer, objects from the others, duplicates from the broken dedupe. This
+     * migrates what it can and drops what it cannot rather than making
+     * everyone clear their storage -- a bare id is still a product somebody
+     * looked at, it just has no name or price to render, so it is kept with
+     * `partial: true` and the reader fills it in.
+     *
+     * @returns {Array<object>}
+     */
+    function read() {
+        const raw = window.AppUtils && window.AppUtils.getJSON
+            ? window.AppUtils.getJSON(STORAGE_KEY, [])
+            : safeParse(window.localStorage.getItem(STORAGE_KEY));
+
+        if (!Array.isArray(raw)) {
+            return [];
+        }
+
+        const now = Date.now();
+        const seen = new Set();
+        const entries = [];
+
+        for (const item of raw) {
+            const entry = normalise(item);
+
+            if (!entry) continue;
+            // The dedupe that never fired. On strings this time.
+            if (seen.has(entry.id)) continue;
+            if (entry.viewedAt && now - entry.viewedAt > MAX_AGE_MS) continue;
+
+            seen.add(entry.id);
+            entries.push(entry);
+        }
+
+        return entries.slice(0, MAX_ENTRIES);
+    }
+
+    /**
+     * Coerce one stored item into the canonical shape, or null.
+     *
+     * @param {*} item
+     * @returns {object|null}
+     */
+    function normalise(item) {
+        if (typeof item === "string") {
+            // The shape trackRecentlyViewed wrote and loadRecentlyViewed
+            // expected. Nothing calls that writer, but a browser may still be
+            // holding what an older build left.
+            const id = item.trim();
+            return id ? { id, partial: true, viewedAt: null } : null;
+        }
+
+        if (!item || typeof item !== "object") {
+            return null;
+        }
+
+        // String, always. An id compared as a number is the bug this module
+        // exists for.
+        const id = item.id === undefined || item.id === null
+            ? ""
+            : String(item.id).trim();
+
+        if (!id) return null;
+
+        return {
+            id,
+            name: item.name || null,
+            brand: item.brand || null,
+            category: item.category || null,
+            price: item.price === undefined ? null : item.price,
+            image: item.image || null,
+            stock: item.stock === undefined ? null : item.stock,
+            rating: item.rating === undefined ? null : item.rating,
+            viewedAt: Number(item.viewedAt) || null,
+            // An entry with no name cannot render a card on its own.
+            partial: !item.name
+        };
+    }
+
+    /**
+     * @param {Array<object>} entries
+     */
+    function write(entries) {
+        const capped = entries.slice(0, MAX_ENTRIES);
+
+        if (window.AppUtils && window.AppUtils.setJSON) {
+            window.AppUtils.setJSON(STORAGE_KEY, capped);
+            return;
+        }
+
+        try {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(capped));
+        } catch (error) {
+            // A full or blocked localStorage must not take the product page
+            // down over a nice-to-have carousel.
+            console.warn("Could not store recently viewed:", error);
+        }
+    }
+
+    /**
+     * Record a product view.
+     *
+     * Idempotent for one product: calling it twice in a row moves the entry to
+     * the front and leaves one of it. That matters because product.js calls
+     * its writer twice from adjacent lines today.
+     *
+     * @param {object|string} product - a product object, or just its id
+     * @returns {Array<object>} the list as it now stands
+     */
+    function record(product) {
+        const entry = normalise(
+            typeof product === "string" ? product : product || null
+        );
+
+        if (!entry) {
+            return read();
+        }
+
+        entry.viewedAt = Date.now();
+
+        const rest = read().filter((item) => item.id !== entry.id);
+        const next = [entry, ...rest];
+
+        write(next);
+        syncToServer(entry.id);
+
+        return next;
+    }
+
+    /**
+     * @returns {Array<object>} most recent first
+     */
+    function list() {
+        return read();
+    }
+
+    /**
+     * Remove one product.
+     *
+     * @param {string} productId
+     */
+    function forget(productId) {
+        const id = String(productId || "").trim();
+        write(read().filter((item) => item.id !== id));
+    }
+
+    /** Drop everything. */
+    function clear() {
+        write([]);
+    }
+
+    // -----------------------------------------------------------------------
+    // The server side
+    // -----------------------------------------------------------------------
+    //
+    // `GET/POST /api/recently-viewed`, `services/recentlyViewedService.js` (453
+    // lines) and the `recently_viewed` table have existed the whole time and no
+    // frontend file has ever referenced the path. So a signed-in shopper's
+    // history is per-browser, is lost when they clear site data, and does not
+    // follow them to another device, while the store built for exactly that
+    // sits empty.
+    //
+    // Both calls are best-effort. Recently-viewed is a convenience, and a
+    // failed sync must never surface to a shopper or block a render.
+
+    /** Whether there is an account to sync against. */
+    function isSignedIn() {
+        return Boolean(
+            window.AppUtils
+            && window.AppUtils.getToken
+            && window.AppUtils.getToken()
+        );
+    }
+
+    /**
+     * @param {string} productId
+     */
+    function syncToServer(productId) {
+        if (!isSignedIn() || !window.AppUtils || !window.AppUtils.apiRequest) {
+            return;
+        }
+
+        window.AppUtils
+            .apiRequest("/recently-viewed", {
+                method: "POST",
+                body: JSON.stringify({ productId })
+            })
+            .catch(() => {});
+    }
+
+    /**
+     * Seed the local list from the account's history.
+     *
+     * Merged rather than replacing: what this browser has is real, and a
+     * shopper who browsed signed out and then signed in should not lose it.
+     *
+     * @returns {Promise<Array<object>>}
+     */
+    async function hydrate() {
+        if (!isSignedIn() || !window.AppUtils || !window.AppUtils.apiRequest) {
+            return read();
+        }
+
+        try {
+            const response = await window.AppUtils.apiRequest("/recently-viewed");
+            const remote = Array.isArray(response && response.data)
+                ? response.data
+                : [];
+
+            if (!remote.length) {
+                return read();
+            }
+
+            const local = read();
+            const seen = new Set(local.map((item) => item.id));
+            const merged = local.slice();
+
+            for (const item of remote) {
+                const entry = normalise(item);
+                if (!entry || seen.has(entry.id)) continue;
+
+                seen.add(entry.id);
+                merged.push(entry);
+            }
+
+            merged.sort((a, b) => (b.viewedAt || 0) - (a.viewedAt || 0));
+            write(merged);
+
+            return merged.slice(0, MAX_ENTRIES);
+        } catch (error) {
+            return read();
+        }
+    }
+
+    /**
+     * @param {string|null} value
+     * @returns {*}
+     */
+    function safeParse(value) {
+        if (!value) return [];
+        try {
+            return JSON.parse(value);
+        } catch (error) {
+            return [];
+        }
+    }
+
+    window.RecentlyViewed = {
+        STORAGE_KEY,
+        MAX_ENTRIES,
+        MAX_AGE_MS,
+        record,
+        list,
+        forget,
+        clear,
+        hydrate,
+        normalise
+    };
+})();

--- a/frontend/scripts/recentlyViewed.js
+++ b/frontend/scripts/recentlyViewed.js
@@ -1,170 +1,294 @@
-import {
-    getJSON,
-    setJSON,
-    $,
-    defaultImage,
-    safeText,
-    safePrice,
-    formatPrice,
-    apiRequest,
-    notify
-} from "./utils.js";
+// frontend/scripts/recentlyViewed.js
+//
+// The Recently Viewed carousel on the homepage (#1497).
+//
+// This file used to be a `type="module"` script that began:
+//
+//     import { getJSON, setJSON, $, defaultImage, safeText, safePrice,
+//              formatPrice, apiRequest, notify } from "./utils.js";
+//
+// `utils.js` contains no `export` statement at all -- it is a classic script
+// that assigns `window.AppUtils` -- and two of those names, `safeText` and
+// `safePrice`, do not exist in it under any spelling. So the import failed at
+// module-resolution time:
+//
+//     Uncaught SyntaxError: The requested module './utils.js'
+//     does not provide an export named 'getJSON'
+//
+// The whole module was discarded before a line of it ran. `loadRecentlyViewed`
+// never executed, `window.loadRecentlyViewed` was never assigned, and the call
+// home-init.js makes to it was guarded by `typeof ... === "function"` so the
+// omission was silent. The section on the homepage has never rendered.
+//
+// It is a classic script now, like every other file in this directory, reading
+// helpers off `window.AppUtils`.
+//
+// The second defect was the shape. It read the key as an array of id strings
+// and fetched each one -- `apiRequest('/products/' + id)`. The writers store
+// objects, so had the module ever loaded the URL would have been
+// `/products/[object Object]`. It reads through window.RecentlyViewed now,
+// which owns the key and hands back one shape, and renders from the stored
+// fields instead of issuing six requests to recover data it already has.
 
-// ========================================
-// STOCK STATUS HELPERS (Issue #1123)
-// ========================================
+(function () {
+    "use strict";
 
-function getStockBadgeHTML(stock) {
-    const stockNum = Number(stock) || 0;
-    
-    if (stockNum === 0) {
-        return `<span class="stock-badge out-of-stock">Out of Stock</span>`;
-    } else if (stockNum <= 5) {
-        return `<span class="stock-badge low-stock">Only ${stockNum} left</span>`;
-    } else {
+    const CONTAINER_ID = "recently-viewed-container";
+    const MAX_CARDS = 6;
+
+    /** Helpers, off the global the rest of the frontend uses. */
+    function utils() {
+        return window.AppUtils || {};
+    }
+
+    function safeText(value, fallback = "") {
+        const text = value === undefined || value === null ? "" : String(value);
+        const resolved = text.trim() || fallback;
+
+        return utils().escapeHTML ? utils().escapeHTML(resolved) : resolved;
+    }
+
+    function safePrice(value) {
+        const price = Number(value);
+        return Number.isFinite(price) && price >= 0 ? price : 0;
+    }
+
+    function formatPrice(value) {
+        return utils().formatPrice ? utils().formatPrice(value) : `₹${value}`;
+    }
+
+    function defaultImage(value) {
+        return utils().defaultImage ? utils().defaultImage(value) : value || "";
+    }
+
+    // ========================================
+    // STOCK STATUS HELPERS (Issue #1123)
+    // ========================================
+
+    function getStockBadgeHTML(stock) {
+        const stockNum = Number(stock) || 0;
+
+        if (stockNum === 0) {
+            return `<span class="stock-badge out-of-stock">Out of Stock</span>`;
+        }
+        if (stockNum <= 5) {
+            return `<span class="stock-badge low-stock">Only ${stockNum} left</span>`;
+        }
         return `<span class="stock-badge in-stock">In Stock</span>`;
     }
-}
 
-function getOutOfStockOverlayHTML(stock) {
-    const stockNum = Number(stock) || 0;
-    if (stockNum === 0) {
-        return `<div class="out-of-stock-overlay">Sold Out</div>`;
+    function getOutOfStockOverlayHTML(stock) {
+        // Via isOutOfStock, not `Number(stock) === 0`: `Number(null)` and
+        // `Number(undefined && "")` are 0, so a stored entry with no stock
+        // figure was rendered as sold out.
+        return isOutOfStock(stock)
+            ? `<div class="out-of-stock-overlay">Sold Out</div>`
+            : "";
     }
-    return '';
-}
 
-function getLowStockTextHTML(stock) {
-    const stockNum = Number(stock) || 0;
-    if (stockNum > 0 && stockNum <= 5) {
-        return `<span class="low-stock-text">⚡ Hurry! Only ${stockNum} left</span>`;
+    function getLowStockTextHTML(stock) {
+        const stockNum = Number(stock) || 0;
+
+        if (stockNum > 0 && stockNum <= 5) {
+            return `<span class="low-stock-text">⚡ Hurry! Only ${stockNum} left</span>`;
+        }
+        return "";
     }
-    return '';
-}
 
-function isOutOfStock(stock) {
-    return Number(stock) === 0;
-}
+    /**
+     * Whether a product is known to be out of stock.
+     *
+     * A stored entry may carry no stock figure at all, and "unknown" is not
+     * "sold out" -- the old check was `Number(stock) === 0`, which reads
+     * `undefined` as in stock and `null` as sold out.
+     */
+    function isOutOfStock(stock) {
+        if (stock === null || stock === undefined || stock === "") {
+            return false;
+        }
+        return Number(stock) === 0;
+    }
 
-// ========================================
-// RECENTLY VIEWED PRODUCT CARD
-// ========================================
+    // ========================================
+    // RECENTLY VIEWED PRODUCT CARD
+    // ========================================
 
-function renderRecentlyViewedCard(product) {
-    if (!product) return '';
-    
-    const stock = Number(product.stock) || 0;
-    const outOfStock = isOutOfStock(stock);
-    const outOfStockClass = outOfStock ? 'out-of-stock' : '';
-    
-    // Rating stars
-    const rating = Math.min(5, Math.max(0, Number(product.rating || 4)));
-    const stars = Array.from({ length: 5 }, (_, i) => {
-        return `<i class="fas fa-star${i < rating ? '' : '-o'}"></i>`;
-    }).join('');
+    function renderRecentlyViewedCard(product) {
+        if (!product) return "";
 
-    return `
-        <div class="pro ${outOfStockClass}" data-id="${product.id}">
+        const stock = product.stock;
+        const outOfStock = isOutOfStock(stock);
+        const outOfStockClass = outOfStock ? "out-of-stock" : "";
+        const productId = safeText(product.id);
+
+        const rating = Math.min(5, Math.max(0, Number(product.rating || 4)));
+        const stars = Array.from({ length: 5 }, (_, index) =>
+            `<i class="fas fa-star${index < rating ? "" : "-o"}"></i>`
+        ).join("");
+
+        return `
+        <div class="pro ${outOfStockClass}" data-id="${productId}">
             <div style="position: relative;">
-                <img 
-                    src="${defaultImage(product.image)}" 
-                    alt="${safeText(product.name, 'Product')}"
+                <img
+                    src="${defaultImage(product.image)}"
+                    alt="${safeText(product.name, "Product")}"
                     loading="lazy"
                 >
-                ${getStockBadgeHTML(stock)}
+                ${stock === null || stock === undefined ? "" : getStockBadgeHTML(stock)}
                 ${getOutOfStockOverlayHTML(stock)}
                 <span class="product-badge" style="background: #6c3bff;">Recently Viewed</span>
             </div>
             <div class="des">
-                <span>${safeText(product.category, 'Fashion')}</span>
-                <h5>${safeText(product.name, 'Product')}</h5>
+                <span>${safeText(product.category, "Fashion")}</span>
+                <h5>${safeText(product.name, "Product")}</h5>
                 <div class="star">${stars}</div>
                 <h4>${formatPrice(safePrice(product.price))}</h4>
                 ${getLowStockTextHTML(stock)}
             </div>
-            ${!outOfStock ? `<a href="product.html?id=${product.id}" class="cart"><i class="fas fa-shopping-cart"></i></a>` : ''}
+            ${!outOfStock
+                ? `<a href="product.html?id=${encodeURIComponent(product.id)}" class="cart"><i class="fas fa-shopping-cart"></i></a>`
+                : ""}
         </div>
     `;
-}
+    }
 
-// ========================================
-// LOAD RECENTLY VIEWED PRODUCTS
-// ========================================
-
-async function loadRecentlyViewed() {
-    const container = document.getElementById('recently-viewed-container');
-    if (!container) return;
-    
-    // Get recently viewed IDs from localStorage
-    const ids = getJSON('recentlyViewed', []);
-    
-    if (!ids || ids.length === 0) {
-        container.innerHTML = `
+    function emptyState(message, hint, icon) {
+        return `
             <div class="empty-recent" style="width:100%; padding:60px 20px; text-align:center; color:#888; font-size:16px; background:#f9f9f9; border-radius:12px;">
-                <i class="fas fa-eye-slash" style="font-size:48px; color:#ccc; display:block; margin-bottom:15px;"></i>
-                <p>No recently viewed products yet.</p>
-                <p style="font-size:14px; margin-top:8px; opacity:0.7;">Start browsing to see products you've viewed here!</p>
+                <i class="fas ${icon}" style="font-size:48px; color:#ccc; display:block; margin-bottom:15px;"></i>
+                <p>${message}</p>
+                ${hint ? `<p style="font-size:14px; margin-top:8px; opacity:0.7;">${hint}</p>` : ""}
             </div>
         `;
-        return;
     }
 
-    if (window.AppUtils && typeof window.AppUtils.renderSkeletonState === 'function') {
-        window.AppUtils.renderSkeletonState(container, Math.min(ids.length, 6));
-    }
-    
-    try {
-        // Fetch product details for the IDs (max 6)
-        const fetchPromises = ids.slice(0, 6).map(id => 
-            apiRequest(`/products/${id}`)
-                .then(res => res.product)
-                .catch(() => null)
-        );
-        
-        const products = await Promise.all(fetchPromises);
-        const validProducts = products.filter(p => p !== null);
-        
-        if (validProducts.length === 0) {
-            container.innerHTML = `
-                <div class="empty-recent" style="width:100%; padding:60px 20px; text-align:center; color:#888; font-size:16px; background:#f9f9f9; border-radius:12px;">
-                    <i class="fas fa-exclamation-circle" style="font-size:48px; color:#ccc; display:block; margin-bottom:15px;"></i>
-                    <p>No recently viewed products available.</p>
-                </div>
-            `;
+    // ========================================
+    // LOAD RECENTLY VIEWED PRODUCTS
+    // ========================================
+
+    async function loadRecentlyViewed() {
+        const container = document.getElementById(CONTAINER_ID);
+        if (!container) return;
+
+        const store = window.RecentlyViewed;
+
+        if (!store) {
+            console.warn(
+                "recently-viewed-store.js is not loaded; skipping Recently Viewed"
+            );
             return;
         }
-        
-        container.innerHTML = validProducts
-            .map(product => renderRecentlyViewedCard(product))
-            .join('');
-            
-        // Re-apply animations
-        if (typeof initializeScrollAnimations === 'function') {
-            initializeScrollAnimations();
+
+        // Seed from the account before reading, so history follows a signed-in
+        // shopper from another device. A no-op when signed out, and it never
+        // rejects.
+        await store.hydrate();
+
+        let entries = store.list().slice(0, MAX_CARDS);
+
+        if (!entries.length) {
+            container.innerHTML = emptyState(
+                "No recently viewed products yet.",
+                "Start browsing to see products you've viewed here!",
+                "fa-eye-slash"
+            );
+            return;
         }
-        
-    } catch (error) {
-        console.error('Error loading recently viewed:', error);
-        container.innerHTML = `
-            <div class="empty-recent" style="width:100%; padding:60px 20px; text-align:center; color:#888; font-size:16px; background:#f9f9f9; border-radius:12px;">
-                <i class="fas fa-exclamation-circle" style="font-size:48px; color:#ccc; display:block; margin-bottom:15px;"></i>
-                <p>Could not load recently viewed products.</p>
-            </div>
-        `;
+
+        // Entries stored by an older build hold only an id, so they have no
+        // name or price to render. Those -- and only those -- are fetched.
+        const partial = entries.filter((entry) => entry.partial);
+
+        if (partial.length) {
+            if (utils().renderSkeletonState) {
+                utils().renderSkeletonState(container, entries.length);
+            }
+
+            entries = await fillIn(entries, partial);
+        }
+
+        const renderable = entries.filter((entry) => !entry.partial);
+
+        if (!renderable.length) {
+            container.innerHTML = emptyState(
+                "No recently viewed products available.",
+                "",
+                "fa-exclamation-circle"
+            );
+            return;
+        }
+
+        container.innerHTML = renderable.map(renderRecentlyViewedCard).join("");
+
+        if (typeof window.initializeScrollAnimations === "function") {
+            window.initializeScrollAnimations();
+        }
     }
-}
 
-// ========================================
-// EXPOSE GLOBALLY
-// ========================================
+    /**
+     * Fetch the products behind id-only entries.
+     *
+     * One request each, and only for entries that need one. The previous
+     * implementation issued a request for every entry on every homepage load,
+     * to recover fields the writers had already stored.
+     *
+     * @param {Array<object>} entries
+     * @param {Array<object>} partial
+     * @returns {Promise<Array<object>>}
+     */
+    async function fillIn(entries, partial) {
+        if (!utils().apiRequest) {
+            return entries;
+        }
 
-window.loadRecentlyViewed = loadRecentlyViewed;
-window.renderRecentlyViewedCard = renderRecentlyViewedCard;
+        const fetched = await Promise.all(
+            partial.map((entry) =>
+                utils()
+                    .apiRequest(`/products/${encodeURIComponent(entry.id)}`)
+                    .then((response) => response && response.product)
+                    .catch(() => null)
+            )
+        );
 
-// Auto-load when DOM is ready
-document.addEventListener('DOMContentLoaded', function() {
-    // Load after a small delay to let other content render
-    setTimeout(() => {
-        loadRecentlyViewed();
-    }, 500);
-});
+        const byId = new Map();
+
+        fetched.filter(Boolean).forEach((product) => {
+            byId.set(String(product.id), product);
+        });
+
+        return entries.map((entry) => {
+            const product = byId.get(entry.id);
+
+            if (!product) return entry;
+
+            return {
+                ...entry,
+                name: product.name,
+                category: product.category,
+                price: product.price,
+                image: product.image,
+                stock: product.stock,
+                rating: product.rating,
+                partial: false
+            };
+        });
+    }
+
+    // ========================================
+    // EXPOSE GLOBALLY
+    // ========================================
+
+    window.loadRecentlyViewed = loadRecentlyViewed;
+    window.renderRecentlyViewedCard = renderRecentlyViewedCard;
+
+    // Auto-load when DOM is ready. home-init.js also calls this behind a
+    // `typeof === "function"` guard -- which is how the module never loading
+    // stayed silent -- and loadRecentlyViewed is safe to call twice.
+    document.addEventListener("DOMContentLoaded", function () {
+        setTimeout(() => {
+            loadRecentlyViewed().catch((error) => {
+                console.error("Error loading recently viewed:", error);
+            });
+        }, 500);
+    });
+})();

--- a/frontend/scripts/related-products.js
+++ b/frontend/scripts/related-products.js
@@ -191,11 +191,23 @@ function renderRelatedProducts(
 
 // recently viewed recommendation
 function loadRecentlyViewedRecommendations() {
+
+    // Read through the store rather than off the key directly (#1497). This
+    // read the raw value and passed each element to renderProductCard, which
+    // works only if every element is an object -- and one of the three writers
+    // stored bare id strings, so what came back depended on which of them had
+    // run last. The store hands back one shape whatever is in storage.
     const viewed =
-        AppUtils.getJSON(
-            "recentlyViewed",
-            []
-        );
+        window.RecentlyViewed
+            ? window.RecentlyViewed.list().filter(
+                (
+                    item
+                ) => {
+
+                    return !item.partial;
+                }
+            )
+            : [];
 
     const recommendationContainer =
         document.getElementById(


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

Four pieces of frontend code shared the `recentlyViewed` localStorage key. Three wrote it, in two incompatible shapes, and the one on the homepage read a third that nothing wrote.

| | File | What it did |
| --- | --- | --- |
| W1 | `product.js` `trackRecentlyViewed()` | id strings, cap 10 — **never called** |
| W2 | `product.js` `saveRecentlyViewed()` | objects `{id,name,price,image}`, cap 10 |
| W3 | `product-render.js` `updateRecentlyViewed()` | objects `{id,name,brand,category,price,image}`, cap **8** |
| R1 | `recentlyViewed.js` `loadRecentlyViewed()` | read as **id strings** |
| R2 | `related-products.js` | read as **objects** |

`product.html` loads W2, W3 and R2. `index.html` loads R1.

---

## 🔗 Related Issue

Closes #1497

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] Testing improvement
- [x] Code refactoring
- [x] New feature
- [ ] Security fix
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Documentation update

---

## 🌐 Additional Notes

### One thing I found while fixing this that is not in the issue, and it is the bigger half

The issue says the homepage reader fetches `/products/[object Object]`. **It does not, because it never runs.**

`frontend/scripts/recentlyViewed.js` was loaded as `type="module"` and began:

```js
import { getJSON, setJSON, $, defaultImage, safeText, safePrice,
         formatPrice, apiRequest, notify } from "./utils.js";
```

`utils.js` contains **no `export` statement at all** — `grep -c "export" frontend/scripts/utils.js` returns 0. It is a classic script that assigns `window.AppUtils` at the bottom. And two of those nine names, `safeText` and `safePrice`, do not exist in `utils.js` under any spelling; they are defined in `product-cards-home.js` and `shop-controls.js`.

So the browser fails module resolution:

```
Uncaught SyntaxError: The requested module './scripts/utils.js'
does not provide an export named 'getJSON'
```

The whole file is discarded before a line of it executes. `window.loadRecentlyViewed` is never assigned — and the only caller, `home-init.js:81`, checks `typeof loadRecentlyViewed === "function"` first. So it fails silently, and the Recently Viewed section on the homepage has **never rendered at all**, for anybody.

The `[object Object]` interpolation is real and is still a bug — it is what would happen the moment the module loaded. Both are fixed; this one is first in the chain.

`recentlyViewed.js` is a classic script now, like every other file in that directory, reading helpers off `window.AppUtils`. There is a test asserting no page in `frontend/` loads a `type="module"` script from `scripts/`.

### Deduplication was off for 100% of products

Both live writers used:

```js
Number(item.id) !== Number(product.id)
```

`products.id` is a `CHAR(36)` UUID. `Number(uuid)` is `NaN`, and `NaN !== NaN` is **true**, so the predicate held for every element and the filter removed nothing. Not "sometimes" — never, for any product, because no UUID converts to a number.

Same family as #1443, where `router.param` ran UUIDs through `parseInt`. There it rejected ~37% of ids; here it silently disabled deduplication entirely.

Then three writes happened per page view:

```js
saveRecentlyViewed(currentProductData);

window.currentProductData = currentProductData;
if (typeof saveRecentlyViewed === "function") {
    saveRecentlyViewed(currentProductData);   // the same function, six lines up
}
```

plus `updateRecentlyViewed(product)` from inside `renderProduct`. **One page view, three copies.** After three views of three different products the list held three copies of the most recent one and nothing else.

The duplicated call is gone, `product-render.js` no longer writes from inside a render function — recording a view is not rendering — and the store deduplicates on the id **as a string**.

### `trackRecentlyViewed` is deleted

It wrote bare id strings, which is exactly what the homepage reader expected, and grepping the whole frontend for the name returned one hit: its own declaration. It was a fourth shape sitting twenty lines above a live writer that produced something else, waiting for its first caller.

### One owner

`frontend/scripts/recently-viewed-store.js` — `window.RecentlyViewed`. One shape, one cap (it was 8 in one writer and 10 in another, **on the same key in the same page load**, so the length depended on which ran last), one dedupe.

It reads defensively, because real browsers are holding the old mixed contents: bare ids, objects, duplicates. Those are migrated rather than discarded. A bare id is still a product somebody looked at — it just has no name or price to render, so it is kept as `partial: true` and the reader fills it in with one request. **Only** those; entries that already carry their fields are rendered from storage, where the old reader issued six requests on every homepage load to recover data the writers had already stored.

Entries older than 30 days are dropped on read. Without that the list is only ever trimmed by the cap, and a product from last spring is not "recently viewed".

### The backend that had no caller

`GET`/`POST /api/recently-viewed`, `services/recentlyViewedService.js` (453 lines) and the `recently_viewed` table have all existed for some time, and **no frontend file has ever referenced the path**. A signed-in shopper's history was per-browser, was lost when they cleared site data, and did not follow them to another device — while the server-side store built for exactly that sat empty.

The store is the first caller. `record()` posts when there is a token; `hydrate()` seeds from the account on load and **merges** rather than replacing, because someone who browsed signed out and then signed in should not lose what they were looking at. Both are best-effort and neither can surface an error to a shopper or block a render — recently-viewed is a convenience.

Two things fixed on those routes while giving them their first caller:

- the failure envelope used `error` where `AGENTS.md` specifies `message`, so a client reading `response.message` on a failure got `undefined`;
- `productId` was checked for presence and nothing else, so a malformed id reached the service and came back as a **500** — a client mistake reported as a server fault. It is `safeUUID` and a 400 now.

### Two smaller things in the renderer

`Number(stock) === 0` decided the sold-out overlay. `Number(null)` is `0`, so a stored entry carrying no stock figure rendered as **Sold Out**. Unknown is not sold out — the badge and overlay are omitted when there is no figure.

`product.html?id=${product.id}` and the card's `data-id` now escape/encode. Names were already escaped via `AppUtils.escapeHTML`, and there is a test that an `<img src=x onerror=...>` product name reaches the DOM inert.

### Tests

**`backend/tests/recentlyViewed.test.js`** — 39 tests, driven for real in jsdom, following the pattern `navbarSearch.test.js` set. That choice is deliberate and its header says why: none of these defects can be caught by reading source. What matters is what ends up in `localStorage` and what ends up in the DOM.

The ones worth reading:

- **`Number() on a UUID is why`** — asserts the predicate itself, so the *reason* is pinned and not only the fix.
- **`recording it three times still leaves one`** — that was the real sequence for one page view.
- **`it loads at all`** — fails against `main`, because the module never executed.
- **`an object in the key never reaches a URL`** — no request contains `[object`.
- **`no page loads recentlyViewed.js as a module`** — sweeps all 30 HTML pages.
- **`%s does not write the key directly`** / **`compares no id with Number()`** — over all four files, with comments stripped first (they quote the old code) and whitespace collapsed, because `product-render.js` spreads that comparison over eight lines.

### Deliberately not in this PR

**A "clear my history" control.** `store.clear()` and `store.forget(id)` exist and nothing calls them; a UI for it is a design question, not a bug.

**Recording views for signed-out shoppers server-side.** `product_views` allows a NULL `user_id` and `recommendationService` counts rows there, so there is a real feature in it — but it needs an identity story for anonymous visitors and belongs in its own issue.

**Reformatting `product-render.js` and `related-products.js`.** They are written one-argument-per-line throughout. I matched the surrounding style rather than reflowing files this PR only touches in one function each.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors — this PR removes one: the module-resolution `SyntaxError` on every homepage load
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

Full suite green on this branch: **67 suites, 1597 tests** (from 66 / 1558 on `main`). `npm run check:a11y` passes — 30 pages. No existing test file is modified.

No files in common with #1498, #1499, #1500 or #1501.
