### PR TITLE
fix(cart): apply the catalogue's product-visibility rule to the cart (#1546)

### DIFF
--- a/backend/controllers/cartController.js
+++ b/backend/controllers/cartController.js
@@ -12,6 +12,11 @@ const {
 const cartLifecycle = require("../services/cartLifecycleService");
 const guestCart = require("../services/guestCartService");
 const cartRestoreService = require("../services/cartRestoreService");
+// The same definition of "a shopper may see this product" the catalogue and
+// the wishlist use (#1456). The cart was the one surface still asking only
+// whether a row existed, so a product an admin had withdrawn stayed addable,
+// stayed in the basket, and travelled to checkout (#1546).
+const { publicProductCondition } = require("../constants/productVisibility");
 
 // Every handler below works from the cart, not from the account (#1427). The
 // two are the same thing for a signed-in shopper and the account is still
@@ -54,6 +59,51 @@ const resolveCartForRead = async (req) => {
     return userId
         ? cartLifecycle.findActiveCartId(userId)
         : guestCart.findCartIdByToken(guestToken);
+};
+
+/**
+ * The ids among `productIds` that a shopper may actually buy right now.
+ *
+ * Existence is not the question. `deleteProduct` is a soft delete and `status`
+ * carries the lifecycle, so a withdrawn product is still a row -- one that
+ * 404s at its own URL, is absent from every listing, and cannot be added to a
+ * wishlist. The cart asked `SELECT id FROM products WHERE id = ?` and got
+ * `true` for all of them (#1546).
+ *
+ * @param {object} connection A pool or an open transaction.
+ * @param {string[]} productIds
+ * @returns {Promise<Set<string>>} the subset that is live
+ */
+const findLiveProductIds = async (connection, productIds) => {
+    const ids = [...new Set(productIds.filter(Boolean))];
+
+    if (!ids.length) {
+        return new Set();
+    }
+
+    const visibility = publicProductCondition("p");
+
+    const [rows] = await connection.query(
+        `SELECT p.id
+           FROM products p
+          WHERE p.id IN (${ids.map(() => "?").join(",")})
+            AND ${visibility.sql}`,
+        [...ids, ...visibility.params]
+    );
+
+    return new Set((rows || []).map((row) => safeUUID(row.id)));
+};
+
+/**
+ * Is this one product live?
+ *
+ * @param {object} connection
+ * @param {string} productId
+ * @returns {Promise<boolean>}
+ */
+const isLiveProduct = async (connection, productId) => {
+    const live = await findLiveProductIds(connection, [productId]);
+    return live.has(productId);
 };
 
 // Shopper activity moves two clocks for a guest: the cart's, which the
@@ -125,6 +175,12 @@ const cartController = {
                 });
             }
 
