### PR TITLE
Let an order reach the database

### DIFF
--- a/backend/services/order.service.js
+++ b/backend/services/order.service.js
@@ -9,17 +9,83 @@ const {
 const logger = require("../utils/logger");
 const { validatePromo } = require("./promo.service");
 const pricing = require("./pricing.service");
+// Order creation prices delivery, chooses the option and records the promised
+// window, so it uses `shipping` in three places -- and required it in none of
+// them. `shipping` was a free variable, so every order died on
+// `ReferenceError: shipping is not defined` before it reached the INSERT. Same
+// class as the missing `stockCounter` below, and from the same cause: a merge
+// that took the calls and left the import (#1521).
+const shipping = require("./shipping.service");
 const cartLifecycle = require("./cartLifecycleService");
+// Abandoned-cart recovery attribution (#1429). Same casualty as `shipping`
+// above: the call site survived the merge and the import did not (#1521).
+const cartRecoveryAttribution = require("./cartRecoveryAttributionService");
 const { generateOrderNumber } = require("./orderNumber.service");
 // `resolveOrderLines` and the stock deduction in `createOrder` both go through
 // this, and neither could: the require went missing, so `stockCounter` was a
 // free variable and every call threw `ReferenceError: stockCounter is not
 // defined`. That is order creation, not an edge case (#1444).
 const stockCounter = require("./stockCounterService");
+// The sentinel for "this line names no variant". Used when the order line is
+// written, and -- like `shipping` and `cartRecoveryAttribution` above -- left
+// undeclared by the same merge (#1521).
+const { NO_VARIANT_ID } = stockCounter;
 
 // Marks the one failure the client can act on, so controllers can answer with
 // the specific figures instead of a generic server error.
 const TOTAL_MISMATCH_CODE = "ORDER_TOTAL_MISMATCH";
+
+/**
+ * A value that is SQL rather than a parameter -- `NOW()` and nothing else so
+ * far. A Symbol rather than the string "NOW()" so that a column whose value
+ * genuinely is the text "NOW()" cannot be mistaken for one.
+ */
+const RAW_NOW = Symbol("SQL:NOW()");
+
+/** What each raw marker renders as. */
+const RAW_SQL = new Map([[RAW_NOW, "NOW()"]]);
+
+/**
+ * Build an INSERT from a list of `[column, value]` pairs.
+ *
+ * The order INSERT used to keep three lists in step by hand -- the columns, the
+ * `?` placeholders and the arguments array -- and three successive merges each
+ * added a column to two of them. What reached `main` was 28 columns, 23
+ * placeholders and 28 arguments, which MySQL rejects outright:
+ *
+ *     ER_WRONG_VALUE_COUNT_ON_ROW: Column count doesn't match value count at row 1
+ *
+ * Deriving all three from one list is not tidiness. It removes the only way
+ * that failure can happen: there is no second list left to forget.
+ *
+ * @param {string} table
+ * @param {Array<[string, any]>} columnValuePairs
+ * @returns {{ sql: string, params: Array<any> }}
+ */
+const buildInsert = (table, columnValuePairs) => {
+    const columns = [];
+    const placeholders = [];
+    const params = [];
+
+    for (const [column, value] of columnValuePairs) {
+        columns.push(column);
+
+        if (RAW_SQL.has(value)) {
+            placeholders.push(RAW_SQL.get(value));
+            continue;
+        }
+
+        placeholders.push("?");
+        params.push(value);
+    }
+
+    return {
+        sql:
+            `INSERT INTO ${table} (${columns.join(", ")})`
+            + ` VALUES (${placeholders.join(", ")})`,
+        params,
+    };
+};
 
 // Validation helper functions
 const isValidEmail = (email) => {
@@ -311,6 +377,9 @@ const createOrderService = async (connection, orderData) => {
             // because a guest's cart cannot be found from `user_id`, which is
             // the only handle the account path ever needed.
             cart_id,
+            // Abandoned-cart recovery (#1429). The reference to the restore
+            // link this basket came back through, if it came back through one.
+            recovery_ref,
         } = orderData;
 
         // validate empty cart
@@ -397,73 +466,62 @@ const createOrderService = async (connection, orderData) => {
         // holder has their order list; a guest has only this (#1427).
         const orderNumber = generateOrderNumber();
 
-        // create order
-        const orderQuery = `
-            INSERT INTO orders (
-                id,
-                order_number,
-                user_id,
-                customer_name,
-                customer_email,
-                customer_phone,
-                city,
-                state,
-                zip,
-                full_address,
-                address_id,
-                shipping_address,
-                payment_method,
-                total,
-                status,
-                subtotal,
-                tax,
-                shipping_method,
-                shipping_cost,
-                estimated_delivery_from,
-                estimated_delivery,
-                discount,
-                discount_code,
-                promo_code,
-                recovery_token_id,
-                recovered_cart_id,
-                discount_amount,
-                final_amount,
-                created_at,
-                updated_at
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
-        `;
+        // Resolved on this connection, inside the caller's transaction: an
+        // order that rolls back must not leave a claim that it was recovered.
+        // A reference that does not check out costs the order nothing -- it is
+        // simply not attributed (#1429).
+        const { recoveryTokenId, recoveredCartId } =
+            await cartRecoveryAttribution.resolveAttribution({
+                recoveryRef: recovery_ref,
+                userId: user_id,
+                connection,
+            });
 
-        const [orderResult] = await connection.query(orderQuery, [
-            orderId,
-            orderNumber,
-            safeUUID(user_id),
-            customer_name,
-            customer_email,
-            customer_phone,
-            city,
-            state,
-            zip,
-            full_address,
-            safeUUID(address_id),
-            JSON.stringify({ street: full_address, city, state, zip }),
-            payment_method,
-            breakdown.total,
-            "pending",
-            breakdown.subtotal,
-            breakdown.tax,
-            delivery.selected.code,
-            breakdown.shipping,
-            estimate ? estimate.from : null,
-            estimate ? estimate.to : null,
-            discountAmount,
-            appliedPromoCode,
-            appliedPromoCode,
-            recoveryTokenId,
-            recoveredCartId,
-            discountAmount,
-            breakdown.total,
+        // create order
+        //
+        // One list, not three. Each entry names a column and carries the value
+        // that goes in it, and `buildInsert` derives the column list and the
+        // placeholder list from that -- so a column added here cannot arrive
+        // without its `?`, which is the failure this replaces.
+        const { sql: orderQuery, params: orderParams } = buildInsert("orders", [
+            ["id", orderId],
+            ["order_number", orderNumber],
+            ["user_id", safeUUID(user_id)],
+            ["customer_name", customer_name],
+            ["customer_email", customer_email],
+            ["customer_phone", customer_phone],
+            ["city", city],
+            ["state", state],
+            ["zip", zip],
+            ["full_address", full_address],
+            ["address_id", safeUUID(address_id)],
+            [
+                "shipping_address",
+                JSON.stringify({ street: full_address, city, state, zip }),
+            ],
+            ["payment_method", payment_method],
+            ["total", breakdown.total],
+            ["status", "pending"],
+            ["subtotal", breakdown.subtotal],
+            ["tax", breakdown.tax],
+            ["shipping_method", delivery.selected.code],
+            ["shipping_cost", breakdown.shipping],
+            ["estimated_delivery_from", estimate ? estimate.from : null],
+            ["estimated_delivery", estimate ? estimate.to : null],
+            ["discount", discountAmount],
+            ["discount_code", appliedPromoCode],
+            ["promo_code", appliedPromoCode],
+            ["recovery_token_id", recoveryTokenId],
+            ["recovered_cart_id", recoveredCartId],
+            ["discount_amount", discountAmount],
+            ["final_amount", breakdown.total],
+            // Not a parameter: `NOW()` is SQL, and passing it as a string would
+            // store the four characters rather than the time.
+            ["created_at", RAW_NOW],
+            ["updated_at", RAW_NOW],
         ]);
+
+        const [orderResult] = await connection.query(orderQuery, orderParams);
 
         // insert into order_items
         //
@@ -473,30 +531,25 @@ const createOrderService = async (connection, orderData) => {
         // guess. Sentinel zero becomes NULL: the column is a foreign key, and
         // no variant has id 0.
         for (const item of validatedItems) {
-            const itemQuery = `
-                INSERT INTO order_items (
-                    order_id,
-                    product_id,
-                    variant_id,
-                    name,
-                    price,
-                    qty,
-                    color,
-                    size,
-                    total
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            `;
-            await connection.query(itemQuery, [
-                orderId,
-                item.id,
-                item.variantId > NO_VARIANT_ID ? item.variantId : null,
-                item.name,
-                item.price,
-                item.qty,
-                item.color,
-                item.size,
-                item.price * item.qty,
-            ]);
+            const { sql: itemQuery, params: itemParams } = buildInsert(
+                "order_items",
+                [
+                    ["order_id", orderId],
+                    ["product_id", item.id],
+                    [
+                        "variant_id",
+                        item.variantId > NO_VARIANT_ID ? item.variantId : null,
+                    ],
+                    ["name", item.name],
+                    ["price", item.price],
+                    ["qty", item.qty],
+                    ["color", item.color],
+                    ["size", item.size],
+                    ["total", item.price * item.qty],
+                ],
+            );
+
+            await connection.query(itemQuery, itemParams);
         }
 
         // Reduce the same counter the availability check was made against, on
@@ -1002,5 +1055,9 @@ module.exports = {
     generateOrderSummaryService,
     validateOrderDataService,
     getOrderSummaryById,
-    getOrderTimeline
+    getOrderTimeline,
+    // Exported for the regression test around the column/placeholder drift
+    // this file was carrying (#1521), not for callers elsewhere.
+    buildInsert,
+    RAW_NOW
 };

--- a/backend/tests/orderInsertShape.test.js
+++ b/backend/tests/orderInsertShape.test.js
@@ -1,0 +1,573 @@
+// The shape of the INSERT statements order creation issues (#1521).
+//
+// `createOrderService` built its order INSERT from three lists kept in step by
+// hand: the column names, the `?` placeholders and the arguments array. Three
+// successive merges each added a column to two of the three, and what reached
+// `main` was 28 columns, 23 placeholders and 28 arguments. MySQL refuses that
+// outright -- ER_WRONG_VALUE_COUNT_ON_ROW -- so every checkout failed.
+//
+// Nothing caught it because every existing test of the order path mocks
+// `services/order.service` wholesale (see the factory at the top of
+// orderController.test.js), so the statement itself is never built. These
+// tests build it.
+//
+// Three layers, deliberately:
+//
+//   1. `buildInsert` itself, because it is now the only thing that can put a
+//      column and its value out of step.
+//   2. The statement `createOrderService` actually issues, against a mocked
+//      connection -- the assertion is on the SQL, since a mock accepts any
+//      string and only a live MySQL would otherwise object.
+//   3. A static sweep of every INSERT in the backend, so the same drift
+//      appearing in a file this PR does not touch fails here too.
+
+const path = require("path");
+const fs = require("fs");
+
+const {
+    buildInsert,
+    RAW_NOW
+} = require("../services/order.service");
+
+const BACKEND_DIR = path.resolve(__dirname, "..");
+
+// ---------------------------------------------------------------------------
+// 1. The builder
+// ---------------------------------------------------------------------------
+
+describe("buildInsert", () => {
+    test("emits one placeholder per column and one parameter per placeholder", () => {
+        const { sql, params } = buildInsert("orders", [
+            ["id", "order-1"],
+            ["total", 499],
+            ["status", "pending"]
+        ]);
+
+        expect(sql).toBe(
+            "INSERT INTO orders (id, total, status) VALUES (?, ?, ?)"
+        );
+        expect(params).toEqual(["order-1", 499, "pending"]);
+        expect(countPlaceholders(sql)).toBe(params.length);
+    });
+
+    test("renders NOW() as SQL rather than passing it as a parameter", () => {
+        const { sql, params } = buildInsert("orders", [
+            ["id", "order-1"],
+            ["created_at", RAW_NOW],
+            ["updated_at", RAW_NOW]
+        ]);
+
+        expect(sql).toBe(
+            "INSERT INTO orders (id, created_at, updated_at)"
+            + " VALUES (?, NOW(), NOW())"
+        );
+        // The point of the marker: two of the three columns take no argument,
+        // and the arguments array is shorter by exactly those two.
+        expect(params).toEqual(["order-1"]);
+    });
+
+    test("stores the literal string 'NOW()' as a value, not as SQL", () => {
+        // The marker is a Symbol precisely so a column whose value happens to
+        // be the text NOW() is not silently turned into a timestamp.
+        const { sql, params } = buildInsert("orders", [["notes", "NOW()"]]);
+
+        expect(sql).toBe("INSERT INTO orders (notes) VALUES (?)");
+        expect(params).toEqual(["NOW()"]);
+    });
+
+    test("keeps columns in the order they were given", () => {
+        const { sql } = buildInsert("t", [
+            ["b", 1],
+            ["a", 2],
+            ["c", 3]
+        ]);
+
+        expect(sql).toContain("(b, a, c)");
+    });
+
+    test("passes null and zero through as parameters", () => {
+        // A falsy value is still a value. Skipping it would shift every
+        // argument after it onto the wrong column, which is a quieter version
+        // of the bug this file exists for.
+        const { params } = buildInsert("t", [
+            ["a", null],
+            ["b", 0],
+            ["c", ""],
+            ["d", false]
+        ]);
+
+        expect(params).toEqual([null, 0, "", false]);
+    });
+
+    test("column count always equals placeholder count, for any input", () => {
+        for (let size = 1; size <= 40; size += 1) {
+            const pairs = Array.from({ length: size }, (_, index) => [
+                `col_${index}`,
+                index % 7 === 0 ? RAW_NOW : index
+            ]);
+
+            const { sql, params } = buildInsert("t", pairs);
+            const { columns, values } = splitInsert(sql);
+
+            expect(columns).toHaveLength(size);
+            expect(values).toHaveLength(size);
+            expect(countPlaceholders(sql)).toBe(params.length);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The statement order creation actually issues
+// ---------------------------------------------------------------------------
+
+describe("the orders INSERT createOrderService issues", () => {
+    let createOrderService;
+    let queries;
+
+    const PRODUCT_ID = "3f2504e0-4f89-11d3-9a0c-0305e82c3301";
+    const USER_ID = "3f2504e0-4f89-11d3-9a0c-0305e82c3302";
+
+    const orderData = (total) => ({
+        user_id: USER_ID,
+        customer_name: "Asha Menon",
+        customer_email: "asha@example.com",
+        customer_phone: "9876543210",
+        city: "Mumbai",
+        state: "Maharashtra",
+        zip: "400001",
+        full_address: "12 Marine Drive",
+        payment_method: "cash_on_delivery",
+        items: [{ id: PRODUCT_ID, qty: 2 }],
+        total
+    });
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        queries = [];
+
+        jest.doMock("../config/db", () => ({
+            query: jest.fn().mockResolvedValue([[]]),
+            getConnection: jest.fn()
+        }));
+
+        jest.doMock("../services/shipping.service", () => ({
+            basketWeightKg: () => 1,
+            quoteOptions: async () => ({
+                selected: { code: "standard", label: "Standard", cost: 0 },
+                options: [],
+                freeShipping: true
+            }),
+            estimateDelivery: async () => ({ from: null, to: null })
+        }));
+
+        jest.doMock("../services/cartLifecycleService", () => ({
+            markCartConverted: async () => ({ converted: false, cartId: null }),
+            markCartConvertedById: async () => ({ converted: false, cartId: null })
+        }));
+
+        jest.doMock("../services/promo.service", () => ({
+            validatePromo: async () => ({ valid: false, message: "no promo" })
+        }));
+
+        ({ createOrderService } = require("../services/order.service"));
+    });
+
+    afterEach(() => {
+        jest.dontMock("../config/db");
+        jest.dontMock("../services/shipping.service");
+        jest.dontMock("../services/cartLifecycleService");
+        jest.dontMock("../services/promo.service");
+    });
+
+    /**
+     * A connection that records what it was asked to run and answers the few
+     * reads order creation makes on the way through.
+     */
+    const mockConnection = () => ({
+        query: jest.fn(async (sql, params) => {
+            queries.push({ sql: String(sql), params });
+
+            if (/FROM products/i.test(sql)) {
+                return [
+                    [
+                        {
+                            id: PRODUCT_ID,
+                            name: "Cotton shirt",
+                            price: 1000,
+                            stock: 50,
+                            image: "shirt.jpg",
+                            weight: 0.5
+                        }
+                    ]
+                ];
+            }
+
+            if (/FROM product_variants/i.test(sql)) {
+                return [[]];
+            }
+
+            if (/^\s*UPDATE products/i.test(sql)) {
+                return [{ affectedRows: 1 }];
+            }
+
+            return [{ affectedRows: 1, insertId: 1 }];
+        })
+    });
+
+    const ordersInsert = () =>
+        queries.find(({ sql }) => /INSERT INTO orders\b/i.test(sql));
+
+    /**
+     * Place one order and leave `queries` holding only that attempt.
+     *
+     * The submitted total has to agree with what the pricing engine makes of
+     * the same basket, and the tax and shipping rules that decide it are
+     * configuration. So the total is asked for rather than hardcoded: the
+     * first attempt is refused and names the computed figure, and the second
+     * uses it. A change to the tax rate then does not break a test that is
+     * about the shape of an INSERT.
+     */
+    const placeOrder = async () => {
+        try {
+            await createOrderService(mockConnection(), orderData(1));
+        } catch (error) {
+            if (!error.computedTotal) throw error;
+
+            queries = [];
+            await createOrderService(
+                mockConnection(),
+                orderData(error.computedTotal)
+            );
+        }
+    };
+
+    test("names as many values as it names columns", async () => {
+        await placeOrder();
+
+        const insert = ordersInsert();
+        expect(insert).toBeDefined();
+
+        const { columns, values } = splitInsert(insert.sql);
+
+        // This is the assertion that fails on the version of this file that
+        // shipped: 28 columns against 23 values.
+        expect(values).toHaveLength(columns.length);
+    });
+
+    test("supplies exactly one argument per placeholder", async () => {
+        await placeOrder();
+
+        const insert = ordersInsert();
+
+        expect(insert.params).toHaveLength(countPlaceholders(insert.sql));
+    });
+
+    test("still writes the columns the order path depends on", async () => {
+        await placeOrder();
+
+        const { columns } = splitInsert(ordersInsert().sql);
+
+        // Each of these arrived in a separate change, and each is one of the
+        // columns the broken statement was silently dropping past the end of
+        // its placeholder list.
+        for (const column of [
+            "order_number",
+            "shipping_method",
+            "estimated_delivery_from",
+            "estimated_delivery",
+            "recovery_token_id",
+            "recovered_cart_id",
+            "final_amount"
+        ]) {
+            expect(columns).toContain(column);
+        }
+    });
+
+    test("writes NOW() as SQL for the timestamps", async () => {
+        await placeOrder();
+
+        const insert = ordersInsert();
+        const { columns, values } = splitInsert(insert.sql);
+
+        expect(values[columns.indexOf("created_at")]).toBe("NOW()");
+        expect(values[columns.indexOf("updated_at")]).toBe("NOW()");
+        expect(insert.params).not.toContain("NOW()");
+    });
+
+    test("puts each value under the column it was paired with", async () => {
+        await placeOrder();
+
+        const insert = ordersInsert();
+        const { columns } = splitInsert(insert.sql);
+
+        // Read the arguments back through the column list. A statement whose
+        // counts happen to match can still be off by one, and that failure is
+        // silent -- an email in the phone column, a total in the tax column --
+        // where a count mismatch at least errors.
+        const written = {};
+        let argument = 0;
+
+        for (const column of columns) {
+            if (column === "created_at" || column === "updated_at") continue;
+            written[column] = insert.params[argument];
+            argument += 1;
+        }
+
+        expect(written.customer_email).toBe("asha@example.com");
+        expect(written.customer_phone).toBe("9876543210");
+        expect(written.zip).toBe("400001");
+        expect(written.status).toBe("pending");
+        expect(written.shipping_method).toBe("standard");
+        expect(written.total).toBe(written.final_amount);
+        expect(written.discount).toBe(written.discount_amount);
+    });
+
+    test("carries the recovery attribution the transaction resolved", async () => {
+        // `recovery_token_id` and `recovered_cart_id` are two of the columns
+        // that fell off the end of the placeholder list, and the call that
+        // produces them lost its import in the same merge -- so this asserts
+        // the whole path, not just that the statement parses.
+        jest.resetModules();
+        jest.doMock("../services/cartRecoveryAttributionService", () => ({
+            resolveAttribution: async () => ({
+                recoveryTokenId: 77,
+                recoveredCartId: 88
+            })
+        }));
+        ({ createOrderService } = require("../services/order.service"));
+
+        await placeOrder();
+
+        expect(ordersInsert().params).toEqual(
+            expect.arrayContaining([77, 88])
+        );
+
+        jest.dontMock("../services/cartRecoveryAttributionService");
+    });
+
+    test("the order_items INSERT is the same shape", async () => {
+        await placeOrder();
+
+        const insert = queries.find(({ sql }) =>
+            /INSERT INTO order_items\b/i.test(sql)
+        );
+
+        expect(insert).toBeDefined();
+
+        const { columns, values } = splitInsert(insert.sql);
+
+        expect(values).toHaveLength(columns.length);
+        expect(insert.params).toHaveLength(countPlaceholders(insert.sql));
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Every other INSERT in the backend
+// ---------------------------------------------------------------------------
+
+describe("INSERT statements across the backend", () => {
+    test("every INSERT names as many values as columns", () => {
+        const offenders = [];
+
+        for (const file of collectSourceFiles(BACKEND_DIR)) {
+            const source = fs.readFileSync(file, "utf8");
+
+            for (const statement of findInsertStatements(source)) {
+                for (const row of statement.rows) {
+                    if (row.length === statement.columns.length) continue;
+
+                    offenders.push(
+                        `${path.relative(BACKEND_DIR, file)}:${statement.line}`
+                        + ` — INSERT INTO ${statement.table}`
+                        + ` has ${statement.columns.length} columns`
+                        + ` and ${row.length} values`
+                    );
+                }
+            }
+        }
+
+        expect(offenders).toEqual([]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Split an INSERT into its column list and its first row of values.
+ *
+ * @param {string} sql
+ * @returns {{ columns: string[], values: string[] }}
+ */
+function splitInsert(sql) {
+    const statement = findInsertStatements(sql)[0];
+
+    if (!statement) {
+        throw new Error(`Not an INSERT this helper understands:\n${sql}`);
+    }
+
+    return { columns: statement.columns, values: statement.rows[0] };
+}
+
+/**
+ * @param {string} sql
+ * @returns {number} how many `?` parameters the statement takes
+ */
+function countPlaceholders(sql) {
+    return (sql.match(/\?/g) || []).length;
+}
+
+/**
+ * Pull every INSERT out of a chunk of source or SQL.
+ *
+ * Statements whose column list or values are assembled at runtime (a batch
+ * insert built with `.map(() => "(?, ?)")`, for instance) are skipped: their
+ * counts are not knowable by reading, and the ones that build both sides from
+ * the same array cannot drift in the first place.
+ *
+ * @param {string} source
+ * @returns {Array<{table: string, columns: string[], rows: string[][], line: number}>}
+ */
+function findInsertStatements(source) {
+    const statements = [];
+    const pattern = /INSERT\s+(?:IGNORE\s+)?INTO\s+`?(\w+)`?\s*\(([^)]*)\)\s*VALUES\s*/gi;
+
+    for (const match of source.matchAll(pattern)) {
+        const columnText = match[2];
+
+        // Interpolated column list — not statically checkable.
+        if (columnText.includes("${")) continue;
+
+        const columns = columnText
+            .split(",")
+            .map((column) => column.trim().replace(/`/g, ""))
+            .filter(Boolean);
+
+        if (!columns.length) continue;
+
+        const rows = readValueRows(source, match.index + match[0].length);
+
+        if (!rows) continue;
+
+        statements.push({
+            table: match[1],
+            columns,
+            rows,
+            line: source.slice(0, match.index).split("\n").length
+        });
+    }
+
+    return statements;
+}
+
+/**
+ * Read the `(...), (...)` row groups that follow a VALUES keyword.
+ *
+ * Returns null when the statement is not statically readable — an interpolated
+ * row group, or a group that never closes because the literal ended.
+ *
+ * @param {string} source
+ * @param {number} start - index of the first `(` after VALUES
+ * @returns {string[][]|null}
+ */
+function readValueRows(source, start) {
+    const rows = [];
+    let index = start;
+
+    while (index < source.length) {
+        while (index < source.length && /[\s,]/.test(source[index])) index += 1;
+        if (source[index] !== "(") break;
+
+        let depth = 0;
+        let end = index;
+
+        for (; end < source.length; end += 1) {
+            if (source[end] === "(") depth += 1;
+            else if (source[end] === ")") {
+                depth -= 1;
+                if (depth === 0) break;
+            }
+            // A statement that runs off the end of its own literal is not one
+            // we can read; bail rather than guess.
+            else if (source[end] === "`" || source[end] === ";") return null;
+        }
+
+        if (depth !== 0) return null;
+
+        const body = source.slice(index + 1, end);
+
+        if (body.includes("${")) return null;
+
+        rows.push(splitTopLevel(body));
+
+        index = end + 1;
+
+        // Anything other than another row group ends the VALUES clause.
+        let lookahead = index;
+        while (lookahead < source.length && /\s/.test(source[lookahead])) {
+            lookahead += 1;
+        }
+        if (source[lookahead] !== ",") break;
+        index = lookahead + 1;
+    }
+
+    return rows.length ? rows : null;
+}
+
+/**
+ * Split a comma-separated value list, ignoring commas inside call parentheses
+ * so `COALESCE(a, b)` counts as one value rather than two.
+ *
+ * @param {string} body
+ * @returns {string[]}
+ */
+function splitTopLevel(body) {
+    const parts = [];
+    let depth = 0;
+    let current = "";
+
+    for (const character of body) {
+        if (character === "(") depth += 1;
+        if (character === ")") depth -= 1;
+
+        if (character === "," && depth === 0) {
+            parts.push(current.trim());
+            current = "";
+            continue;
+        }
+
+        current += character;
+    }
+
+    if (current.trim()) parts.push(current.trim());
+
+    return parts;
+}
+
+/**
+ * Every backend source file, skipping dependencies, coverage output and the
+ * tests themselves.
+ *
+ * @param {string} directory
+ * @param {string[]} [collected]
+ * @returns {string[]}
+ */
+function collectSourceFiles(directory, collected = []) {
+    const SKIP = new Set(["node_modules", "coverage", "tests", "logs", ".git"]);
+
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        if (SKIP.has(entry.name)) continue;
+
+        const full = path.join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            collectSourceFiles(full, collected);
+        } else if (entry.name.endsWith(".js")) {
+            collected.push(full);
+        }
+    }
+
+    return collected;
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`createOrderService` is the only path that writes an order, and it could not complete. Four things were missing from it, all of them the residue of merges that kept a call site and dropped what it depends on.

**The INSERT named 28 columns and supplied 23 values.**

```
INSERT INTO orders (id, order_number, ..., discount_amount, final_amount, created_at, updated_at)
VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
```

30 columns; 23 placeholders and two `NOW()`. The arguments array below it held 28 entries, so it agreed with the column list and not with the placeholders. `ER_WRONG_VALUE_COUNT_ON_ROW`.

**And three identifiers were free variables**: `shipping` (used three times, imported never), `cartRecoveryAttribution` together with the `resolveAttribution` call that defines `recoveryTokenId` and `recoveredCartId`, and `NO_VARIANT_ID`. Each throws a `ReferenceError`, and the first of them fires before the statement is even built — which is why the placeholder count had gone unnoticed.

---

## 🔗 Related Issue

Closes #1521

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] Testing improvement
- [x] Code refactoring
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Security fix

---

## 🌐 Additional Notes

### One list instead of three

The old statement kept the column names, the `?` placeholders and the arguments array in step by hand. Every merge that added a column updated two of the three, and the one that lost is the one nobody reads — a string of 23 question marks is not something a reviewer counts.

`buildInsert` takes `[column, value]` pairs and derives the other two:

```js
const { sql, params } = buildInsert("orders", [
    ["id", orderId],
    ["order_number", orderNumber],
    ...
    ["created_at", RAW_NOW],
    ["updated_at", RAW_NOW],
]);
```

That is not tidiness. It removes the only way the failure can happen: there is no second list left to forget.

`RAW_NOW` is a `Symbol` rather than the string `"NOW()"`, so a column whose value genuinely is the text `NOW()` is stored as text rather than silently becoming a timestamp. There is a test for that specifically.

`order_items` is built the same way. Its counts were correct, but it is on the same path and the pattern is worth having in one shape rather than two.

### The three missing imports

All three are restorations, not new behaviour — every call site was already written against them:

| Missing | Used at | Restored as |
| --- | --- | --- |
| `shipping` | `quoteOptions`, `basketWeightKg`, `estimateDelivery` | `require("./shipping.service")` |
| `cartRecoveryAttribution` | the `resolveAttribution` that defines both attribution columns | `require("./cartRecoveryAttributionService")` |
| `NO_VARIANT_ID` | the order-line `variant_id` | `const { NO_VARIANT_ID } = stockCounter` |

The attribution call also needed its `recovery_ref` destructure back, and it is placed inside the caller's transaction exactly as #1429 put it: an order that rolls back must not leave behind a claim that it was recovered. `cartRecoveryAttributionService` had been left in the tree with no caller, and `recovered_cart_id` was still being logged at the bottom of the same function by a variable nothing produced.

### Why nothing caught this

Worth writing down, because the repo has three gates for exactly this family and all three passed:

- **`check:syntax`** parses. `shipping.quoteOptions(...)` with no `shipping` in scope is a valid expression.
- **`check:boot`** and **`check:modules`** *require* each module. All four defects are inside a function body, so `require("./services/order.service")` succeeds. `check-modules.js` says in its own header that it exists to catch "undeclared identifiers" — it catches the ones that run at require time, and these do not.
- **The suite** never ran the function. `tests/orderController.test.js:14` mocks `services/order.service` wholesale, which is correct for testing a controller and means the real `createOrderService` had no test at all. 1,742 passing tests over a checkout that 500s.

A repo-wide `no-undef` gate would have caught three of the four, and would be the right answer — but `AGENTS.md` records that there is no lint config here, and adding one is its own change with its own noise to work through. It is not in this PR.

### Tests

`tests/orderInsertShape.test.js`, 14 tests in three layers:

1. **`buildInsert`** — placeholder/parameter parity across sizes 1 to 40, `NOW()` rendering, the literal-string case, and that `null`, `0`, `""` and `false` are still passed as arguments. A falsy value skipped rather than passed shifts every argument after it onto the wrong column, which is the same bug in a quieter form.
2. **The statement `createOrderService` actually issues**, against a mocked connection. The assertions are on the SQL, deliberately: a mock accepts any string, so no behavioural assertion can see a missing placeholder. One test reads the arguments back through the column list and checks the email is in `customer_email` and the total matches `final_amount` — counts that match can still be off by one, and that failure is silent where a count mismatch at least errors. Another mocks the attribution service and asserts its ids reach the parameters, which covers the whole restored path rather than only that the statement parses.
3. **Every `INSERT` in the backend**, parsed statically, column count against value count per row group. Batch inserts that build both sides from one array are skipped — they cannot drift — and so is anything interpolated. This is the check that would have caught the original.

The submitted total in the behavioural tests is asked for rather than hardcoded: the first attempt is refused and names the computed figure, and the second uses it. A change to the tax rate should not break a test about the shape of a statement.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

Full suite green on this branch: **76 suites, 1756 tests** (from 75 / 1742 on `main`). No migration — every column in the statement already exists in the baseline schema, which is how the mismatch stayed invisible to `migrate:status`.

Touches `backend/services/order.service.js` and one new test file, and nothing else.
