### PR TITLE
Give the metrics dashboard a number to show

### DIFF
--- a/backend/routes/metricsRoutes.js
+++ b/backend/routes/metricsRoutes.js
@@ -1,14 +1,48 @@
 // backend/routes/metricsRoutes.js
+//
+// Business metrics: revenue, conversion, churn, customer lifetime value.
+//
+// Every route here was `authMiddleware` and nothing else (#1529), so any
+// signed-in shopper could read the store's takings -- and
+// /customer-lifetime-value returns the names of the hundred highest-spending
+// customers alongside what each of them has spent. `adminOnly` is applied at
+// the router now, so a route added later cannot be missing it.
 const express = require('express');
 const router = express.Router();
 const authMiddleware = require('../middleware/authMiddleware');
+const { authorizeRoles } = require('../middleware/rbacMiddleware');
+const { ROLES } = require('../config/policy');
 const { metricsAggregationService, METRIC_TYPES, TIME_PERIODS } = require('../services/metricsAggregationService');
+
+// What the store earns is not a fact about the shopper reading it.
+router.use(authMiddleware);
+router.use(authorizeRoles(ROLES.ADMIN));
+
+/**
+ * Answer with the status the error carries.
+ *
+ * A filter this service does not implement is the caller's mistake, not the
+ * server's, and reporting it as a 500 hides which of the two it was.
+ */
+function fail(res, error, fallback) {
+    const status = error.status || 500;
+
+    if (status >= 500) {
+        console.error(`${fallback}:`, error);
+    }
+
+    return res.status(status).json({
+        success: false,
+        error: status >= 500 ? fallback : error.message,
+        code: error.code
+    });
+}
 
 /**
  * GET /api/metrics/dashboard
  * Get metrics dashboard
  */
