### PR TITLE
fix(risk): fix module coupling calculation and eliminate unreachable dead code #1510

### DIFF
--- a/backend/services/architecturalRiskService.js
+++ b/backend/services/architecturalRiskService.js
@@ -274,19 +274,20 @@ class ArchitecturalRiskService extends EventEmitter {
                 const content = fs.readFileSync(file, 'utf8');
                 const deps = this.extractDependencies(content);
                 
-                // Check if this module depends on the target module
+                // Check if another module depends on the target module
                 if (deps.some(d => d.includes(moduleName))) {
                     incoming++;
                 }
             }
         }
         
-        // Calculate outgoing separately
+        // Calculate outgoing coupling (external / cross-module dependencies)
         const targetFiles = this.findFilesInModule(modulePath);
         for (const file of targetFiles) {
             const content = fs.readFileSync(file, 'utf8');
             const deps = this.extractDependencies(content);
-            outgoing += deps.length;
+            const crossModuleDeps = deps.filter(d => !d.startsWith('./') && !d.includes(`/${moduleName}/`));
+            outgoing += crossModuleDeps.length;
         }
 
         return {

--- a/backend/tests/architecturalRiskService.test.js
+++ b/backend/tests/architecturalRiskService.test.js
@@ -1,0 +1,45 @@
+const { ArchitecturalRiskService } = require('../services/architecturalRiskService');
+const fs = require('fs');
+const path = require('path');
+
+jest.mock('fs');
+
+describe('ArchitecturalRiskService - calculateCoupling', () => {
+    let service;
+
+    beforeEach(() => {
+        service = new ArchitecturalRiskService();
+        jest.clearAllMocks();
+    });
+
+    test('should calculate incoming and outgoing coupling correctly', async () => {
+        jest.spyOn(service, 'findModules').mockReturnValue(['/project/backend/controllers', '/project/backend/services']);
+        
+        jest.spyOn(service, 'findFilesInModule').mockImplementation((modPath) => {
+            if (modPath === '/project/backend/controllers') {
+                return ['/project/backend/controllers/userController.js'];
+            }
+            if (modPath === '/project/backend/services') {
+                return ['/project/backend/services/userService.js'];
+            }
+            return [];
+        });
+
+        fs.readFileSync.mockImplementation((filePath) => {
+            if (filePath === '/project/backend/controllers/userController.js') {
+                return "const service = require('../services/userService');";
+            }
+            if (filePath === '/project/backend/services/userService.js') {
+                return "const db = require('../config/db');";
+            }
+            return "";
+        });
+
+        const result = await service.calculateCoupling('/project/backend/services');
+        expect(result).toHaveProperty('incoming');
+        expect(result).toHaveProperty('outgoing');
+        expect(result.incoming).toBe(1); // userController.js imports userService
+        expect(result.outgoing).toBe(1); // userService imports ../config/db
+        expect(result.total).toBe(2);
+    });
+});


### PR DESCRIPTION
## Description
Fixes #1510

Fixes broken module coupling metrics in \ackend/services/architecturalRiskService.js\. Previously, an unreachable \if (modulePath === mod)\ statement inside a loop that skipped \mod === modulePath\ caused outgoing coupling to always report \