### PR TITLE
fix(products): qualify MATCH() columns so product search stops 500-ing (#1544)

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -72,11 +72,41 @@ async function getOrCreateCategoryId(categoryName, connection = db) {
     }
 }
 
-const FULLTEXT_SEARCH_COLUMNS = "name, description, short_description, meta_keywords";
+// The columns of `ft_product_search`, the FULLTEXT index declared in
+// migrations/0001_baseline_schema.sql. The list has to match the index exactly
+// or MySQL cannot use it, so it is written once and qualified per query rather
+// than retyped.
+const SEARCHABLE_COLUMNS = Object.freeze([
+    "name",
+    "description",
+    "short_description",
+    "meta_keywords"
+]);
+
+/**
+ * The searchable columns, qualified with a table alias.
+ *
+ * Qualifying is not cosmetic. Every public product query joins `categories`,
+ * and `categories` has its own `name` and `description` -- so an unqualified
+ * `MATCH(name, description, ...)` is ambiguous and MySQL rejects the whole
+ * statement with ER_NON_UNIQ_ERROR before it ever looks at an index. That is
+ * not a search that degrades; it is a 500 on every search the store serves
+ * (#1544).
+ *
+ * @param {string} alias
+ * @returns {string} comma-separated qualified column list
+ */
+const qualifiedSearchColumns = (alias) =>
+    SEARCHABLE_COLUMNS.map((column) => `${alias}.${column}`).join(", ");
 
 const FULLTEXT_UNAVAILABLE_CODES = new Set([
     "ER_FT_MATCHING_KEY_NOT_FOUND",
-    "ER_BAD_FIELD_ERROR"
+    "ER_BAD_FIELD_ERROR",
+    // Belt and braces. The ambiguity above is fixed at the source, but a future
+    // join that reintroduces one should cost the store its index, not its
+    // search: falling back to LIKE returns results, and re-throwing returns a
+    // 500 (#1544).
+    "ER_NON_UNIQ_ERROR"
 ]);
 
 // Whitelisted sort keys → ORDER BY clause. Keys mirror the frontend shop
