### PR TITLE
feat: add checkout progress stepper (Cart -> Details -> Payment -> Co…

### DIFF
--- a/frontend/cart.html
+++ b/frontend/cart.html
@@ -81,6 +81,12 @@
         href="styles/cart.css"
     >
 
+    <link
+        rel="stylesheet"
+        href="styles/checkout-stepper.css"
+    >
+
+
     <!-- Icons -->
 
     <link
@@ -99,8 +105,16 @@
 
     <div id="navbar"></div>
 
-    <main id="main-content" tabindex="-1">
+   <main id="main-content" tabindex="-1">
         <h1 class="visually-hidden">Cart</h1>
+
+        <!-- Checkout Progress Stepper -->
+        <ul
+            id="checkout-stepper"
+            data-current-step="cart"
+        ></ul>
+
+  
 
 
 
@@ -345,6 +359,15 @@
         defer
         src="scripts/components.js"
     ></script>
+
+    <script
+        defer
+        src="scripts/checkout-stepper.js"
+    ></script>
+
+    
+
+    <!-- Cart Scripts -->
 
     
 

--- a/frontend/checkout.html
+++ b/frontend/checkout.html
@@ -81,6 +81,11 @@
         href="styles/checkout.css"
     >
 
+    <link
+        rel="stylesheet"
+        href="styles/checkout-stepper.css"
+    >
+
     <!-- Icons -->
 
     <link
@@ -102,7 +107,11 @@
     <main id="main-content" tabindex="-1">
         <h1 class="visually-hidden">Checkout</h1>
 
-
+        <!-- Checkout Progress Stepper -->
+        <ul
+            id="checkout-stepper"
+            data-current-step="payment"
+        ></ul>
 
     <!-- Checkout Header -->
 
@@ -488,6 +497,11 @@
     <script
         defer
         src="scripts/components.js"
+    ></script>
+
+    <script
+        defer
+        src="scripts/checkout-stepper.js"
     ></script>
 
     <!-- Checkout Script -->

--- a/frontend/scripts/checkout-stepper.js
+++ b/frontend/scripts/checkout-stepper.js
@@ -1,0 +1,115 @@
+/**
+ * Checkout Progress Stepper
+ * -------------------------------------------------------------
+ * Renders a 4-step progress bar (Cart -> Details -> Payment ->
+ * Confirmation) into any element with id="checkout-stepper".
+ *
+ * The host page declares which step is "current" via a
+ * data attribute on that same container:
+ *
+ *   <div id="checkout-stepper" data-current-step="cart"></div>
+ *   <div id="checkout-stepper" data-current-step="details"></div>
+ *   <div id="checkout-stepper" data-current-step="confirmation"></div>
+ *
+ * Valid values: "cart" | "details" | "payment" | "confirmation"
+ *
+ * No backend changes required — purely presentational, driven by
+ * which page is currently loaded.
+ */
+
+(function () {
+
+    const STEPS = [
+        { key: "cart", label: "Cart", icon: "fa-shopping-cart" },
+        { key: "details", label: "Details", icon: "fa-user" },
+        { key: "payment", label: "Payment", icon: "fa-credit-card" },
+        { key: "confirmation", label: "Confirmation", icon: "fa-check" }
+    ];
+
+    function renderCheckoutStepper() {
+
+        const container = document.getElementById("checkout-stepper");
+
+        if (!container) {
+            return;
+        }
+
+        const currentKey = container.dataset.currentStep;
+
+        const currentIndex = STEPS.findIndex(
+            (step) => step.key === currentKey
+        );
+
+        // If an unrecognized/missing step is passed, fail quietly
+        // rather than rendering a broken/misleading stepper.
+        if (currentIndex === -1) {
+            console.warn(
+                `checkout-stepper: unknown data-current-step "${currentKey}". ` +
+                `Expected one of: ${STEPS.map((s) => s.key).join(", ")}`
+            );
+            return;
+        }
+
+        container.setAttribute("role", "list");
+        container.setAttribute(
+            "aria-label",
+            "Checkout progress"
+        );
+        container.classList.add("checkout-stepper");
+
+        container.innerHTML = STEPS.map((step, index) => {
+
+            const isCompleted = index < currentIndex;
+            const isActive = index === currentIndex;
+
+            const stateClass = isCompleted
+                ? "is-completed"
+                : isActive
+                    ? "is-active"
+                    : "";
+
+            const icon = isCompleted
+                ? '<i class="fal fa-check" aria-hidden="true"></i>'
+                : (index + 1);
+
+            const stepStatus = isCompleted
+                ? "completed"
+                : isActive
+                    ? "current"
+                    : "upcoming";
+
+            return `
+                <li
+                    class="checkout-stepper__step ${stateClass}"
+                    role="listitem"
+                    aria-current="${isActive ? "step" : "false"}"
+                >
+                    <span class="checkout-stepper__circle">
+                        ${icon}
+                    </span>
+                    <span class="checkout-stepper__label">
+                        ${step.label}
+                        <span class="visually-hidden">
+                            (${stepStatus})
+                        </span>
+                    </span>
+                </li>
+            `;
+
+        }).join("");
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener(
+            "DOMContentLoaded",
+            renderCheckoutStepper
+        );
+    } else {
+        renderCheckoutStepper();
+    }
+
+    // Expose for pages that render checkout content dynamically
+    // and may need to re-run this after DOM updates.
+    window.renderCheckoutStepper = renderCheckoutStepper;
+
+})();

--- a/frontend/styles/checkout-stepper.css
+++ b/frontend/styles/checkout-stepper.css
@@ -1,0 +1,160 @@
+/* ==========================================================================
+   Checkout Progress Stepper
+   Shared across cart.html -> checkout.html -> success.html
+   Steps: Cart -> Details -> Payment -> Confirmation
+   ========================================================================== */
+
+.checkout-stepper {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    max-width: 720px;
+    margin: 24px auto 8px;
+    padding: 0 20px;
+    list-style: none;
+}
+
+.checkout-stepper__step {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex: 1 1 0;
+    position: relative;
+    text-align: center;
+}
+
+/* connecting line between steps */
+.checkout-stepper__step:not(:last-child)::after {
+    content: "";
+    position: absolute;
+    top: 17px;
+    left: calc(50% + 22px);
+    right: calc(-50% + 22px);
+    height: 2px;
+    background: var(--border-color, #e1e1e1);
+    z-index: 0;
+    transition: background var(--transition-fast, 0.3s ease);
+}
+
+.checkout-stepper__step.is-completed:not(:last-child)::after {
+    background: var(--primary-color, #088178);
+}
+
+.checkout-stepper__circle {
+    width: 34px;
+    height: 34px;
+    min-width: 34px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--white, #fff);
+    border: 2px solid var(--border-color, #e1e1e1);
+    color: var(--text-light, #465b52);
+    font-size: 14px;
+    font-weight: 700;
+    position: relative;
+    z-index: 1;
+    transition: all var(--transition-fast, 0.3s ease);
+}
+
+.checkout-stepper__circle i {
+    font-size: 13px;
+}
+
+.checkout-stepper__label {
+    margin-top: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-light, #465b52);
+    transition: color var(--transition-fast, 0.3s ease);
+}
+
+/* Active step */
+.checkout-stepper__step.is-active .checkout-stepper__circle {
+    border-color: var(--primary-color, #088178);
+    background: var(--primary-color, #088178);
+    color: #fff;
+    box-shadow: 0 0 0 4px rgba(8, 129, 120, 0.15);
+}
+
+.checkout-stepper__step.is-active .checkout-stepper__label {
+    color: var(--primary-color, #088178);
+    font-weight: 700;
+}
+
+/* Completed step */
+.checkout-stepper__step.is-completed .checkout-stepper__circle {
+    border-color: var(--primary-color, #088178);
+    background: var(--primary-color, #088178);
+    color: #fff;
+}
+
+.checkout-stepper__step.is-completed .checkout-stepper__label {
+    color: var(--primary-color, #088178);
+}
+
+/* Upcoming (future) step stays muted/greyed out — default state above already covers it */
+
+/* Mobile: shrink labels, tighten spacing */
+@media (max-width: 576px) {
+    .checkout-stepper {
+        margin: 16px auto 4px;
+        padding: 0 10px;
+    }
+
+    .checkout-stepper__circle {
+        width: 28px;
+        height: 28px;
+        min-width: 28px;
+        font-size: 12px;
+    }
+
+    .checkout-stepper__step:not(:last-child)::after {
+        top: 14px;
+        left: calc(50% + 18px);
+        right: calc(-50% + 18px);
+    }
+
+    .checkout-stepper__label {
+        margin-top: 6px;
+        font-size: 10.5px;
+    }
+}
+
+/* Dark theme */
+body.dark-theme .checkout-stepper__circle {
+    background: #2a2a2a;
+    border-color: #444;
+    color: #d1d1d1;
+}
+
+body.dark-theme .checkout-stepper__label {
+    color: #d1d1d1;
+}
+
+body.dark-theme .checkout-stepper__step:not(:last-child)::after {
+    background: #444;
+}
+
+body.dark-theme .checkout-stepper__step.is-completed:not(:last-child)::after,
+body.dark-theme .checkout-stepper__step.is-completed .checkout-stepper__circle,
+body.dark-theme .checkout-stepper__step.is-active .checkout-stepper__circle {
+    background: var(--primary-color, #088178);
+    border-color: var(--primary-color, #088178);
+    color: #fff;
+}
+
+body.dark-theme .checkout-stepper__step.is-active .checkout-stepper__label,
+body.dark-theme .checkout-stepper__step.is-completed .checkout-stepper__label {
+    color: var(--primary-color, #088178);
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    .checkout-stepper__circle,
+    .checkout-stepper__label,
+    .checkout-stepper__step::after {
+        transition: none;
+    }
+}

--- a/frontend/success.html
+++ b/frontend/success.html
@@ -81,6 +81,11 @@
         href="styles/success.css"
     >
 
+    <link
+        rel="stylesheet"
+        href="styles/checkout-stepper.css"
+    >
+
     <!-- Icons -->
 
     <link
@@ -102,7 +107,11 @@
     <main id="main-content" tabindex="-1">
         <h1 class="visually-hidden">Order Success</h1>
 
-
+        <!-- Checkout Progress Stepper -->
+        <ul
+            id="checkout-stepper"
+            data-current-step="confirmation"
+        ></ul>
 
     <!-- Success Section -->
 
@@ -217,6 +226,11 @@
     <script
         defer
         src="scripts/components.js"
+    ></script>
+
+    <script
+        defer
+        src="scripts/checkout-stepper.js"
     ></script>
 
     <!-- Success Script -->


### PR DESCRIPTION
Fixes: #1170

Description
The checkout flow (cart.html -> checkout.html -> success.html) had no
visual indicator of where the user was in the purchase process. Users
had no way to tell how many steps remained, which is a known driver of
checkout abandonment.

Added a 4-step progress stepper (Cart -> Details -> Payment -> Confirmation)
rendered via a shared, reusable component so the same logic/markup isn't
duplicated across the three pages. Each page just declares its current
step via a data attribute:

  <ul id="checkout-stepper" data-current-step="cart"></ul>

Note: checkout.html combines Billing Details and Payment Method on a
single physical page (there's no separate "details" page in this app),
so that page's stepper defaults to data-current-step="payment" -- Cart
and Details show as completed, Payment shows as the active step. This
matches how most real single-page checkouts (e.g. Stripe Checkout)
treat address + payment as one combined step.

Fix
- Added frontend/styles/checkout-stepper.css -- stepper styling, reuses
  existing --primary-color/--border-color tokens and includes full
  body.dark-theme support + a mobile breakpoint.
- Added frontend/scripts/checkout-stepper.js -- small self-contained
  renderer, no framework/dependency needed. Reads data-current-step off
  #checkout-stepper and builds the step list (circles + checkmarks +
  connecting line) accordingly.
- Wired the stepper into cart.html, checkout.html, success.html: one
  <link> for the CSS, one <script defer> for the JS, and one
  <ul id="checkout-stepper" data-current-step="..."></ul> placed right
  under <main> on each page.
- Pure frontend change -- no backend changes required.

Testing
- Ran through the full flow locally (cart -> checkout -> place order ->
  success) and confirmed the correct step highlights + checkmarks at
  each stage.
- Verified in both light and dark theme (body.dark-theme).
- Verified responsive behavior at mobile width -- stepper labels/circles
  shrink via the included @media (max-width: 576px) rule and don't
  overflow.
- Verified prefers-reduced-motion is respected (transitions disabled).

Screenshot
<img width="1919" height="1033" alt="image" src="https://github.com/user-attachments/assets/44503feb-bf5e-4dca-ad99-b9d59aef5fcd" />


Fixes #1170
Related to # (none)