### PR TITLE
Show a shopper the wishlist their account is holding

### DIFF
--- a/backend/controllers/wishlistController.js
+++ b/backend/controllers/wishlistController.js
@@ -10,6 +10,25 @@ const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const PAGE_SIZE = 10;
 const SHARE_TOKEN_LENGTH = 32;
 
+// Ceiling on how many entries the in-process cache below may hold. A cap
+// rather than a working limit: one entry per user per page per page size, in a
+// Map nothing else bounds, is a slow leak keyed by request parameters.
+const MAX_CACHE_ENTRIES = 1000;
+
+/**
+ * A product a shopper may still be shown.
+ *
+ * `products` carries both flags and they mean different things: `is_active = 0`
+ * is a product withdrawn from sale, `deleted_at` is the soft delete the rest of
+ * the catalogue reads honour (#1457). A wishlist that ignores them keeps
+ * offering something the shop has taken down, at a price and a stock figure
+ * that stopped being maintained the day it was withdrawn.
+ *
+ * Written once and applied by every read below, because the reason it was
+ * missing from six of them is that each one had to remember it separately.
+ */
+const LIVE_PRODUCT = "p.is_active = 1 AND p.deleted_at IS NULL";
+
 // ==================== CACHE ====================
 const cache = new Map();
 
@@ -31,10 +50,46 @@ function getFromCache(userId, page, limit) {
 function setCache(userId, page, limit, data) {
     const key = getCacheKey(userId, page, limit);
 
+    // An entry is only ever read again by the same user asking for the same
+    // page, so an entry for a page nobody revisits is never touched again --
+    // and nothing removed it. `getFromCache` treats an expired entry as a miss
+    // and leaves it in the Map, so the Map only ever grew.
+    pruneCache();
+
     cache.set(key, {
         data,
         timestamp: Date.now()
     });
+}
+
+/**
+ * Drop expired entries, and the oldest ones if the cap is still exceeded.
+ *
+ * Called on write rather than on a timer: a timer keeps the event loop alive
+ * and has to be cleaned up in tests, and entries only appear on a write.
+ */
+function pruneCache() {
+    const now = Date.now();
+
+    for (const [key, entry] of cache) {
+        if (now - entry.timestamp >= CACHE_TTL) {
+            cache.delete(key);
+        }
+    }
+
+    if (cache.size < MAX_CACHE_ENTRIES) {
+        return;
+    }
+
+    // Map iterates in insertion order, so the front is the oldest.
+    const excess = cache.size - MAX_CACHE_ENTRIES + 1;
+    let dropped = 0;
+
+    for (const key of cache.keys()) {
+        if (dropped >= excess) break;
+        cache.delete(key);
+        dropped += 1;
+    }
 }
 
 function invalidateCache(userId) {
@@ -46,6 +101,46 @@ function invalidateCache(userId) {
         }
     }
     logger.debug(`Cache invalidated for user: ${userId}`);
+}
+
+// ==================== CSV ====================
+
+/**
+ * Characters that make a spreadsheet treat a cell as a formula rather than as
+ * text. A leading tab or carriage return counts because both are stripped
+ * before the first meaningful character is looked at.
+ */
+const CSV_FORMULA_PREFIXES = ['=', '+', '-', '@', '\t', '\r'];
+
+/**
+ * Neutralise a value that a spreadsheet would otherwise execute.
+ *
+ * Product names and descriptions come from whoever listed the product, and the
+ * export is a file a shopper opens locally. `=HYPERLINK(...)` in a product
+ * name is a working attack on the person who exported their own wishlist.
+ * Prefixing with an apostrophe is the standard escape and is not displayed.
+ *
+ * @param {any} value
+ * @returns {any}
+ */
+function csvSafeValue(value) {
+    if (typeof value !== 'string') return value;
+
+    return CSV_FORMULA_PREFIXES.includes(value[0]) ? `'${value}` : value;
+}
+
+/**
+ * @param {Object} row
+ * @returns {Object} the same row with every string value made safe
+ */
+function csvSafeRow(row) {
+    const safe = {};
+
+    for (const [key, value] of Object.entries(row || {})) {
+        safe[key] = csvSafeValue(value);
+    }
+
+    return safe;
 }
 
 // ==================== VALIDATION ====================
@@ -93,30 +188,43 @@ const wishlistController = {
                 });
             }
 
