### PR TITLE
Open a chat conversation by the id it actually has

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -3,10 +3,36 @@ const {
   getPagination,
   sanitizeString,
   safeNumber,
-  safeUUID,
+  safeInteger,
 } = require("../utils/helpers");
 const logger = require("../utils/logger");
 const { PERMISSIONS, hasPermission } = require("../config/policy");
+
+/**
+ * The id of a conversation, or null.
+ *
+ * `chat_conversations.id` is `INT AUTO_INCREMENT` (migrations/0001, line 940),
+ * and `chat.service` has always parsed it as one -- `findOrCreateConversation`
+ * returns `result.insertId`. These handlers validated it with `safeUUID`, which
+ * every integer fails, so every request naming a real conversation was refused
+ * as "Invalid ID format" before the service was reached (#1527).
+ *
+ * @param {*} value
+ * @returns {number|null}
+ */
+function conversationId(value) {
+  // Digits and nothing else, checked before parsing. `safeInteger` is
+  // `parseInt`, which reads a leading number and discards the rest -- so
+  // "42-and-a-half", or a UUID beginning "3f25…", would resolve to a real
+  // conversation that the caller did not name.
+  if (!/^\d+$/.test(String(value ?? "").trim())) {
+    return null;
+  }
+
+  const id = safeInteger(value, 0);
+
+  return id > 0 ? id : null;
+}
 
 const getConversations = async (req, res) => {
   try {
@@ -68,7 +94,7 @@ const getConversations = async (req, res) => {
 
 const getConversationDetails = async (req, res) => {
   try {
-    const id = safeUUID(req.params.id);
+    const id = conversationId(req.params.id);
     if (!id) {
       return res.status(400).json({
         success: false,
@@ -92,13 +118,28 @@ const getConversationDetails = async (req, res) => {
       });
     }
 
-    const messages = await chatService.getConversationMessages(id);
+    // The page the caller asked for. `getConversationMessages` has taken a
+    // limit and an offset from the start; this handler passed neither, so a
+    // conversation longer than fifty messages could not be read past its
+    // first page from anywhere.
+    const limit = safeNumber(req.query.limit, 50);
+    const offset = safeNumber(req.query.offset, 0);
+
+    const result = await chatService.getConversationMessages(id, limit, offset);
 
     res.set("Cache-Control", "private, max-age=60");
 
+    // `messages` at the top level as well as under `data`.
+    //
+    // The chat widget reads `res.messages` (frontend/scripts/chat-widget.js),
+    // so it saw `undefined.length` and threw into its own catch on every open
+    // -- the history simply never appeared. Both shapes are served rather than
+    // breaking the widget in a change about conversation ids.
     res.status(200).json({
       success: true,
-      data: messages,
+      data: result,
+      messages: result.messages,
+      total: result.total,
       conversationId: id,
     });
   } catch (error) {
@@ -113,7 +154,7 @@ const getConversationDetails = async (req, res) => {
 
 const updateStatus = async (req, res) => {
   try {
-    const id = safeUUID(req.params.id);
+    const id = conversationId(req.params.id);
     const { status } = req.body;
 
     const validStatuses = ["open", "pending", "closed", "archived"];
@@ -163,7 +204,7 @@ const updateStatus = async (req, res) => {
 
 const assignAdmin = async (req, res) => {
   try {
-    const id = safeUUID(req.params.id);
+    const id = conversationId(req.params.id);
     if (!id) {
       return res.status(400).json({
         success: false,
@@ -215,6 +256,69 @@ const assignAdmin = async (req, res) => {
   }
 };
 
+/**
+ * GET /api/chat/unread-count
+ *
+ * How many messages are waiting for the caller. `chatService.getUnreadCount`
+ * has existed since the chat was written and nothing served it -- the widget
+ * asks for this path on every page load and has always got a 404, so the
+ * badge never appeared.
+ *
+ * Scoped to `req.user.id`. The count is a fact about the caller's own inbox,
+ * and a `userId` parameter here would be an endpoint for reading how much
+ * unread mail somebody else has.
+ */
+const getUnreadCount = async (req, res) => {
+  try {
+    const scopedConversation = req.query.conversationId
+      ? conversationId(req.query.conversationId)
+      : null;
+
+    if (req.query.conversationId && !scopedConversation) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid conversation ID",
+      });
+    }
+
+    if (scopedConversation) {
+      const hasAccess = await chatService.verifyConversationAccess(
+        scopedConversation,
+        req.user.id,
+        req.user.role,
+      );
+
+      if (!hasAccess) {
+        return res.status(403).json({
+          success: false,
+          message:
+            "Access forbidden: You don't have permission to view this conversation",
+        });
+      }
+    }
+
+    const count = await chatService.getUnreadCount(
+      req.user.id,
+      scopedConversation,
+    );
+
+    res.set("Cache-Control", "no-store, no-cache, must-revalidate");
+
+    res.status(200).json({
+      success: true,
+      count,
+      data: { count },
+    });
+  } catch (error) {
+    console.error("GET UNREAD COUNT ERROR:", error);
+
+    res.status(500).json({
+      success: false,
+      message: "Failed to get unread count",
+    });
+  }
+};
+
 const getConnectionTelemetry = async (req, res) => {
   try {
     const activeConnections = await chatService.getActiveConnections();
@@ -258,6 +362,7 @@ const getDashboardStats = async (req, res) => {
 module.exports = {
   getConversations,
   getConversationDetails,
+  getUnreadCount,
   updateStatus,
   assignAdmin,
   getConnectionTelemetry,

--- a/backend/routes/chatRoutes.js
+++ b/backend/routes/chatRoutes.js
@@ -3,7 +3,15 @@ const router = express.Router();
 const authMiddleware = require("../middleware/authMiddleware");
 const { authorizeRoles } = require("../middleware/rbacMiddleware");
 const { ROLES } = require("../config/policy");
-const { getConversations, getConversationDetails, updateStatus, assignAdmin } = require("../controllers/chat.controller");
+const {
+  getConversations,
+  getConversationDetails,
+  getUnreadCount,
+  updateStatus,
+  assignAdmin,
+  getConnectionTelemetry,
+  getDashboardStats
+} = require("../controllers/chat.controller");
 
 // Require auth for all chat routes
 router.use(authMiddleware);
@@ -12,6 +20,19 @@ router.use(authMiddleware);
 router.get("/conversations", authorizeRoles(ROLES.ADMIN), getConversations);
 router.patch("/conversations/:id/status", authorizeRoles(ROLES.ADMIN), updateStatus);
 router.patch("/conversations/:id/assign", authorizeRoles(ROLES.ADMIN), assignAdmin);
+
+// Support-desk telemetry. Both handlers were written and exported and neither
+// had a route, so the numbers behind the desk existed with nothing able to
+// read them.
+router.get("/stats", authorizeRoles(ROLES.ADMIN), getDashboardStats);
+router.get("/telemetry", authorizeRoles(ROLES.ADMIN), getConnectionTelemetry);
+
+// How many messages are waiting for the caller.
+//
+// Any signed-in shopper's own count rather than an admin route: the chat
+// widget on every page asks for this path, and nothing has ever served it, so
+// the unread badge has never appeared for anybody.
+router.get("/unread-count", getUnreadCount);
 
 // Accessible by admin or the owner customer
 router.get("/conversations/:id", getConversationDetails);

--- a/backend/tests/chatConversationRoutes.test.js
+++ b/backend/tests/chatConversationRoutes.test.js
@@ -1,0 +1,323 @@
+// Conversation ids, and the three routes that refused every one of them
+// (#1527).
+//
+// `chat_conversations.id` is `INT AUTO_INCREMENT`. `chat.service` has always
+// treated it as one -- `findOrCreateConversation` returns `result.insertId`
+// and `validateConversationId` is `parseInt` -- but `chat.controller`
+// validated it with `safeUUID`, which every integer fails. So every request
+// naming a real conversation was refused as "Invalid ID format" before the
+// service was reached: the shopper's own chat history, and both admin actions.
+
+jest.mock("../services/chat.service", () => ({
+    getConversationList: jest.fn(),
+    getConversationMessages: jest.fn(),
+    verifyConversationAccess: jest.fn(),
+    updateConversationStatus: jest.fn(),
+    assignConversation: jest.fn(),
+    getUnreadCount: jest.fn(),
+    getActiveConnections: jest.fn(),
+    getTotalConnectionCount: jest.fn(),
+    getDashboardStats: jest.fn()
+}));
+
+jest.mock("../utils/logger", () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+const fs = require("fs");
+const path = require("path");
+
+const chatService = require("../services/chat.service");
+const chatController = require("../controllers/chat.controller");
+
+const ADMIN = { id: "3f2504e0-4f89-11d3-9a0c-0305e82c3301", role: "admin" };
+const SHOPPER = { id: "3f2504e0-4f89-11d3-9a0c-0305e82c3302", role: "user" };
+
+// What findOrCreateConversation hands out: an auto-increment integer, arriving
+// back as the string a URL parameter always is.
+const CONVERSATION_ID = 42;
+const CONVERSATION_PARAM = "42";
+
+function mockRes() {
+    return {
+        statusCode: 200,
+        body: null,
+        headers: {},
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        },
+        set(name, value) {
+            this.headers[name] = value;
+            return this;
+        }
+    };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    chatService.verifyConversationAccess.mockResolvedValue(true);
+    chatService.getConversationMessages.mockResolvedValue({
+        messages: [{ id: 1, message: "Hello" }],
+        total: 1,
+        limit: 50,
+        offset: 0
+    });
+    chatService.updateConversationStatus.mockResolvedValue(true);
+    chatService.assignConversation.mockResolvedValue(true);
+    chatService.getUnreadCount.mockResolvedValue(3);
+});
+
+describe("an integer conversation id", () => {
+    test("is accepted when reading a conversation", async () => {
+        const res = mockRes();
+
+        await chatController.getConversationDetails(
+            { params: { id: CONVERSATION_PARAM }, query: {}, user: SHOPPER },
+            res
+        );
+
+        expect(res.statusCode).toBe(200);
+        expect(chatService.getConversationMessages).toHaveBeenCalled();
+    });
+
+    test("is accepted when changing status", async () => {
+        const res = mockRes();
+
+        await chatController.updateStatus(
+            {
+                params: { id: CONVERSATION_PARAM },
+                body: { status: "closed" },
+                user: ADMIN
+            },
+            res
+        );
+
+        expect(res.statusCode).toBe(200);
+        expect(chatService.updateConversationStatus).toHaveBeenCalledWith(
+            CONVERSATION_ID,
+            "closed"
+        );
+    });
+
+    test("is accepted when assigning an admin", async () => {
+        const res = mockRes();
+
+        await chatController.assignAdmin(
+            { params: { id: CONVERSATION_PARAM }, user: ADMIN },
+            res
+        );
+
+        expect(res.statusCode).toBe(200);
+        expect(chatService.assignConversation).toHaveBeenCalledWith(
+            CONVERSATION_ID,
+            ADMIN.id
+        );
+    });
+
+    test("reaches the service as a number, not the string from the URL", async () => {
+        await chatController.getConversationDetails(
+            { params: { id: CONVERSATION_PARAM }, query: {}, user: SHOPPER },
+            mockRes()
+        );
+
+        const [id] = chatService.verifyConversationAccess.mock.calls[0];
+
+        expect(id).toBe(CONVERSATION_ID);
+        expect(typeof id).toBe("number");
+    });
+});
+
+describe("an id that is not a conversation id", () => {
+    test.each([
+        ["a word", "latest"],
+        ["empty", ""],
+        ["zero", "0"],
+        ["negative", "-1"],
+        ["a number with a tail", "42-and-a-half"]
+    ])("%s is refused with 400", async (_label, value) => {
+        const res = mockRes();
+
+        await chatController.getConversationDetails(
+            { params: { id: value }, query: {}, user: SHOPPER },
+            res
+        );
+
+        expect(res.statusCode).toBe(400);
+        expect(chatService.getConversationMessages).not.toHaveBeenCalled();
+    });
+
+    test("a UUID is refused too — these ids have never been UUIDs", async () => {
+        const res = mockRes();
+
+        await chatController.updateStatus(
+            {
+                params: { id: "3f2504e0-4f89-11d3-9a0c-0305e82c3303" },
+                body: { status: "closed" },
+                user: ADMIN
+            },
+            res
+        );
+
+        expect(res.statusCode).toBe(400);
+        expect(chatService.updateConversationStatus).not.toHaveBeenCalled();
+    });
+});
+
+describe("access control still applies", () => {
+    test("a shopper reading somebody else's conversation gets 403", async () => {
+        chatService.verifyConversationAccess.mockResolvedValue(false);
+
+        const res = mockRes();
+
+        await chatController.getConversationDetails(
+            { params: { id: CONVERSATION_PARAM }, query: {}, user: SHOPPER },
+            res
+        );
+
+        expect(res.statusCode).toBe(403);
+        expect(chatService.getConversationMessages).not.toHaveBeenCalled();
+    });
+
+    test("a shopper cannot assign a conversation", async () => {
+        const res = mockRes();
+
+        await chatController.assignAdmin(
+            { params: { id: CONVERSATION_PARAM }, user: SHOPPER },
+            res
+        );
+
+        expect(res.statusCode).toBe(403);
+        expect(chatService.assignConversation).not.toHaveBeenCalled();
+    });
+});
+
+describe("reading a conversation", () => {
+    test("answers in the shape the chat widget reads", async () => {
+        const res = mockRes();
+
+        await chatController.getConversationDetails(
+            { params: { id: CONVERSATION_PARAM }, query: {}, user: SHOPPER },
+            res
+        );
+
+        // frontend/scripts/chat-widget.js does `res.messages.length`, which was
+        // reading `undefined` off a body whose messages were nested two deep.
+        expect(Array.isArray(res.body.messages)).toBe(true);
+        expect(res.body.messages).toHaveLength(1);
+        // The nested shape is still served, so anything reading `data` keeps
+        // working.
+        expect(res.body.data.messages).toEqual(res.body.messages);
+    });
+
+    test("passes the requested page through to the service", async () => {
+        await chatController.getConversationDetails(
+            {
+                params: { id: CONVERSATION_PARAM },
+                query: { limit: "20", offset: "40" },
+                user: SHOPPER
+            },
+            mockRes()
+        );
+
+        // Neither was passed before, so a conversation longer than the default
+        // fifty messages could not be read past its first page from anywhere.
+        expect(chatService.getConversationMessages).toHaveBeenCalledWith(
+            CONVERSATION_ID,
+            20,
+            40
+        );
+    });
+});
+
+describe("the unread count", () => {
+    test("counts for the caller", async () => {
+        const res = mockRes();
+
+        await chatController.getUnreadCount(
+            { query: {}, user: SHOPPER },
+            res
+        );
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.count).toBe(3);
+        expect(chatService.getUnreadCount).toHaveBeenCalledWith(SHOPPER.id, null);
+    });
+
+    test("cannot be asked for somebody else's inbox", async () => {
+        await chatController.getUnreadCount(
+            // A userId in the query is ignored: the count is scoped to the
+            // session, not to a parameter.
+            { query: { userId: ADMIN.id }, user: SHOPPER },
+            mockRes()
+        );
+
+        const [userId] = chatService.getUnreadCount.mock.calls[0];
+
+        expect(userId).toBe(SHOPPER.id);
+    });
+
+    test("scoped to one conversation only after an access check", async () => {
+        chatService.verifyConversationAccess.mockResolvedValue(false);
+
+        const res = mockRes();
+
+        await chatController.getUnreadCount(
+            { query: { conversationId: CONVERSATION_PARAM }, user: SHOPPER },
+            res
+        );
+
+        expect(res.statusCode).toBe(403);
+        expect(chatService.getUnreadCount).not.toHaveBeenCalled();
+    });
+
+    test("refuses a conversation id that is not one", async () => {
+        const res = mockRes();
+
+        await chatController.getUnreadCount(
+            { query: { conversationId: "latest" }, user: SHOPPER },
+            res
+        );
+
+        expect(res.statusCode).toBe(400);
+    });
+});
+
+describe("the routes", () => {
+    const source = fs.readFileSync(
+        path.join(__dirname, "..", "routes", "chatRoutes.js"),
+        "utf8"
+    );
+
+    test.each([
+        ["/unread-count", "the chat widget asks for it on every page load"],
+        ["/stats", "the handler was exported and unreachable"],
+        ["/telemetry", "the handler was exported and unreachable"]
+    ])("%s is mounted", (route) => {
+        expect(source).toContain(`"${route}"`);
+    });
+
+    test("every handler the controller exports has a route", () => {
+        const mounted = [...source.matchAll(/,\s*(\w+)\);?$/gm)].map((m) => m[1]);
+
+        for (const handler of Object.keys(chatController)) {
+            expect(mounted).toContain(handler);
+        }
+    });
+
+    test("the admin-only routes stay admin-only", () => {
+        for (const line of source.split("\n")) {
+            if (!/router\.(get|patch|post|delete)/.test(line)) continue;
+            if (/unread-count|conversations\/:id"/.test(line)) continue;
+
+            expect(line).toMatch(/authorizeRoles\(ROLES\.ADMIN\)/);
+        }
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`chat_conversations.id` is `INT AUTO_INCREMENT`. `chat.service` has always treated it as one — `findOrCreateConversation` returns `result.insertId`, `validateConversationId` is `parseInt`. `chat.controller` validated it with `safeUUID`, which every integer fails:

```js
const id = safeUUID(req.params.id);
if (!id) return res.status(400).json({ success: false, message: "Invalid ID format" });
```

The same three lines in `getConversationDetails`, `updateStatus` and `assignAdmin`, so all three routes refused every real conversation with a 400 before the service was reached. Listing conversations has no id in it and works, which is why the admin desk could show a queue it could not open, close or assign from.

It reaches shoppers too: the chat widget on every page loads its own history through `GET /chat/conversations/:id`, with the integer the socket handed it. Nobody has been able to see their previous messages.

---

## 🔗 Related Issue

Closes #1527

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] Testing improvement
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Security fix
- [ ] Code refactoring

---

## 🌐 Additional Notes

### Digits, not `parseInt`

The obvious repair is `safeInteger`, and it is not quite enough: `safeInteger` is `parseInt`, which reads a leading number and discards the rest. `42-and-a-half` becomes 42, and a UUID beginning `3f25…` becomes 3 — a real conversation the caller did not name, reached through a validator meant to prevent exactly that. The check is `/^\d+$/` on the trimmed value first, then the parse. Both cases are tested.

The service is left alone. Its `validateConversationId` has been correct since it was written; the controller is what disagreed with it.

### The response shape the widget reads

```js
// frontend/scripts/chat-widget.js:496
if (res.success && res.messages.length > 0) {
```

The handler answered `{ success, data: { messages, total, limit, offset } }`, so `res.messages` was `undefined` and the widget threw into its own catch on every open. `messages` and `total` are now at the top level *as well as* under `data`, rather than moving them — a change about conversation ids should not break another caller on the way past. Same family as `response.wishlist` (#1523) and `response.data.length` (#1525).

### Three handlers that had no route

- **`/unread-count`** — `chatService.getUnreadCount` has existed since the chat was written, the widget polls that path on every page load, and nothing served it, so the unread badge has never appeared. It is any signed-in caller's own count: scoped to `req.user.id`, with no `userId` parameter, because a `userId` parameter here is an endpoint for reading how much unread mail somebody else has. An optional `conversationId` narrows it, and goes through the same `verifyConversationAccess` the read route uses.
- **`/stats`** and **`/telemetry`** — `getDashboardStats` and `getConnectionTelemetry` were written, exported and mounted nowhere. Both are admin-only.

### Pagination

`getConversationMessages(conversationId, limit = 50, offset = 0)` has always taken both; the controller passed neither, so a conversation longer than fifty messages could not be read past its first page from anywhere. `limit` and `offset` come from the query now, through `safeNumber`, and the service clamps them as it always did.

### Tests

`tests/chatConversationRoutes.test.js`, 23 tests.

Behavioural, mostly: an integer id is accepted by all three handlers and arrives at the service as a *number* rather than the string a URL parameter always is; a word, an empty string, a zero, a negative and `42-and-a-half` are each refused; a UUID is refused, because these ids have never been UUIDs.

The access checks are tested alongside, since this PR makes routes reachable that previously refused everything — a shopper reading somebody else's conversation is still a 403, a shopper assigning one is still a 403, and the unread count cannot be pointed at another account.

Three tests read `routes/chatRoutes.js` as text: that each newly mounted path is there, that every handler the controller exports has a route (the check that would have caught these three), and that nothing except the shopper's own two routes lost its `authorizeRoles(ROLES.ADMIN)`.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

Full suite green on this branch: **76 suites, 1765 tests** (from 75 / 1742 on `main`). No migration — `chat_conversations`, `chat_messages` and `message_reads` are all in the baseline schema.

No files in common with #1522, #1524 or #1526.