+            // Filtered on read as well as on write, because a product can be
+            // withdrawn *after* it entered the basket. Without this, an item
+            // added last week stays in the cart forever, rendered from its
+            // stale snapshot, and is carried to checkout (#1546).
+            const visibility = publicProductCondition("p");
+
             const [rows] = await promisePool.query(`
                 SELECT
                     p.id,
@@ -140,13 +196,28 @@ const cartController = {
                     c.created_at AS added_at
                 FROM cart_items c
                 JOIN products p ON c.product_id = p.id
-                WHERE c.cart_id = ?
+                WHERE c.cart_id = ? AND ${visibility.sql}
                 ORDER BY c.created_at DESC
-            `, [cartId]);
+            `, [cartId, ...visibility.params]);
+
+            // How many lines the basket holds versus how many are still
+            // buyable. Silently returning fewer rows than the shopper put in
+            // reads as data loss; naming the count lets the cart page say
+            // "1 item is no longer available" instead.
+            const [[held]] = await promisePool.query(
+                "SELECT COUNT(*) AS total FROM cart_items WHERE cart_id = ?",
+                [cartId]
+            );
+
+            const unavailableCount = Math.max(
+                0,
+                Number(held?.total || 0) - (rows?.length || 0)
+            );
 
             return res.status(200).json({
                 success: true,
-                cart: rows
+                cart: rows,
+                unavailableCount
             });
 
         } catch (error) {
@@ -196,21 +267,24 @@ const cartController = {
 
             let placeholders = [];
             let values = [];
+            const droppedProductIds = [];
 
             if (lines.length) {
                 const productIds = [...new Set(lines.map((line) => line.productId))];
 
-                const [products] = await connection.query(
-                    `SELECT id FROM products WHERE id IN (${productIds.map(() => "?").join(",")})`,
+                // Live, not merely present. This asked only whether the row
+                // existed, so a soft-deleted or deactivated product synced
+                // straight back into the basket (#1546).
+                const liveProductIds = await findLiveProductIds(
+                    connection,
                     productIds
                 );
 
-                const knownProductIds = new Set(
-                    products.map((product) => safeUUID(product.id))
-                );
-
                 for (const line of lines) {
-                    if (!knownProductIds.has(line.productId)) continue;
+                    if (!liveProductIds.has(line.productId)) {
+                        droppedProductIds.push(line.productId);
+                        continue;
+                    }
 
                     // Reservations are held against an account, so a guest
                     // basket holds no stock. Nothing is oversold by that: the
@@ -269,6 +343,12 @@ const cartController = {
             return res.status(200).json({
                 success: true,
                 message: "Cart synced",
+                // Named, not silently swallowed. A sync that quietly returns
+                // fewer lines than it was sent looks to the client like its
+                // own state is wrong; saying which ids were withdrawn lets the
+                // cart page tell the shopper what happened.
+                droppedProductIds,
+                dropped: droppedProductIds.length,
                 ...issuedToken(cart)
             });
 
@@ -305,6 +385,17 @@ const cartController = {
             }
 
             await connection.beginTransaction();
+
+            // Before the cart is opened and before stock is reserved: a
+            // product nobody may buy should not cause either (#1546).
+            if (!(await isLiveProduct(connection, line.productId))) {
+                await connection.rollback();
+
+                return res.status(404).json({
+                    success: false,
+                    message: "This product is no longer available"
+                });
+            }
 
             const cart = await resolveCartForWrite(req, connection);
 
@@ -380,10 +471,15 @@ const cartController = {
 
             await connection.beginTransaction();
 
-            const [products] = await connection.query("SELECT id FROM products WHERE id = ?", [line.productId]);
-            if (products.length === 0) {
+            // Live, not merely present. Raising the quantity of a product that
+            // has been withdrawn reserves stock for something that cannot be
+            // sold, and leaves a bigger line to carry to checkout (#1546).
+            if (!(await isLiveProduct(connection, line.productId))) {
                 await connection.rollback();
-                return res.status(404).json({ success: false, message: "Product not found" });
+                return res.status(404).json({
+                    success: false,
+                    message: "This product is no longer available"
+                });
             }
 
             // Move the reservation for this line to the new quantity (release

--- a/backend/tests/cartProductVisibility.test.js
+++ b/backend/tests/cartProductVisibility.test.js
@@ -1,0 +1,430 @@
+// backend/tests/cartProductVisibility.test.js
+//
+// The cart obeys the same visibility rule as the rest of the catalogue (#1546).
+//
+// `deleteProduct` is a soft delete and `products.status` carries the lifecycle,
+// so "the row exists" and "a shopper may buy this" are different questions. The
+// catalogue and the wishlist have asked the second one since #1456; the cart
+// asked the first, so a withdrawn product stayed addable, stayed in the basket
+// and travelled to checkout.
+//
+// The database is mocked at the module boundary, as the rest of this suite
+// does. What is pinned here is not SQL text but the property that every cart
+// path -- read and write -- carries the visibility predicate, and that a line
+// it excludes is reported rather than silently dropped.
+
+jest.mock("../config/db", () => {
+    const query = jest.fn();
+    const pool = { query, getConnection: jest.fn() };
+    pool.promise = pool;
+    return pool;
+});
+
+jest.mock("../services/inventoryReservationService", () => ({
+    reserveStock: jest.fn().mockResolvedValue(true),
+    releaseUserLocks: jest.fn().mockResolvedValue(),
+    releaseLineLocks: jest.fn().mockResolvedValue(),
+    consumeLocks: jest.fn().mockResolvedValue()
+}));
+
+jest.mock("../services/cartLifecycleService", () => ({
+    resolveActiveCart: jest.fn().mockResolvedValue("cart-1"),
+    findActiveCartId: jest.fn().mockResolvedValue("cart-1"),
+    touchCart: jest.fn().mockResolvedValue()
+}));
+
+jest.mock("../services/guestCartService", () => ({
+    resolveCart: jest.fn().mockResolvedValue({ cartId: "cart-1", token: null }),
+    findCartIdByToken: jest.fn().mockResolvedValue("cart-1"),
+    touchToken: jest.fn().mockResolvedValue()
+}));
+
+jest.mock("../services/cartRestoreService", () => ({
+    issueLink: jest.fn(),
+    redeemLink: jest.fn()
+}));
+
+const db = require("../config/db");
+const cartController = require("../controllers/cartController");
+const {
+    PUBLIC_PRODUCT_STATUSES
+} = require("../constants/productVisibility");
+
+const USER = "11111111-1111-4111-8111-111111111111";
+const LIVE_PRODUCT = "22222222-2222-4222-8222-222222222222";
+const WITHDRAWN_PRODUCT = "33333333-3333-4333-8333-333333333333";
+
+function mockRes() {
+    return {
+        statusCode: null,
+        body: null,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        }
+    };
+}
+
+/**
+ * A connection double that answers the product lookup with whichever ids are
+ * declared live, and everything else with an empty result.
+ */
+function fakeConnection(liveIds = []) {
+    const calls = [];
+
+    return {
+        calls,
+        query: jest.fn(async (sql, params = []) => {
+            calls.push({ sql, params });
+
+            if (/FROM products/.test(sql)) {
+                return [liveIds.map((id) => ({ id }))];
+            }
+
+            if (/SELECT COUNT/.test(sql)) {
+                return [[{ total: 0 }]];
+            }
+
+            return [{ affectedRows: 1 }];
+        }),
+        beginTransaction: jest.fn().mockResolvedValue(),
+        commit: jest.fn().mockResolvedValue(),
+        rollback: jest.fn().mockResolvedValue(),
+        release: jest.fn()
+    };
+}
+
+function productLookups(connection) {
+    return connection.calls.filter(({ sql }) => /FROM products/.test(sql));
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    db.query.mockReset();
+});
+
+// ----------------------------------------------------------------------
+// Reading the cart
+// ----------------------------------------------------------------------
+
+describe("GET /cart", () => {
+    function stubRead(cartRows, heldTotal) {
+        db.query.mockImplementation(async (sql) => {
+            if (/SELECT COUNT/.test(sql)) return [[{ total: heldTotal }]];
+            return [cartRows];
+        });
+    }
+
+    test("the join carries the visibility predicate", async () => {
+        stubRead([], 0);
+
+        await cartController.getUserCart(
+            { cartIdentity: { userId: USER, guestToken: null } },
+            mockRes()
+        );
+
+        const [sql, params] = db.query.mock.calls.find(([text]) =>
+            /FROM cart_items/.test(text) && /JOIN products/.test(text)
+        );
+
+        expect(sql).toMatch(/p\.deleted_at IS NULL/);
+        expect(sql).toMatch(/p\.status IN/);
+        expect(params).toEqual(
+            expect.arrayContaining(PUBLIC_PRODUCT_STATUSES)
+        );
+    });
+
+    test("a line whose product was withdrawn is reported, not silently lost", async () => {
+        // Two lines held, one still buyable.
+        stubRead([{ id: LIVE_PRODUCT, qty: 1 }], 2);
+
+        const res = mockRes();
+
+        await cartController.getUserCart(
+            { cartIdentity: { userId: USER, guestToken: null } },
+            res
+        );
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.cart).toHaveLength(1);
+        expect(res.body.unavailableCount).toBe(1);
+    });
+
+    test("a basket with nothing withdrawn reports a count of zero", async () => {
+        stubRead([{ id: LIVE_PRODUCT, qty: 1 }], 1);
+
+        const res = mockRes();
+
+        await cartController.getUserCart(
+            { cartIdentity: { userId: USER, guestToken: null } },
+            res
+        );
+
+        expect(res.body.unavailableCount).toBe(0);
+    });
+
+    test("an empty cart never reaches the database", async () => {
+        const cartLifecycle = require("../services/cartLifecycleService");
+        cartLifecycle.findActiveCartId.mockResolvedValueOnce(null);
+
+        const res = mockRes();
+
+        await cartController.getUserCart(
+            { cartIdentity: { userId: USER, guestToken: null } },
+            res
+        );
+
+        expect(res.body.cart).toEqual([]);
+        expect(db.query).not.toHaveBeenCalled();
+    });
+});
+
+// ----------------------------------------------------------------------
+// POST /cart/sync
+// ----------------------------------------------------------------------
+
+describe("POST /cart/sync", () => {
+    test("the product lookup asks whether the product is live, not whether it exists", async () => {
+        const connection = fakeConnection([LIVE_PRODUCT]);
+        db.getConnection.mockResolvedValue(connection);
+
+        await cartController.syncCart(
+            {
+                cartIdentity: { userId: USER, guestToken: null },
+                body: { items: [{ productId: LIVE_PRODUCT, quantity: 1 }] }
+            },
+            mockRes()
+        );
+
+        const [lookup] = productLookups(connection);
+
+        expect(lookup.sql).toMatch(/p\.deleted_at IS NULL/);
+        expect(lookup.sql).toMatch(/p\.status IN/);
+        expect(lookup.params).toEqual(
+            expect.arrayContaining([LIVE_PRODUCT, ...PUBLIC_PRODUCT_STATUSES])
+        );
+    });
+
+    test("a withdrawn product is not written into the basket", async () => {
+        const connection = fakeConnection([LIVE_PRODUCT]);
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+
+        await cartController.syncCart(
+            {
+                cartIdentity: { userId: USER, guestToken: null },
+                body: {
+                    items: [
+                        { productId: LIVE_PRODUCT, quantity: 1 },
+                        { productId: WITHDRAWN_PRODUCT, quantity: 2 }
+                    ]
+                }
+            },
+            res
+        );
+
+        const insert = connection.calls.find(({ sql }) =>
+            /INSERT INTO cart_items/.test(sql)
+        );
+
+        expect(insert).toBeDefined();
+        expect(insert.params).toContain(LIVE_PRODUCT);
+        expect(insert.params).not.toContain(WITHDRAWN_PRODUCT);
+        expect(res.statusCode).toBe(200);
+    });
+
+    test("the dropped ids come back on the response", async () => {
+        const connection = fakeConnection([LIVE_PRODUCT]);
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+
+        await cartController.syncCart(
+            {
+                cartIdentity: { userId: USER, guestToken: null },
+                body: {
+                    items: [
+                        { productId: LIVE_PRODUCT, quantity: 1 },
+                        { productId: WITHDRAWN_PRODUCT, quantity: 2 }
+                    ]
+                }
+            },
+            res
+        );
+
+        expect(res.body.droppedProductIds).toEqual([WITHDRAWN_PRODUCT]);
+        expect(res.body.dropped).toBe(1);
+    });
+
+    test("a sync with nothing withdrawn reports no drops", async () => {
+        const connection = fakeConnection([LIVE_PRODUCT]);
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+
+        await cartController.syncCart(
+            {
+                cartIdentity: { userId: USER, guestToken: null },
+                body: { items: [{ productId: LIVE_PRODUCT, quantity: 1 }] }
+            },
+            res
+        );
+
+        expect(res.body.dropped).toBe(0);
+        expect(res.body.droppedProductIds).toEqual([]);
+    });
+
+    test("no stock is reserved for a product that is not live", async () => {
+        const inventory = require("../services/inventoryReservationService");
+        const connection = fakeConnection([]);
+        db.getConnection.mockResolvedValue(connection);
+
+        await cartController.syncCart(
+            {
+                cartIdentity: { userId: USER, guestToken: null },
+                body: { items: [{ productId: WITHDRAWN_PRODUCT, quantity: 3 }] }
+            },
+            mockRes()
+        );
+
+        expect(inventory.reserveStock).not.toHaveBeenCalled();
+    });
+
+    test("an empty payload does not go looking for products at all", async () => {
+        const connection = fakeConnection([]);
+        db.getConnection.mockResolvedValue(connection);
+
+        await cartController.syncCart(
+            {
+                cartIdentity: { userId: USER, guestToken: null },
+                body: { items: [] }
+            },
+            mockRes()
+        );
+
+        expect(productLookups(connection)).toHaveLength(0);
+    });
+});
+
+// ----------------------------------------------------------------------
+// POST /cart  (add a single line)
+// ----------------------------------------------------------------------
+
+describe("POST /cart", () => {
+    test("adding a withdrawn product is a 404, not a silent success", async () => {
+        const connection = fakeConnection([]);
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+
+        await cartController.addToCart(
+            {
+                cartIdentity: { userId: USER, guestToken: null },
+                body: { productId: WITHDRAWN_PRODUCT, quantity: 1 }
+            },
+            res
+        );
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body.success).toBe(false);
+        expect(connection.rollback).toHaveBeenCalled();
+    });
+
+    test("the check runs before any stock is reserved", async () => {
+        const inventory = require("../services/inventoryReservationService");
+        const connection = fakeConnection([]);
+        db.getConnection.mockResolvedValue(connection);
+
+        await cartController.addToCart(
+            {
+                cartIdentity: { userId: USER, guestToken: null },
+                body: { productId: WITHDRAWN_PRODUCT, quantity: 1 }
+            },
+            mockRes()
+        );
+
+        expect(inventory.reserveStock).not.toHaveBeenCalled();
+    });
+
+    test("a live product still goes in", async () => {
+        const connection = fakeConnection([LIVE_PRODUCT]);
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+
+        await cartController.addToCart(
+            {
+                cartIdentity: { userId: USER, guestToken: null },
+                body: { productId: LIVE_PRODUCT, quantity: 1 }
+            },
+            res
+        );
+
+        expect(res.statusCode).toBe(200);
+        expect(connection.commit).toHaveBeenCalled();
+    });
+});
+
+// ----------------------------------------------------------------------
+// PATCH /cart  (change a line's quantity)
+// ----------------------------------------------------------------------
+
+describe("PATCH /cart", () => {
+    test("raising the quantity of a withdrawn product is refused", async () => {
+        const connection = fakeConnection([]);
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+
+        await cartController.updateCartItem(
+            {
+                cartIdentity: { userId: USER, guestToken: null },
+                body: { productId: WITHDRAWN_PRODUCT, quantity: 5 }
+            },
+            res
+        );
+
+        expect(res.statusCode).toBe(404);
+        expect(connection.rollback).toHaveBeenCalled();
+    });
+
+    test("the reservation is not moved for a product that is not live", async () => {
+        const inventory = require("../services/inventoryReservationService");
+        const connection = fakeConnection([]);
+        db.getConnection.mockResolvedValue(connection);
+
+        await cartController.updateCartItem(
+            {
+                cartIdentity: { userId: USER, guestToken: null },
+                body: { productId: WITHDRAWN_PRODUCT, quantity: 5 }
+            },
+            mockRes()
+        );
+
+        expect(inventory.releaseLineLocks).not.toHaveBeenCalled();
+        expect(inventory.reserveStock).not.toHaveBeenCalled();
+    });
+
+    test("the lookup carries the visibility predicate", async () => {
+        const connection = fakeConnection([LIVE_PRODUCT]);
+        db.getConnection.mockResolvedValue(connection);
+
+        await cartController.updateCartItem(
+            {
+                cartIdentity: { userId: USER, guestToken: null },
+                body: { productId: LIVE_PRODUCT, quantity: 2 }
+            },
+            mockRes()
+        );
+
+        const [lookup] = productLookups(connection);
+
+        expect(lookup.sql).toMatch(/p\.deleted_at IS NULL/);
+        expect(lookup.sql).toMatch(/p\.status IN/);
+    });
+});

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -1688,6 +1688,31 @@ const pushCartToBackend = async (cart) => {
     }
 
     if (response && response.success) {
+        // The server drops lines whose product has been withdrawn from sale
+        // and names them (#1546). Keeping a line the server refused would
+        // resurrect it on the next sync and carry it all the way to checkout,
+        // so the acknowledged basket is what the server actually stored.
+        const droppedIds = safeArray(response.droppedProductIds)
+            .map((id) => String(id));
+
+        if (droppedIds.length) {
+            const kept = safeArray(cart).filter(
+                (item) => !droppedIds.includes(String(item.id))
+            );
+
+            notify(
+                droppedIds.length === 1
+                    ? "An item in your cart is no longer available and has been removed."
+                    : `${droppedIds.length} items in your cart are no longer available and have been removed.`,
+                "warning"
+            );
+
+            serverAcknowledgedItems = kept;
+            saveCart(kept, { sync: false });
+
+            return true;
+        }
+
         serverAcknowledgedItems = cart;
         return true;
     }
@@ -1770,6 +1795,21 @@ const fetchServerCart = async () => {
         const data = await apiRequest("/cart", {}, false);
 
         if (data && data.success) {
+            // Lines whose product has since been withdrawn are not returned
+            // (#1546). The count of them is, so a basket that comes back
+            // shorter than the shopper left it can say why instead of looking
+            // like the cart lost their items.
+            const unavailableCount = Number(data.unavailableCount) || 0;
+
+            if (unavailableCount > 0) {
+                notify(
+                    unavailableCount === 1
+                        ? "An item in your cart is no longer available and has been removed."
+                        : `${unavailableCount} items in your cart are no longer available and have been removed.`,
+                    "warning"
+                );
+            }
+
             return safeArray(data.cart)
                 .map(normalizeCartItem)
                 .filter(Boolean);


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`deleteProduct` is a **soft** delete and `products.status` carries the lifecycle, so "the row exists" and "a shopper may buy this" are different questions.

Everywhere else asks the second one. `productController` uses `publicProductCondition("p")` on both the list and the detail endpoint (#1456). `wishlistController` carries `LIVE_PRODUCT = "p.is_active = 1 AND p.deleted_at IS NULL"` on its add, its read and its move-to-cart.

The cart asked the first:

```js
// POST /cart/sync
SELECT id FROM products WHERE id IN (...)

