### PR TITLE
fix(orders): sort order history by date, paginate it, and hide deleted orders (#1545)

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -42,6 +42,27 @@ const orderStatusHistoryService = require("../services/orderStatusHistoryService
 const guestCart = require("../services/guestCartService");
 const { findGuestOrder } = require("../services/guestOrderService");
 
+// The most orders one page of the customer's history may carry. The list is
+// rendered as cards, so a page that needs scrolling past this is a page nobody
+// reads; the number matches MAX_PRODUCT_LIMIT so the two paginated customer
+// surfaces behave the same. `orderRoutes` rejects anything above 100 outright;
+// a request between the two is clamped here and reports the clamped figure
+// back in the pagination meta rather than pretending it was honoured (#1545).
+const MAX_ORDER_PAGE_SIZE = 50;
+
+/** What `?limit=` defaults to when the client does not ask for a page size. */
+const DEFAULT_ORDER_PAGE_SIZE = 10;
+
+// The statuses `?status=` may name. Same list `orderRoutes` validates against,
+// so a value that clears the route is a value this can filter on.
+const ORDER_HISTORY_STATUSES = Object.freeze([
+    "pending",
+    "processing",
+    "shipped",
+    "delivered",
+    "cancelled"
+]);
+
 /**
  * Whoever is checking out, and the cart they are checking out of (#1427).
  *
@@ -443,27 +464,98 @@ const getAllOrders = async (req, res) => {
 
 // get user orders
 const getUserOrders = async (req, res) => {
-    const query = `
-        SELECT
-            id,
-            customer_name,
-            payment_method,
-            total,
-            status,
-            created_at
-        FROM orders
-        WHERE user_id = ?
-        ORDER BY id DESC
-    `;
+    // `created_at DESC`, not `id DESC`.
+    //
+    // `orders.id` is a CHAR(36) filled with `crypto.randomUUID()`
+    // (order.service.js), so ordering by it descending orders a random string.
+    // The customer's history came back shuffled: a purchase from last year
+    // could sit above one from this morning, and "your latest order" was
+    // whichever UUID happened to sort highest (#1545).
+    //
+    // `id` stays on as the tie-breaker. Two orders placed in the same second
+    // need a total order, or pagination overlaps and drops rows between pages
+    // -- the same reason the product list carries one.
+    const ORDER_BY = "ORDER BY created_at DESC, id DESC";
+
+    // A soft-deleted order is not one of the customer's orders. The column has
+    // been there from the start and is honoured elsewhere -- giftCardService
+    // refuses to settle an order carrying `deleted_at` -- but this list read
+    // straight past it.
+    const conditions = ["user_id = ?", "deleted_at IS NULL"];
+    const filterParams = [req.user.id];
+
+    // The route has validated `?status=` since it was written, and the handler
+    // never read it -- so "Get current user orders with pagination and
+    // filtering" filtered nothing. Re-checked here against the same list
+    // rather than trusted, because the handler is reachable from tests and
+    // from any future mount that does not carry the route's validator.
+    const requestedStatus = sanitizeString(req.query.status || "")
+        .trim()
+        .toLowerCase();
+
+    // Echoed back as null when nothing was applied. Reflecting the requested
+    // value regardless would tell a client its filter took effect when the
+    // list it is looking at is unfiltered.
+    const appliedStatus = ORDER_HISTORY_STATUSES.includes(requestedStatus)
+        ? requestedStatus
+        : null;
+
+    if (appliedStatus) {
+        conditions.push("status = ?");
+        filterParams.push(appliedStatus);
+    }
+
+    const WHERE = `WHERE ${conditions.join(" AND ")}`;
+
+    // Paginated, because an order history grows for as long as the account
+    // lives. This returned every order ever placed in one response, which is
+    // the defect #1349 fixed for reviews.
+    const { page, limit, offset } = getPagination(
+        req.query.page,
+        req.query.limit ?? DEFAULT_ORDER_PAGE_SIZE,
+        MAX_ORDER_PAGE_SIZE
+    );
 
     try {
-        const [results] = await db.query(query, [req.user.id]);
+        // The count runs against the same WHERE the page does. A total drawn
+        // from a different predicate is a pager that promises pages which come
+        // back empty.
+        const [countRows] = await db.query(
+            `SELECT COUNT(*) AS total FROM orders ${WHERE}`,
+            filterParams
+        );
+
+        const total = Number(safeArray(countRows)[0]?.total || 0);
+
+        const [results] = await db.query(
+            `
+                SELECT
+                    id,
+                    order_number,
+                    customer_name,
+                    payment_method,
+                    payment_status,
+                    total,
+                    status,
+                    created_at
+                FROM orders
+                ${WHERE}
+                ${ORDER_BY}
+                LIMIT ?
+                OFFSET ?
+            `,
+            [...filterParams, limit, offset]
+        );
+
         res.status(200).json({
             success: true,
+            ...buildPaginationMeta(total, page, limit),
+            count: safeArray(results).length,
+            status: appliedStatus,
             orders: safeArray(results)
         });
     } catch (err) {
-        console.error(err);
+        console.error("GET USER ORDERS ERROR:", err);
         return res.status(500).json({
             success: false,
             message: "Server error"
@@ -482,10 +574,14 @@ const getOrderById = async (req, res) => {
         });
     }
 
+    // Same rule as the list, and for the same reason it applies to products:
+    // an order hidden from the history but readable at its own URL is not
+    // hidden. It applies to admins too -- `ORDER_READ_ANY` is permission to
+    // read any *order*, not to read past a delete (#1545).
     let query = `
         SELECT *
         FROM orders
-        WHERE id = ?
+        WHERE id = ? AND deleted_at IS NULL
     `;
 
     const queryParams = [id];

--- a/backend/tests/orderController.test.js
+++ b/backend/tests/orderController.test.js
@@ -294,6 +294,32 @@ describe("getOrderById", () => {
         expect(sql).not.toMatch(/AND user_id = \?/);
         expect(params).toEqual([VALID_ORDER_ID]);
     });
+
+    // #1545 — an order hidden from the history but readable at its own URL is
+    // not hidden.
+    test("a soft-deleted order is not fetchable by id", async () => {
+        db.query.mockResolvedValueOnce([[{ id: VALID_ORDER_ID, user_id: 1 }]]);
+        db.query.mockResolvedValueOnce([[]]);
+
+        const req = { params: { id: VALID_ORDER_ID }, user: { id: 1, role: "user" } };
+        const res = mockRes();
+
+        await getOrderById(req, res);
+
+        expect(db.query.mock.calls[0][0]).toMatch(/deleted_at IS NULL/);
+    });
+
+    test("the soft-delete guard applies to admins too", async () => {
+        db.query.mockResolvedValueOnce([[{ id: VALID_ORDER_ID, user_id: 42 }]]);
+        db.query.mockResolvedValueOnce([[]]);
+
+        const req = { params: { id: VALID_ORDER_ID }, user: { id: 1, role: "admin" } };
+        const res = mockRes();
+
+        await getOrderById(req, res);
+
+        expect(db.query.mock.calls[0][0]).toMatch(/deleted_at IS NULL/);
+    });
 });
 
 describe("updateOrderStatus", () => {
@@ -481,32 +507,186 @@ describe("getAllOrders", () => {
 });
 
 describe("getUserOrders", () => {
+    // The endpoint issues two statements now: a COUNT for the pagination meta
+    // and the page itself. Both are stubbed by shape rather than by call order,
+    // so a future reordering does not silently mis-assert (#1545).
+    function stubOrders(total, rows) {
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT COUNT/.test(sql)) return [[{ total }]];
+            return [rows];
+        });
+    }
+
+    function listQuery() {
+        return db.query.mock.calls.find(([sql]) => /LIMIT/.test(sql));
+    }
+
+    function countQuery() {
+        return db.query.mock.calls.find(([sql]) => /SELECT COUNT/.test(sql));
+    }
+
     beforeEach(() => {
         jest.clearAllMocks();
+        db.query.mockReset();
     });
 
     test("scopes the query to the requesting user and returns their orders", async () => {
-        db.query.mockResolvedValueOnce([[{ id: "o1", customer_name: "Ishwari" }]]);
-        const req = { user: { id: 7 } };
+        stubOrders(1, [{ id: "o1", customer_name: "Ishwari" }]);
+        const req = { user: { id: 7 }, query: {} };
         const res = mockRes();
 
         await getUserOrders(req, res);
 
-        const [sql, params] = db.query.mock.calls[0];
+        const [sql, params] = listQuery();
         expect(sql).toMatch(/WHERE user_id = \?/);
-        expect(params).toEqual([7]);
+        expect(params[0]).toBe(7);
         expect(res.statusCode).toBe(200);
         expect(res.body.orders).toHaveLength(1);
     });
 
     test("returns 500 on a DB failure", async () => {
         db.query.mockRejectedValue(new Error("boom"));
-        const req = { user: { id: 7 } };
+        const req = { user: { id: 7 }, query: {} };
         const res = mockRes();
 
         await getUserOrders(req, res);
 
         expect(res.statusCode).toBe(500);
+    });
+
+    // ------------------------------------------------------------------
+    // #1545
+    // ------------------------------------------------------------------
+
+    test("orders by created_at, not by the random UUID primary key", async () => {
+        stubOrders(0, []);
+        const req = { user: { id: 7 }, query: {} };
+        const res = mockRes();
+
+        await getUserOrders(req, res);
+
+        const [sql] = listQuery();
+
+        expect(sql).toMatch(/ORDER BY created_at DESC/);
+        // `ORDER BY id DESC` on a CHAR(36) UUID is a random shuffle.
+        expect(sql).not.toMatch(/ORDER BY\s+id DESC/);
+    });
+
+    test("keeps id as a tie-breaker so pages cannot overlap", async () => {
+        stubOrders(0, []);
+        const req = { user: { id: 7 }, query: {} };
+        const res = mockRes();
+
+        await getUserOrders(req, res);
+
+        const [sql] = listQuery();
+        expect(sql).toMatch(/ORDER BY created_at DESC,\s*id DESC/);
+    });
+
+    test("excludes soft-deleted orders from the list and from the count", async () => {
+        stubOrders(0, []);
+        const req = { user: { id: 7 }, query: {} };
+        const res = mockRes();
+
+        await getUserOrders(req, res);
+
+        expect(listQuery()[0]).toMatch(/deleted_at IS NULL/);
+        expect(countQuery()[0]).toMatch(/deleted_at IS NULL/);
+    });
+
+    test("paginates, defaulting to the first page", async () => {
+        stubOrders(34, [{ id: "o1" }]);
+        const req = { user: { id: 7 }, query: {} };
+        const res = mockRes();
+
+        await getUserOrders(req, res);
+
+        const [sql, params] = listQuery();
+
+        expect(sql).toMatch(/LIMIT \?/);
+        expect(sql).toMatch(/OFFSET \?/);
+        expect(params).toEqual([7, 10, 0]);
+    });
+
+    test("honours an explicit page and limit", async () => {
+        stubOrders(34, [{ id: "o1" }]);
+        const req = { user: { id: 7 }, query: { page: "3", limit: "5" } };
+        const res = mockRes();
+
+        await getUserOrders(req, res);
+
+        const [, params] = listQuery();
+        expect(params).toEqual([7, 5, 10]);
+    });
+
+    test("caps an oversized limit rather than honouring it", async () => {
+        stubOrders(5000, []);
+        const req = { user: { id: 7 }, query: { limit: "100000" } };
+        const res = mockRes();
+
+        await getUserOrders(req, res);
+
+        const [, params] = listQuery();
+        expect(params[1]).toBeLessThanOrEqual(50);
+    });
+
+    test("returns pagination metadata alongside the page", async () => {
+        stubOrders(34, [{ id: "o1" }, { id: "o2" }]);
+        const req = { user: { id: 7 }, query: { page: "2", limit: "10" } };
+        const res = mockRes();
+
+        await getUserOrders(req, res);
+
+        expect(res.body).toMatchObject({
+            success: true,
+            total: 34,
+            page: 2,
+            limit: 10,
+            totalPages: 4,
+            hasNextPage: true,
+            hasPrevPage: true,
+            count: 2
+        });
+    });
+
+    test("the count query is scoped to the same user as the page", async () => {
+        stubOrders(3, []);
+        const req = { user: { id: 7 }, query: {} };
+        const res = mockRes();
+
+        await getUserOrders(req, res);
+
+        const [sql, params] = countQuery();
+        expect(sql).toMatch(/WHERE user_id = \?/);
+        expect(params).toEqual([7]);
+    });
+
+    test("filters on a valid status and counts against the same predicate", async () => {
+        stubOrders(2, [{ id: "o1" }]);
+        const req = { user: { id: 7 }, query: { status: "Delivered" } };
+        const res = mockRes();
+
+        await getUserOrders(req, res);
+
+        expect(listQuery()[0]).toMatch(/status = \?/);
+        expect(listQuery()[1]).toEqual([7, "delivered", 10, 0]);
+
+        expect(countQuery()[0]).toMatch(/status = \?/);
+        expect(countQuery()[1]).toEqual([7, "delivered"]);
+
+        expect(res.body.status).toBe("delivered");
+    });
+
+    test("ignores a status that is not one of the known values", async () => {
+        stubOrders(0, []);
+        const req = { user: { id: 7 }, query: { status: "teleported" } };
+        const res = mockRes();
+
+        await getUserOrders(req, res);
+
+        expect(listQuery()[0]).not.toMatch(/status = \?/);
+        expect(listQuery()[1]).toEqual([7, 10, 0]);
+        expect(res.body.status).toBeNull();
     });
 });
 

--- a/frontend/scripts/dashboard-orders.js
+++ b/frontend/scripts/dashboard-orders.js
@@ -11,6 +11,10 @@ const dashboardOrderElements = {
         )
 };
 
+// How many orders the dashboard panel shows. It is a summary, not the history
+// -- the full paged list lives on the orders page.
+const DASHBOARD_ORDERS_LIMIT = 5;
+
 // order badge color
 function getOrderStatusClass(
     status = "pending"
@@ -41,14 +45,23 @@ async function renderDashboardOrders() {
     }
 
     try {
-        const data = await AppUtils.apiRequest("/orders/my-orders");
+        // The endpoint is paginated (#1545), so ask for a page explicitly
+        // rather than relying on whatever the server's default happens to be.
+        const data = await AppUtils.apiRequest(
+            `/orders/my-orders?page=1&limit=${DASHBOARD_ORDERS_LIMIT}`
+        );
+
         const orders = data.orders || [];
 
         if (
             dashboardOrderElements.ordersCount
         ) {
+            // `total` is every order the account has; `orders.length` is only
+            // how many fit on this panel. The badge means the former.
             dashboardOrderElements.ordersCount.innerText =
-                orders.length;
+                Number.isFinite(Number(data.total))
+                    ? Number(data.total)
+                    : orders.length;
         }
 
         if (

--- a/frontend/scripts/ordersHistory.js
+++ b/frontend/scripts/ordersHistory.js
@@ -11,6 +11,19 @@ const elements = {
         )
 };
 
+// How many orders one request asks for. The endpoint is paginated (#1545);
+// asking for a page is how you get one, and asking for none used to get you
+// every order the account had ever placed.
+const ORDERS_PAGE_SIZE = 10;
+
+// Which page is on screen, and whether there is another one behind it.
+const state = {
+    page: 1,
+    totalPages: 1,
+    total: 0,
+    loading: false
+};
+
 // empty state
 function renderEmptyState(
     message
@@ -47,6 +60,90 @@ function formatOrderDate(
         : parsedDate.toLocaleDateString();
 }
 
+/**
+ * The "Showing 1-10 of 34" line and the page buttons.
+ *
+ * Rendered only when there is more than one page. A single-page history is the
+ * common case and a pager on it is noise.
+ */
+function renderPager(shownOnPage) {
+    if (state.totalPages <= 1) {
+        return null;
+    }
+
+    const firstOnPage =
+        (state.page - 1) * ORDERS_PAGE_SIZE + 1;
+
+    const lastOnPage =
+        firstOnPage + shownOnPage - 1;
+
+    const pager =
+        document.createElement("div");
+
+    pager.className =
+        "orders-history-pager";
+
+    pager.innerHTML =
+        `
+            <button
+                type="button"
+                class="orders-page-prev"
+                ${state.page <= 1 ? "disabled" : ""}
+            >
+                Previous
+            </button>
+            <span class="orders-page-status">
+                Showing ${firstOnPage}-${lastOnPage} of ${state.total}
+            </span>
+            <button
+                type="button"
+                class="orders-page-next"
+                ${state.page >= state.totalPages ? "disabled" : ""}
+            >
+                Next
+            </button>
+        `;
+
+    pager
+        .querySelector(".orders-page-prev")
+        ?.addEventListener("click", () => {
+            goToOrdersPage(state.page - 1);
+        });
+
+    pager
+        .querySelector(".orders-page-next")
+        ?.addEventListener("click", () => {
+            goToOrdersPage(state.page + 1);
+        });
+
+    return pager;
+}
+
+/**
+ * Move to a page, clamped to the range that exists.
+ *
+ * Guarded on `state.loading` so a double-click does not put two requests in
+ * flight and render whichever happens to come back last.
+ */
+function goToOrdersPage(page) {
+    const target =
+        Math.min(
+            Math.max(1, page),
+            Math.max(1, state.totalPages)
+        );
+
+    if (
+        state.loading
+        ||
+        target === state.page
+    ) {
+        return;
+    }
+
+    state.page = target;
+    renderOrders();
+}
+
 // render orders
 async function renderOrders() {
     if (
@@ -55,18 +152,49 @@ async function renderOrders() {
         return;
     }
 
+    state.loading = true;
+
     try {
-        const data = await AppUtils.apiRequest("/orders/my-orders");
+        const params =
+            new URLSearchParams({
+                page: String(state.page),
+                limit: String(ORDERS_PAGE_SIZE)
+            });
+
+        const data = await AppUtils.apiRequest(
+            `/orders/my-orders?${params.toString()}`
+        );
+
         const orders = data.orders || [];
+
+        // `total` is every order the account has, not the length of this page.
+        // The count next to the heading means "your orders", so it has to come
+        // from the pagination meta rather than from `orders.length`.
+        state.total =
+            Number.isFinite(Number(data.total))
+                ? Number(data.total)
+                : (Array.isArray(orders) ? orders.length : 0);
+
+        state.totalPages =
+            Math.max(1, Number(data.totalPages) || 1);
+
+        // A page that no longer exists -- the last order on page 3 was
+        // cancelled and removed while it was on screen -- steps back rather
+        // than showing an empty list under a pager that says there is more.
+        if (
+            state.page > state.totalPages
+        ) {
+            state.page = state.totalPages;
+            state.loading = false;
+            return renderOrders();
+        }
 
         // render count
         if (
             elements.ordersCount
         ) {
             elements.ordersCount.innerText =
-                Array.isArray(orders)
-                    ? orders.length
-                    : 0;
+                state.total;
         }
 
         elements.ordersContainer.innerHTML =
@@ -171,8 +299,26 @@ async function renderOrders() {
         elements.ordersContainer.appendChild(
             fragment
         );
+
+        const pager =
+            renderPager(orders.length);
+
+        if (pager) {
+            elements.ordersContainer.appendChild(
+                pager
+            );
+        }
     } catch (error) {
         console.error("Failed to fetch orders history:", error);
+
+        // A failed page turn used to log to the console and leave the previous
+        // page on screen under a pager that had already moved, which reads as
+        // "this page is identical to the last one". Say what happened instead.
+        renderEmptyState(
+            "Could not load your orders. Please try again."
+        );
+    } finally {
+        state.loading = false;
     }
 }
 


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`GET /orders/my-orders` was three problems in one query:

```js
SELECT id, customer_name, payment_method, total, status, created_at
FROM orders
WHERE user_id = ?
ORDER BY id DESC
```

**1. It did not sort by recency.** `orders.id` is a `CHAR(36)` filled with `crypto.randomUUID()` (`order.service.js:463`), so `ORDER BY id DESC` sorts a random string. The customer's history came back shuffled — a purchase from last year could sit above one from this morning, and "your latest order" was whichever UUID happened to sort highest.

**2. It had no `LIMIT`.** Every order the account had ever placed was serialised into one response, growing without bound with the age of the account. This is the same defect #1349 fixed for reviews.

**3. It ignored `deleted_at`.** A soft-deleted order stayed in the history and stayed readable at its own URL, even though the column is honoured elsewhere — `giftCardService.lockPayableOrder` refuses to settle an order carrying it.

And a fourth thing worth noting: the route has validated `?page=`, `?limit=` and `?status=` since it was written, under the comment *"Get current user orders with pagination and filtering"*. The handler read none of them.

### What changed

**Backend**

- `ORDER BY created_at DESC, id DESC` — `created_at` for recency, `id` as the stable tie-breaker so two orders placed in the same second still have a total order and pagination has no overlaps or gaps.
- Pagination via the existing `getPagination` / `buildPaginationMeta` helpers, defaulting to 10 and capped at 50, returning the same envelope the product list uses.
- `AND deleted_at IS NULL` on the list **and** on `getOrderById` — admins included. `ORDER_READ_ANY` is permission to read any order, not permission to read past a delete.
- `?status=` now narrows the list, re-checked here against the same list the route validates rather than trusted. The COUNT runs against the same predicate as the page, so the pager cannot promise pages that come back empty. The applied status is echoed as `null` when nothing was applied, so a client is never told a filter took effect on an unfiltered list.
- `order_number` and `payment_status` added to the selected columns — both already on the row, both wanted by the cards being rendered.

**Frontend**

- `ordersHistory.js` asks for a page and gets a Previous / Next pager with a "Showing 1-10 of 34" line. It steps back if the page it is on stops existing (last order on page 3 cancelled while it was on screen), guards against a double-click putting two requests in flight, takes its count from `total` rather than `orders.length`, and now says something when a page fails to load instead of leaving the previous page on screen under a pager that has already moved.
- `dashboard-orders.js` asks for the five most recent and takes its badge count from `total`.

---

## 🔗 Related Issue

Closes: #1545

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [x] UI/UX improvement
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 🧪 Tests

Twelve new cases in `backend/tests/orderController.test.js`, and the two existing `getUserOrders` cases updated for the second statement:

| Test | What it pins |
|---|---|
| orders by `created_at`, not by the random UUID primary key | the sort fix, and that `ORDER BY id DESC` is gone |
| keeps `id` as a tie-breaker so pages cannot overlap | the total order |
| excludes soft-deleted orders from the list and from the count | both statements, not just the visible one |
| paginates, defaulting to the first page | `LIMIT`/`OFFSET` present, params `[user, 10, 0]` |
| honours an explicit page and limit | offset arithmetic |
| caps an oversized limit rather than honouring it | `?limit=100000` |
| returns pagination metadata alongside the page | the response envelope |
| the count query is scoped to the same user as the page | |
| filters on a valid status and counts against the same predicate | |
| ignores a status that is not one of the known values | and reports `status: null` |
| a soft-deleted order is not fetchable by id | `getOrderById` |
| the soft-delete guard applies to admins too | |

Local run:

```
Test Suites: 86 passed, 86 total
Tests:       1928 passed, 1928 total
```

Plus `check:syntax`, `check:boot`, `check:modules`, `check:sitemap`, `check:a11y` — all green.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

`GET /orders/my-orders` gains `page` / `limit` / `totalPages` / `hasNextPage` / `hasPrevPage` / `count` / `status` alongside `orders`. `orders` is still an array in the same shape, so any consumer that only reads `data.orders` keeps working — it just receives the first 10 instead of everything. Both in-repo consumers are updated in this PR.