-router.get('/dashboard', authMiddleware, async (req, res) => {
+router.get('/dashboard', async (req, res) => {
     try {
         const { period = TIME_PERIODS.WEEK, ...filters } = req.query;
         const dashboard = await metricsAggregationService.getDashboard(period, filters);
@@ -18,11 +52,7 @@ router.get('/dashboard', authMiddleware, async (req, res) => {
             data: dashboard
         });
     } catch (error) {
-        console.error('Dashboard error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get dashboard'
-        });
+        return fail(res, error, 'Failed to get dashboard');
     }
 });
 
@@ -30,7 +60,7 @@ router.get('/dashboard', authMiddleware, async (req, res) => {
  * GET /api/metrics/conversion-rate
  * Get conversion rate
  */
-router.get('/conversion-rate', authMiddleware, async (req, res) => {
+router.get('/conversion-rate', async (req, res) => {
     try {
         const { period = TIME_PERIODS.WEEK, ...filters } = req.query;
         const result = await metricsAggregationService.getConversionRate(period, filters);
@@ -40,11 +70,7 @@ router.get('/conversion-rate', authMiddleware, async (req, res) => {
             data: result
         });
     } catch (error) {
-        console.error('Conversion rate error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get conversion rate'
-        });
+        return fail(res, error, 'Failed to get conversion rate');
     }
 });
 
@@ -52,7 +78,7 @@ router.get('/conversion-rate', authMiddleware, async (req, res) => {
  * GET /api/metrics/average-order-value
  * Get average order value
  */
-router.get('/average-order-value', authMiddleware, async (req, res) => {
+router.get('/average-order-value', async (req, res) => {
     try {
         const { period = TIME_PERIODS.WEEK, ...filters } = req.query;
         const result = await metricsAggregationService.getAverageOrderValue(period, filters);
@@ -62,11 +88,7 @@ router.get('/average-order-value', authMiddleware, async (req, res) => {
             data: result
         });
     } catch (error) {
-        console.error('AOV error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get average order value'
-        });
+        return fail(res, error, 'Failed to get average order value');
     }
 });
 
@@ -74,7 +96,7 @@ router.get('/average-order-value', authMiddleware, async (req, res) => {
  * GET /api/metrics/abandoned-cart
  * Get abandoned cart rate
  */
-router.get('/abandoned-cart', authMiddleware, async (req, res) => {
+router.get('/abandoned-cart', async (req, res) => {
     try {
         const { period = TIME_PERIODS.WEEK, ...filters } = req.query;
         const result = await metricsAggregationService.getAbandonedCartRate(period, filters);
@@ -84,11 +106,7 @@ router.get('/abandoned-cart', authMiddleware, async (req, res) => {
             data: result
         });
     } catch (error) {
-        console.error('Abandoned cart error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get abandoned cart rate'
-        });
+        return fail(res, error, 'Failed to get abandoned cart rate');
     }
 });
 
@@ -96,7 +114,7 @@ router.get('/abandoned-cart', authMiddleware, async (req, res) => {
  * GET /api/metrics/recommendation-ctr
  * Get recommendation CTR
  */
-router.get('/recommendation-ctr', authMiddleware, async (req, res) => {
+router.get('/recommendation-ctr', async (req, res) => {
     try {
         const { period = TIME_PERIODS.WEEK, ...filters } = req.query;
         const result = await metricsAggregationService.getRecommendationCTR(period, filters);
@@ -106,11 +124,7 @@ router.get('/recommendation-ctr', authMiddleware, async (req, res) => {
             data: result
         });
     } catch (error) {
-        console.error('Recommendation CTR error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get recommendation CTR'
-        });
+        return fail(res, error, 'Failed to get recommendation CTR');
     }
 });
 
@@ -118,7 +132,7 @@ router.get('/recommendation-ctr', authMiddleware, async (req, res) => {
  * GET /api/metrics/coupon-effectiveness
  * Get coupon effectiveness
  */
-router.get('/coupon-effectiveness', authMiddleware, async (req, res) => {
+router.get('/coupon-effectiveness', async (req, res) => {
     try {
         const { period = TIME_PERIODS.WEEK, ...filters } = req.query;
         const result = await metricsAggregationService.getCouponEffectiveness(period, filters);
@@ -128,11 +142,7 @@ router.get('/coupon-effectiveness', authMiddleware, async (req, res) => {
             data: result
         });
     } catch (error) {
-        console.error('Coupon effectiveness error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get coupon effectiveness'
-        });
+        return fail(res, error, 'Failed to get coupon effectiveness');
     }
 });
 
@@ -140,7 +150,7 @@ router.get('/coupon-effectiveness', authMiddleware, async (req, res) => {
  * GET /api/metrics/customer-lifetime-value
  * Get customer lifetime value
  */
-router.get('/customer-lifetime-value', authMiddleware, async (req, res) => {
+router.get('/customer-lifetime-value', async (req, res) => {
     try {
         const { period = TIME_PERIODS.MONTH, ...filters } = req.query;
         const result = await metricsAggregationService.getCustomerLifetimeValue(period, filters);
@@ -150,11 +160,7 @@ router.get('/customer-lifetime-value', authMiddleware, async (req, res) => {
             data: result
         });
     } catch (error) {
-        console.error('CLV error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get customer lifetime value'
-        });
+        return fail(res, error, 'Failed to get customer lifetime value');
     }
 });
 
@@ -162,7 +168,7 @@ router.get('/customer-lifetime-value', authMiddleware, async (req, res) => {
  * GET /api/metrics/revenue-growth
  * Get revenue growth
  */
-router.get('/revenue-growth', authMiddleware, async (req, res) => {
+router.get('/revenue-growth', async (req, res) => {
     try {
         const { period = TIME_PERIODS.MONTH, ...filters } = req.query;
         const result = await metricsAggregationService.getRevenueGrowth(period, filters);
@@ -172,11 +178,7 @@ router.get('/revenue-growth', authMiddleware, async (req, res) => {
             data: result
         });
     } catch (error) {
-        console.error('Revenue growth error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get revenue growth'
-        });
+        return fail(res, error, 'Failed to get revenue growth');
     }
 });
 
@@ -184,7 +186,7 @@ router.get('/revenue-growth', authMiddleware, async (req, res) => {
  * GET /api/metrics/churn-rate
  * Get churn rate
  */
-router.get('/churn-rate', authMiddleware, async (req, res) => {
+router.get('/churn-rate', async (req, res) => {
     try {
         const { period = TIME_PERIODS.MONTH, ...filters } = req.query;
         const result = await metricsAggregationService.getChurnRate(period, filters);
@@ -194,11 +196,7 @@ router.get('/churn-rate', authMiddleware, async (req, res) => {
             data: result
         });
     } catch (error) {
-        console.error('Churn rate error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get churn rate'
-        });
+        return fail(res, error, 'Failed to get churn rate');
     }
 });
 
@@ -206,7 +204,7 @@ router.get('/churn-rate', authMiddleware, async (req, res) => {
  * GET /api/metrics/types
  * Get metric types
  */
-router.get('/types', authMiddleware, (req, res) => {
+router.get('/types', (req, res) => {
     res.json({
         success: true,
         data: METRIC_TYPES
@@ -217,7 +215,7 @@ router.get('/types', authMiddleware, (req, res) => {
  * GET /api/metrics/periods
  * Get time periods
  */
-router.get('/periods', authMiddleware, (req, res) => {
+router.get('/periods', (req, res) => {
     res.json({
         success: true,
         data: TIME_PERIODS
@@ -228,15 +226,10 @@ router.get('/periods', authMiddleware, (req, res) => {
  * POST /api/metrics/aggregate
  * Trigger metrics aggregation (admin only)
  */
-router.post('/aggregate', authMiddleware, async (req, res) => {
+router.post('/aggregate', async (req, res) => {
     try {
-        if (req.user.role !== 'admin') {
-            return res.status(403).json({
-                success: false,
-                error: 'Admin access required'
-            });
-        }
-
+        // The router already refuses anybody who is not an admin, so the
+        // inline check that used to be here said nothing extra.
         await metricsAggregationService.aggregateMetrics();
 
         res.json({
@@ -244,11 +237,7 @@ router.post('/aggregate', authMiddleware, async (req, res) => {
             message: 'Metrics aggregation triggered'
         });
     } catch (error) {
-        console.error('Aggregation error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to trigger aggregation'
-        });
+        return fail(res, error, 'Failed to trigger aggregation');
     }
 });
 
@@ -256,7 +245,7 @@ router.post('/aggregate', authMiddleware, async (req, res) => {
  * GET /api/metrics/stats
  * Get metrics service statistics
  */
-router.get('/stats', authMiddleware, async (req, res) => {
+router.get('/stats', async (req, res) => {
     try {
         const stats = await metricsAggregationService.getStatistics();
 
@@ -265,11 +254,7 @@ router.get('/stats', authMiddleware, async (req, res) => {
             data: stats
         });
     } catch (error) {
-        console.error('Stats error:', error);
-        res.status(500).json({
-            success: false,
-            error: 'Failed to get statistics'
-        });
+        return fail(res, error, 'Failed to get statistics');
     }
 });
 

--- a/backend/services/metricsAggregationService.js
+++ b/backend/services/metricsAggregationService.js
@@ -37,6 +37,75 @@ const TIME_PERIODS = {
 // do with trading.
 const EXCLUDE_MERGED_CARTS = "AND c.status <> 'merged'";
 
+/**
+ * An order that counts towards revenue (#1529).
+ *
+ * The money metrics filtered on `status = 'completed'`, which is not a member
+ * of the `orders.status` ENUM -- pending, processing, shipped, delivered,
+ * cancelled, refunded, on_hold -- so each of them matched no rows even before
+ * the column they summed turned out not to exist either.
+ *
+ * A cancelled or refunded order is not revenue; everything else that has been
+ * placed is, which is the rule `admin.service` already reads its dashboard by.
+ */
+const REVENUE_ORDERS = `
+    o.status NOT IN ('cancelled', 'refunded') AND o.deleted_at IS NULL
+`;
+
+/**
+ * The column holding what an order was worth.
+ *
+ * `orders.total_amount` does not exist. `total` is the figure the order path
+ * writes and verifies the shopper's claimed total against (`order.service`).
+ */
+const ORDER_VALUE = 'o.total';
+
+/**
+ * A caller-supplied filter this service does not implement.
+ *
+ * Carries the status the route should answer with, so an unsupported filter is
+ * a 400 rather than a 500 -- and, more to the point, rather than a whole-store
+ * number quietly returned to somebody who asked for a slice of it.
+ */
+class MetricsError extends Error {
+    constructor(message, status = 400, code = 'METRICS_ERROR') {
+        super(message);
+        this.name = 'MetricsError';
+        this.status = status;
+        this.code = code;
+    }
+}
+
+/**
+ * Refuse a filter this metric does not understand.
+ *
+ * Several metrics appended conditions over columns that have never existed
+ * (`orders.category`, `orders.user_segment`). Those queries could not run at
+ * all, but the failure worth guarding against is the quiet one: a dashboard
+ * that answers a filtered question with an unfiltered number.
+ *
+ * @param {Object} filters
+ * @param {string[]} supported
+ * @throws {MetricsError}
+ */
+function assertSupportedFilters(filters = {}, supported = []) {
+    const unsupported = Object.keys(filters).filter(
+        (key) =>
+            filters[key] !== undefined
+            && filters[key] !== ''
+            && !supported.includes(key)
+    );
+
+    if (unsupported.length) {
+        throw new MetricsError(
+            `Unsupported filter(s): ${unsupported.join(', ')}. `
+            + `This metric supports: ${supported.join(', ') || 'none'}`,
+            400,
+            'UNSUPPORTED_FILTER'
+        );
+    }
+}
+
 // ============================================
 // METRICS AGGREGATION SERVICE
 // ============================================
@@ -50,6 +119,8 @@ class MetricsAggregationService extends EventEmitter {
         this.lastAggregation = null;
         this.isAggregating = false;
         this.cacheTTL = 300; // 5 minutes
+        // Handle for the hourly aggregation, so shutdown can stop it.
+        this.aggregationTimer = null;
     }
 
     /**
@@ -59,8 +130,14 @@ class MetricsAggregationService extends EventEmitter {
         // Load historical metrics
         await this.loadHistoricalMetrics();
 
-        // Start periodic aggregation
-        setInterval(() => this.aggregateMetrics(), 3600000); // 1 hour
+        // Start periodic aggregation. The handle is retained so shutdown can
+        // stop it, and unref'd so a pending timer does not keep the process
+        // alive on its own -- the interval was previously created and dropped,
+        // which is the leak #1294 fixed in the recommendation service.
+        this.aggregationTimer = setInterval(() => this.aggregateMetrics(), 3600000); // 1 hour
+        if (typeof this.aggregationTimer.unref === 'function') {
+            this.aggregationTimer.unref();
+        }
 
         console.log('✅ Metrics Aggregation Service initialized');
         return this;
@@ -131,24 +208,30 @@ class MetricsAggregationService extends EventEmitter {
         const dateRange = this.getDateRange(period);
         const params = [dateRange.start, dateRange.end];
 
+        assertSupportedFilters(filters, ['category']);
+
         let query = `
-            SELECT 
-                AVG(total_amount) as avg_order_value,
+            SELECT
+                AVG(${ORDER_VALUE}) as avg_order_value,
                 COUNT(*) as order_count,
-                SUM(total_amount) as total_revenue
-            FROM orders
-            WHERE status = 'completed'
-            AND created_at BETWEEN ? AND ?
+                SUM(${ORDER_VALUE}) as total_revenue
+            FROM orders o
+            WHERE ${REVENUE_ORDERS}
+            AND o.created_at BETWEEN ? AND ?
         `;
 
+        // An order has no category of its own; the category of what was in it
+        // is the question being asked. `orders.category` and
+        // `orders.user_segment` were both filtered on here and neither exists.
         if (filters.category) {
-            query += ' AND category = ?';
+            query += `
+                AND EXISTS (
+                    SELECT 1 FROM order_items oi
+                    JOIN products p ON p.id = oi.product_id
+                    WHERE oi.order_id = o.id AND p.category_id = ?
+                )
+            `;
             params.push(filters.category);
-        }
-
-        if (filters.userSegment) {
-            query += ' AND user_segment = ?';
-            params.push(filters.userSegment);
         }
 
         const [rows] = await db.query(query, params);
@@ -239,36 +322,32 @@ class MetricsAggregationService extends EventEmitter {
         const cached = this.getFromCache(cacheKey);
         if (cached) return cached;
 
-        const dateRange = this.getDateRange(period);
-        const params = [dateRange.start, dateRange.end];
-
-        let query = `
-            SELECT 
-                COUNT(*) as total_impressions,
-                SUM(CASE WHEN clicked = 1 THEN 1 ELSE 0 END) as clicks,
-                (SUM(CASE WHEN clicked = 1 THEN 1 ELSE 0 END) / COUNT(*)) * 100 as ctr,
-                SUM(CASE WHEN purchased = 1 THEN 1 ELSE 0 END) as purchases
-            FROM recommendation_interactions
-            WHERE created_at BETWEEN ? AND ?
-        `;
-
-        if (filters.recommendationType) {
-            query += ' AND recommendation_type = ?';
-            params.push(filters.recommendationType);
-        }
-
-        if (filters.userSegment) {
-            query += ' AND user_segment = ?';
-            params.push(filters.userSegment);
-        }
-
-        const [rows] = await db.query(query, params);
+        // Reported as unavailable rather than computed.
+        //
+        // This read `recommendation_interactions`, a table that appears in no
+        // migration and in no other file -- so the query failed and, because
+        // `getDashboard` awaits this alongside the rest, took the whole
+        // dashboard down with it.
+        //
+        // It cannot be computed from what is recorded either: a click-through
+        // rate needs impressions, and nothing logs that a recommendation was
+        // *shown*. `user_interactions` holds view, cart_add, wishlist_add,
+        // purchase and share, all of which are clicks or better.
+        //
+        // Saying so is the honest answer. Inventing a denominator out of
+        // product views would produce a number that looks like a CTR, moves
+        // when the catalogue changes, and means nothing. Recording impressions
+        // is a feature, and belongs in its own change.
         const result = {
             metric: 'recommendation_ctr',
-            value: parseFloat(rows[0]?.ctr || 0),
-            impressions: parseInt(rows[0]?.total_impressions || 0),
-            clicks: parseInt(rows[0]?.clicks || 0),
-            purchases: parseInt(rows[0]?.purchases || 0),
+            available: false,
+            reason:
+                'Recommendation impressions are not recorded, so a '
+                + 'click-through rate cannot be computed.',
+            value: null,
+            impressions: null,
+            clicks: null,
+            purchases: null,
             period,
             filters,
             timestamp: new Date().toISOString()
@@ -289,27 +368,45 @@ class MetricsAggregationService extends EventEmitter {
         const dateRange = this.getDateRange(period);
         const params = [dateRange.start, dateRange.end];
 
-        let query = `
-            SELECT 
+        assertSupportedFilters(filters, ['couponType']);
+
+        // The filter is applied where a filter goes.
+        //
+        // It used to be appended after `GROUP BY c.id ORDER BY ...`, producing
+        // `... ORDER BY revenue_generated DESC AND c.discount_type = ?`, which
+        // is a syntax error -- so asking for one type of coupon was a 500, and
+        // asking for none returned figures summed over a column that does not
+        // exist.
+        let conditions = `
+            c.created_at BETWEEN ? AND ?
+            AND c.usage_count > 0
+        `;
+
+        if (filters.couponType) {
+            conditions += ' AND c.discount_type = ?';
+            params.push(filters.couponType);
+        }
+
+        // `orders.coupon_code` does not exist. The order path writes the code
+        // it applied to `promo_code` and `discount_code` (`order.service`).
+        const query = `
+            SELECT
                 c.code,
                 c.discount_type,
                 c.discount_value,
                 COUNT(o.id) as usage_count,
-                SUM(o.total_amount) as revenue_generated,
-                AVG(o.total_amount) as avg_order_value,
-                (SUM(o.total_amount) / NULLIF(COUNT(o.id), 0)) - c.discount_value as net_value
+                COALESCE(SUM(${ORDER_VALUE}), 0) as revenue_generated,
+                COALESCE(AVG(${ORDER_VALUE}), 0) as avg_order_value,
+                (COALESCE(SUM(${ORDER_VALUE}), 0) / NULLIF(COUNT(o.id), 0))
+                    - c.discount_value as net_value
             FROM coupons c
-            LEFT JOIN orders o ON o.coupon_code = c.code AND o.status = 'completed'
-            WHERE c.created_at BETWEEN ? AND ?
-            AND c.usage_count > 0
+            LEFT JOIN orders o
+                ON o.promo_code = c.code
+                AND ${REVENUE_ORDERS}
+            WHERE ${conditions}
             GROUP BY c.id
             ORDER BY revenue_generated DESC
         `;
-
-        if (filters.couponType) {
-            query += ' AND c.discount_type = ?';
-            params.push(filters.couponType);
-        }
 
         const [rows] = await db.query(query, params);
         const result = {
@@ -345,28 +442,39 @@ class MetricsAggregationService extends EventEmitter {
         const dateRange = this.getDateRange(period);
         const params = [dateRange.start, dateRange.end];
 
-        let query = `
-            SELECT 
+        assertSupportedFilters(filters, ['minOrders']);
+
+        // One HAVING, and the threshold is a parameter.
+        //
+        // The previous version bolted a second one on with
+        // `query.replace('ORDER BY', 'HAVING order_count >= ${filters.minOrders} ORDER BY')`.
+        // Two HAVING clauses is a syntax error, and `filters` is `req.query`
+        // spread straight from the URL -- so `?minOrders=1 UNION SELECT ...`
+        // was concatenated into the statement. Every other query in this
+        // service parameterises; this one interpolated.
+        const minOrders = Math.max(1, parseInt(filters.minOrders, 10) || 1);
+
+        const query = `
+            SELECT
                 u.id,
                 u.name,
                 COUNT(o.id) as order_count,
-                SUM(o.total_amount) as total_spent,
-                AVG(o.total_amount) as avg_order_value,
+                COALESCE(SUM(${ORDER_VALUE}), 0) as total_spent,
+                COALESCE(AVG(${ORDER_VALUE}), 0) as avg_order_value,
                 DATEDIFF(NOW(), MAX(o.created_at)) as days_since_last_order,
                 DATEDIFF(NOW(), u.created_at) as customer_age_days,
-                (SUM(o.total_amount) / NULLIF(DATEDIFF(NOW(), u.created_at), 0)) * 30 as monthly_value
+                (COALESCE(SUM(${ORDER_VALUE}), 0)
+                    / NULLIF(DATEDIFF(NOW(), u.created_at), 0)) * 30 as monthly_value
             FROM users u
-            LEFT JOIN orders o ON o.user_id = u.id AND o.status = 'completed'
+            LEFT JOIN orders o ON o.user_id = u.id AND ${REVENUE_ORDERS}
             WHERE u.created_at BETWEEN ? AND ?
             GROUP BY u.id
-            HAVING order_count > 0
+            HAVING order_count >= ?
             ORDER BY total_spent DESC
             LIMIT 100
         `;
 
-        if (filters.minOrders) {
-            query = query.replace('ORDER BY', `HAVING order_count >= ${filters.minOrders} ORDER BY`);
-        }
+        params.push(minOrders);
 
         const [rows] = await db.query(query, params);
         const result = {
@@ -403,12 +511,14 @@ class MetricsAggregationService extends EventEmitter {
         const dateRange = this.getDateRange(period);
         const params = [dateRange.start, dateRange.end];
 
+        assertSupportedFilters(filters, []);
+
         // Get current period revenue
         const [currentRevenue] = await db.query(
-            `SELECT SUM(total_amount) as revenue, COUNT(*) as orders 
-             FROM orders 
-             WHERE status = 'completed' 
-             AND created_at BETWEEN ? AND ?`,
+            `SELECT SUM(${ORDER_VALUE}) as revenue, COUNT(*) as orders
+             FROM orders o
+             WHERE ${REVENUE_ORDERS}
+             AND o.created_at BETWEEN ? AND ?`,
             params
         );
 
@@ -418,10 +528,10 @@ class MetricsAggregationService extends EventEmitter {
         const previousEnd = new Date(dateRange.end - periodDuration);
 
         const [previousRevenue] = await db.query(
-            `SELECT SUM(total_amount) as revenue 
-             FROM orders 
-             WHERE status = 'completed' 
-             AND created_at BETWEEN ? AND ?`,
+            `SELECT SUM(${ORDER_VALUE}) as revenue
+             FROM orders o
+             WHERE ${REVENUE_ORDERS}
+             AND o.created_at BETWEEN ? AND ?`,
             [previousStart, previousEnd]
         );
 
@@ -455,27 +565,43 @@ class MetricsAggregationService extends EventEmitter {
         const dateRange = this.getDateRange(period);
         const params = [dateRange.start, dateRange.end];
 
-        // Get active users at start of period
+        assertSupportedFilters(filters, []);
+
+        // Who was buying in the thirty days before the window opened.
         const [activeUsers] = await db.query(
-            `SELECT COUNT(DISTINCT user_id) as active 
-             FROM orders 
-             WHERE status = 'completed' 
-             AND created_at < ? 
-             AND created_at > DATE_SUB(?, INTERVAL 30 DAY)`,
+            `SELECT COUNT(DISTINCT o.user_id) as active
+             FROM orders o
+             WHERE ${REVENUE_ORDERS}
+             AND o.user_id IS NOT NULL
+             AND o.created_at < ?
+             AND o.created_at > DATE_SUB(?, INTERVAL 30 DAY)`,
             [dateRange.start, dateRange.start]
         );
 
-        // Get users who churned (no activity in period)
+        // How many of *those* did not come back during the window.
+        //
+        // The previous version counted every user account older than the
+        // window that had not ordered inside it -- which is almost the whole
+        // register, most of whom were never active and so cannot have churned.
+        // Divided by the active count it produced churn rates far above 100%.
+        //
+        // `NOT IN` was also unsafe against NULL: a guest order carries a null
+        // `user_id`, and `id NOT IN (… NULL …)` is never true for any row, so
+        // one guest order in the window made the churned count zero.
         const [churnedUsers] = await db.query(
-            `SELECT COUNT(DISTINCT user_id) as churned 
-             FROM users u
-             WHERE u.created_at < ?
-             AND u.id NOT IN (
-                 SELECT DISTINCT user_id 
-                 FROM orders 
-                 WHERE created_at BETWEEN ? AND ?
+            `SELECT COUNT(DISTINCT prior.user_id) as churned
+             FROM orders prior
+             WHERE prior.status NOT IN ('cancelled', 'refunded')
+             AND prior.deleted_at IS NULL
+             AND prior.user_id IS NOT NULL
+             AND prior.created_at < ?
+             AND prior.created_at > DATE_SUB(?, INTERVAL 30 DAY)
+             AND NOT EXISTS (
+                 SELECT 1 FROM orders during
+                 WHERE during.user_id = prior.user_id
+                 AND during.created_at BETWEEN ? AND ?
              )`,
-            [dateRange.start, dateRange.start, dateRange.end]
+            [dateRange.start, dateRange.start, dateRange.start, dateRange.end]
         );
 
         const active = parseInt(activeUsers[0]?.active || 0);
@@ -637,6 +763,19 @@ class MetricsAggregationService extends EventEmitter {
     }
 
     /**
+     * Stop the periodic aggregation.
+     *
+     * Every other service with a timer in this repo exposes one of these; this
+     * one created an interval it kept no handle to, so nothing could.
+     */
+    shutdown() {
+        if (this.aggregationTimer) {
+            clearInterval(this.aggregationTimer);
+            this.aggregationTimer = null;
+        }
+    }
+
+    /**
      * Database operations
      */
     async loadHistoricalMetrics() {
@@ -702,7 +841,11 @@ class MetricsAggregationService extends EventEmitter {
 
 module.exports = {
     MetricsAggregationService,
+    MetricsError,
     METRIC_TYPES,
     TIME_PERIODS,
+    REVENUE_ORDERS,
+    ORDER_VALUE,
+    assertSupportedFilters,
     metricsAggregationService: new MetricsAggregationService()
 };

--- a/backend/tests/businessMetrics.test.js
+++ b/backend/tests/businessMetrics.test.js
@@ -1,0 +1,324 @@
+// The business metrics, the columns they read, and who may read them (#1529).
+//
+// Every money figure this service produced was summed from `orders.total_amount`
+// -- a column that does not exist -- and filtered on `status = 'completed'`,
+// which is not a member of the `orders.status` ENUM. So average order value,
+// customer lifetime value, revenue growth and coupon effectiveness all failed,
+// and `/dashboard` awaits several of them at once, so it failed with them.
+//
+// Two of the defects are not about columns:
+//
+//   * `getCustomerLifetimeValue` built its threshold with
+//     `query.replace('ORDER BY', 'HAVING order_count >= ${filters.minOrders} …')`
+//     and `filters` is `req.query` spread from the URL.
+//   * every route was `authMiddleware` and nothing more, and
+//     /customer-lifetime-value returns the names and spend of the hundred
+//     biggest customers.
+
+jest.mock("../config/db", () => {
+    const query = jest.fn();
+    return { query, promise: { query }, getConnection: jest.fn() };
+});
+
+const fs = require("fs");
+const path = require("path");
+
+const db = require("../config/db");
+const {
+    MetricsAggregationService,
+    MetricsError,
+    TIME_PERIODS,
+    assertSupportedFilters
+} = require("../services/metricsAggregationService");
+
+/** Every statement issued, whitespace collapsed. */
+const statements = () =>
+    db.query.mock.calls.map(([sql]) => String(sql).replace(/\s+/g, " ").trim());
+
+const paramsOf = (index = 0) => db.query.mock.calls[index][1];
+
+let metrics;
+
+beforeEach(() => {
+    db.query.mockReset();
+    db.query.mockResolvedValue([[{}]]);
+    // A fresh instance per test: the service caches by metric and period, and
+    // a cached answer issues no statement to assert on.
+    metrics = new MetricsAggregationService();
+});
+
+// ---------------------------------------------------------------------------
+// The columns the money comes from
+// ---------------------------------------------------------------------------
+
+describe("what a metric sums", () => {
+    const MONEY_METRICS = [
+        ["average order value", (m) => m.getAverageOrderValue(TIME_PERIODS.WEEK)],
+        ["customer lifetime value", (m) => m.getCustomerLifetimeValue(TIME_PERIODS.MONTH)],
+        ["revenue growth", (m) => m.getRevenueGrowth(TIME_PERIODS.MONTH)],
+        ["coupon effectiveness", (m) => m.getCouponEffectiveness(TIME_PERIODS.WEEK)]
+    ];
+
+    test.each(MONEY_METRICS)("%s reads orders.total", async (_label, run) => {
+        await run(metrics);
+
+        const money = statements().filter((sql) => /SUM\(|AVG\(/.test(sql));
+
+        expect(money.length).toBeGreaterThan(0);
+
+        for (const sql of money) {
+            expect(sql).not.toMatch(/total_amount/);
+            expect(sql).toMatch(/o\.total/);
+        }
+    });
+
+    test.each(MONEY_METRICS)(
+        "%s does not filter on a status the enum has no member for",
+        async (_label, run) => {
+            await run(metrics);
+
+            for (const sql of statements()) {
+                // 'completed' is not one of pending, processing, shipped,
+                // delivered, cancelled, refunded, on_hold.
+                expect(sql).not.toMatch(/status = 'completed'/);
+            }
+        }
+    );
+
+    test.each(MONEY_METRICS)("%s excludes cancelled and refunded orders", async (_label, run) => {
+        await run(metrics);
+
+        const money = statements().filter((sql) => /FROM orders|JOIN orders/.test(sql));
+
+        expect(money.length).toBeGreaterThan(0);
+
+        for (const sql of money) {
+            expect(sql).toMatch(/NOT IN \('cancelled', 'refunded'\)/);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The clause that was in the wrong place
+// ---------------------------------------------------------------------------
+
+describe("coupon effectiveness", () => {
+    test("puts the type filter in the WHERE clause, not after ORDER BY", async () => {
+        await metrics.getCouponEffectiveness(TIME_PERIODS.WEEK, {
+            couponType: "percentage"
+        });
+
+        const sql = statements()[0];
+
+        // It used to append ` AND c.discount_type = ?` after
+        // `ORDER BY revenue_generated DESC`, which is a syntax error.
+        expect(sql).toMatch(/WHERE[\s\S]*discount_type = \?[\s\S]*GROUP BY/);
+        expect(sql).not.toMatch(/ORDER BY[\s\S]*AND c\.discount_type/);
+        expect(paramsOf(0)).toContain("percentage");
+    });
+
+    test("joins orders on the column the order path writes", async () => {
+        await metrics.getCouponEffectiveness(TIME_PERIODS.WEEK);
+
+        // `orders.coupon_code` does not exist; the applied code is written to
+        // promo_code and discount_code.
+        expect(statements()[0]).not.toMatch(/coupon_code/);
+        expect(statements()[0]).toMatch(/o\.promo_code = c\.code/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The interpolated filter
+// ---------------------------------------------------------------------------
+
+describe("customer lifetime value", () => {
+    test("passes the order threshold as a parameter", async () => {
+        await metrics.getCustomerLifetimeValue(TIME_PERIODS.MONTH, { minOrders: 3 });
+
+        const sql = statements()[0];
+
+        expect(sql).toMatch(/HAVING order_count >= \?/);
+        expect(paramsOf(0)).toContain(3);
+    });
+
+    test("does not concatenate a query parameter into the statement", async () => {
+        const injection = "1 UNION SELECT id, email, password, 1, 1, 1, 1 FROM users -- ";
+
+        await metrics.getCustomerLifetimeValue(TIME_PERIODS.MONTH, {
+            minOrders: injection
+        });
+
+        const sql = statements()[0];
+
+        expect(sql).not.toContain("UNION");
+        expect(sql).not.toContain("password");
+        // parseInt of that string is 1, and 1 is what the parameter becomes.
+        expect(paramsOf(0)).toContain(1);
+    });
+
+    test("has exactly one HAVING clause", async () => {
+        await metrics.getCustomerLifetimeValue(TIME_PERIODS.MONTH, { minOrders: 5 });
+
+        const having = statements()[0].match(/HAVING/g) || [];
+
+        // The replace-based version produced two, which MySQL rejects.
+        expect(having).toHaveLength(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Filters that are not implemented
+// ---------------------------------------------------------------------------
+
+describe("an unsupported filter", () => {
+    test("is refused rather than ignored", async () => {
+        await expect(
+            metrics.getAverageOrderValue(TIME_PERIODS.WEEK, { userSegment: "vip" })
+        ).rejects.toThrow(MetricsError);
+    });
+
+    test("is refused with a 400, not a 500", async () => {
+        expect.assertions(2);
+
+        try {
+            await metrics.getRevenueGrowth(TIME_PERIODS.MONTH, { region: "west" });
+        } catch (error) {
+            expect(error.status).toBe(400);
+            expect(error.code).toBe("UNSUPPORTED_FILTER");
+        }
+    });
+
+    test("names both what was asked for and what is available", () => {
+        try {
+            assertSupportedFilters({ userSegment: "vip" }, ["category"]);
+        } catch (error) {
+            expect(error.message).toContain("userSegment");
+            expect(error.message).toContain("category");
+        }
+    });
+
+    test("an empty or absent filter is not treated as one", () => {
+        expect(() =>
+            assertSupportedFilters({ category: undefined, userSegment: "" }, [])
+        ).not.toThrow();
+    });
+
+    test("a supported filter still works", async () => {
+        await metrics.getAverageOrderValue(TIME_PERIODS.WEEK, { category: 3 });
+
+        // A category belongs to what was in the order, not to the order.
+        expect(statements()[0]).toMatch(/EXISTS \( SELECT 1 FROM order_items oi/);
+        expect(paramsOf(0)).toContain(3);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Metrics that cannot be computed
+// ---------------------------------------------------------------------------
+
+describe("recommendation CTR", () => {
+    test("says it is unavailable instead of querying a table that does not exist", async () => {
+        const result = await metrics.getRecommendationCTR(TIME_PERIODS.WEEK);
+
+        expect(result.available).toBe(false);
+        expect(result.reason).toMatch(/impressions are not recorded/i);
+        expect(db.query).not.toHaveBeenCalled();
+    });
+
+    test("does not report a fabricated rate", async () => {
+        const result = await metrics.getRecommendationCTR(TIME_PERIODS.WEEK);
+
+        // null, not 0. "We do not measure this" and "nobody clicked" are
+        // different statements and a dashboard should not confuse them.
+        expect(result.value).toBeNull();
+        expect(result.impressions).toBeNull();
+    });
+
+    test("no longer takes the dashboard down with it", async () => {
+        const dashboard = await metrics.getDashboard(TIME_PERIODS.WEEK);
+
+        expect(dashboard.metrics.recommendationCTR.available).toBe(false);
+        expect(dashboard.summary).toBeDefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Churn
+// ---------------------------------------------------------------------------
+
+describe("churn rate", () => {
+    test("counts only shoppers who were active before the window", async () => {
+        await metrics.getChurnRate(TIME_PERIODS.MONTH);
+
+        const [, churned] = statements();
+
+        // The previous version counted every account older than the window
+        // that had not ordered inside it -- almost the whole register, most of
+        // whom were never active and so cannot have churned.
+        expect(churned).toMatch(/FROM orders prior/);
+        expect(churned).toMatch(/NOT EXISTS/);
+        expect(churned).not.toMatch(/FROM users u/);
+    });
+
+    test("is not defeated by a guest order in the window", async () => {
+        await metrics.getChurnRate(TIME_PERIODS.MONTH);
+
+        const [, churned] = statements();
+
+        // A guest order carries a null user_id, and `id NOT IN (… NULL …)` is
+        // never true for any row -- so one guest order made churn zero.
+        expect(churned).not.toMatch(/NOT IN \(\s*SELECT/);
+        expect(churned).toMatch(/prior\.user_id IS NOT NULL/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Who may read any of this
+// ---------------------------------------------------------------------------
+
+describe("the metrics routes", () => {
+    const source = fs.readFileSync(
+        path.join(__dirname, "..", "routes", "metricsRoutes.js"),
+        "utf8"
+    );
+
+    test("require an admin, at the router", () => {
+        expect(source).toMatch(/router\.use\(authMiddleware\)/);
+        expect(source).toMatch(/router\.use\(authorizeRoles\(ROLES\.ADMIN\)\)/);
+    });
+
+    test("declare the guard before the first route", () => {
+        // Applied at the router and before anything is mounted, so a route
+        // added later cannot be missing it -- which is how nine of them came
+        // to be readable by any signed-in shopper.
+        const guard = source.indexOf("authorizeRoles(ROLES.ADMIN)");
+        const firstRoute = source.search(/router\.(get|post)\(/);
+
+        expect(guard).toBeGreaterThan(-1);
+        expect(guard).toBeLessThan(firstRoute);
+    });
+
+    test("carry the status an error names", () => {
+        // Without this an unsupported filter is reported as a server error,
+        // which hides whose mistake it was.
+        expect(source).toMatch(/const status = error\.status \|\| 500/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The interval
+// ---------------------------------------------------------------------------
+
+describe("the hourly aggregation", () => {
+    test("keeps a handle that shutdown can clear", async () => {
+        db.query.mockResolvedValue([[]]);
+
+        await metrics.initialize();
+
+        expect(metrics.aggregationTimer).not.toBeNull();
+
+        metrics.shutdown();
+
+        expect(metrics.aggregationTimer).toBeNull();
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

Every money figure this service produced was summed from `orders.total_amount` — a column that does not exist — and filtered on `status = 'completed'`, which is not a member of the `orders.status` ENUM. Average order value, customer lifetime value, revenue growth and coupon effectiveness all failed, and `getDashboard` awaits several of them at once, so it failed with them. None of these numbers has ever been reported.

Two of the defects are not about columns:

- `getCustomerLifetimeValue` built its threshold with `query.replace('ORDER BY', \`HAVING order_count >= ${filters.minOrders} ORDER BY\`)`, and `filters` is `req.query` spread straight from the URL.
- Every route was `authMiddleware` and nothing more, and `/customer-lifetime-value` returns the names of the hundred highest-spending customers alongside what each has spent.

---

## 🔗 Related Issue

Closes #1529

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] Security fix
- [x] Testing improvement
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Code refactoring

---

## 🌐 Additional Notes

### What counts as revenue, written down once

`REVENUE_ORDERS` — not cancelled, not refunded, not soft-deleted — and `ORDER_VALUE` — `o.total`, the figure the order path writes and verifies the shopper's claim against. Five queries restated the status filter and five of them got it wrong the same way; one definition is harder to get wrong in only some places.

Not-cancelled-and-not-refunded is the rule `admin.service` already reads its dashboard by, so the two surfaces now agree about what the store earned, which they did not before.

### The route guard

`authorizeRoles(ROLES.ADMIN)` at the **router**, before anything is mounted, so a route added later cannot be missing it — which is how eight of the nine came to be readable by any signed-in shopper. `/aggregate` had an inline `req.user.role !== 'admin'` check, which is what tells you the whole file was meant to be admin surface; that check is now redundant and gone.

`/customer-lifetime-value` is the one that matters most: it was returning customer names and spend to anybody with an account.

### The interpolated threshold

```js
query = query.replace('ORDER BY', `HAVING order_count >= ${filters.minOrders} ORDER BY`);
```

The statement it produced was invalid anyway — the query already had `HAVING order_count > 0`, and two HAVING clauses is a syntax error — so this was not exploitable as it stood. That is the uncomfortable part: fixing the surrounding SQL without fixing this is precisely what would have made it live. One HAVING, and the threshold is a bound parameter.

### The clause in the wrong place

`getCouponEffectiveness` appended ` AND c.discount_type = ?` **after** `GROUP BY c.id ORDER BY revenue_generated DESC`. The conditions are assembled before the query is, so the filter lands in the WHERE clause. The join also moved from `o.coupon_code` (no such column) to `o.promo_code`, which is where `order.service` writes the code that was applied.

### Filters that are not implemented

`getAverageOrderValue` appended `AND category = ?` and `AND user_segment = ?` to a query on `orders`; neither column exists. `category` is now implemented properly — as an `EXISTS` over the order's lines, since a category belongs to what was *in* the order — and the same shape `getConversionRate` already uses for carts.

Anything else is refused with a 400 by `assertSupportedFilters`. That is the deliberate part: those broken filters could not run, but the failure worth defending against is the quiet one, where a dashboard answers a filtered question with an unfiltered number and nobody can tell.

The routes now honour `error.status`, so a caller's mistake is a 400 and the server's is a 500, instead of both arriving as "Failed to get …".

### Recommendation CTR

`recommendation_interactions` appears in no migration, in `backend/sql/`, or in any other file. The metric took the whole dashboard down with it.

It also cannot be computed from what is recorded: a click-through rate needs impressions, and nothing logs that a recommendation was *shown* — `user_interactions` holds view, cart_add, wishlist_add, purchase and share, all of which are clicks or better. So it reports `available: false` with the reason, and `value: null` rather than `0`, because "we do not measure this" and "nobody clicked" are different statements and a dashboard must not conflate them.

Inventing a denominator from product views would produce a number that looks like a CTR, moves when the catalogue changes, and means nothing. **Recording impressions is a feature and is deliberately not in this PR.**

### Churn

"Active" was users who ordered in the 30 days before the window; "churned" was *every account older than the window* that did not order during it — most of whom were never active. The two are not comparable and the rate routinely exceeded 100%. Churn is now counted among the shoppers who were actually buying beforehand.

The old query also used `u.id NOT IN (SELECT user_id FROM orders …)`, and a guest order carries a null `user_id`: `x NOT IN (… NULL …)` is never true for any row, so one guest order in the window made churn read as exactly zero. `NOT EXISTS` does not have that hole.

### The interval

`initialize()` created an hourly `setInterval` and kept no handle, so nothing could stop it. It is retained, `unref`'d, and there is a `shutdown()` — the same fix and the same reasoning as `recommendationService` in #1294.

### Tests

`tests/businessMetrics.test.js`, 31 tests. A fresh service instance per test, because the results are cached by metric and period and a cached answer issues no statement to assert on.

The column and status assertions are on the **SQL**: `db.query` is mocked and accepts any string, so nothing behavioural can see `total_amount`. Four money metrics × three properties (reads `o.total`, never filters on `'completed'`, excludes cancelled and refunded) is most of the file, deliberately — that is the defect, repeated five times, and a regression would be too.

The injection test passes a real `UNION SELECT … FROM users` as `minOrders` and asserts neither `UNION` nor `password` appears in the statement, and that the parameter is the integer 1.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

Full suite green on this branch: **76 suites, 1773 tests** (from 75 / 1742 on `main`). No migration — every column this now reads has been in the baseline schema from the start, which is why nothing flagged the ones that were not.

No files in common with #1522, #1524, #1526 or #1528.
