### PR TITLE
fix(sla): sanitize period query parameter and prevent SQL injection

### DIFF
--- a/backend/services/businessSLAService.js
+++ b/backend/services/businessSLAService.js
@@ -289,8 +289,18 @@ class BusinessSLAService extends EventEmitter {
      * Get SLA metrics summary
      */
     async getMetricsSummary(metric = null, period = 'DAY') {
-        const VALID_PERIODS = ['HOUR', 'DAY', 'WEEK', 'MONTH'];
-        const safePeriod = VALID_PERIODS.includes(period?.toUpperCase()) ? period.toUpperCase() : 'DAY';
+        const PERIOD_MAP = {
+            '1H': 'HOUR',
+            '24H': 'DAY',
+            '7D': 'WEEK',
+            '30D': 'MONTH',
+            'HOUR': 'HOUR',
+            'DAY': 'DAY',
+            'WEEK': 'WEEK',
+            'MONTH': 'MONTH'
+        };
+        const uppercasePeriod = String(period || '').trim().toUpperCase();
+        const safePeriod = PERIOD_MAP[uppercasePeriod] || 'DAY';
 
         const query = `
             SELECT 

--- a/backend/tests/businessSLAService.test.js
+++ b/backend/tests/businessSLAService.test.js
@@ -1,0 +1,39 @@
+const { BusinessSLAService } = require('../services/businessSLAService');
+const db = require('../config/db');
+
+jest.mock('../config/db', () => ({
+    promise: {
+        query: jest.fn()
+    }
+}));
+
+describe('BusinessSLAService SQL Injection Defense', () => {
+    let slaService;
+
+    beforeEach(() => {
+        slaService = new BusinessSLAService();
+        jest.clearAllMocks();
+        db.promise.query.mockResolvedValue([[]]);
+    });
+
+    test('should map valid period shorthands correctly', async () => {
+        await slaService.getMetricsSummary('checkout_completion', '24h');
+        expect(db.promise.query).toHaveBeenCalledTimes(1);
+        const sqlQuery = db.promise.query.mock.calls[0][0];
+        expect(sqlQuery).toContain('INTERVAL 1 DAY');
+    });
+
+    test('should map 1h shorthand to HOUR', async () => {
+        await slaService.getMetricsSummary('checkout_completion', '1h');
+        const sqlQuery = db.promise.query.mock.calls[0][0];
+        expect(sqlQuery).toContain('INTERVAL 1 HOUR');
+    });
+
+    test('should neutralize SQL injection payloads by falling back to DAY', async () => {
+        const injectionPayload = "HOUR) OR 1=1; DROP TABLE sla_measurements;--";
+        await slaService.getMetricsSummary('checkout_completion', injectionPayload);
+        const sqlQuery = db.promise.query.mock.calls[0][0];
+        expect(sqlQuery).toContain('INTERVAL 1 DAY');
+        expect(sqlQuery).not.toContain('DROP TABLE');
+    });
+});


### PR DESCRIPTION
## Description
This PR resolves the critical SQL Injection vulnerability in the SLA Metrics Summary endpoint. The \period\ query parameter is now mapped against a strict whitelist of valid interval units before query construction.

## Related Issue
Closes #1508

## Clean Architecture & Changes
- Refactored \getMetricsSummary\ in \ackend/services/businessSLAService.js\ to use \PERIOD_MAP\ and strict fallback handling.
- Added comprehensive unit tests in \ackend/tests/businessSLAService.test.js\ verifying SQL injection payload neutralization.

## Verification
- Run \
px jest tests/businessSLAService.test.js\ (All 3 unit tests passing).