### PR TITLE
feat: add Notify Me back-in-stock alert (#1233)

### DIFF
--- a/frontend/product.html
+++ b/frontend/product.html
@@ -978,6 +978,9 @@
     <!-- 🔥 SHARE SCRIPT - NEW -->
     <script defer src="scripts/shareService.js"></script>
 
+    <!-- Stock Alert: Notify Me (#1233) -->
+    <script defer src="scripts/stock-alert.js"></script>
+
     <script>
     (function () {
         var modal = document.getElementById('size-guide-modal');

--- a/frontend/scripts/product.js
+++ b/frontend/scripts/product.js
@@ -498,6 +498,11 @@ async function toggleWishlist(productId) {
         // 🔥 Initialize Share Button
         initShareButton(product);
 
+        // Notify Me button for out-of-stock products (#1233)
+        if (typeof StockAlert !== "undefined" && StockAlert.initStockAlert) {
+            StockAlert.initStockAlert(product);
+        }
+
         productElements.mainImage.alt = escapeHTML(product.name || "Product image");
 
         if (typeof loadProductReviews === "function") {

--- a/frontend/scripts/stock-alert.js
+++ b/frontend/scripts/stock-alert.js
@@ -46,10 +46,19 @@
         }
     }
 
+    // FIX: use createElement instead of innerHTML to avoid quote-escaping issues
+    function makeIcon(iconClass) {
+        const i = document.createElement("i");
+        i.className = iconClass;
+        i.setAttribute("aria-hidden", "true");
+        return i;
+    }
+
     function paintSubscribed(btn) {
         btn.disabled = false;
         btn.dataset.subscribed = "true";
-        btn.innerHTML = "<i class="fas fa-bell-slash" aria-hidden="true"></i> Cancel Alert";
+        btn.textContent = " Cancel Alert";
+        btn.insertBefore(makeIcon("fas fa-bell-slash"), btn.firstChild);
         btn.classList.add("notify-me-btn--active");
         btn.setAttribute("aria-pressed", "true");
         btn.setAttribute("title", "Cancel back-in-stock notification");
@@ -57,14 +66,16 @@
     function paintUnsubscribed(btn) {
         btn.disabled = false;
         btn.dataset.subscribed = "false";
-        btn.innerHTML = "<i class="fas fa-bell" aria-hidden="true"></i> Notify Me";
+        btn.textContent = " Notify Me";
+        btn.insertBefore(makeIcon("fas fa-bell"), btn.firstChild);
         btn.classList.remove("notify-me-btn--active");
         btn.setAttribute("aria-pressed", "false");
         btn.setAttribute("title", "Get notified when this is back in stock");
     }
     function paintLoading(btn) {
         btn.disabled = true;
-        btn.innerHTML = "<i class="fas fa-spinner fa-spin" aria-hidden="true"></i> Please wait...";
+        btn.textContent = " Please wait...";
+        btn.insertBefore(makeIcon("fas fa-spinner fa-spin"), btn.firstChild);
     }
 
     // FIX: validate productId is a non-empty, finite value before proceeding
@@ -88,11 +99,11 @@
             }, 800);
             return;
         }
-        const alreadySubscribed = btn.dataset.subscribed === "true";
+        var alreadySubscribed = btn.dataset.subscribed === "true";
         paintLoading(btn);
         try {
             if (alreadySubscribed) {
-                const res = await unsubscribeAlert(productId);
+                var res = await unsubscribeAlert(productId);
                 if (res && res.success) {
                     markUnsubscribed(productId);
                     paintUnsubscribed(btn);
@@ -101,13 +112,13 @@
                     throw new Error((res && res.message) || "Could not cancel alert.");
                 }
             } else {
-                const res = await subscribeAlert(productId);
-                if (res && res.success) {
+                var res2 = await subscribeAlert(productId);
+                if (res2 && res2.success) {
                     markSubscribed(productId);
                     paintSubscribed(btn);
                     AppUtils.notify("We will email you when this is back in stock!", "success");
                 } else {
-                    throw new Error((res && res.message) || "Could not set alert.");
+                    throw new Error((res2 && res2.message) || "Could not set alert.");
                 }
             }
         } catch (err) {
@@ -123,7 +134,7 @@
             console.warn("stockAlert: createNotifyBtn called with invalid productId", productId);
             return null;
         }
-        const btn = document.createElement("button");
+        var btn = document.createElement("button");
         btn.type = "button";
         btn.className = "notify-me-btn";
         btn.dataset.productId = String(productId);
@@ -135,26 +146,31 @@
     function initStockAlert(product) {
         if (product == null) return;
         if (Number(product.stock) > 0) return;
-        const container = document.getElementById("product-buttons");
+        var container = document.getElementById("product-buttons");
         if (container == null) return;
         if (container.querySelector(".notify-me-btn")) return;
-        const btn = createNotifyBtn(product.id);
-        if (btn) container.appendChild(btn);
+        var btn = createNotifyBtn(product.id);
+        if (btn) { container.appendChild(btn); }
     }
 
     function injectNotifyBtnIntoCard(card, product) {
         if (card == null || product == null) return;
-        const stock = product.stock;
+        var stock = product.stock;
         if (stock === undefined || stock === null || Number(stock) > 0) return;
-        const productId = product.id || product.productId;
+        var productId = product.id || product.productId;
         if (!isValidProductId(productId)) return;
         if (card.querySelector(".notify-me-btn")) return;
-        const btn = createNotifyBtn(productId);
+        var btn = createNotifyBtn(productId);
         if (!btn) return;
-        const buttonRow = card.querySelector(".wishlist-buttons");
+        var buttonRow = card.querySelector(".wishlist-buttons");
         if (buttonRow) { buttonRow.appendChild(btn); }
-        else { const content = card.querySelector(".wishlist-content"); if (content) content.appendChild(btn); }
+        else { var content = card.querySelector(".wishlist-content"); if (content) { content.appendChild(btn); } }
     }
 
-    window.StockAlert = { initStockAlert: initStockAlert, injectNotifyBtnIntoCard: injectNotifyBtnIntoCard, isSubscribed: isSubscribed, createNotifyBtn: createNotifyBtn };
+    window.StockAlert = {
+        initStockAlert: initStockAlert,
+        injectNotifyBtnIntoCard: injectNotifyBtnIntoCard,
+        isSubscribed: isSubscribed,
+        createNotifyBtn: createNotifyBtn
+    };
 })();

--- a/frontend/scripts/stock-alert.js
+++ b/frontend/scripts/stock-alert.js
@@ -1,5 +1,6 @@
 // frontend/scripts/stock-alert.js
 // Notify Me / back-in-stock alert feature (#1233)
+
 (() => {
     const ALERT_TYPE_STOCK = "back_in_stock";
     const SUBSCRIBED_KEY = "stockAlertSubscriptions";
@@ -19,17 +20,30 @@
     function markSubscribed(productId) { const s = getSubscribed(); s.add(String(productId)); saveSubscribed(s); }
     function markUnsubscribed(productId) { const s = getSubscribed(); s.delete(String(productId)); saveSubscribed(s); }
 
+    // FIX: try-catch added to handle API errors gracefully
     async function subscribeAlert(productId) {
-        return AppUtils.apiRequest("/stock-alerts", {
-            method: "POST",
-            body: JSON.stringify({ productId: String(productId), alertType: ALERT_TYPE_STOCK })
-        });
+        try {
+            return await AppUtils.apiRequest("/stock-alerts", {
+                method: "POST",
+                body: JSON.stringify({ productId: String(productId), alertType: ALERT_TYPE_STOCK })
+            });
+        } catch (err) {
+            console.error("stockAlert: subscribeAlert failed", err);
+            return { success: false, message: err.message || "Subscription request failed." };
+        }
     }
+
+    // FIX: try-catch added to handle API errors gracefully
     async function unsubscribeAlert(productId) {
-        return AppUtils.apiRequest("/stock-alerts", {
-            method: "DELETE",
-            body: JSON.stringify({ productId: String(productId), alertType: ALERT_TYPE_STOCK })
-        });
+        try {
+            return await AppUtils.apiRequest("/stock-alerts", {
+                method: "DELETE",
+                body: JSON.stringify({ productId: String(productId), alertType: ALERT_TYPE_STOCK })
+            });
+        } catch (err) {
+            console.error("stockAlert: unsubscribeAlert failed", err);
+            return { success: false, message: err.message || "Unsubscribe request failed." };
+        }
     }
 
     function paintSubscribed(btn) {
@@ -53,8 +67,20 @@
         btn.innerHTML = "<i class="fas fa-spinner fa-spin" aria-hidden="true"></i> Please wait...";
     }
 
+    // FIX: validate productId is a non-empty, finite value before proceeding
+    function isValidProductId(productId) {
+        if (productId === null || productId === undefined) return false;
+        const str = String(productId).trim();
+        return str.length > 0 && str !== "undefined" && str !== "null";
+    }
+
     async function handleToggle(btn, productId) {
-        if (productId == null) return;
+        // FIX: validate productId before any action
+        if (!isValidProductId(productId)) {
+            console.error("stockAlert: invalid productId", productId);
+            AppUtils.notify("Cannot set alert: product ID is missing.", "error");
+            return;
+        }
         if (AppUtils.isAuthenticated() === false) {
             AppUtils.notify("Please sign in to set stock alerts.", "error");
             setTimeout(function() {
@@ -85,13 +111,18 @@
                 }
             }
         } catch (err) {
-            console.error("stockAlert toggle error:", err);
+            console.error("stockAlert: handleToggle error", err);
             AppUtils.notify(err.message || "Something went wrong. Please try again.", "error");
             if (alreadySubscribed) { paintSubscribed(btn); } else { paintUnsubscribed(btn); }
         }
     }
 
+    // FIX: guard against null/undefined productId before creating button
     function createNotifyBtn(productId) {
+        if (!isValidProductId(productId)) {
+            console.warn("stockAlert: createNotifyBtn called with invalid productId", productId);
+            return null;
+        }
         const btn = document.createElement("button");
         btn.type = "button";
         btn.className = "notify-me-btn";
@@ -107,7 +138,8 @@
         const container = document.getElementById("product-buttons");
         if (container == null) return;
         if (container.querySelector(".notify-me-btn")) return;
-        container.appendChild(createNotifyBtn(product.id));
+        const btn = createNotifyBtn(product.id);
+        if (btn) container.appendChild(btn);
     }
 
     function injectNotifyBtnIntoCard(card, product) {
@@ -115,9 +147,10 @@
         const stock = product.stock;
         if (stock === undefined || stock === null || Number(stock) > 0) return;
         const productId = product.id || product.productId;
-        if (productId == null) return;
+        if (!isValidProductId(productId)) return;
         if (card.querySelector(".notify-me-btn")) return;
         const btn = createNotifyBtn(productId);
+        if (!btn) return;
         const buttonRow = card.querySelector(".wishlist-buttons");
         if (buttonRow) { buttonRow.appendChild(btn); }
         else { const content = card.querySelector(".wishlist-content"); if (content) content.appendChild(btn); }

--- a/frontend/scripts/stock-alert.js
+++ b/frontend/scripts/stock-alert.js
@@ -1,0 +1,127 @@
+// frontend/scripts/stock-alert.js
+// Notify Me / back-in-stock alert feature (#1233)
+(() => {
+    const ALERT_TYPE_STOCK = "back_in_stock";
+    const SUBSCRIBED_KEY = "stockAlertSubscriptions";
+
+    function getSubscribed() {
+        try {
+            const raw = localStorage.getItem(SUBSCRIBED_KEY);
+            const parsed = raw ? JSON.parse(raw) : [];
+            return Array.isArray(parsed) ? new Set(parsed) : new Set();
+        } catch (e) { return new Set(); }
+    }
+    function saveSubscribed(set) {
+        try { localStorage.setItem(SUBSCRIBED_KEY, JSON.stringify([...set])); }
+        catch (err) { console.warn("stockAlert: could not persist", err); }
+    }
+    function isSubscribed(productId) { return getSubscribed().has(String(productId)); }
+    function markSubscribed(productId) { const s = getSubscribed(); s.add(String(productId)); saveSubscribed(s); }
+    function markUnsubscribed(productId) { const s = getSubscribed(); s.delete(String(productId)); saveSubscribed(s); }
+
+    async function subscribeAlert(productId) {
+        return AppUtils.apiRequest("/stock-alerts", {
+            method: "POST",
+            body: JSON.stringify({ productId: String(productId), alertType: ALERT_TYPE_STOCK })
+        });
+    }
+    async function unsubscribeAlert(productId) {
+        return AppUtils.apiRequest("/stock-alerts", {
+            method: "DELETE",
+            body: JSON.stringify({ productId: String(productId), alertType: ALERT_TYPE_STOCK })
+        });
+    }
+
+    function paintSubscribed(btn) {
+        btn.disabled = false;
+        btn.dataset.subscribed = "true";
+        btn.innerHTML = "<i class="fas fa-bell-slash" aria-hidden="true"></i> Cancel Alert";
+        btn.classList.add("notify-me-btn--active");
+        btn.setAttribute("aria-pressed", "true");
+        btn.setAttribute("title", "Cancel back-in-stock notification");
+    }
+    function paintUnsubscribed(btn) {
+        btn.disabled = false;
+        btn.dataset.subscribed = "false";
+        btn.innerHTML = "<i class="fas fa-bell" aria-hidden="true"></i> Notify Me";
+        btn.classList.remove("notify-me-btn--active");
+        btn.setAttribute("aria-pressed", "false");
+        btn.setAttribute("title", "Get notified when this is back in stock");
+    }
+    function paintLoading(btn) {
+        btn.disabled = true;
+        btn.innerHTML = "<i class="fas fa-spinner fa-spin" aria-hidden="true"></i> Please wait...";
+    }
+
+    async function handleToggle(btn, productId) {
+        if (productId == null) return;
+        if (AppUtils.isAuthenticated() === false) {
+            AppUtils.notify("Please sign in to set stock alerts.", "error");
+            setTimeout(function() {
+                window.location.href = "signin.html?next=" + encodeURIComponent(window.location.href);
+            }, 800);
+            return;
+        }
+        const alreadySubscribed = btn.dataset.subscribed === "true";
+        paintLoading(btn);
+        try {
+            if (alreadySubscribed) {
+                const res = await unsubscribeAlert(productId);
+                if (res && res.success) {
+                    markUnsubscribed(productId);
+                    paintUnsubscribed(btn);
+                    AppUtils.notify("You will no longer be notified for this product.", "info");
+                } else {
+                    throw new Error((res && res.message) || "Could not cancel alert.");
+                }
+            } else {
+                const res = await subscribeAlert(productId);
+                if (res && res.success) {
+                    markSubscribed(productId);
+                    paintSubscribed(btn);
+                    AppUtils.notify("We will email you when this is back in stock!", "success");
+                } else {
+                    throw new Error((res && res.message) || "Could not set alert.");
+                }
+            }
+        } catch (err) {
+            console.error("stockAlert toggle error:", err);
+            AppUtils.notify(err.message || "Something went wrong. Please try again.", "error");
+            if (alreadySubscribed) { paintSubscribed(btn); } else { paintUnsubscribed(btn); }
+        }
+    }
+
+    function createNotifyBtn(productId) {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "notify-me-btn";
+        btn.dataset.productId = String(productId);
+        if (isSubscribed(productId)) { paintSubscribed(btn); } else { paintUnsubscribed(btn); }
+        btn.addEventListener("click", function() { handleToggle(btn, productId); });
+        return btn;
+    }
+
+    function initStockAlert(product) {
+        if (product == null) return;
+        if (Number(product.stock) > 0) return;
+        const container = document.getElementById("product-buttons");
+        if (container == null) return;
+        if (container.querySelector(".notify-me-btn")) return;
+        container.appendChild(createNotifyBtn(product.id));
+    }
+
+    function injectNotifyBtnIntoCard(card, product) {
+        if (card == null || product == null) return;
+        const stock = product.stock;
+        if (stock === undefined || stock === null || Number(stock) > 0) return;
+        const productId = product.id || product.productId;
+        if (productId == null) return;
+        if (card.querySelector(".notify-me-btn")) return;
+        const btn = createNotifyBtn(productId);
+        const buttonRow = card.querySelector(".wishlist-buttons");
+        if (buttonRow) { buttonRow.appendChild(btn); }
+        else { const content = card.querySelector(".wishlist-content"); if (content) content.appendChild(btn); }
+    }
+
+    window.StockAlert = { initStockAlert: initStockAlert, injectNotifyBtnIntoCard: injectNotifyBtnIntoCard, isSubscribed: isSubscribed, createNotifyBtn: createNotifyBtn };
+})();

--- a/frontend/scripts/wishlist.js
+++ b/frontend/scripts/wishlist.js
@@ -77,6 +77,11 @@ function renderWishlist() {
                 }
             });
         });
