### PR TITLE
Have the recommendations shelf recommend something

### DIFF
--- a/backend/routes/recommendationRoutes.js
+++ b/backend/routes/recommendationRoutes.js
@@ -27,23 +27,32 @@ router.post("/interaction", recordInteraction);
 router.get("/", async (req, res) => {
   try {
     const userId = req.user.id;
-    const { strategy = 'hybrid', limit = 10 } = req.query;
+    const { strategy = 'hybrid', limit } = req.query;
 
     // Create strategy instance
     const strategyInstance = RecommendationStrategyFactory.createStrategy(strategy);
-    
-    // Get recommendations
-    const recommendations = await strategyInstance.getRecommendations(userId, parseInt(limit));
 
-    // Return response matching existing format
+    // Get recommendations. The limit is clamped inside the strategy now,
+    // rather than going from the query string into a LIMIT clause.
+    const recommendations = await strategyInstance.getRecommendations(userId, limit);
+
+    // `data` is the list.
+    //
+    // It was an object wrapping the list, and the only caller reads
+    // `response.data.length` (frontend/scripts/recommendations.js:366) -- so
+    // every response, including a good one, fell through to "Explore more
+    // products to get personalized recommendations!". Which strategy ran is
+    // still reported, beside the list instead of around it, which is also the
+    // { success, message, data } envelope AGENTS.md specifies.
     res.json({
       success: true,
-      data: {
+      message: 'Recommendations fetched successfully',
+      data: recommendations,
+      meta: {
         userId,
         strategy: strategyInstance.name,
-        strategyType: strategy,
-        count: recommendations.length,
-        recommendations
+        strategyType: strategyInstance.type,
+        count: recommendations.length
       }
     });
   } catch (error) {

--- a/backend/services/recommendationStrategyService.js
+++ b/backend/services/recommendationStrategyService.js
@@ -1,5 +1,24 @@
 // backend/services/recommendationStrategyService.js
-const db = require('../config/db').promise;
+//
+// The strategies behind GET /api/recommendations (#1525).
+//
+// Every one of them was written against a schema this project does not have:
+// `products.image_url` and `products.category` (the columns are `image` and
+// `category_id`), `products.discount_price` and `products.discount_percentage`
+// (there are none -- a discount is `compare_price` above `price`), and, in four
+// separate queries, `orders.product_id`. Orders have never carried a product;
+// what was bought lives in `order_items`.
+//
+// Each strategy then caught the resulting `ER_BAD_FIELD_ERROR` and returned an
+// empty array, so the endpoint answered `200 {"count": 0}` and the homepage
+// rendered "Explore more products to get personalized recommendations!" to
+// every shopper, forever. Failing loudly is why the catches below rethrow.
+//
+// The queries here go through `order_items`, `product_views`, `wishlist_items`
+// and `categories`, which is where this data actually is.
+
+const db = require("../config/db");
+const logger = require("../utils/logger");
 
 // ============================================
 // STRATEGY TYPES
@@ -16,6 +35,107 @@ const STRATEGY_TYPES = {
 };
 
 // ============================================
+// SHARED SQL
+// ============================================
+
+/**
+ * A product that may be recommended.
+ *
+ * Recommending something the shop has withdrawn wastes the slot and sends the
+ * shopper to a product page that will not load.
+ */
+const LIVE_PRODUCT = "p.is_active = 1 AND p.deleted_at IS NULL";
+
+/**
+ * The columns every strategy returns, so one mapper can shape all of them.
+ *
+ * `p.image`, not `p.image_url`. `c.name` through `categories`, because a
+ * product carries a `category_id` and not a category name.
+ */
+const PRODUCT_COLUMNS = `
+    p.id,
+    p.name,
+    p.price,
+    p.compare_price,
+    p.image,
+    p.stock,
+    p.rating,
+    p.num_reviews,
+    p.category_id,
+    c.name AS category
+`;
+
+const PRODUCT_SOURCE = `
+    FROM products p
+    LEFT JOIN categories c ON c.id = p.category_id
+`;
+
+/**
+ * Orders that count as a purchase.
+ *
+ * Cancelled and refunded orders say nothing about what somebody wanted, and a
+ * soft-deleted one should not be read at all.
+ */
+const PURCHASED = `
+    o.status NOT IN ('cancelled', 'refunded') AND o.deleted_at IS NULL
+`;
+
+/**
+ * Shape a product row for the client.
+ *
+ * `discount` is derived rather than stored: `compare_price` is the "was" price,
+ * so a compare price above the selling price is the discount. The columns the
+ * old code read (`discount_price`, `discount_percentage`) have never existed.
+ *
+ * @param {Object} row
+ * @param {Object} [extra] strategy-specific fields (score, reason, viewedAt)
+ * @returns {Object}
+ */
+function toRecommendation(row, extra = {}) {
+    const price = Number(row.price) || 0;
+    const comparePrice = Number(row.compare_price) || 0;
+    const hasDiscount = comparePrice > price && price > 0;
+
+    return {
+        id: row.id,
+        name: row.name,
+        price,
+        // The card reads `original_price` and `discount`; both are absent
+        // rather than zero when the product is not on offer, so no badge is
+        // rendered for a product that is simply at its normal price.
+        original_price: hasDiscount ? comparePrice : null,
+        discount: hasDiscount
+            ? Math.round(((comparePrice - price) / comparePrice) * 100)
+            : null,
+        image: row.image,
+        imageUrl: row.image,
+        stock: Number(row.stock) || 0,
+        rating: Number(row.rating) || 0,
+        review_count: Number(row.num_reviews) || 0,
+        categoryId: row.category_id,
+        category: row.category,
+        ...extra
+    };
+}
+
+/**
+ * Clamp a caller-supplied limit.
+ *
+ * `parseInt(req.query.limit)` reaches these straight from the query string, so
+ * without this `?limit=1000000` is a LIMIT clause.
+ */
+const MAX_LIMIT = 50;
+const DEFAULT_LIMIT = 10;
+
+function clampLimit(limit) {
+    const parsed = Number.parseInt(limit, 10);
+
+    if (!Number.isInteger(parsed) || parsed < 1) return DEFAULT_LIMIT;
+
+    return Math.min(parsed, MAX_LIMIT);
+}
+
+// ============================================
 // BASE STRATEGY CLASS
 // ============================================
 
@@ -25,8 +145,22 @@ class RecommendationStrategy {
         this.type = type;
     }
 
-    async getRecommendations(userId, limit = 10) {
+    async getRecommendations(userId, limit = DEFAULT_LIMIT) {
         throw new Error('getRecommendations must be implemented');
+    }
+
+    /**
+     * Report a failure and let it travel.
+     *
+     * The previous version logged and returned `[]`, which turned "the query
+     * does not compile" into "we have nothing to suggest" -- indistinguishable
+     * from the ordinary empty case, and the reason a broken file sat in the
+     * request path unnoticed. The route turns a thrown error into a 500, which
+     * is what a failed lookup is.
+     */
+    fail(error) {
+        logger.error(`${this.name} strategy failed: ${error.message}`);
+        throw error;
     }
 }
 
@@ -36,7 +170,10 @@ class RecommendationStrategy {
 
 /**
  * Trending Products Strategy
- * Returns most popular products based on sales/views
+ *
+ * Popularity over the last 30 days: units sold, views logged, and how many
+ * people have saved it. Bounded to a window because "most sold ever" is a
+ * list that stops moving.
  */
 class TrendingStrategy extends RecommendationStrategy {
     constructor() {
@@ -49,223 +186,238 @@ class TrendingStrategy extends RecommendationStrategy {
         };
     }
 
-    async getRecommendations(userId, limit = 10) {
-        try {
-            const [products] = await db.query(`
-                SELECT 
-                    p.id,
-                    p.name,
-                    p.price,
-                    p.image_url,
-                    p.category,
-                    COUNT(o.id) as sales_count,
-                    COUNT(v.id) as view_count,
-                    COUNT(w.id) as wishlist_count,
-                    DATEDIFF(NOW(), p.created_at) as days_old
-                FROM products p
-                LEFT JOIN orders o ON o.product_id = p.id
-                LEFT JOIN product_views v ON v.product_id = p.id
-                LEFT JOIN wishlist_items w ON w.product_id = p.id
-                WHERE p.stock > 0
-                GROUP BY p.id
-                ORDER BY 
-                    (COUNT(o.id) * 0.4 + COUNT(v.id) * 0.3 + COUNT(w.id) * 0.2 + 1/DATEDIFF(NOW(), p.created_at) * 0.1) DESC
-                LIMIT ?
-            `, [limit]);
+    async getRecommendations(userId, limit = DEFAULT_LIMIT) {
+        const safeLimit = clampLimit(limit);
 
-            return products.map(p => ({
-                id: p.id,
-                name: p.name,
-                price: p.price,
-                imageUrl: p.image_url,
-                category: p.category,
-                score: (p.sales_count * 0.4 + p.view_count * 0.3 + p.wishlist_count * 0.2 + 1/(p.days_old+1) * 0.1),
+        try {
+            // Counted in subqueries rather than three JOINs against one row.
+            // Joining sales, views and wishlist rows together multiplies them
+            // -- a product with 4 sales and 10 views counts 40 of each -- and
+            // the original did exactly that, then divided by DATEDIFF, which
+            // is a division by zero on anything added today.
+            const [rows] = await db.query(`
+                SELECT
+                    ${PRODUCT_COLUMNS},
+                    COALESCE(sales.units, 0) AS sales_count,
+                    COALESCE(views.total, 0) AS view_count,
+                    COALESCE(saves.total, 0) AS wishlist_count,
+                    DATEDIFF(NOW(), p.created_at) AS days_old
+                ${PRODUCT_SOURCE}
+                LEFT JOIN (
+                    SELECT oi.product_id, SUM(oi.qty) AS units
+                    FROM order_items oi
+                    JOIN orders o ON o.id = oi.order_id
+                    WHERE ${PURCHASED}
+                      AND o.created_at > DATE_SUB(NOW(), INTERVAL 30 DAY)
+                    GROUP BY oi.product_id
+                ) sales ON sales.product_id = p.id
+                LEFT JOIN (
+                    SELECT product_id, COUNT(*) AS total
+                    FROM product_views
+                    WHERE viewed_at > DATE_SUB(NOW(), INTERVAL 30 DAY)
+                    GROUP BY product_id
+                ) views ON views.product_id = p.id
+                LEFT JOIN (
+                    SELECT product_id, COUNT(*) AS total
+                    FROM wishlist_items
+                    GROUP BY product_id
+                ) saves ON saves.product_id = p.id
+                WHERE p.stock > 0 AND ${LIVE_PRODUCT}
+                ORDER BY
+                    COALESCE(sales.units, 0) * 0.4
+                    + COALESCE(views.total, 0) * 0.3
+                    + COALESCE(saves.total, 0) * 0.2
+                    + (1 / (DATEDIFF(NOW(), p.created_at) + 1)) * 0.1 DESC
+                LIMIT ?
+            `, [safeLimit]);
+
+            return rows.map((row) => toRecommendation(row, {
+                score:
+                    Number(row.sales_count) * this.weight.sales
+                    + Number(row.view_count) * this.weight.views
+                    + Number(row.wishlist_count) * this.weight.wishlist
+                    + (1 / (Number(row.days_old) + 1)) * this.weight.recency,
                 reason: 'Trending product'
             }));
         } catch (error) {
-            console.error('Trending strategy error:', error);
-            return [];
+            return this.fail(error);
         }
     }
 }
 
 /**
  * Recently Viewed Strategy
- * Returns products based on user's viewing history
+ *
+ * The last few products this shopper looked at, one row per product rather
+ * than one per view -- `product_views` is an append-only log, so a product
+ * looked at five times filled five of the ten slots.
  */
 class RecentlyViewedStrategy extends RecommendationStrategy {
     constructor() {
         super('Recently Viewed', STRATEGY_TYPES.RECENTLY_VIEWED);
     }
 
-    async getRecommendations(userId, limit = 10) {
-        try {
-            const [products] = await db.query(`
-                SELECT 
-                    p.id,
-                    p.name,
-                    p.price,
-                    p.image_url,
-                    p.category,
-                    v.viewed_at
-                FROM product_views v
-                JOIN products p ON p.id = v.product_id
-                WHERE v.user_id = ?
-                AND p.stock > 0
-                ORDER BY v.viewed_at DESC
-                LIMIT ?
-            `, [userId, limit]);
+    async getRecommendations(userId, limit = DEFAULT_LIMIT) {
+        const safeLimit = clampLimit(limit);
 
-            return products.map(p => ({
-                id: p.id,
-                name: p.name,
-                price: p.price,
-                imageUrl: p.image_url,
-                category: p.category,
-                viewedAt: p.viewed_at,
+        try {
+            const [rows] = await db.query(`
+                SELECT
+                    ${PRODUCT_COLUMNS},
+                    MAX(v.viewed_at) AS viewed_at
+                ${PRODUCT_SOURCE}
+                JOIN product_views v ON v.product_id = p.id
+                WHERE v.user_id = ? AND p.stock > 0 AND ${LIVE_PRODUCT}
+                GROUP BY p.id
+                ORDER BY viewed_at DESC
+                LIMIT ?
+            `, [userId, safeLimit]);
+
+            return rows.map((row) => toRecommendation(row, {
+                viewedAt: row.viewed_at,
                 reason: 'Recently viewed'
             }));
         } catch (error) {
-            console.error('Recently viewed strategy error:', error);
-            return [];
+            return this.fail(error);
         }
     }
 }
 
 /**
  * Collaborative Filtering Strategy
- * Finds products based on similar users' preferences
+ *
+ * What people who bought what this shopper bought also bought.
  */
 class CollaborativeStrategy extends RecommendationStrategy {
     constructor() {
         super('Collaborative Filtering', STRATEGY_TYPES.COLLABORATIVE);
     }
 
-    async getRecommendations(userId, limit = 10) {
+    async getRecommendations(userId, limit = DEFAULT_LIMIT) {
+        const safeLimit = clampLimit(limit);
+
         try {
-            // Find similar users based on purchase history
+            // Shoppers who bought at least one of the same products, ordered
+            // by how much overlap there is. The join is order_items to
+            // order_items through orders, because that is where a product id
+            // on a purchase can be found.
             const [similarUsers] = await db.query(`
-                SELECT DISTINCT o2.user_id
-                FROM orders o1
-                JOIN orders o2 ON o1.product_id = o2.product_id
+                SELECT o2.user_id, COUNT(DISTINCT oi2.product_id) AS shared
+                FROM order_items oi1
+                JOIN orders o1 ON o1.id = oi1.order_id
+                JOIN order_items oi2 ON oi2.product_id = oi1.product_id
+                JOIN orders o2 ON o2.id = oi2.order_id
                 WHERE o1.user_id = ?
-                AND o2.user_id != ?
+                  AND o2.user_id IS NOT NULL
+                  AND o2.user_id <> ?
+                  AND o1.status NOT IN ('cancelled', 'refunded')
+                  AND o1.deleted_at IS NULL
+                  AND o2.status NOT IN ('cancelled', 'refunded')
+                  AND o2.deleted_at IS NULL
                 GROUP BY o2.user_id
-                ORDER BY COUNT(o2.product_id) DESC
+                ORDER BY shared DESC
                 LIMIT 5
             `, [userId, userId]);
 
-            if (similarUsers.length === 0) {
+            if (!similarUsers.length) {
                 return [];
             }
 
-            const userIds = similarUsers.map(u => u.user_id);
+            const userIds = similarUsers.map((row) => row.user_id);
             const placeholders = userIds.map(() => '?').join(',');
 
-            const [products] = await db.query(`
-                SELECT 
-                    p.id,
-                    p.name,
-                    p.price,
-                    p.image_url,
-                    p.category,
-                    COUNT(o.id) as purchase_count
-                FROM orders o
-                JOIN products p ON p.id = o.product_id
+            const [rows] = await db.query(`
+                SELECT
+                    ${PRODUCT_COLUMNS},
+                    COUNT(*) AS purchase_count
+                ${PRODUCT_SOURCE}
+                JOIN order_items oi ON oi.product_id = p.id
+                JOIN orders o ON o.id = oi.order_id
                 WHERE o.user_id IN (${placeholders})
-                AND p.id NOT IN (
-                    SELECT product_id FROM orders WHERE user_id = ?
-                )
-                AND p.stock > 0
+                  AND ${PURCHASED}
+                  AND p.stock > 0 AND ${LIVE_PRODUCT}
+                  AND p.id NOT IN (
+                      SELECT oi_own.product_id
+                      FROM order_items oi_own
+                      JOIN orders o_own ON o_own.id = oi_own.order_id
+                      WHERE o_own.user_id = ?
+                  )
                 GROUP BY p.id
                 ORDER BY purchase_count DESC
                 LIMIT ?
-            `, [...userIds, userId, limit]);
+            `, [...userIds, userId, safeLimit]);
 
-            return products.map(p => ({
-                id: p.id,
-                name: p.name,
-                price: p.price,
-                imageUrl: p.image_url,
-                category: p.category,
-                score: p.purchase_count,
+            return rows.map((row) => toRecommendation(row, {
+                score: Number(row.purchase_count),
                 reason: 'Users like you also bought'
             }));
         } catch (error) {
-            console.error('Collaborative strategy error:', error);
-            return [];
+            return this.fail(error);
         }
     }
 }
 
 /**
  * Content-Based Strategy
- * Recommends products similar to what user has viewed/purchased
+ *
+ * More of the categories this shopper buys from.
  */
 class ContentBasedStrategy extends RecommendationStrategy {
     constructor() {
         super('Content-Based', STRATEGY_TYPES.CONTENT_BASED);
     }
 
-    async getRecommendations(userId, limit = 10) {
+    async getRecommendations(userId, limit = DEFAULT_LIMIT) {
+        const safeLimit = clampLimit(limit);
+
         try {
-            // Get user's preferred categories
             const [preferences] = await db.query(`
-                SELECT 
-                    p.category,
-                    COUNT(*) as count
-                FROM orders o
-                JOIN products p ON p.id = o.product_id
-                WHERE o.user_id = ?
-                GROUP BY p.category
-                ORDER BY count DESC
+                SELECT p.category_id, COUNT(*) AS purchases
+                FROM order_items oi
+                JOIN orders o ON o.id = oi.order_id
+                JOIN products p ON p.id = oi.product_id
+                WHERE o.user_id = ? AND ${PURCHASED} AND p.category_id IS NOT NULL
+                GROUP BY p.category_id
+                ORDER BY purchases DESC
                 LIMIT 3
             `, [userId]);
 
-            if (preferences.length === 0) {
-                // Fallback to trending
-                const trending = new TrendingStrategy();
-                return trending.getRecommendations(userId, limit);
+            if (!preferences.length) {
+                // Nothing bought yet, so nothing to be similar to.
+                return new TrendingStrategy().getRecommendations(userId, safeLimit);
             }
 
-            const categories = preferences.map(p => p.category);
-            const placeholders = categories.map(() => '?').join(',');
+            const categoryIds = preferences.map((row) => row.category_id);
+            const placeholders = categoryIds.map(() => '?').join(',');
 
-            const [products] = await db.query(`
-                SELECT 
-                    p.id,
-                    p.name,
-                    p.price,
-                    p.image_url,
-                    p.category
-                FROM products p
-                WHERE p.category IN (${placeholders})
-                AND p.id NOT IN (
-                    SELECT product_id FROM orders WHERE user_id = ?
-                )
-                AND p.stock > 0
-                ORDER BY RAND()
+            const [rows] = await db.query(`
+                SELECT ${PRODUCT_COLUMNS}
+                ${PRODUCT_SOURCE}
+                WHERE p.category_id IN (${placeholders})
+                  AND p.stock > 0 AND ${LIVE_PRODUCT}
+                  AND p.id NOT IN (
+                      SELECT oi.product_id
+                      FROM order_items oi
+                      JOIN orders o ON o.id = oi.order_id
+                      WHERE o.user_id = ?
+                  )
+                ORDER BY p.rating DESC, p.sold_count DESC
                 LIMIT ?
-            `, [...categories, userId, limit]);
+            `, [...categoryIds, userId, safeLimit]);
 
-            return products.map(p => ({
-                id: p.id,
-                name: p.name,
-                price: p.price,
-                imageUrl: p.image_url,
-                category: p.category,
+            return rows.map((row) => toRecommendation(row, {
                 reason: 'Based on your preferences'
             }));
         } catch (error) {
-            console.error('Content-based strategy error:', error);
-            return [];
+            return this.fail(error);
         }
     }
 }
 
 /**
  * Hybrid Strategy
- * Combines multiple strategies for better recommendations
+ *
+ * The four above, weighted and deduplicated.
  */
 class HybridStrategy extends RecommendationStrategy {
     constructor() {
@@ -284,153 +436,164 @@ class HybridStrategy extends RecommendationStrategy {
         };
     }
 
-    async getRecommendations(userId, limit = 10) {
-        try {
-            const allRecommendations = [];
-            const seen = new Set();
+    async getRecommendations(userId, limit = DEFAULT_LIMIT) {
+        const safeLimit = clampLimit(limit);
+        const allRecommendations = [];
+        const seen = new Set();
+        let succeeded = 0;
+        let lastError = null;
 
-            // Get recommendations from each strategy
-            for (const strategy of this.strategies) {
-                const results = await strategy.getRecommendations(userId, Math.ceil(limit / this.strategies.length));
-                
-                // Score and deduplicate
-                for (const item of results) {
-                    if (!seen.has(item.id)) {
-                        seen.add(item.id);
-                        const weight = this.weights[strategy.type] || 0.25;
-                        item.weightedScore = (item.score || 0) * weight;
-                        allRecommendations.push(item);
-                    }
-                }
+        for (const strategy of this.strategies) {
+            let results;
+
+            // The one place a failure is absorbed, and only because this is
+            // four independent lookups: one of them failing should cost its
+            // share of the list, not the whole response. If every one fails
+            // the error is rethrown below rather than reported as "nothing to
+            // suggest".
+            try {
+                results = await strategy.getRecommendations(
+                    userId,
+                    Math.ceil(safeLimit / this.strategies.length)
+                );
+                succeeded += 1;
+            } catch (error) {
+                lastError = error;
+                continue;
             }
 
-            // Sort by weighted score and limit
-            return allRecommendations
-                .sort((a, b) => (b.weightedScore || 0) - (a.weightedScore || 0))
-                .slice(0, limit)
-                .map(item => ({
+            for (const item of results) {
+                if (seen.has(item.id)) continue;
+
+                seen.add(item.id);
+                allRecommendations.push({
                     ...item,
-                    reason: item.reason || 'Recommended for you'
-                }));
-        } catch (error) {
-            console.error('Hybrid strategy error:', error);
-            return [];
+                    weightedScore:
+                        (item.score || 0) * (this.weights[strategy.type] || 0.25)
+                });
+            }
         }
+
+        if (!succeeded && lastError) {
+            logger.error(`Hybrid strategy failed: every strategy errored`);
+            throw lastError;
+        }
+
+        return allRecommendations
+            .sort((a, b) => (b.weightedScore || 0) - (a.weightedScore || 0))
+            .slice(0, safeLimit)
+            .map((item) => ({
+                ...item,
+                reason: item.reason || 'Recommended for you'
+            }));
     }
 }
 
 /**
  * Promotional Strategy
- * Recommends products with active promotions/discounts
+ *
+ * Products currently marked down. A discount is `compare_price` standing above
+ * `price` -- the "was" price the product page already shows. The columns the
+ * previous version read, `discount_price` and `discount_percentage`, do not
+ * exist on `products` and never have.
  */
 class PromotionalStrategy extends RecommendationStrategy {
     constructor() {
         super('Promotional', STRATEGY_TYPES.PROMOTIONAL);
     }
 
-    async getRecommendations(userId, limit = 10) {
-        try {
-            const [products] = await db.query(`
-                SELECT 
-                    p.id,
-                    p.name,
-                    p.price,
-                    p.image_url,
-                    p.category,
-                    p.discount_price,
-                    p.discount_percentage
-                FROM products p
-                WHERE p.discount_percentage > 0
-                AND p.stock > 0
-                ORDER BY p.discount_percentage DESC
-                LIMIT ?
-            `, [limit]);
+    async getRecommendations(userId, limit = DEFAULT_LIMIT) {
+        const safeLimit = clampLimit(limit);
 
-            return products.map(p => ({
-                id: p.id,
-                name: p.name,
-                price: p.price,
-                discountPrice: p.discount_price,
-                discountPercentage: p.discount_percentage,
-                imageUrl: p.image_url,
-                category: p.category,
-                reason: `${p.discount_percentage}% OFF - Special deal!`
+        try {
+            const [rows] = await db.query(`
+                SELECT
+                    ${PRODUCT_COLUMNS},
+                    ROUND(((p.compare_price - p.price) / p.compare_price) * 100) AS discount_percentage
+                ${PRODUCT_SOURCE}
+                WHERE p.compare_price > p.price
+                  AND p.price > 0
+                  AND p.stock > 0
+                  AND ${LIVE_PRODUCT}
+                ORDER BY discount_percentage DESC
+                LIMIT ?
+            `, [safeLimit]);
+
+            return rows.map((row) => toRecommendation(row, {
+                score: Number(row.discount_percentage) || 0,
+                reason: `${Number(row.discount_percentage) || 0}% OFF - Special deal!`
             }));
         } catch (error) {
-            console.error('Promotional strategy error:', error);
-            return [];
+            return this.fail(error);
         }
     }
 }
 
 /**
  * Personalized Strategy
- * Uses user data for personalized recommendations
+ *
+ * A shopper who has bought before gets collaborative and content-based
+ * suggestions, which are the two that can use a purchase history; everyone
+ * else gets the hybrid mix.
+ *
+ * The previous version read `users.preferences` -- a column that does not
+ * exist -- to decide which strategies to combine, and read `total_orders` off
+ * the rows *array* rather than off a row, so the check for a new shopper was
+ * `undefined === 0` and never true.
  */
 class PersonalizedStrategy extends RecommendationStrategy {
     constructor() {
         super('Personalized', STRATEGY_TYPES.PERSONALIZED);
     }
 
-    async getRecommendations(userId, limit = 10) {
+    async getRecommendations(userId, limit = DEFAULT_LIMIT) {
+        const safeLimit = clampLimit(limit);
+
         try {
-            // Get user's purchase history and preferences
-            const [userData] = await db.query(`
-                SELECT 
-                    u.id,
-                    u.preferences,
-                    COUNT(o.id) as total_orders,
-                    AVG(o.total_amount) as avg_order_value
-                FROM users u
-                LEFT JOIN orders o ON o.user_id = u.id
-                WHERE u.id = ?
-                GROUP BY u.id
+            const [rows] = await db.query(`
+                SELECT COUNT(*) AS total_orders
+                FROM orders o
+                WHERE o.user_id = ? AND ${PURCHASED}
             `, [userId]);
 
-            if (!userData || userData.total_orders === 0) {
-                // New user - use hybrid
-                const hybrid = new HybridStrategy();
-                return hybrid.getRecommendations(userId, limit);
+            const totalOrders = Number(rows[0]?.total_orders) || 0;
+
+            if (totalOrders === 0) {
+                return new HybridStrategy().getRecommendations(userId, safeLimit);
             }
 
-            // Use combined approach based on user preferences
-            const preferences = JSON.parse(userData.preferences || '{}');
-            const strategies = [];
+            const strategies = [
+                new CollaborativeStrategy(),
+                new ContentBasedStrategy()
+            ];
 
-            if (preferences.trending) {
-                strategies.push(new TrendingStrategy());
-            }
-            if (preferences.collaborative) {
-                strategies.push(new CollaborativeStrategy());
-            }
-            if (preferences.content_based) {
-                strategies.push(new ContentBasedStrategy());
-            }
-
-            if (strategies.length === 0) {
-                // Default to hybrid
-                const hybrid = new HybridStrategy();
-                return hybrid.getRecommendations(userId, limit);
-            }
-
-            // Combine selected strategies
-            const allRecommendations = [];
+            const combined = [];
             const seen = new Set();
 
             for (const strategy of strategies) {
-                const results = await strategy.getRecommendations(userId, Math.ceil(limit / strategies.length));
+                const results = await strategy.getRecommendations(
+                    userId,
+                    Math.ceil(safeLimit / strategies.length)
+                );
+
                 for (const item of results) {
-                    if (!seen.has(item.id)) {
-                        seen.add(item.id);
-                        allRecommendations.push(item);
-                    }
+                    if (seen.has(item.id)) continue;
+
+                    seen.add(item.id);
+                    combined.push(item);
                 }
             }
 
-            return allRecommendations.slice(0, limit);
+            // Both of those need a purchase history to say anything, and a
+            // shopper can have orders and still produce nothing from either --
+            // one order of a product nobody else bought, in no category.
+            if (!combined.length) {
+                return new HybridStrategy().getRecommendations(userId, safeLimit);
+            }
+
+            return combined.slice(0, safeLimit);
         } catch (error) {
-            console.error('Personalized strategy error:', error);
-            return [];
+            return this.fail(error);
         }
     }
 }
@@ -481,7 +644,12 @@ class RecommendationStrategyFactory {
 module.exports = {
     RecommendationStrategyFactory,
     STRATEGY_TYPES,
+    MAX_LIMIT,
+    DEFAULT_LIMIT,
+    clampLimit,
+    toRecommendation,
     // Individual strategies for testing
+    RecommendationStrategy,
     TrendingStrategy,
     RecentlyViewedStrategy,
     CollaborativeStrategy,

--- a/backend/tests/recommendationStrategies.test.js
+++ b/backend/tests/recommendationStrategies.test.js
@@ -1,0 +1,399 @@
+// The recommendation strategies, and the schema they query (#1525).
+//
+// Every strategy selected `p.image_url` and `p.category`, and four of them
+// joined `orders o ON o.product_id = p.id`. None of those exist: the columns
+// are `image` and `category_id`, and a product id on a purchase lives in
+// `order_items`. Each strategy caught the resulting ER_BAD_FIELD_ERROR and
+// returned `[]`, so `GET /api/recommendations` answered 200 with an empty list
+// and the homepage showed "Explore more products to get personalized
+// recommendations!" to everybody.
+//
+// Two kinds of test here:
+//
+//   * the SQL each strategy issues, checked against the column and table names
+//     the migrations define. `db.query` is mocked, so a mock would accept
+//     `p.image_url` happily -- only reading the statement can catch it.
+//   * what a failure does. The old code turned "this query does not compile"
+//     into "we have nothing to suggest", which is why it survived.
+
+jest.mock("../config/db", () => ({
+    query: jest.fn(),
+    getConnection: jest.fn()
+}));
+
+jest.mock("../utils/logger", () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+const fs = require("fs");
+const path = require("path");
+
+const db = require("../config/db");
+const logger = require("../utils/logger");
+const {
+    RecommendationStrategyFactory,
+    STRATEGY_TYPES,
+    MAX_LIMIT,
+    clampLimit,
+    toRecommendation,
+    TrendingStrategy,
+    RecentlyViewedStrategy,
+    CollaborativeStrategy,
+    ContentBasedStrategy,
+    HybridStrategy,
+    PromotionalStrategy,
+    PersonalizedStrategy
+} = require("../services/recommendationStrategyService");
+
+const USER_ID = "3f2504e0-4f89-11d3-9a0c-0305e82c3301";
+
+/** A product row shaped like the columns the strategies select. */
+const productRow = (overrides = {}) => ({
+    id: "3f2504e0-4f89-11d3-9a0c-0305e82c3302",
+    name: "Cotton shirt",
+    price: 800,
+    compare_price: 1000,
+    image: "shirt.jpg",
+    stock: 5,
+    rating: 4.5,
+    num_reviews: 12,
+    category_id: 3,
+    category: "Shirts",
+    ...overrides
+});
+
+/** Everything the strategy asked the database, whitespace collapsed. */
+const statements = () =>
+    db.query.mock.calls.map(([sql]) => String(sql).replace(/\s+/g, " ").trim());
+
+beforeEach(() => {
+    db.query.mockReset();
+    logger.error.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// Columns and tables that do not exist
+// ---------------------------------------------------------------------------
+
+describe("the schema the strategies query", () => {
+    /** Names that appear nowhere in the migrations. */
+    const IMAGINARY = [
+        /\bp\.image_url\b/,
+        /\bp\.category\b(?!_id)/,
+        /\bp\.discount_price\b/,
+        /\bp\.discount_percentage\b/,
+        /\bo\.product_id\b/,
+        /\bu\.preferences\b/,
+        /\bo\.total_amount\b/
+    ];
+
+    const EVERY_STRATEGY = [
+        ["trending", () => new TrendingStrategy()],
+        ["recently viewed", () => new RecentlyViewedStrategy()],
+        ["collaborative", () => new CollaborativeStrategy()],
+        ["content-based", () => new ContentBasedStrategy()],
+        ["promotional", () => new PromotionalStrategy()],
+        ["personalized", () => new PersonalizedStrategy()]
+    ];
+
+    test.each(EVERY_STRATEGY)(
+        "%s asks only for columns that exist",
+        async (_label, build) => {
+            db.query.mockResolvedValue([[productRow()]]);
+
+            await build().getRecommendations(USER_ID, 5);
+
+            expect(statements().length).toBeGreaterThan(0);
+
+            for (const sql of statements()) {
+                for (const pattern of IMAGINARY) {
+                    expect(sql).not.toMatch(pattern);
+                }
+            }
+        }
+    );
+
+    test("the source file names no column the migrations do not define", () => {
+        // A static sweep as well as the per-strategy checks, so a query added
+        // to a branch nobody exercises is covered too.
+        const source = fs.readFileSync(
+            path.join(__dirname, "..", "services", "recommendationStrategyService.js"),
+            "utf8"
+        );
+
+        // Read out of the schema rather than listed here, so a column added
+        // by a migration tomorrow counts without editing this test.
+        const schema = fs.readFileSync(
+            path.join(__dirname, "..", "..", "migrations", "0001_baseline_schema.sql"),
+            "utf8"
+        );
+
+        const productColumns = new Set();
+        const table = schema.slice(
+            schema.indexOf("CREATE TABLE IF NOT EXISTS products")
+        );
+
+        for (const match of table.slice(0, table.indexOf("ENGINE=")).matchAll(
+            /^\s{4}(\w+)\s+[A-Z]/gm
+        )) {
+            productColumns.add(match[1]);
+        }
+
+        // Sanity: the parse found the table, not an empty set.
+        expect(productColumns.has("image")).toBe(true);
+        expect(productColumns.has("compare_price")).toBe(true);
+        expect(productColumns.has("image_url")).toBe(false);
+
+        // Comments are stripped first: the header of that file names the
+        // columns it used to read wrongly, and those are the point of it.
+        const code = source
+            .replace(/\/\*[\s\S]*?\*\//g, "")
+            .replace(/^\s*\/\/.*$/gm, "");
+
+        for (const match of code.matchAll(/\bp\.(\w+)\b/g)) {
+            expect(productColumns).toContain(match[1]);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Purchases come from order_items
+// ---------------------------------------------------------------------------
+
+describe("where a purchase is read from", () => {
+    test("collaborative filtering joins order_items, not orders.product_id", async () => {
+        db.query
+            .mockResolvedValueOnce([[{ user_id: "other-user", shared: 2 }]])
+            .mockResolvedValueOnce([[productRow()]]);
+
+        await new CollaborativeStrategy().getRecommendations(USER_ID, 5);
+
+        const [similar, products] = statements();
+
+        expect(similar).toMatch(/FROM order_items oi1/);
+        expect(similar).toMatch(/JOIN orders o1 ON o1\.id = oi1\.order_id/);
+        expect(products).toMatch(/JOIN order_items oi ON oi\.product_id = p\.id/);
+    });
+
+    test("content-based reads categories through order_items", async () => {
+        db.query
+            .mockResolvedValueOnce([[{ category_id: 3, purchases: 4 }]])
+            .mockResolvedValueOnce([[productRow()]]);
+
+        await new ContentBasedStrategy().getRecommendations(USER_ID, 5);
+
+        expect(statements()[0]).toMatch(/FROM order_items oi/);
+        expect(statements()[0]).toMatch(/p\.category_id/);
+    });
+
+    test("cancelled and refunded orders are not treated as purchases", async () => {
+        db.query
+            .mockResolvedValueOnce([[{ category_id: 3, purchases: 4 }]])
+            .mockResolvedValueOnce([[productRow()]]);
+
+        await new ContentBasedStrategy().getRecommendations(USER_ID, 5);
+
+        expect(statements()[0]).toMatch(/NOT IN \('cancelled', 'refunded'\)/);
+    });
+
+    test("trending counts sales, views and saves without multiplying them", async () => {
+        db.query.mockResolvedValue([[productRow({ sales_count: 3, view_count: 9, wishlist_count: 2, days_old: 10 })]]);
+
+        await new TrendingStrategy().getRecommendations(USER_ID, 5);
+
+        const sql = statements()[0];
+
+        // Three LEFT JOINs onto one product row multiply each other -- 3 sales
+        // and 9 views count as 27 of each -- so each total is its own
+        // aggregate subquery.
+        expect(sql).toMatch(/LEFT JOIN \( SELECT oi\.product_id, SUM\(oi\.qty\)/);
+        expect(sql).toMatch(/LEFT JOIN \( SELECT product_id, COUNT\(\*\) AS total FROM product_views/);
+    });
+
+    test("trending does not divide by the age of a product added today", async () => {
+        db.query.mockResolvedValue([[productRow()]]);
+
+        await new TrendingStrategy().getRecommendations(USER_ID, 5);
+
+        // `1/DATEDIFF(NOW(), created_at)` is a division by zero for anything
+        // added today, which MySQL answers as NULL and which then poisons the
+        // whole ORDER BY expression.
+        expect(statements()[0]).toMatch(/DATEDIFF\(NOW\(\), p\.created_at\) \+ 1/);
+        expect(statements()[0]).not.toMatch(/1 \/ DATEDIFF\(NOW\(\), p\.created_at\)\s*\)/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Failure is reported, not swallowed
+// ---------------------------------------------------------------------------
+
+describe("when a query fails", () => {
+    test("the strategy raises instead of answering with an empty list", async () => {
+        db.query.mockRejectedValue(new Error("ER_BAD_FIELD_ERROR"));
+
+        await expect(
+            new TrendingStrategy().getRecommendations(USER_ID, 5)
+        ).rejects.toThrow("ER_BAD_FIELD_ERROR");
+
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.stringContaining("Trending Products strategy failed")
+        );
+    });
+
+    test("the hybrid mix survives one strategy failing", async () => {
+        const hybrid = new HybridStrategy();
+
+        jest.spyOn(hybrid.strategies[0], "getRecommendations")
+            .mockRejectedValue(new Error("trending is down"));
+        jest.spyOn(hybrid.strategies[1], "getRecommendations")
+            .mockResolvedValue([toRecommendation(productRow(), { score: 1 })]);
+        jest.spyOn(hybrid.strategies[2], "getRecommendations").mockResolvedValue([]);
+        jest.spyOn(hybrid.strategies[3], "getRecommendations").mockResolvedValue([]);
+
+        const results = await hybrid.getRecommendations(USER_ID, 8);
+
+        expect(results).toHaveLength(1);
+    });
+
+    test("the hybrid mix raises when every strategy fails", async () => {
+        const hybrid = new HybridStrategy();
+
+        for (const strategy of hybrid.strategies) {
+            jest.spyOn(strategy, "getRecommendations")
+                .mockRejectedValue(new Error("database is down"));
+        }
+
+        // Four failed lookups is not "we have no suggestions for you".
+        await expect(hybrid.getRecommendations(USER_ID, 8)).rejects.toThrow(
+            "database is down"
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The shape handed back
+// ---------------------------------------------------------------------------
+
+describe("the recommendation each strategy returns", () => {
+    test("carries the image column the catalogue has", async () => {
+        db.query.mockResolvedValue([[productRow()]]);
+
+        const [item] = await new PromotionalStrategy().getRecommendations(USER_ID, 5);
+
+        expect(item.image).toBe("shirt.jpg");
+        expect(item.imageUrl).toBe("shirt.jpg");
+    });
+
+    test("derives the discount from compare_price", async () => {
+        db.query.mockResolvedValue([
+            [productRow({ price: 800, compare_price: 1000, discount_percentage: 20 })]
+        ]);
+
+        const [item] = await new PromotionalStrategy().getRecommendations(USER_ID, 5);
+
+        expect(item.original_price).toBe(1000);
+        expect(item.discount).toBe(20);
+    });
+
+    test("reports no discount for a product at its normal price", async () => {
+        db.query.mockResolvedValue([[productRow({ price: 800, compare_price: null })]]);
+
+        const [item] = await new TrendingStrategy().getRecommendations(USER_ID, 5);
+
+        // null rather than 0, so the card renders no badge at all.
+        expect(item.discount).toBeNull();
+        expect(item.original_price).toBeNull();
+    });
+
+    test("names the category rather than its id alone", async () => {
+        db.query.mockResolvedValue([[productRow()]]);
+
+        const [item] = await new TrendingStrategy().getRecommendations(USER_ID, 5);
+
+        expect(item.category).toBe("Shirts");
+        expect(item.categoryId).toBe(3);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Limits
+// ---------------------------------------------------------------------------
+
+describe("the limit", () => {
+    test.each([
+        ["a sane number", 12, 12],
+        ["absent", undefined, 10],
+        ["zero", 0, 10],
+        ["negative", -5, 10],
+        ["not a number", "many", 10],
+        ["absurd", 100000, MAX_LIMIT]
+    ])("a limit that is %s", (_label, given, expected) => {
+        expect(clampLimit(given)).toBe(expected);
+    });
+
+    test("reaches the SQL clamped", async () => {
+        db.query.mockResolvedValue([[]]);
+
+        await new PromotionalStrategy().getRecommendations(USER_ID, 100000);
+
+        const [, params] = db.query.mock.calls[0];
+
+        expect(params[params.length - 1]).toBe(MAX_LIMIT);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Fallbacks
+// ---------------------------------------------------------------------------
+
+describe("shoppers with no history", () => {
+    test("personalized falls back to hybrid for someone who has never ordered", async () => {
+        db.query.mockResolvedValueOnce([[{ total_orders: 0 }]]);
+        db.query.mockResolvedValue([[productRow()]]);
+
+        const results = await new PersonalizedStrategy().getRecommendations(USER_ID, 4);
+
+        // The previous version read total_orders off the rows array rather
+        // than a row, so this branch was `undefined === 0` and never taken.
+        expect(Array.isArray(results)).toBe(true);
+        expect(statements()[0]).toMatch(/COUNT\(\*\) AS total_orders/);
+    });
+
+    test("collaborative returns nothing when no similar shopper exists", async () => {
+        db.query.mockResolvedValueOnce([[]]);
+
+        const results = await new CollaborativeStrategy().getRecommendations(USER_ID, 5);
+
+        expect(results).toEqual([]);
+        // No second query — there is nobody to look up products for.
+        expect(db.query).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+describe("the factory", () => {
+    test.each(Object.values(STRATEGY_TYPES))("builds %s", (type) => {
+        const strategy = RecommendationStrategyFactory.createStrategy(type);
+
+        expect(strategy.type).toBe(type);
+        expect(typeof strategy.getRecommendations).toBe("function");
+    });
+
+    test("falls back to hybrid for a strategy nobody has written", () => {
+        expect(RecommendationStrategyFactory.createStrategy("astrology").type).toBe(
+            STRATEGY_TYPES.HYBRID
+        );
+    });
+
+    test("lists every strategy the factory can build", () => {
+        const listed = RecommendationStrategyFactory.getAllStrategies().map((s) => s.type);
+
+        expect(new Set(listed)).toEqual(new Set(Object.values(STRATEGY_TYPES)));
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`GET /api/recommendations` has never returned a product. Every strategy queries a schema this project does not have:

| Referenced | Reality |
| --- | --- |
| `products.image_url` | the column is `image` |
| `products.category` | products carry `category_id`; the name is on `categories` |
| `products.discount_price`, `products.discount_percentage` | neither exists — a discount is `compare_price` standing above `price` |
| `orders.product_id` (four separate joins) | orders have never carried a product; what was bought is in `order_items` |
| `users.preferences` | no such column |

And each of the seven strategies ends `catch (error) { console.error(...); return []; }`, so `ER_BAD_FIELD_ERROR` arrived at the caller as "we have nothing to suggest" — indistinguishable from a genuinely empty result, and the reason a file that cannot run a single one of its queries has been sitting in the request path.

---

## 🔗 Related Issue

Closes #1525

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] Testing improvement
- [x] Performance improvement
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Documentation update
- [ ] Security fix
- [ ] Code refactoring

---

## 🌐 Additional Notes

### Where the data actually is

Purchases come from `order_items` joined through `orders`, views from `product_views`, saves from `wishlist_items`, the category name from `categories`. Cancelled and refunded orders are excluded from every "what people bought" query — a refunded order says nothing about what somebody wanted — as are soft-deleted ones, and only live products (`is_active = 1 AND deleted_at IS NULL`) can be recommended, since the alternative is a slot spent on a product page that will not load.

The column list and the product source are written once (`PRODUCT_COLUMNS`, `PRODUCT_SOURCE`) and shared by all six queries, so a strategy added later starts from the right columns rather than inventing its own.

### Three defects that outlive the column names

**The trending counts multiplied each other.** Three LEFT JOINs onto one product row and a `COUNT()` over each: a product with 3 sales and 9 views produced 27 rows, so all three figures were wrong and the ranking with them. Each total is now its own aggregate subquery.

**And it divided by zero.** `1/DATEDIFF(NOW(), p.created_at)` is a division by zero for anything added today; MySQL answers NULL, and the NULL propagates through the whole `ORDER BY` expression. It is `1/(DATEDIFF(...) + 1)` now, which is also what the in-JS score already used.

**`PersonalizedStrategy` read a row off the rows array.**

```js
const [userData] = await db.query(`SELECT ... FROM users u ...`);
if (!userData || userData.total_orders === 0) { ... }        // undefined === 0
const preferences = JSON.parse(userData.preferences || '{}'); // always {}
```

`userData` is the array. So the new-shopper branch was never taken and the preference-driven strategy selection always selected nothing — before you get to `users.preferences` not existing. It now counts orders, and a shopper with a history gets collaborative + content-based, which are the two strategies that can use one; everyone else gets the hybrid mix. A shopper with orders that yield nothing (one product nobody else bought, in no category) falls back to hybrid rather than to an empty page.

### Failing loudly

A strategy that cannot query raises, and the route turns that into a 500 — which is what a failed lookup is. The one exception is inside `HybridStrategy`, and only because it is four independent lookups: one failing should cost its share of the list, not the whole response. If all four fail it rethrows, because four failed queries is not "no suggestions for you".

That is the change that would have made this visible on day one, so it is the one with the most tests.

### The response shape

`data` is now the list. It was an object wrapping the list, and the only caller does:

```js
// frontend/scripts/recommendations.js:366
if (response && response.success && response.data && response.data.length > 0) {
```

`data.length` on an object is `undefined`, so every response — including a full one — fell through to the empty state. Which strategy ran is still reported, in `meta`, beside the list instead of around it. That is also the `{ success, message, data }` envelope `AGENTS.md` specifies, which the `/compare` route on this router already follows for its own shape.

No frontend change is needed: `data` as an array is what that file has always expected.

### The limit

`parseInt(req.query.limit)` went from the query string into a `LIMIT` clause. It is clamped to `[1, 50]` inside the strategy — in the strategy rather than the route, so a second caller cannot skip it. Same bound and same reasoning as `clampLimit` in `recommendationService` (#1294).

### Tests

`tests/recommendationStrategies.test.js`, 37 tests.

The column assertions are on the **SQL**: `db.query` is mocked and would accept `p.image_url` happily, so only reading the statement can catch it. Each strategy is run and its statements are checked against a list of names that appear nowhere in the migrations, and there is a static sweep that pulls the real `products` column list *out of the baseline migration* and asserts every `p.<column>` in the source is one of them — so a column added by a migration tomorrow counts without anyone editing the test, and a query added to a branch these tests do not exercise is still covered. (Comments are stripped before that sweep; the file's header names the old wrong columns on purpose.)

The rest are behavioural: a failing query raises rather than returning `[]`, hybrid survives one failure and not four, the discount is derived from `compare_price` and is `null` rather than `0` for a product at its normal price, and the limit reaches SQL clamped.

### Deliberately not in this PR

**The two recommendation engines.** `services/recommendationService.js` is a second implementation, fixed in #1294, and `controllers/recommendationController.getRecommendations` — which uses it — is imported by this router and never mounted. Two engines is exactly what #1294 removed once already, and consolidating them is a judgement about which strategies to keep, not a bug fix. This PR fixes the one that is actually serving requests and leaves that decision to be made on its own.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

Full suite green on this branch: **76 suites, 1779 tests** (from 75 / 1742 on `main`). No migration — every table this reads has been in the schema since `0001` and `0024`.

No files in common with #1522 or #1524.
