### PR TITLE
fix(reviews): a review you deleted should not block you forever (#1547)

### DIFF
--- a/backend/controllers/reviewController.js
+++ b/backend/controllers/reviewController.js
@@ -16,10 +16,29 @@ const {
     sanitizeString
 } = require("../utils/helpers");
 
-async function productExists(productId) {
-    const [products] = await db.query(
-        "SELECT id FROM products WHERE id = ? LIMIT 1",
-        [productId]
+// The same definition of "a shopper may see this product" the catalogue uses
+// (#1456). Reviews were reachable for a product that had been withdrawn from
+// sale: `SELECT id FROM products WHERE id = ?` matches a soft-deleted row, so
+// a product that 404s at its own URL still accepted new reviews and still
+// served old ones (#1547).
+const { publicProductCondition } = require("../constants/productVisibility");
+
+/**
+ * Is this a product a shopper may still see?
+ *
+ * @param {string} productId
+ * @param {object} [connection] A pool or an open transaction.
+ * @returns {Promise<boolean>}
+ */
+async function productExists(productId, connection = db) {
+    const visibility = publicProductCondition("p");
+
+    const [products] = await connection.query(
+        `SELECT p.id
+           FROM products p
+          WHERE p.id = ? AND ${visibility.sql}
+          LIMIT 1`,
+        [productId, ...visibility.params]
     );
 
     return safeArray(products).length > 0;
@@ -165,12 +184,7 @@ const createProductReview = async (req, res) => {
     try {
         await connection.beginTransaction();
 
-        const [products] = await connection.query(
-            "SELECT id FROM products WHERE id = ? LIMIT 1",
-            [productId]
-        );
-
-        if (!safeArray(products).length) {
+        if (!(await productExists(productId, connection))) {
             await connection.rollback();
 
             return res.status(404).json({
@@ -179,8 +193,28 @@ const createProductReview = async (req, res) => {
             });
         }
 
+        // `deleted_at IS NULL`, and locked.
+        //
+        // Two separate problems lived in this one statement (#1547).
+        //
+        // Deletion is a *soft* delete -- #1349 made it one deliberately, so
+        // there is a record of what was removed and by whom. This check matched
+        // any row, so the tombstone of a review the shopper had withdrawn went
+        // on blocking them forever: they were told "you have already reviewed
+        // this product" while the product page showed no review of theirs,
+        // because every read filters `deleted_at IS NULL`. There was no way out
+        // of that state from the UI.
+        //
+        // And it was a plain read inside the transaction, which locks nothing.
+        // Two submissions arriving together both saw no review and both
+        // inserted one; there is no unique key on (product_id, user_id) to
+        // catch it. `FOR UPDATE` makes the second wait for the first.
         const [existing] = await connection.query(
-            "SELECT id FROM reviews WHERE product_id = ? AND user_id = ? LIMIT 1",
+            `SELECT id
+               FROM reviews
+              WHERE product_id = ? AND user_id = ? AND deleted_at IS NULL
+              LIMIT 1
+              FOR UPDATE`,
             [productId, userId]
         );
 

--- a/backend/tests/reviewResubmission.test.js
+++ b/backend/tests/reviewResubmission.test.js
@@ -1,0 +1,359 @@
+// backend/tests/reviewResubmission.test.js
+//
+// A review you deleted is not a review you have (#1547).
+//
+// Review deletion has been a soft delete since #1349, so the row survives with
+// `deleted_at` set. Every read filters it out -- `listProductReviews`,
+// `getRatingBreakdown` and the product's cached rating all do -- but the
+// duplicate-review guard on the create path did not, so the tombstone went on
+// blocking the shopper forever. They were told "you have already reviewed this
+// product" while the product page showed no review of theirs, with no way out
+// of that state from the UI.
+//
+// The database is mocked at the module boundary, as the rest of this suite
+// does. What is pinned here is which rows the guard is allowed to see, that it
+// takes a lock while it looks, and that both product lookups ask whether the
+// product is still on sale rather than merely whether the row exists.
+
+jest.mock("../config/db", () => ({
+    query: jest.fn(),
+    getConnection: jest.fn()
+}));
+
+jest.mock("../services/reviewModerationService", () => {
+    class ReviewError extends Error {
+        constructor(message, status = 400, code = "REVIEW_ERROR") {
+            super(message);
+            this.status = status;
+            this.code = code;
+        }
+    }
+
+    return {
+        ReviewError,
+        REPORT_REASONS: ["spam"],
+        listProductReviews: jest.fn(),
+        getRatingBreakdown: jest.fn(),
+        voteHelpful: jest.fn(),
+        unvoteHelpful: jest.fn(),
+        reportReview: jest.fn(),
+        getModerationQueue: jest.fn(),
+        getReviewReports: jest.fn(),
+        moderateReview: jest.fn()
+    };
+});
+
+jest.mock("../models/Review", () => ({}));
+
+const db = require("../config/db");
+const reviewModerationService = require("../services/reviewModerationService");
+const {
+    PUBLIC_PRODUCT_STATUSES
+} = require("../constants/productVisibility");
+
+const {
+    createProductReview,
+    getProductReviews
+} = require("../controllers/reviewController");
+
+const PRODUCT = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+const USER = "11111111-1111-4111-8111-111111111111";
+
+function mockRes() {
+    return {
+        statusCode: null,
+        body: null,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        }
+    };
+}
+
+/**
+ * A connection double answering by statement shape.
+ *
+ * @param {object} options
+ * @param {boolean} options.productLive   does the product lookup match?
+ * @param {boolean} options.hasLiveReview does the duplicate guard match?
+ * @param {boolean} options.hasPurchase   does the delivered-order check match?
+ */
+function fakeConnection({
+    productLive = true,
+    hasLiveReview = false,
+    hasPurchase = true
+} = {}) {
+    const calls = [];
+
+    return {
+        calls,
+        query: jest.fn(async (sql, params = []) => {
+            calls.push({ sql, params });
+
+            if (/FROM products/.test(sql)) {
+                return [productLive ? [{ id: PRODUCT }] : []];
+            }
+
+            if (/FROM reviews/.test(sql)) {
+                return [hasLiveReview ? [{ id: 42 }] : []];
+            }
+
+            if (/FROM orders/.test(sql)) {
+                return [hasPurchase ? [{ id: "order-1" }] : []];
+            }
+
+            if (/INSERT INTO reviews/.test(sql)) {
+                return [{ insertId: 99 }];
+            }
+
+            if (/SELECT[\s\S]*AVG\(rating\)/.test(sql)) {
+                return [[{ average_rating: 4.5, review_count: 2 }]];
+            }
+
+            return [{ affectedRows: 1 }];
+        }),
+        beginTransaction: jest.fn().mockResolvedValue(),
+        commit: jest.fn().mockResolvedValue(),
+        rollback: jest.fn().mockResolvedValue(),
+        release: jest.fn()
+    };
+}
+
+function reviewGuard(connection) {
+    return connection.calls.find(
+        ({ sql }) => /SELECT/.test(sql) && /FROM reviews/.test(sql)
+    );
+}
+
+function productLookup(connection) {
+    return connection.calls.find(({ sql }) => /FROM products/.test(sql));
+}
+
+function validRequest(overrides = {}) {
+    return {
+        params: { id: PRODUCT },
+        user: { id: USER },
+        body: {
+            rating: 5,
+            comment: "Arrived on time and fits well.",
+            ...overrides
+        }
+    };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    db.query.mockReset();
+});
+
+// ----------------------------------------------------------------------
+// The duplicate guard
+// ----------------------------------------------------------------------
+
+describe("createProductReview — the duplicate guard", () => {
+    test("ignores a review the shopper has already deleted", async () => {
+        // `hasLiveReview: false` is what the guard now sees, because the
+        // tombstone no longer matches the WHERE.
+        const connection = fakeConnection({ hasLiveReview: false });
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+
+        await createProductReview(validRequest(), res);
+
+        expect(res.statusCode).toBe(201);
+        expect(connection.commit).toHaveBeenCalled();
+    });
+
+    test("the guard only matches rows that are not soft-deleted", async () => {
+        const connection = fakeConnection();
+        db.getConnection.mockResolvedValue(connection);
+
+        await createProductReview(validRequest(), mockRes());
+
+        expect(reviewGuard(connection).sql).toMatch(/deleted_at IS NULL/);
+    });
+
+    test("a live review still blocks a second one", async () => {
+        const connection = fakeConnection({ hasLiveReview: true });
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+
+        await createProductReview(validRequest(), res);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toMatch(/already reviewed/i);
+        expect(connection.rollback).toHaveBeenCalled();
+    });
+
+    test("nothing is inserted when a live review already exists", async () => {
+        const connection = fakeConnection({ hasLiveReview: true });
+        db.getConnection.mockResolvedValue(connection);
+
+        await createProductReview(validRequest(), mockRes());
+
+        expect(
+            connection.calls.some(({ sql }) => /INSERT INTO reviews/.test(sql))
+        ).toBe(false);
+    });
+
+    test("the guard takes a row lock so two submissions cannot both pass it", async () => {
+        const connection = fakeConnection();
+        db.getConnection.mockResolvedValue(connection);
+
+        await createProductReview(validRequest(), mockRes());
+
+        // There is no unique key on (product_id, user_id) to catch a race, so
+        // the lock is the only thing serialising them.
+        expect(reviewGuard(connection).sql).toMatch(/FOR UPDATE/);
+    });
+
+    test("the guard is scoped to this product and this shopper", async () => {
+        const connection = fakeConnection();
+        db.getConnection.mockResolvedValue(connection);
+
+        await createProductReview(validRequest(), mockRes());
+
+        expect(reviewGuard(connection).params).toEqual([PRODUCT, USER]);
+    });
+});
+
+// ----------------------------------------------------------------------
+// Product visibility
+// ----------------------------------------------------------------------
+
+describe("createProductReview — product visibility", () => {
+    test("the product lookup carries the visibility predicate", async () => {
+        const connection = fakeConnection();
+        db.getConnection.mockResolvedValue(connection);
+
+        await createProductReview(validRequest(), mockRes());
+
+        const lookup = productLookup(connection);
+
+        expect(lookup.sql).toMatch(/p\.deleted_at IS NULL/);
+        expect(lookup.sql).toMatch(/p\.status IN/);
+        expect(lookup.params).toEqual([PRODUCT, ...PUBLIC_PRODUCT_STATUSES]);
+    });
+
+    test("a withdrawn product cannot be reviewed", async () => {
+        const connection = fakeConnection({ productLive: false });
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+
+        await createProductReview(validRequest(), res);
+
+        expect(res.statusCode).toBe(404);
+        expect(connection.rollback).toHaveBeenCalled();
+    });
+
+    test("the product check runs before the duplicate guard", async () => {
+        const connection = fakeConnection({ productLive: false });
+        db.getConnection.mockResolvedValue(connection);
+
+        await createProductReview(validRequest(), mockRes());
+
+        expect(reviewGuard(connection)).toBeUndefined();
+    });
+
+    test("GET reviews 404s for a withdrawn product", async () => {
+        db.query.mockResolvedValue([[]]);
+
+        const res = mockRes();
+
+        await getProductReviews({ params: { id: PRODUCT }, query: {} }, res);
+
+        expect(res.statusCode).toBe(404);
+        expect(reviewModerationService.listProductReviews).not.toHaveBeenCalled();
+    });
+
+    test("GET reviews still serves a live product", async () => {
+        db.query.mockResolvedValue([[{ id: PRODUCT }]]);
+
+        reviewModerationService.listProductReviews.mockResolvedValue({
+            reviews: [],
+            pagination: { page: 1 },
+            sort: "recent"
+        });
+
+        reviewModerationService.getRatingBreakdown.mockResolvedValue({
+            average: 4.5,
+            total: 2,
+            verifiedCount: 2,
+            distribution: {}
+        });
+
+        const res = mockRes();
+
+        await getProductReviews({ params: { id: PRODUCT }, query: {} }, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
+    test("the GET lookup carries the visibility predicate too", async () => {
+        db.query.mockResolvedValue([[]]);
+
+        await getProductReviews({ params: { id: PRODUCT }, query: {} }, mockRes());
+
+        const [sql, params] = db.query.mock.calls[0];
+
+        expect(sql).toMatch(/p\.deleted_at IS NULL/);
+        expect(sql).toMatch(/p\.status IN/);
+        expect(params).toEqual([PRODUCT, ...PUBLIC_PRODUCT_STATUSES]);
+    });
+});
+
+// ----------------------------------------------------------------------
+// Rules that must not have moved
+// ----------------------------------------------------------------------
+
+describe("createProductReview — unchanged rules", () => {
+    test("still requires a delivered order containing the product", async () => {
+        const connection = fakeConnection({ hasPurchase: false });
+        db.getConnection.mockResolvedValue(connection);
+
+        const res = mockRes();
+
+        await createProductReview(validRequest(), res);
+
+        expect(res.statusCode).toBe(403);
+        expect(connection.rollback).toHaveBeenCalled();
+    });
+
+    test("still rejects a rating outside 1-5", async () => {
+        const res = mockRes();
+
+        await createProductReview(validRequest({ rating: 9 }), res);
+
+        expect(res.statusCode).toBe(400);
+        expect(db.getConnection).not.toHaveBeenCalled();
+    });
+
+    test("still rejects an empty comment", async () => {
+        const res = mockRes();
+
+        await createProductReview(validRequest({ comment: "x" }), res);
+
+        expect(res.statusCode).toBe(400);
+    });
+
+    test("still refreshes the product's cached rating on success", async () => {
+        const connection = fakeConnection();
+        db.getConnection.mockResolvedValue(connection);
+
+        await createProductReview(validRequest(), mockRes());
+
+        const refresh = connection.calls.find(({ sql }) =>
+            /UPDATE products/.test(sql) && /num_reviews/.test(sql)
+        );
+
+        expect(refresh).toBeDefined();
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

Deleting your own review permanently bans you from ever reviewing that product again.

Review deletion has been a **soft** delete since #1349 — deliberately, so there is a record of what was removed and by whom. The row survives with `deleted_at` set, and every read filters it out: `listProductReviews`, `getRatingBreakdown` and the product's cached rating all do.

The duplicate-review guard on the create path did not:

```js
SELECT id FROM reviews WHERE product_id = ? AND user_id = ? LIMIT 1
```

So the tombstone went on blocking the shopper forever. They are told *"You have already reviewed this product"* while the product page shows no review of theirs — and the Delete button that put them there is on that same page (`product-reviews.js:147`, `:447`). There is no way out of that state from the UI.

### What changed

**The guard matches only live rows.** `AND deleted_at IS NULL` — a review you withdrew is not a review you have.

**The guard takes a row lock.** It was a plain read inside the transaction, which locks nothing: two submissions arriving together both saw no review and both inserted one. There is no unique key on `(product_id, user_id)` to catch that, so `FOR UPDATE` is the only thing serialising them.

**Both product lookups go through `publicProductCondition`**, the same definition `productController` imports. `SELECT id FROM products WHERE id = ?` matches a soft-deleted row, so a product that 404s at its own URL was still accepting new reviews and still serving old ones. `productExists` now takes an optional connection so the create path runs the same check inside its transaction instead of keeping a second copy.

---

## 🔗 Related Issue

Closes: #1547

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 🧪 Tests

New suite, `backend/tests/reviewResubmission.test.js` — 16 cases.

**The duplicate guard** — ignores a review the shopper has already deleted; the guard only matches rows that are not soft-deleted; a live review still blocks a second one; nothing is inserted when one exists; the guard takes a row lock; the guard is scoped to this product and this shopper.

**Product visibility** — the product lookup carries the predicate; a withdrawn product cannot be reviewed; the product check runs before the duplicate guard; `GET` reviews 404s for a withdrawn product and still serves a live one; the `GET` lookup carries the predicate too.

**Rules that must not have moved** — still requires a `delivered` order containing the product; still rejects a rating outside 1–5; still rejects an empty comment; still refreshes the product's cached rating on success.

Local run:

```
Test Suites: 87 passed, 87 total
Tests:       1932 passed, 1932 total
```

Plus `check:syntax`, `check:boot`, `check:modules`, `check:sitemap`, `check:a11y` — all green.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

Reviewers may want to check one consequence: an account that deletes and re-reviews now has more than one row for `(product_id, user_id)` — one carrying `deleted_at`, one live. That is already how the schema works (no unique key on the pair), and every read in `reviewModerationService` filters `deleted_at IS NULL`, so the extra row is inert. It is the record #1349 wanted kept.

No frontend change is needed: the page already surfaces the API's message, and the path it was blocking now succeeds.