// PATCH /cart  (quantity change)
SELECT id FROM products WHERE id = ?
```

So a product an admin had withdrawn — one that 404s at its own URL, is absent from every listing, and cannot be added to a wishlist — was still addable to a basket, still syncable, still quantity-editable, and still travelled to checkout, rendered the whole way from a stale client-side snapshot of its name and price.

### What changed

**Both lookups go through one helper** built on `publicProductCondition`, the same definition the rest of the catalogue imports rather than retypes.

**The check runs before any stock is reserved.** A withdrawn product no longer holds inventory that nobody can buy.

**The read path filters too.** A product can be withdrawn *after* it entered the basket; without this, the item stays in the cart indefinitely.

**Nothing disappears silently.** This is the part worth reviewing:

- `GET /cart` returns `unavailableCount` — how many held lines are no longer buyable.
- `POST /cart/sync` returns `droppedProductIds` and `dropped`.
- The frontend removes those lines from its local copy and tells the shopper. Keeping one locally would resurrect it on the very next sync, since `/cart/sync` is replace-all.

`POST /cart` and `PATCH /cart` answer `404 "This product is no longer available"` rather than a generic "Product not found", because the row does exist and the shopper's copy of it is what is stale.

---

## 🔗 Related Issue

Closes: #1546

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [x] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 🧪 Tests

New suite, `backend/tests/cartProductVisibility.test.js` — 16 cases across all four cart paths:

**`GET /cart`** — the join carries the predicate; a withdrawn line is reported via `unavailableCount` rather than silently lost; a clean basket reports zero; an empty cart still never reaches the database.

**`POST /cart/sync`** — the lookup asks whether the product is live rather than whether it exists; a withdrawn product is not written into the basket; the dropped ids come back on the response; a clean sync reports no drops; no stock is reserved for a product that is not live; an empty payload does not go looking for products at all.

**`POST /cart`** — adding a withdrawn product is a 404 rather than a silent success; the check runs before any stock is reserved; a live product still goes in.

**`PATCH /cart`** — raising the quantity of a withdrawn product is refused; the reservation is not moved; the lookup carries the predicate.

Local run:

```
Test Suites: 87 passed, 87 total
Tests:       1932 passed, 1932 total
```

Plus `check:syntax`, `check:boot`, `check:modules`, `check:sitemap`, `check:a11y` — all green.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

Related, same rule, already fixed elsewhere: #1456 (product visibility) and #1457 (product soft delete). This closes the last surface that was still asking the wrong question.

The two new response fields are additive — `cart` and the sync envelope are otherwise unchanged, so a client that ignores them behaves exactly as before, minus the withdrawn lines.