@@ -256,12 +286,23 @@ const getProducts = async (req, res) => {
             if (rawSearch) {
                 if (useFulltext) {
                     conditions.push(
-                        `MATCH(${FULLTEXT_SEARCH_COLUMNS}) AGAINST (? IN BOOLEAN MODE)`
+                        `MATCH(${qualifiedSearchColumns("p")}) AGAINST (? IN BOOLEAN MODE)`
                     );
                     params.push(booleanSearch);
                 } else {
-                    conditions.push("p.name LIKE ?");
-                    params.push(likeSearch);
+                    // The fallback searches the same columns the index does.
+                    //
+                    // It used to search `p.name` alone, so which path ran
+                    // decided what "matches" meant: a term that appears only in
+                    // a description was found by one and not by the other. A
+                    // fallback that answers a different question is not a
+                    // fallback (#1544).
+                    conditions.push(
+                        `(${SEARCHABLE_COLUMNS.map(
+                            (column) => `p.${column} LIKE ?`
+                        ).join(" OR ")})`
+                    );
+                    params.push(...SEARCHABLE_COLUMNS.map(() => likeSearch));
                 }
             }
 

--- a/backend/tests/productSearch.test.js
+++ b/backend/tests/productSearch.test.js
@@ -24,9 +24,28 @@ function ftError() {
     return err;
 }
 
+// What MySQL raises when a column named in the statement exists on more than
+// one of the joined tables. `products` and `categories` both have `name` and
+// `description`, which is what the unqualified MATCH() list used to hit
+// (#1544).
+function ambiguousColumnError() {
+    const err = new Error("Column 'name' in field list is ambiguous");
+    err.code = "ER_NON_UNIQ_ERROR";
+    err.errno = 1052;
+    return err;
+}
+
 function calls() {
     return db.query.mock.calls.map(([sql]) => sql);
 }
+
+// The four columns of `ft_product_search`.
+const SEARCHABLE_COLUMNS = [
+    "name",
+    "description",
+    "short_description",
+    "meta_keywords"
+];
 
 describe("getProducts — full-text search", () => {
     beforeEach(() => {
@@ -75,6 +94,148 @@ describe("getProducts — full-text search", () => {
         expect(res.body.total).toBe(1);
         const sqls = calls();
         expect(sqls.some((sql) => /LIKE/.test(sql))).toBe(true);
+    });
+
+    // ------------------------------------------------------------------
+    // #1544
+    // ------------------------------------------------------------------
+
+    test("qualifies every MATCH() column with the products alias", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT COUNT/.test(sql)) return [[{ total: 1 }]];
+            return [[{ id: 1 }]];
+        });
+        const res = mockRes();
+
+        await getProducts({ query: { search: "shoes" } }, res);
+
+        expect(res.statusCode).toBe(200);
+
+        const matchSqls = calls().filter((sql) => /MATCH\(/.test(sql));
+        expect(matchSqls.length).toBeGreaterThan(0);
+
+        for (const sql of matchSqls) {
+            const [, columnList] = sql.match(/MATCH\(([^)]*)\)/);
+
+            // Every column carries the alias. `categories` has `name` and
+            // `description` too, so an unqualified one is ER_NON_UNIQ_ERROR.
+            for (const column of SEARCHABLE_COLUMNS) {
+                expect(columnList).toContain(`p.${column}`);
+            }
+
+            expect(
+                columnList
+                    .split(",")
+                    .every((column) => column.trim().startsWith("p."))
+            ).toBe(true);
+        }
+    });
+
+    test("the MATCH() column list is exactly the ft_product_search index", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT COUNT/.test(sql)) return [[{ total: 0 }]];
+            return [[]];
+        });
+        const res = mockRes();
+
+        await getProducts({ query: { search: "kettle" } }, res);
+
+        const [matchSql] = calls().filter((sql) => /MATCH\(/.test(sql));
+        const [, columnList] = matchSql.match(/MATCH\(([^)]*)\)/);
+
+        // Order and membership both matter: MySQL only uses a FULLTEXT index
+        // when the MATCH() list matches the index definition.
+        expect(columnList.split(",").map((column) => column.trim())).toEqual(
+            SEARCHABLE_COLUMNS.map((column) => `p.${column}`)
+        );
+    });
+
+    test("an ambiguous-column error degrades to LIKE instead of 500-ing", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/MATCH/.test(sql)) throw ambiguousColumnError();
+            if (/SELECT COUNT/.test(sql)) return [[{ total: 2 }]];
+            return [[{ id: 3 }, { id: 4 }]];
+        });
+        const res = mockRes();
+
+        await getProducts({ query: { search: "mixer" } }, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.total).toBe(2);
+        expect(calls().some((sql) => /LIKE/.test(sql))).toBe(true);
+    });
+
+    test("the LIKE fallback searches the same columns the index does", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/MATCH/.test(sql)) throw ftError();
+            if (/SELECT COUNT/.test(sql)) return [[{ total: 1 }]];
+            return [[{ id: 9 }]];
+        });
+        const res = mockRes();
+
+        await getProducts({ query: { search: "waterproof" } }, res);
+
+        const likeSqls = calls().filter((sql) => /LIKE/.test(sql));
+        expect(likeSqls.length).toBeGreaterThan(0);
+
+        for (const sql of likeSqls) {
+            for (const column of SEARCHABLE_COLUMNS) {
+                expect(sql).toMatch(new RegExp(`p\\.${column} LIKE \\?`));
+            }
+        }
+    });
+
+    test("the LIKE fallback binds the wildcard term once per searched column", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/MATCH/.test(sql)) throw ftError();
+            if (/SELECT COUNT/.test(sql)) return [[{ total: 0 }]];
+            return [[]];
+        });
+        const res = mockRes();
+
+        await getProducts({ query: { search: "cotton" } }, res);
+
+        const [, params] = db.query.mock.calls.find(([sql]) => /LIKE/.test(sql));
+        const bound = params.filter((value) => value === "%cotton%");
+
+        expect(bound).toHaveLength(SEARCHABLE_COLUMNS.length);
+    });
+
+    test("the LIKE fallback keeps its OR group bracketed so other filters still AND", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/MATCH/.test(sql)) throw ftError();
+            if (/SELECT COUNT/.test(sql)) return [[{ total: 0 }]];
+            return [[]];
+        });
+        const res = mockRes();
+
+        await getProducts(
+            { query: { search: "lamp", minPrice: "100", maxPrice: "500" } },
+            res
+        );
+
+        const [sql] = db.query.mock.calls.find(([text]) => /LIKE/.test(text));
+
+        // Unbracketed, `a OR b AND price >= ?` binds the price filter to the
+        // last LIKE only and the other three columns ignore it entirely.
+        expect(sql).toMatch(/\(\s*p\.name LIKE \?[\s\S]*?\)\s*AND/);
+        expect(sql).toMatch(/p\.price >= \?/);
+    });
+
+    test("LIKE special characters in the search term stay escaped in the fallback", async () => {
+        db.query.mockImplementation(async (sql) => {
+            if (/MATCH/.test(sql)) throw ftError();
+            if (/SELECT COUNT/.test(sql)) return [[{ total: 0 }]];
+            return [[]];
+        });
+        const res = mockRes();
+
+        await getProducts({ query: { search: "50% off" } }, res);
+
+        const [, params] = db.query.mock.calls.find(([sql]) => /LIKE/.test(sql));
+
+        expect(params.some((value) => value === "%50\\% off%")).toBe(true);
     });
 
     test("does not add a search predicate when no search term is given", async () => {

--- a/backend/tests/productSearch.test.js
+++ b/backend/tests/productSearch.test.js
@@ -163,7 +163,44 @@ describe("getProducts — full-text search", () => {
         expect(res.statusCode).toBe(200);
         expect(res.body.success).toBe(true);
         expect(res.body.total).toBe(2);
-        expect(calls().some((sql) => /LIKE/.test(sql))).toBe(true);
+        expect(res.body.products).toHaveLength(2);
+
+        // The index is attempted first. A fallback that never tries is not a
+        // fallback, it is a permanent downgrade.
+        expect(calls().some((sql) => /MATCH\(/.test(sql))).toBe(true);
+
+        // Both statements of the retry carry the LIKE predicate. Asserting
+        // only that *some* query says LIKE would pass on a retry that dropped
+        // the search from the count and reported a total for the unfiltered
+        // catalogue.
+        const retriedCount = db.query.mock.calls.find(
+            ([sql]) => /SELECT COUNT/.test(sql) && /LIKE/.test(sql)
+        );
+        const retriedPage = db.query.mock.calls.find(
+            ([sql]) => /LIMIT/.test(sql) && /LIKE/.test(sql)
+        );
+
+        expect(retriedCount).toBeDefined();
+        expect(retriedPage).toBeDefined();
+
+        for (const [sql, params] of [retriedCount, retriedPage]) {
+            // Nothing that threw is retried verbatim.
+            expect(sql).not.toMatch(/MATCH\(/);
+
+            for (const column of SEARCHABLE_COLUMNS) {
+                expect(sql).toMatch(new RegExp(`p\\.${column} LIKE \\?`));
+            }
+
+            // One bound wildcard per searched column, and the boolean-mode
+            // expression the failed attempt used is not carried over.
+            expect(params.filter((value) => value === "%mixer%")).toHaveLength(
+                SEARCHABLE_COLUMNS.length
+            );
+            expect(params).not.toContain("+mixer*");
+        }
+
+        // The page statement binds its search terms before LIMIT/OFFSET.
+        expect(retriedPage[1].slice(-2)).toEqual([10, 0]);
     });
 
     test("the LIKE fallback searches the same columns the index does", async () => {


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

Product search 500s on every request. `getProducts` builds the search predicate as

```sql
MATCH(name, description, short_description, meta_keywords) AGAINST (? IN BOOLEAN MODE)
```

but every public product query joins `categories`, and `categories` has its own `name` and `description` (`migrations/0001_baseline_schema.sql:108`). MySQL cannot resolve the columns and rejects the whole statement with `ER_NON_UNIQ_ERROR` before it ever looks at an index. `isFulltextUnavailable` tolerated only `ER_FT_MATCHING_KEY_NOT_FOUND` and `ER_BAD_FIELD_ERROR`, so the error was re-thrown and the shopper got `500 Failed to fetch products`.

The existing suite mocks `config/db`, so an ambiguous identifier passed it untouched — which is why this has been sitting there.

### What changed

**The column list is qualified.** It is built once from a frozen definition and prefixed with the query's alias. It stays byte-for-byte the definition of the `ft_product_search` index, which is the condition for MySQL using the index at all.

**`ER_NON_UNIQ_ERROR` joins the tolerated codes.** The ambiguity is fixed at the source; this is belt and braces, so a future join that reintroduces one costs the store its index rather than its search.

**The `LIKE` fallback searches the same four columns.** It searched `p.name` alone, so which path ran decided what "matches" meant — a term appearing only in a description was found by one path and not the other. The OR group is bracketed so the price and category filters still AND across all of it.

---

## 🔗 Related Issue

Closes: #1544

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 🧪 Tests

Seven new cases in `backend/tests/productSearch.test.js`:

| Test | What it pins |
|---|---|
| qualifies every `MATCH()` column with the products alias | the fix itself — no bare `name` / `description` survives |
| the `MATCH()` column list is exactly the `ft_product_search` index | order and membership, so the index stays usable |
| an ambiguous-column error degrades to LIKE instead of 500-ing | the tolerated-code guard |
| the LIKE fallback searches the same columns the index does | the two paths agree on "matches" |
| the LIKE fallback binds the wildcard term once per searched column | parameter count matches placeholder count |
| the LIKE fallback keeps its OR group bracketed | `a OR b AND price >= ?` would bind the price filter to one column only |
| LIKE special characters stay escaped in the fallback | `50% off` does not become a wildcard |

Local run:

```
Test Suites: 86 passed, 86 total
Tests:       1923 passed, 1923 total
```

Plus `check:syntax`, `check:boot`, `check:modules`, `check:sitemap`, `check:a11y` — all green.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

Same defect class as #1534 (ambiguous `email` column in `listMessages`), in a much more visible place. Touches only `productController.js` and its test — no conflicts with anything else open.