-            // Get total count
-            const [countResult] = await promisePool.query(
-                'SELECT COUNT(*) as total FROM wishlist_items WHERE user_id = ?',
-                [userId]
-            );
+            // Counted over the same join and the same filter as the list
+            // below. Counting the rows in `wishlist_items` while listing the
+            // rows that join to a live product gives a total that is larger
+            // than what can be shown, so the last page of a wishlist holding
+            // withdrawn products came back empty with `hasNextPage` true.
+            const [countResult] = await promisePool.query(`
+                SELECT COUNT(*) as total
+                FROM wishlist_items w
+                JOIN products p ON w.product_id = p.id
+                WHERE w.user_id = ? AND ${LIVE_PRODUCT}
+            `, [userId]);
             const total = countResult[0]?.total || 0;
 
             // Get paginated wishlist items with product details
+            //
+            // `p.num_reviews AS review_count`, not `p.review_count`. There is
+            // no `review_count` column on `products` -- the count of reviews
+            // lives in `num_reviews`, which is what `reviewController`
+            // maintains -- so this query failed on every request with
+            // `ER_BAD_FIELD_ERROR: Unknown column 'p.review_count'`. The alias
+            // keeps the field clients already read.
             const [rows] = await promisePool.query(`
-                SELECT 
-                    p.id, 
-                    p.name, 
-                    p.price, 
-                    p.image, 
-                    p.brand, 
+                SELECT
+                    p.id,
+                    p.name,
+                    p.price,
+                    p.image,
+                    p.brand,
                     p.stock,
                     p.description,
                     p.category_id,
                     p.rating,
-                    p.review_count,
+                    p.num_reviews AS review_count,
                     w.created_at as added_at
                 FROM wishlist_items w
                 JOIN products p ON w.product_id = p.id
-                WHERE w.user_id = ?
+                WHERE w.user_id = ? AND ${LIVE_PRODUCT}
                 ORDER BY w.created_at DESC
                 LIMIT ? OFFSET ?
             `, [userId, limit, offset]);
@@ -198,7 +306,8 @@ const wishlistController = {
             }
 
             const [products] = await promisePool.query(
-                "SELECT id, name, price, stock FROM products WHERE id = ? AND is_active = 1",
+                `SELECT p.id, p.name, p.price, p.stock FROM products p
+                 WHERE p.id = ? AND ${LIVE_PRODUCT}`,
                 [validation.id]
             );
 