+        // Notify Me button for out-of-stock wishlist items (#1233)
+        if (typeof StockAlert !== "undefined" && StockAlert.injectNotifyBtnIntoCard) {
+            StockAlert.injectNotifyBtnIntoCard(card, product);
+        }
+
         fragment.appendChild(card);
     });
     wishlistContainer.appendChild(fragment);

--- a/frontend/scripts/wishlist.js
+++ b/frontend/scripts/wishlist.js
@@ -78,8 +78,13 @@ function renderWishlist() {
             });
         });
         // Notify Me button for out-of-stock wishlist items (#1233)
-        if (typeof StockAlert !== "undefined" && StockAlert.injectNotifyBtnIntoCard) {
-            StockAlert.injectNotifyBtnIntoCard(card, product);
+        // FIX: wrapped in try-catch to prevent render errors from blocking the wishlist
+        try {
+            if (typeof StockAlert !== "undefined" && StockAlert.injectNotifyBtnIntoCard) {
+                StockAlert.injectNotifyBtnIntoCard(card, product);
+            }
+        } catch (alertErr) {
+            console.warn("stockAlert: injectNotifyBtnIntoCard failed", alertErr);
         }
 
         fragment.appendChild(card);

--- a/frontend/wishlist.html
+++ b/frontend/wishlist.html
@@ -180,5 +180,8 @@
         src="scripts/wishlist.js"
     ></script>
     <script defer src="scripts/ui.js"></script>
+
+    <!-- Stock Alert: Notify Me (#1233) -->
+    <script defer src="scripts/stock-alert.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## feat: Notify Me — back-in-stock alert (#1233)

### What
Adds a "Notify Me" button for out-of-stock products on both the
product page and wishlist page.

### Related Issue:
Closes #1488 

### Changes
- `frontend/scripts/stock-alert.js` — new module (subscribe/unsubscribe,
  localStorage state cache, guest gate)
- `frontend/product.html` — load stock-alert.js
- `frontend/scripts/product.js` — call StockAlert.initStockAlert(product)
  inside initializeProductPage() when stock === 0
- `frontend/wishlist.html` — load stock-alert.js
- `frontend/scripts/wishlist.js` — call StockAlert.injectNotifyBtnIntoCard()
  per card when stock === 0

### API
- Subscribe:   POST   /api/stock-alerts  { productId, alertType: "back_in_stock" }
- Unsubscribe: DELETE /api/stock-alerts  { productId, alertType: "back_in_stock" }
- Backend: backend/routes/stockAlertRoutes.js (already existed)

### UX
- Button only appears when stock === 0
- Toggles between "Notify Me" and "Cancel Alert"
- Spinner during request, error recovery restores previous state
- Guest users redirected to signin with ?next= return URL
- Subscription state persisted in localStorage across reloads