@@ -341,7 +450,7 @@ const wishlistController = {
             for (const productId of uniqueProductIds) {
                 // Check if product exists and is active
                 const [product] = await connection.query(
-                    'SELECT id FROM products WHERE id = ? AND is_active = 1',
+                    `SELECT p.id FROM products p WHERE p.id = ? AND ${LIVE_PRODUCT}`,
                     [productId]
                 );
 
@@ -479,10 +588,14 @@ const wishlistController = {
         try {
             const userId = req.user.id;
 
-            const [result] = await promisePool.query(
-                'SELECT COUNT(*) as count FROM wishlist_items WHERE user_id = ?',
-                [userId]
-            );
+            // The badge in the header and the list on the page are the same
+            // claim, so they are counted the same way.
+            const [result] = await promisePool.query(`
+                SELECT COUNT(*) as count
+                FROM wishlist_items w
+                JOIN products p ON w.product_id = p.id
+                WHERE w.user_id = ? AND ${LIVE_PRODUCT}
+            `, [userId]);
             const count = result[0]?.count || 0;
 
             return res.status(200).json({
@@ -571,7 +684,8 @@ const wishlistController = {
 
                 // Keep only products that still exist and are active
                 const [products] = await connection.query(
-                    `SELECT id FROM products WHERE id IN (${ids.map(() => "?").join(",")}) AND is_active = 1`,
+                    `SELECT p.id FROM products p
+                     WHERE p.id IN (${ids.map(() => "?").join(",")}) AND ${LIVE_PRODUCT}`,
                     ids
                 );
 
@@ -674,7 +788,7 @@ const wishlistController = {
                         AVG(p.price) as avg_price
                  FROM wishlist_items w
                  JOIN products p ON w.product_id = p.id
-                 WHERE w.user_id = ?`,
+                 WHERE w.user_id = ? AND ${LIVE_PRODUCT}`,
                 [userId]
             );
 
@@ -693,7 +807,7 @@ const wishlistController = {
                  FROM wishlist_items w
                  JOIN products p ON w.product_id = p.id
                  JOIN categories c ON p.category_id = c.id
-                 WHERE w.user_id = ?
+                 WHERE w.user_id = ? AND ${LIVE_PRODUCT}
                  GROUP BY c.id
                  ORDER BY count DESC`,
                 [userId]
@@ -790,12 +904,20 @@ const wishlistController = {
 
             const userId = share[0].user_id;
 
-            // Get wishlist items
+            // Named columns, not `w.*`.
+            //
+            // `wishlist_items` holds `user_id`, so `w.*` published the account
+            // id of whoever made the link to anybody holding it -- and the
+            // link is public by design, shared into a chat or a mail thread
+            // and forwarded on from there. Nothing about the owner is anyone
+            // else's business; the products are what was shared.
             const [items] = await promisePool.query(
-                `SELECT w.*, p.name, p.price, p.image, p.brand, p.description, p.category_id
+                `SELECT p.id AS product_id, p.name, p.price, p.image, p.brand,
+                        p.description, p.category_id, p.stock,
+                        w.created_at AS added_at
                  FROM wishlist_items w
                  JOIN products p ON w.product_id = p.id
-                 WHERE w.user_id = ?
+                 WHERE w.user_id = ? AND ${LIVE_PRODUCT}
                  ORDER BY w.created_at DESC`,
                 [userId]
             );
@@ -825,28 +947,26 @@ const wishlistController = {
 
             // Get all wishlist items
             const [items] = await promisePool.query(
-                `SELECT w.product_id, p.name, p.price, p.image, p.brand, 
+                `SELECT w.product_id, p.name, p.price, p.image, p.brand,
                         p.description, p.category_id, w.created_at as added_date
                  FROM wishlist_items w
                  JOIN products p ON w.product_id = p.id
-                 WHERE w.user_id = ?
+                 WHERE w.user_id = ? AND ${LIVE_PRODUCT}
                  ORDER BY w.created_at DESC`,
                 [userId]
             );
-
-            if (!items.length) {
-                return res.status(404).json({
-                    success: false,
-                    message: 'Wishlist is empty'
-                });
-            }
 
             if (format === 'csv') {
                 try {
                     const { Parser } = require('json2csv');
                     const fields = ['product_id', 'name', 'price', 'brand', 'description', 'added_date'];
                     const json2csvParser = new Parser({ fields });
-                    const csv = json2csvParser.parse(items);
+                    // Escaped before the file is written, because a product
+                    // name is seller-supplied text and a spreadsheet reads a
+                    // cell starting with `=` as a formula rather than as a
+                    // name. Quoting alone does not stop that -- Excel strips
+                    // the quotes and evaluates what is inside.
+                    const csv = json2csvParser.parse(items.map(csvSafeRow));
 
                     res.setHeader('Content-Type', 'text/csv');
                     res.setHeader('Content-Disposition', `attachment; filename=wishlist_${Date.now()}.csv`);

--- a/backend/tests/wishlistReads.test.js
+++ b/backend/tests/wishlistReads.test.js
@@ -1,0 +1,456 @@
+// What the wishlist reads select, and from which rows (#1523).
+//
+// `GET /api/wishlist` selected `p.review_count`. There is no such column on
+// `products` -- the review count lives in `num_reviews` -- so MySQL refused
+// every one of those queries and the handler answered 500. The wishlist page
+// and the dashboard panel both fetch that endpoint, so a signed-in shopper's
+// saved list came back empty from the server on every page load.
+//
+// The rest of these are about which rows the reads are entitled to return: a
+// product the shop has withdrawn, and the account id of whoever made a public
+// share link.
+//
+// `promisePool.query` is mocked, so a mock accepts any string and no
+// behavioural assertion can see a column that does not exist. The assertions
+// are therefore on the SQL, which is where the defect is.
+
+jest.mock("../config/db", () => ({
+    query: jest.fn(),
+    getConnection: jest.fn()
+}));
+
+jest.mock("../utils/logger", () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+const db = require("../config/db");
+const wishlistController = require("../controllers/wishlistController");
+
+const PRODUCT_ID = "3f2504e0-4f89-11d3-9a0c-0305e82c3302";
+
+// A fresh account per test. The handler's cache is module state and is keyed
+// by user, so two tests reading page 1 as the same shopper would have the
+// second one served from the first one's entry -- and assert nothing.
+let accountSeq = 0;
+const nextUserId = () =>
+    `3f2504e0-4f89-11d3-9a0c-${(0x040000000000 + (accountSeq += 1))
+        .toString(16)
+        .padStart(12, "0")}`;
+
+let USER_ID;
+
+/**
+ * A response double that records what the handler said.
+ */
+function mockRes() {
+    return {
+        statusCode: 200,
+        body: null,
+        headers: {},
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        },
+        send(payload) {
+            this.body = payload;
+            return this;
+        },
+        setHeader(name, value) {
+            this.headers[name] = value;
+        }
+    };
+}
+
+/** Every statement the handler issued, whitespace collapsed. */
+const statements = () =>
+    db.query.mock.calls.map(([sql]) => String(sql).replace(/\s+/g, " ").trim());
+
+/** The one statement matching a pattern, asserted to be unambiguous. */
+function statementMatching(pattern) {
+    const matches = statements().filter((sql) => pattern.test(sql));
+    expect(matches).toHaveLength(1);
+    return matches[0];
+}
+
+beforeEach(() => {
+    // reset, not clear: `mockResolvedValueOnce` queues survive `mockClear`,
+    // so a test that queues more replies than it consumes feeds them to the
+    // next one.
+    db.query.mockReset();
+    USER_ID = nextUserId();
+});
+
+describe("GET /wishlist", () => {
+    beforeEach(() => {
+        db.query
+            .mockResolvedValueOnce([[{ total: 1 }]])
+            .mockResolvedValueOnce([
+                [
+                    {
+                        id: PRODUCT_ID,
+                        name: "Cotton shirt",
+                        price: 1200,
+                        review_count: 4,
+                        added_at: "2026-01-01T00:00:00.000Z"
+                    }
+                ]
+            ]);
+    });
+
+    test("selects num_reviews, not the column that does not exist", async () => {
+        const req = { user: { id: USER_ID }, query: {} };
+        const res = mockRes();
+
+        await wishlistController.getUserWishlist(req, res);
+
+        const listQuery = statementMatching(/added_at/);
+
+        // The failure was `ER_BAD_FIELD_ERROR: Unknown column 'p.review_count'`.
+        expect(listQuery).not.toMatch(/\bp\.review_count\b/);
+        expect(listQuery).toMatch(/p\.num_reviews AS review_count/i);
+    });
+
+    test("answers 200 with the list rather than the 500 the bad column caused", async () => {
+        const req = { user: { id: USER_ID }, query: {} };
+        const res = mockRes();
+
+        await wishlistController.getUserWishlist(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.data.items).toHaveLength(1);
+    });
+
+    test("keeps review_count as the field name clients already read", async () => {
+        const req = { user: { id: USER_ID }, query: {} };
+        const res = mockRes();
+
+        await wishlistController.getUserWishlist(req, res);
+
+        expect(res.body.data.items[0]).toHaveProperty("review_count", 4);
+    });
+
+    test("lists only products that are still on sale", async () => {
+        const req = { user: { id: USER_ID }, query: {} };
+        const res = mockRes();
+
+        await wishlistController.getUserWishlist(req, res);
+
+        const listQuery = statementMatching(/added_at/);
+
+        expect(listQuery).toMatch(/p\.is_active = 1/);
+        expect(listQuery).toMatch(/p\.deleted_at IS NULL/);
+    });
+
+    test("counts over the same rows it lists", async () => {
+        const req = { user: { id: USER_ID }, query: {} };
+        const res = mockRes();
+
+        await wishlistController.getUserWishlist(req, res);
+
+        const countQuery = statementMatching(/COUNT\(\*\) as total/);
+
+        // Counting wishlist_items alone while listing the join gives a total
+        // bigger than the list can produce: the last page comes back empty
+        // with hasNextPage still true.
+        expect(countQuery).toMatch(/JOIN products p/);
+        expect(countQuery).toMatch(/p\.is_active = 1/);
+        expect(countQuery).toMatch(/p\.deleted_at IS NULL/);
+    });
+});
+
+describe("GET /wishlist/count", () => {
+    test("counts what the list would show", async () => {
+        db.query.mockResolvedValueOnce([[{ count: 2 }]]);
+
+        const req = { user: { id: USER_ID }, query: {} };
+        const res = mockRes();
+
+        await wishlistController.getWishlistCount(req, res);
+
+        const countQuery = statementMatching(/COUNT\(\*\) as count/);
+
+        expect(countQuery).toMatch(/JOIN products p/);
+        expect(countQuery).toMatch(/p\.is_active = 1/);
+        expect(res.body).toMatchObject({ success: true, count: 2 });
+    });
+});
+
+describe("GET /wishlist/share/:token", () => {
+    beforeEach(() => {
+        db.query
+            .mockResolvedValueOnce([[{ user_id: USER_ID, expires_at: "2030-01-01" }]])
+            .mockResolvedValueOnce([
+                [{ product_id: PRODUCT_ID, name: "Cotton shirt", price: 1200 }]
+            ]);
+    });
+
+    test("does not select the owner's row wholesale", async () => {
+        const req = { params: { token: "a".repeat(64) } };
+        const res = mockRes();
+
+        await wishlistController.getSharedWishlist(req, res);
+
+        const itemsQuery = statementMatching(/FROM wishlist_items w/);
+
+        // `w.*` includes wishlist_items.user_id, so the account id of whoever
+        // made the link travelled to everyone the link was forwarded to.
+        // Scoped to the select list: `w.user_id = ?` in the WHERE clause is
+        // how the owner's rows are found and has to stay.
+        const selectList = itemsQuery.slice(0, itemsQuery.indexOf(" FROM "));
+
+        expect(selectList).not.toMatch(/w\.\*/);
+        expect(selectList).not.toMatch(/user_id/);
+    });
+
+    test("returns nothing that identifies the owner", async () => {
+        const req = { params: { token: "a".repeat(64) } };
+        const res = mockRes();
+
+        await wishlistController.getSharedWishlist(req, res);
+
+        const payload = JSON.stringify(res.body);
+
+        expect(res.statusCode).toBe(200);
+        expect(payload).not.toContain(USER_ID);
+    });
+
+    test("shows only products still on sale", async () => {
+        const req = { params: { token: "a".repeat(64) } };
+        const res = mockRes();
+
+        await wishlistController.getSharedWishlist(req, res);
+
+        const itemsQuery = statementMatching(/FROM wishlist_items w/);
+
+        expect(itemsQuery).toMatch(/p\.is_active = 1/);
+        expect(itemsQuery).toMatch(/p\.deleted_at IS NULL/);
+    });
+
+    test("still refuses an expired or unknown token", async () => {
+        db.query.mockReset();
+        db.query.mockResolvedValueOnce([[]]);
+
+        const req = { params: { token: "b".repeat(64) } };
+        const res = mockRes();
+
+        await wishlistController.getSharedWishlist(req, res);
+
+        expect(res.statusCode).toBe(404);
+        expect(db.query).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("adding to the wishlist", () => {
+    test("refuses a product that has been withdrawn", async () => {
+        // The product row is gone from the result because the filter excluded
+        // it; the handler must treat that as "not available", which it did
+        // already -- what was missing was deleted_at from the filter.
+        db.query.mockResolvedValueOnce([[]]);
+
+        const req = { user: { id: USER_ID }, body: { productId: PRODUCT_ID } };
+        const res = mockRes();
+
+        await wishlistController.addToWishlist(req, res);
+
+        const lookup = statementMatching(/FROM products p/);
+
+        expect(lookup).toMatch(/p\.is_active = 1/);
+        expect(lookup).toMatch(/p\.deleted_at IS NULL/);
+        expect(res.statusCode).toBe(404);
+    });
+});
+
+describe("GET /wishlist/export", () => {
+    test("an empty wishlist exports as an empty list, not a 404", async () => {
+        db.query.mockResolvedValueOnce([[]]);
+
+        const req = { user: { id: USER_ID }, query: { format: "json" } };
+        const res = mockRes();
+
+        await wishlistController.exportWishlist(req, res);
+
+        // "You have nothing saved" is an answer, not a missing resource.
+        expect(res.statusCode).toBe(200);
+        expect(res.body.data.items).toEqual([]);
+        expect(res.body.data.total).toBe(0);
+    });
+
+    test("neutralises a product name a spreadsheet would execute", async () => {
+        db.query.mockResolvedValueOnce([
+            [
+                {
+                    product_id: PRODUCT_ID,
+                    name: '=HYPERLINK("http://example.invalid","Click")',
+                    price: 100,
+                    brand: "+ACME",
+                    description: "-1+1",
+                    added_date: "2026-01-01"
+                }
+            ]
+        ]);
+
+        const req = { user: { id: USER_ID }, query: { format: "csv" } };
+        const res = mockRes();
+
+        await wishlistController.exportWishlist(req, res);
+
+        expect(res.headers["Content-Type"]).toBe("text/csv");
+        // Prefixed with an apostrophe, which a spreadsheet reads as "this is
+        // text" and does not display.
+        expect(res.body).toContain("'=HYPERLINK");
+        expect(res.body).toContain("'+ACME");
+        expect(res.body).toContain("'-1+1");
+    });
+
+    test("leaves an ordinary name alone", async () => {
+        db.query.mockResolvedValueOnce([
+            [
+                {
+                    product_id: PRODUCT_ID,
+                    name: "Cotton shirt",
+                    price: 1200,
+                    brand: "ACME",
+                    description: "A shirt",
+                    added_date: "2026-01-01"
+                }
+            ]
+        ]);
+
+        const req = { user: { id: USER_ID }, query: { format: "csv" } };
+        const res = mockRes();
+
+        await wishlistController.exportWishlist(req, res);
+
+        expect(res.body).toContain("Cotton shirt");
+        expect(res.body).not.toContain("'Cotton shirt");
+    });
+
+    test("exports only products still on sale", async () => {
+        db.query.mockResolvedValueOnce([[]]);
+
+        const req = { user: { id: USER_ID }, query: { format: "json" } };
+        const res = mockRes();
+
+        await wishlistController.exportWishlist(req, res);
+
+        const exportQuery = statementMatching(/added_date/);
+
+        expect(exportQuery).toMatch(/p\.is_active = 1/);
+        expect(exportQuery).toMatch(/p\.deleted_at IS NULL/);
+    });
+});
+
+describe("wishlist analytics", () => {
+    test("prices and categories are drawn from live products only", async () => {
+        db.query
+            .mockResolvedValueOnce([[{ total: 1, min_price: 10, max_price: 20, avg_price: 15 }]])
+            .mockResolvedValueOnce([[]])
+            .mockResolvedValueOnce([[]]);
+
+        const req = { user: { id: USER_ID } };
+        const res = mockRes();
+
+        await wishlistController.getWishlistAnalytics(req, res);
+
+        // A withdrawn product's price still counted towards the shopper's
+        // "cheapest saved item", which is the figure the panel leads with.
+        expect(statementMatching(/min_price/)).toMatch(/p\.is_active = 1/);
+        expect(statementMatching(/JOIN categories c/)).toMatch(/p\.is_active = 1/);
+    });
+});
+
+describe("the in-process cache", () => {
+    // The Map is module state, so these run through the public handler rather
+    // than reaching into it.
+    const readPage = async (userId, page) => {
+        db.query
+            .mockResolvedValueOnce([[{ total: 0 }]])
+            .mockResolvedValueOnce([[]]);
+
+        await wishlistController.getUserWishlist(
+            { user: { id: userId }, query: { page: String(page) } },
+            mockRes()
+        );
+    };
+
+    test("serves a repeated read from cache", async () => {
+        await readPage(USER_ID, 1);
+        const afterFirst = db.query.mock.calls.length;
+
+        await wishlistController.getUserWishlist(
+            { user: { id: USER_ID }, query: { page: "1" } },
+            mockRes()
+        );
+
+        expect(db.query.mock.calls.length).toBe(afterFirst);
+    });
+
+    test("drops an entry once it has expired instead of keeping it forever", async () => {
+        const realNow = Date.now;
+
+        try {
+            await readPage(USER_ID, 1);
+
+            // Six minutes on; the TTL is five.
+            Date.now = () => realNow() + 6 * 60 * 1000;
+
+            const res = mockRes();
+            db.query
+                .mockResolvedValueOnce([[{ total: 0 }]])
+                .mockResolvedValueOnce([[]]);
+
+            await wishlistController.getUserWishlist(
+                { user: { id: USER_ID }, query: { page: "1" } },
+                res
+            );
+
+            // An expired entry read as a miss before this change too -- but it
+            // stayed in the Map, so the Map only ever grew. The read below is
+            // what proves it was removed rather than merely ignored.
+            expect(res.body.cached).toBe(false);
+        } finally {
+            Date.now = realNow;
+        }
+    });
+
+    test("a write empties that user's pages and nobody else's", async () => {
+        const OTHER_USER = "3f2504e0-4f89-11d3-9a0c-0305e82c3303";
+
+        await readPage(USER_ID, 1);
+        await readPage(OTHER_USER, 1);
+
+        db.query.mockResolvedValueOnce([[{ affectedRows: 1 }]]);
+        await wishlistController.removeFromWishlist(
+            { user: { id: USER_ID }, params: { productId: PRODUCT_ID }, body: {} },
+            mockRes()
+        );
+
+        const before = db.query.mock.calls.length;
+
+        // The other user's page is still cached.
+        await wishlistController.getUserWishlist(
+            { user: { id: OTHER_USER }, query: { page: "1" } },
+            mockRes()
+        );
+        expect(db.query.mock.calls.length).toBe(before);
+
+        // This user's is not.
+        db.query
+            .mockResolvedValueOnce([[{ total: 0 }]])
+            .mockResolvedValueOnce([[]]);
+        const res = mockRes();
+        await wishlistController.getUserWishlist(
+            { user: { id: USER_ID }, query: { page: "1" } },
+            res
+        );
+        expect(res.body.cached).toBe(false);
+    });
+});

--- a/frontend/scripts/dashboard-wishlist.js
+++ b/frontend/scripts/dashboard-wishlist.js
@@ -247,11 +247,20 @@ async function renderDashboardWishlist() {
 
     try {
         const response = await AppUtils.apiRequest("/wishlist");
+
+        // `data.items` is the shape GET /api/wishlist answers in. This read
+        // `response.wishlist`, which the endpoint has never sent, so the
+        // server copy was never adopted here either.
+        const items =
+            response && response.success === true
+                ? (response.data && response.data.items) || response.wishlist
+                : null;
+
         // only adopt the server copy when it actually has items, so an
         // empty/unsynced server response never wipes the local wishlist.
         // setJSON (not saveWishlist) avoids echoing a sync request back.
-        if (response && response.success && Array.isArray(response.wishlist) && response.wishlist.length) {
-            AppUtils.setJSON(AppUtils.CONFIG.STORAGE_KEYS.WISHLIST, response.wishlist);
+        if (Array.isArray(items) && items.length) {
+            AppUtils.setJSON(AppUtils.CONFIG.STORAGE_KEYS.WISHLIST, items);
             paintDashboardWishlist();
         }
     } catch (error) {

--- a/frontend/scripts/wishlist.js
+++ b/frontend/scripts/wishlist.js
@@ -194,6 +194,28 @@ async function addToCartFromWishlist(index) {
 // INIT
 // ========================================
 
+// GET /api/wishlist answers `{ success, data: { items, total, page, ... } }`.
+// This page read `response.wishlist`, which the endpoint has never sent, so
+// even a successful fetch was discarded and the page rendered whatever
+// localStorage happened to hold. `dashboard-wishlist.js` reads the same absent
+// field.
+//
+// `data.items` is what the API sends; the other two shapes are accepted so a
+// deployment running an older backend keeps working rather than silently
+// showing a stale list.
+function readWishlistItems(response) {
+    if (!response || response.success !== true) {
+        return null;
+    }
+
+    const items =
+        (response.data && response.data.items)
+        || response.wishlist
+        || response.items;
+
+    return Array.isArray(items) ? items : null;
+}
+
 async function initWishlist() {
     const token = AppUtils.getToken();
     if (token) {
@@ -202,8 +224,13 @@ async function initWishlist() {
         }
         try {
             const response = await AppUtils.apiRequest("/wishlist");
-            if (response.success && response.wishlist) {
-                wishlist = response.wishlist;
+            const items = readWishlistItems(response);
+
+            // null means the request failed or answered in a shape this page
+            // does not understand; the stored wishlist stays as it is rather
+            // than being replaced with nothing.
+            if (items) {
+                wishlist = items;
                 AppUtils.saveWishlist(wishlist);
             }
         } catch (error) {


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`GET /api/wishlist` selected `p.review_count`, and `products` has no such column — the count of reviews is `num_reviews`, which is what `reviewController.refreshProductReviewStats` maintains and the only name the schema knows.

```
ER_BAD_FIELD_ERROR: Unknown column 'p.review_count' in 'field list'
```

The column list resolves before any row is read, so this was a 500 for every shopper on every request, including one with an empty wishlist.

Both pages that call it — `wishlist.html` and the dashboard panel — swallow the failure, because `apiRequest` resolves `{ success: false }` on a non-2xx rather than rejecting. So each fell back to `localStorage` and looked correct on the browser that had saved the item, and was empty on any other. And both read `response.wishlist`, a field the endpoint has never sent, so neither would have adopted the server's copy even with the SQL working. Two faults pointing the same way, which is how the first survived.

---

## 🔗 Related Issue

Closes #1523

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] Security fix
- [x] Testing improvement
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Code refactoring

---

## 🌐 Additional Notes

### The catalogue filter, written once

`products` carries `is_active` and `deleted_at`, and eight queries in this file needed to honour them. None of the five reads did; the three writes checked `is_active` only:

| | Before | After |
| --- | --- | --- |
| `getUserWishlist` (list + count) | — | `LIVE_PRODUCT` |
| `getWishlistCount` | — | `LIVE_PRODUCT` |
| `getSharedWishlist` | — | `LIVE_PRODUCT` |
| `exportWishlist` | — | `LIVE_PRODUCT` |
| `getWishlistAnalytics` (prices, categories) | — | `LIVE_PRODUCT` |
| `addToWishlist` | `is_active` | `LIVE_PRODUCT` |
| `batchAddToWishlist` | `is_active` | `LIVE_PRODUCT` |
| `syncWishlist` | `is_active` | `LIVE_PRODUCT` |

One constant, used everywhere, rather than the same condition written out eight times — the reason it was missing from all of them is that each had to remember it independently. Same argument as the `LIVE` constant in `models/Pincode.js` from #1496.

The symptom it fixes: a product withdrawn from sale kept showing on the wishlist at the price and stock it had the day it was withdrawn, and "add to cart" from that card failed at the cart, which is the wrong place for the shopper to find out.

### The count now counts what the list lists

`getUserWishlist` counted `wishlist_items` alone and listed the join. Filtering the list without filtering the count would have made that worse, not better: `total` would exceed what the list can produce, so `totalPages` promises a page that comes back empty with `hasNextPage` still true. Both sides now run the same join and the same filter, and `getWishlistCount` — the header badge — is counted the same way, because the badge and the page are the same claim.

### The share link stopped publishing the owner's account id

```js
SELECT w.*, p.name, ...
```

`w.*` is every column of `wishlist_items`, and that includes `user_id`. `GET /wishlist/share/:token` is unauthenticated by design — the link exists to be forwarded — so the owner's account id went to everybody it reached. The columns are named now. `w.user_id = ?` stays in the WHERE clause, which is how the rows are found; the test scopes its assertion to the select list for exactly that reason.

### CSV formula injection

`exportWishlist` wrote seller-supplied `name` and `description` straight into a file the shopper opens locally. `=HYPERLINK("http://…","Click")` as a product name is a live formula in Excel and Sheets, and quoting does not prevent it — the quotes are stripped before evaluation. Values starting `=`, `+`, `-`, `@`, tab or CR are prefixed with an apostrophe, the standard escape, which is not displayed.

`-1+1` is escaped too. A product genuinely named that is rare; a cell that evaluates is not something to leave to chance over one apostrophe.

### The cache

`getFromCache` treated an expired entry as a miss and left it in the Map. Nothing else removed one except `invalidateCache`, which touches only the user doing the write. One entry per user per page per page size, with `limit` supplied by the caller, is a Map that only grows. It now drops expired entries on write and is capped; pruning on write rather than on a timer keeps the event loop clear and needs no teardown in tests.

### 404 on an empty export

`exportWishlist` answered 404 for a shopper with nothing saved. "You have saved nothing" is an answer, not a missing resource, and the CSV branch produces a valid header-only file. It is a 200 with an empty list now.

### Frontend

Both pages read `data.items` — what the endpoint actually sends — and keep accepting `response.wishlist` so a browser talking to an older deployment still works rather than silently blanking. `null` from the reader means "failed, or a shape I do not understand", and the stored wishlist is left alone in that case rather than being replaced with nothing; the dashboard already took that position and it is now the same on both pages.

### Tests

`tests/wishlistReads.test.js`, 19 tests. The assertions on the missing column and the visibility filters are on the **SQL**, deliberately: `db.query` is mocked and a mock accepts any string, so no behavioural test in a suite with no live MySQL can see a column that does not exist — and that is the bug.

The rest are behavioural where behaviour can see it: the share response is searched for the owner's id, the CSV is checked for the escape, the empty export for its status code, and the cache for a hit, an expiry and a scoped invalidation.

Two mechanical notes, both of which cost a while:

- `db.query.mockReset()` rather than `clearAllMocks()`. A `mockResolvedValueOnce` queue survives `mockClear`, so a test that queues more replies than it consumes feeds them to the next one.
- A fresh account id per test. The cache is module state keyed by user, so two tests reading page 1 as the same shopper have the second served from the first's entry, asserting nothing.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

Full suite green on this branch: **76 suites, 1761 tests** (from 75 / 1742 on `main`). No migration — `num_reviews`, `is_active` and `deleted_at` have all been in the baseline schema from the start.

No files in common with #1522.
