### PR TITLE
feat(profile): give the profile page a server to save to (#1548)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -38,6 +38,11 @@ const loginLockoutService = require("../services/loginLockoutService");
 const otpRequestLimiter = require("../services/otpRequestLimiter");
 // A basket built before signing in belongs to the account afterwards (#1427).
 const { mergeGuestCartOnSignIn } = require("../services/cartMergeService");
+// The shopper's own profile (#1548). Every rule about what may be written, and
+// how wide it may be, lives in the service: the columns are the constraint, and
+// a controller is not where a schema belongs.
+const profileService = require("../services/profileService");
+const { ProfileError } = require("../services/profileService");
 
 // Appwrite SDK
 const { Client, Account, ID, Databases } = require('node-appwrite');
@@ -914,6 +919,80 @@ const getMe = async (req, res) => {
     }
 };
 
+// ==================== PROFILE (#1548) ====================
+
+/**
+ * Map a profile-service error onto a response.
+ *
+ * ProfileError carries the status it wants. Anything else is unexpected, so
+ * the detail goes to the log and the caller gets a generic message -- the same
+ * split reviewController uses.
+ */
+const handleProfileError = (res, error, context) => {
+    if (error instanceof ProfileError) {
+        return res.status(error.status).json({
+            success: false,
+            code: error.code,
+            message: error.message,
+            ...(error.details || {})
+        });
+    }
+
+    console.error(`${context}:`, error);
+
+    return res.status(500).json({
+        success: false,
+        message: "Something went wrong. Please try again."
+    });
+};
+
+/**
+ * GET /api/auth/profile
+ *
+ * The shopper's own profile, from the database. `getMe` returns the four
+ * fields a session needs; this returns the ones a profile page edits, and it
+ * is what makes a saved profile survive a different browser (#1548).
+ */
+const getProfile = async (req, res) => {
+    try {
+        const profile = await profileService.getProfile(req.user?.id);
+
+        return res.status(200).json({
+            success: true,
+            profile
+        });
+    } catch (error) {
+        return handleProfileError(res, error, "GET PROFILE ERROR");
+    }
+};
+
+/**
+ * PUT /api/auth/profile
+ *
+ * Partial update: only the fields present in the body are written, so a client
+ * sending `{ name }` does not blank the phone number.
+ *
+ * The stored profile comes back on the response. The two editors this replaces
+ * re-rendered from what they had just typed, which is exactly why "Profile
+ * saved successfully!" could be true of nothing at all.
+ */
+const updateProfile = async (req, res) => {
+    try {
+        const profile = await profileService.updateProfile(
+            req.user?.id,
+            req.body
+        );
+
+        return res.status(200).json({
+            success: true,
+            message: "Profile updated",
+            profile
+        });
+    } catch (error) {
+        return handleProfileError(res, error, "UPDATE PROFILE ERROR");
+    }
+};
+
 // ==================== GDPR / DPDP ERASURE (#1397) ====================
 
 const dataErasureService = require("../services/dataErasureService");
@@ -1040,6 +1119,8 @@ module.exports = {
     getSecurityAudit, 
     getFraudStatus,
     getMe,
+    getProfile,
+    updateProfile,
     requestDataErasure,
     confirmDataErasure,
     getMyErasureStatus,

--- a/backend/openapi/ecommerce.openapi.yaml
+++ b/backend/openapi/ecommerce.openapi.yaml
@@ -125,6 +125,85 @@ paths:
                 unauthorized:
                   $ref: "#/components/examples/Unauthorized401"
 
+  /auth/profile:
+    get:
+      tags: [Auth]
+      summary: The signed-in shopper's editable profile
+      description: >
+        Distinct from /auth/me, which returns the fields a session needs. This
+        returns the fields a profile page edits.
+      operationId: getProfile
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: The stored profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProfileSuccess"
+        "401":
+          description: Missing or invalid token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+              examples:
+                unauthorized:
+                  $ref: "#/components/examples/Unauthorized401"
+        "403":
+          description: Account deactivated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+    put:
+      tags: [Auth]
+      summary: Save a partial profile update
+      description: >
+        Only the fields present in the body are written, so sending {name}
+        does not blank the phone number. `email` is refused -- changing the
+        address on an account is an identity change and goes through the
+        verification flow. An unknown field is a 400 rather than being
+        silently ignored.
+      operationId: updateProfile
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProfileUpdateRequest"
+      responses:
+        "200":
+          description: The stored profile, re-read after the write
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProfileSuccess"
+        "400":
+          description: Invalid, unknown or non-editable field
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "401":
+          description: Missing or invalid token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+              examples:
+                unauthorized:
+                  $ref: "#/components/examples/Unauthorized401"
+        "404":
+          description: Account not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
   /auth/refresh-token:
     post:
       tags: [Auth]
@@ -700,6 +779,109 @@ components:
           const: true
         user:
           $ref: "#/components/schemas/UserSummary"
+
+    Profile:
+      type: object
+      description: >
+        The shopper's own profile. Unset fields are null rather than empty
+        strings, so a client can tell "not provided" from "provided as empty".
+      required: [id, name, email]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 255
+        email:
+          type: string
+          format: email
+          readOnly: true
+        role:
+          type: string
+        phone:
+          type: string
+          nullable: true
+          maxLength: 20
+        address:
+          type: string
+          nullable: true
+          maxLength: 500
+        city:
+          type: string
+          nullable: true
+          maxLength: 100
+        state:
+          type: string
+          nullable: true
+          maxLength: 100
+        zip:
+          type: string
+          nullable: true
+          maxLength: 20
+        country:
+          type: string
+          nullable: true
+          maxLength: 100
+        avatar:
+          type: string
+          nullable: true
+          maxLength: 500
+          description: An http(s) URL or an image data URL.
+        isVerified:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    ProfileSuccess:
+      type: object
+      required: [success, profile]
+      properties:
+        success:
+          type: boolean
+          const: true
+        message:
+          type: string
+        profile:
+          $ref: "#/components/schemas/Profile"
+
+    ProfileUpdateRequest:
+      type: object
+      description: >
+        A partial update. Every property is optional; only what is present is
+        written. `email`, `password`, `role` and `id` are refused with a 400.
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        name:
+          type: string
+          minLength: 2
+          maxLength: 255
+        phone:
+          type: string
+          maxLength: 20
+        address:
+          type: string
+          maxLength: 500
+        city:
+          type: string
+          maxLength: 100
+        state:
+          type: string
+          maxLength: 100
+        zip:
+          type: string
+          maxLength: 20
+        country:
+          type: string
+          maxLength: 100
+        avatar:
+          type: string
+          maxLength: 500
 
     TokenRefreshSuccess:
       type: object

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -9,6 +9,9 @@ const {
     resetPassword,
     refreshAccessToken,
     getMe,
+    // The shopper's own profile (#1548).
+    getProfile,
+    updateProfile,
     getStatus,
     logout,
     validateToken,
@@ -165,6 +168,35 @@ router.get(
     "/me",
     authMiddleware,
     getMe
+);
+
+/**
+ * GET /api/auth/profile
+ * The signed-in shopper's editable profile.
+ *
+ * Distinct from `/me`, which returns the four fields a session needs. This
+ * returns the fields a profile page edits, and it is the read half of the pair
+ * that makes a saved profile survive a different browser (#1548).
+ */
+router.get(
+    "/profile",
+    authMiddleware,
+    getProfile
+);
+
+/**
+ * PUT /api/auth/profile
+ * Save a partial profile update.
+ *
+ * No separate validator middleware here: what may be written, and how wide it
+ * may be, is derived from the `users` column definitions inside
+ * profileService. Restating those limits at the route is how two copies of a
+ * rule drift apart.
+ */
+router.put(
+    "/profile",
+    authMiddleware,
+    updateProfile
 );
 
 /**

--- a/backend/services/profileService.js
+++ b/backend/services/profileService.js
@@ -1,0 +1,325 @@
+// backend/services/profileService.js
+//
+// The signed-in shopper's own profile (#1548).
+//
+// There was no server side to this at all. `profile.js` and
+// `dashboard-settings.js` both validated a form, wrote it to `localStorage`
+// and said "Profile saved successfully!". Nothing was sent anywhere. The
+// change was gone on any other device and gone after clearing site data, the
+// two editors kept separate copies under different keys, and the `phone`,
+// `address`, `city`, `state`, `zip`, `country` and `avatar` columns that have
+// been on `users` since the baseline schema were written by nothing but
+// signup. Same shape of defect as the newsletter form in #1459.
+//
+// Three rules shape everything below.
+//
+// EMAIL IS NOT A PROFILE FIELD. `dashboard-settings.js` let the shopper edit
+// it and wrote the new address into the cached `user` object -- the identity
+// the rest of the frontend reads -- so the UI showed an address the account
+// could not be logged in with. Changing an account's email is an identity
+// change and belongs with the existing verification flow. It is ignored here,
+// loudly enough that a caller sending one is told why.
+//
+// ONLY WHAT WAS SENT IS WRITTEN. A client that submits `{ name }` must not
+// blank the phone number. Same partial-update rule the address book uses.
+//
+// THE COLUMN WIDTHS ARE THE LIMITS. Validation is derived from the schema
+// rather than picked, so a value that passes here cannot be truncated on the
+// way in -- silently, outside strict mode.
+
+'use strict';
+
+const db = require('../config/db');
+const { safeArray, sanitizeString } = require('../utils/helpers');
+
+/**
+ * Field -> column, and the column's width.
+ *
+ * Straight from migrations/0001_baseline_schema.sql. `address` is TEXT, so it
+ * gets a policy limit rather than a schema one: an address longer than this is
+ * a paste of something else.
+ */
+const PROFILE_FIELDS = Object.freeze({
+    name: { column: 'name', maxLength: 255, required: true, minLength: 2 },
+    phone: { column: 'phone', maxLength: 20 },
+    address: { column: 'address', maxLength: 500 },
+    city: { column: 'city', maxLength: 100 },
+    state: { column: 'state', maxLength: 100 },
+    zip: { column: 'zip', maxLength: 20 },
+    country: { column: 'country', maxLength: 100 },
+    avatar: { column: 'avatar', maxLength: 500 }
+});
+
+/** Fields a client may send. Anything else is rejected rather than ignored. */
+const WRITABLE_FIELDS = Object.freeze(Object.keys(PROFILE_FIELDS));
+
+/**
+ * Fields a client may *think* it can send, with the reason it cannot.
+ *
+ * Named explicitly so the refusal says what to do instead. Silently dropping
+ * an email change is how the frontend came to believe it had made one.
+ */
+const REFUSED_FIELDS = Object.freeze({
+    email:
+        'Email cannot be changed here. Changing the address on an account is '
+        + 'an identity change and needs to be verified.',
+    password: 'Use the change-password endpoint.',
+    role: 'Roles are set by an administrator.',
+    id: 'The account id is not editable.'
+});
+
+/**
+ * Deliberately the same permissive shape the rest of the codebase uses for
+ * phone numbers rather than a stricter one. A profile form is not the place to
+ * reject a number that works.
+ */
+const PHONE_PATTERN = /^[+\d][\d\s\-()]{7,19}$/;
+
+/** Avatars are URLs, and a `javascript:` one in an `<img src>` is a payload. */
+const AVATAR_URL_PATTERN = /^https?:\/\//i;
+
+/** Also allowed for avatars: a data: image, which is what the file picker produces. */
+const AVATAR_DATA_PATTERN = /^data:image\/(png|jpe?g|gif|webp);base64,/i;
+
+/**
+ * Error carrying the HTTP status the controller should use.
+ *
+ * Without it the controller has to pattern-match on message text to tell 400
+ * from 404, which is how "not found" ends up as a 500.
+ */
+class ProfileError extends Error {
+    constructor(message, status = 400, code = 'PROFILE_ERROR', details = null) {
+        super(message);
+        this.name = 'ProfileError';
+        this.status = status;
+        this.code = code;
+        this.details = details;
+    }
+}
+
+/**
+ * Shape a `users` row for the API.
+ *
+ * `null` rather than `""` for anything unset, so a client can tell "not
+ * provided" from "provided as empty".
+ *
+ * @param {object} row
+ * @returns {object|null}
+ */
+function toPublicProfile(row) {
+    if (!row) return null;
+
+    return {
+        id: row.id,
+        name: row.name,
+        email: row.email,
+        role: row.role,
+        phone: row.phone || null,
+        address: row.address || null,
+        city: row.city || null,
+        state: row.state || null,
+        zip: row.zip || null,
+        country: row.country || null,
+        avatar: row.avatar || null,
+        isVerified: Boolean(row.is_verified),
+        createdAt: row.created_at,
+        updatedAt: row.updated_at
+    };
+}
+
+/**
+ * Check one field's value.
+ *
+ * Returns the value to store, or throws. An empty string is a deliberate
+ * clear and becomes NULL -- except on `name`, which the account cannot be
+ * without.
+ *
+ * @param {string} field
+ * @param {unknown} rawValue
+ * @returns {string|null}
+ */
+function normalizeField(field, rawValue) {
+    const spec = PROFILE_FIELDS[field];
+    const value = sanitizeString(rawValue == null ? '' : rawValue).trim();
+
+    if (!value) {
+        if (spec.required) {
+            throw new ProfileError(`${field} cannot be empty`, 400, 'INVALID_PROFILE');
+        }
+
+        return null;
+    }
+
+    if (value.length > spec.maxLength) {
+        throw new ProfileError(
+            `${field} cannot be longer than ${spec.maxLength} characters`,
+            400,
+            'INVALID_PROFILE'
+        );
+    }
+
+    if (spec.minLength && value.length < spec.minLength) {
+        throw new ProfileError(
+            `${field} must be at least ${spec.minLength} characters`,
+            400,
+            'INVALID_PROFILE'
+        );
+    }
+
+    if (field === 'phone' && !PHONE_PATTERN.test(value)) {
+        throw new ProfileError(
+            'Please enter a valid phone number',
+            400,
+            'INVALID_PROFILE'
+        );
+    }
+
+    if (
+        field === 'avatar'
+        && !AVATAR_URL_PATTERN.test(value)
+        && !AVATAR_DATA_PATTERN.test(value)
+    ) {
+        // The value ends up in an `<img src>`. A `javascript:` or `vbscript:`
+        // URL there is stored XSS, and this repo has already had one class of
+        // that (#1276).
+        throw new ProfileError(
+            'Avatar must be an http(s) URL or an image data URL',
+            400,
+            'INVALID_PROFILE'
+        );
+    }
+
+    return value;
+}
+
+/**
+ * Turn a request body into the set of columns to write.
+ *
+ * @param {object} payload
+ * @returns {{assignments: string[], values: Array, fields: string[]}}
+ * @throws {ProfileError} on an unknown field, a refused one, or a bad value
+ */
+function buildUpdate(payload) {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        throw new ProfileError('A profile object is required', 400, 'INVALID_PROFILE');
+    }
+
+    const assignments = [];
+    const values = [];
+    const fields = [];
+
+    for (const key of Object.keys(payload)) {
+        if (REFUSED_FIELDS[key]) {
+            throw new ProfileError(REFUSED_FIELDS[key], 400, 'FIELD_NOT_EDITABLE');
+        }
+
+        if (!WRITABLE_FIELDS.includes(key)) {
+            // Rejected rather than ignored. A client sending a field this does
+            // not know about believes it is saving something.
+            throw new ProfileError(
+                `Unknown profile field: ${key}`,
+                400,
+                'UNKNOWN_FIELD',
+                { allowed: WRITABLE_FIELDS }
+            );
+        }
+
+        // `undefined` is "not sent". Only what is present is written, so
+        // `{ name }` does not blank the phone number.
+        if (payload[key] === undefined) {
+            continue;
+        }
+
+        assignments.push(`${PROFILE_FIELDS[key].column} = ?`);
+        values.push(normalizeField(key, payload[key]));
+        fields.push(key);
+    }
+
+    if (!assignments.length) {
+        throw new ProfileError('No profile fields were supplied', 400, 'EMPTY_UPDATE');
+    }
+
+    return { assignments, values, fields };
+}
+
+const profileService = {
+    PROFILE_FIELDS,
+    WRITABLE_FIELDS,
+    REFUSED_FIELDS,
+    ProfileError,
+    toPublicProfile,
+    buildUpdate,
+
+    /**
+     * The signed-in shopper's profile.
+     *
+     * @param {string} userId
+     * @returns {Promise<object>}
+     */
+    getProfile: async (userId) => {
+        if (!userId) {
+            throw new ProfileError('Authentication required', 401, 'UNAUTHENTICATED');
+        }
+
+        const [rows] = await db.query(
+            `SELECT id, name, email, role, phone, address, city, state, zip,
+                    country, avatar, is_verified, is_active, created_at, updated_at
+               FROM users
+              WHERE id = ? AND deleted_at IS NULL
+              LIMIT 1`,
+            [userId]
+        );
+
+        const user = safeArray(rows)[0];
+
+        if (!user) {
+            throw new ProfileError('User not found', 404, 'NOT_FOUND');
+        }
+
+        // A deactivated account is answered the same way `getMe` answers it,
+        // so the two do not disagree about whether the session is usable.
+        if (Number(user.is_active) === 0) {
+            throw new ProfileError('Account has been deactivated', 403, 'ACCOUNT_DISABLED');
+        }
+
+        return toPublicProfile(user);
+    },
+
+    /**
+     * Save a partial profile update.
+     *
+     * Returns the stored profile, so the client renders what the server holds
+     * rather than what it hoped it sent -- which is exactly the gap that let
+     * "Profile saved successfully!" mean nothing.
+     *
+     * @param {string} userId
+     * @param {object} payload
+     * @returns {Promise<object>}
+     */
+    updateProfile: async (userId, payload) => {
+        if (!userId) {
+            throw new ProfileError('Authentication required', 401, 'UNAUTHENTICATED');
+        }
+
+        const { assignments, values } = buildUpdate(payload);
+
+        const [result] = await db.query(
+            `UPDATE users
+                SET ${assignments.join(', ')}, updated_by = ?
+              WHERE id = ? AND deleted_at IS NULL`,
+            [...values, userId, userId]
+        );
+
+        // affectedRows counts rows matched, not rows changed, so re-saving an
+        // unchanged profile is a success rather than a 404. Zero means the
+        // account is gone.
+        if (!result || result.affectedRows === 0) {
+            throw new ProfileError('User not found', 404, 'NOT_FOUND');
+        }
+
+        return profileService.getProfile(userId);
+    }
+};
+
+module.exports = profileService;
+module.exports.ProfileError = ProfileError;

--- a/backend/tests/profile.test.js
+++ b/backend/tests/profile.test.js
@@ -1,0 +1,486 @@
+// backend/tests/profile.test.js
+//
+// The signed-in shopper's own profile (#1548).
+//
+// There was no server side to this at all: both editors wrote to localStorage
+// and reported success, so a saved profile was gone on the next device and the
+// `phone`, `address`, `city`, `state`, `zip`, `country` and `avatar` columns on
+// `users` were written by nothing but signup.
+//
+// The database is mocked at the module boundary, as the rest of this suite
+// does. What is pinned here is not SQL text but the rules the endpoint has to
+// hold whatever the SQL looks like:
+//
+//   * only the fields that were sent are written, so a partial save does not
+//     blank the rest of the profile;
+//   * email is refused rather than silently dropped, because a caller that
+//     believes it changed one is the defect this replaces;
+//   * an unknown field is an error, for the same reason;
+//   * the widths come from the columns, so nothing that passes can be
+//     truncated on the way in;
+//   * an avatar can only be a scheme that is safe in an `<img src>`.
+
+jest.mock("../config/db", () => ({
+    query: jest.fn(),
+    getConnection: jest.fn()
+}));
+
+const db = require("../config/db");
+const profileService = require("../services/profileService");
+const { ProfileError } = require("../services/profileService");
+
+const USER = "11111111-1111-4111-8111-111111111111";
+
+const STORED_ROW = {
+    id: USER,
+    name: "Ishwari D",
+    email: "ishwari@example.com",
+    role: "customer",
+    phone: "9999999999",
+    address: "12 Main St",
+    city: "Kolhapur",
+    state: "MH",
+    zip: "416001",
+    country: "India",
+    avatar: "https://cdn.example.com/a.png",
+    is_verified: 1,
+    is_active: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z"
+};
+
+/** The UPDATE, plus the SELECT the service re-reads through afterwards. */
+function stubUpdateThenRead(row = STORED_ROW, affectedRows = 1) {
+    db.query.mockImplementation(async (sql) => {
+        if (/^\s*UPDATE users/i.test(sql)) {
+            return [{ affectedRows }];
+        }
+        return [[row]];
+    });
+}
+
+function updateStatement() {
+    return db.query.mock.calls.find(([sql]) => /^\s*UPDATE users/i.test(sql));
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    db.query.mockReset();
+});
+
+// ----------------------------------------------------------------------
+// Reading
+// ----------------------------------------------------------------------
+
+describe("profileService.getProfile", () => {
+    test("returns the columns a profile page edits", async () => {
+        db.query.mockResolvedValue([[STORED_ROW]]);
+
+        const profile = await profileService.getProfile(USER);
+
+        expect(profile).toMatchObject({
+            id: USER,
+            name: "Ishwari D",
+            email: "ishwari@example.com",
+            phone: "9999999999",
+            address: "12 Main St",
+            city: "Kolhapur",
+            state: "MH",
+            zip: "416001",
+            country: "India",
+            avatar: "https://cdn.example.com/a.png",
+            isVerified: true
+        });
+    });
+
+    test("never returns the password hash", async () => {
+        db.query.mockResolvedValue([[{ ...STORED_ROW, password: "$2a$hash" }]]);
+
+        const profile = await profileService.getProfile(USER);
+
+        expect(profile.password).toBeUndefined();
+        expect(db.query.mock.calls[0][0]).not.toMatch(/\bpassword\b/);
+    });
+
+    test("unset fields come back as null, not as empty strings", async () => {
+        db.query.mockResolvedValue([
+            [{ ...STORED_ROW, phone: "", address: null, city: null }]
+        ]);
+
+        const profile = await profileService.getProfile(USER);
+
+        expect(profile.phone).toBeNull();
+        expect(profile.address).toBeNull();
+        expect(profile.city).toBeNull();
+    });
+
+    test("is scoped to the caller and skips deleted accounts", async () => {
+        db.query.mockResolvedValue([[STORED_ROW]]);
+
+        await profileService.getProfile(USER);
+
+        const [sql, params] = db.query.mock.calls[0];
+
+        expect(sql).toMatch(/WHERE id = \?/);
+        expect(sql).toMatch(/deleted_at IS NULL/);
+        expect(params).toEqual([USER]);
+    });
+
+    test("an unknown account is a 404", async () => {
+        db.query.mockResolvedValue([[]]);
+
+        await expect(profileService.getProfile(USER)).rejects.toMatchObject({
+            status: 404,
+            code: "NOT_FOUND"
+        });
+    });
+
+    test("a deactivated account is a 403, matching getMe", async () => {
+        db.query.mockResolvedValue([[{ ...STORED_ROW, is_active: 0 }]]);
+
+        await expect(profileService.getProfile(USER)).rejects.toMatchObject({
+            status: 403,
+            code: "ACCOUNT_DISABLED"
+        });
+    });
+
+    test("no user id is a 401, not a query", async () => {
+        await expect(profileService.getProfile(null)).rejects.toMatchObject({
+            status: 401
+        });
+
+        expect(db.query).not.toHaveBeenCalled();
+    });
+});
+
+// ----------------------------------------------------------------------
+// Writing
+// ----------------------------------------------------------------------
+
+describe("profileService.updateProfile", () => {
+    test("writes only the fields that were sent", async () => {
+        stubUpdateThenRead();
+
+        await profileService.updateProfile(USER, { name: "Ishwari Deshmukh" });
+
+        const [sql, params] = updateStatement();
+
+        expect(sql).toMatch(/SET name = \?/);
+        expect(sql).not.toMatch(/phone = \?/);
+        expect(sql).not.toMatch(/address = \?/);
+        expect(params[0]).toBe("Ishwari Deshmukh");
+    });
+
+    test("a partial save does not blank the rest of the profile", async () => {
+        stubUpdateThenRead();
+
+        await profileService.updateProfile(USER, { phone: "9876543210" });
+
+        const [sql] = updateStatement();
+
+        expect(sql).toMatch(/phone = \?/);
+        expect(sql).not.toMatch(/\bname = \?/);
+    });
+
+    test("writes every supported field when all are sent", async () => {
+        stubUpdateThenRead();
+
+        await profileService.updateProfile(USER, {
+            name: "Ishwari D",
+            phone: "9999999999",
+            address: "12 Main St",
+            city: "Kolhapur",
+            state: "MH",
+            zip: "416001",
+            country: "India",
+            avatar: "https://cdn.example.com/a.png"
+        });
+
+        const [sql] = updateStatement();
+
+        for (const column of [
+            "name", "phone", "address", "city", "state", "zip", "country", "avatar"
+        ]) {
+            expect(sql).toMatch(new RegExp(`${column} = \\?`));
+        }
+    });
+
+    test("an explicitly emptied optional field is cleared to NULL", async () => {
+        stubUpdateThenRead();
+
+        await profileService.updateProfile(USER, { phone: "" });
+
+        const [, params] = updateStatement();
+
+        expect(params[0]).toBeNull();
+    });
+
+    test("the update is scoped to the caller", async () => {
+        stubUpdateThenRead();
+
+        await profileService.updateProfile(USER, { name: "Ishwari D" });
+
+        const [sql, params] = updateStatement();
+
+        expect(sql).toMatch(/WHERE id = \?/);
+        expect(sql).toMatch(/deleted_at IS NULL/);
+        expect(params[params.length - 1]).toBe(USER);
+    });
+
+    test("returns what the server stored, re-read after the write", async () => {
+        stubUpdateThenRead();
+
+        const profile = await profileService.updateProfile(USER, {
+            name: "Ishwari D"
+        });
+
+        expect(profile.name).toBe(STORED_ROW.name);
+        expect(
+            db.query.mock.calls.filter(([sql]) => /SELECT/i.test(sql))
+        ).toHaveLength(1);
+    });
+
+    test("an account that no longer exists is a 404", async () => {
+        stubUpdateThenRead(STORED_ROW, 0);
+
+        await expect(
+            profileService.updateProfile(USER, { name: "Ishwari D" })
+        ).rejects.toMatchObject({ status: 404 });
+    });
+});
+
+// ----------------------------------------------------------------------
+// What may not be written
+// ----------------------------------------------------------------------
+
+describe("profileService — refused fields", () => {
+    test("email is refused, with a reason", async () => {
+        await expect(
+            profileService.updateProfile(USER, { email: "new@example.com" })
+        ).rejects.toMatchObject({ code: "FIELD_NOT_EDITABLE" });
+
+        expect(db.query).not.toHaveBeenCalled();
+    });
+
+    test("the email refusal explains what to do instead", async () => {
+        await expect(
+            profileService.updateProfile(USER, { email: "new@example.com" })
+        ).rejects.toThrow(/verified/i);
+    });
+
+    test("email is refused even alongside fields that are allowed", async () => {
+        await expect(
+            profileService.updateProfile(USER, {
+                name: "Ishwari D",
+                email: "new@example.com"
+            })
+        ).rejects.toMatchObject({ code: "FIELD_NOT_EDITABLE" });
+
+        // Nothing is written. A partial save that quietly drops the email is
+        // how the frontend came to believe it had changed one.
+        expect(db.query).not.toHaveBeenCalled();
+    });
+
+    test("role is refused", async () => {
+        await expect(
+            profileService.updateProfile(USER, { role: "admin" })
+        ).rejects.toMatchObject({ code: "FIELD_NOT_EDITABLE" });
+    });
+
+    test("password is refused", async () => {
+        await expect(
+            profileService.updateProfile(USER, { password: "hunter2" })
+        ).rejects.toMatchObject({ code: "FIELD_NOT_EDITABLE" });
+    });
+
+    test("an unknown field is an error, not silently ignored", async () => {
+        await expect(
+            profileService.updateProfile(USER, { nickname: "Ish" })
+        ).rejects.toMatchObject({ code: "UNKNOWN_FIELD" });
+    });
+
+    test("the unknown-field error lists what is allowed", async () => {
+        try {
+            await profileService.updateProfile(USER, { nickname: "Ish" });
+            throw new Error("should have thrown");
+        } catch (error) {
+            expect(error.details.allowed).toEqual(
+                expect.arrayContaining(["name", "phone", "address", "avatar"])
+            );
+        }
+    });
+
+    test("an empty body is an error rather than a no-op success", async () => {
+        await expect(
+            profileService.updateProfile(USER, {})
+        ).rejects.toMatchObject({ code: "EMPTY_UPDATE" });
+    });
+
+    test("a non-object body is refused", async () => {
+        await expect(
+            profileService.updateProfile(USER, "name=x")
+        ).rejects.toBeInstanceOf(ProfileError);
+    });
+});
+
+// ----------------------------------------------------------------------
+// Validation
+// ----------------------------------------------------------------------
+
+describe("profileService — validation", () => {
+    test("name cannot be emptied", async () => {
+        await expect(
+            profileService.updateProfile(USER, { name: "   " })
+        ).rejects.toThrow(/name cannot be empty/i);
+    });
+
+    test("name has a minimum length", async () => {
+        await expect(
+            profileService.updateProfile(USER, { name: "I" })
+        ).rejects.toThrow(/at least 2/i);
+    });
+
+    test("a value wider than its column is refused, not truncated", async () => {
+        await expect(
+            profileService.updateProfile(USER, { city: "x".repeat(101) })
+        ).rejects.toThrow(/100 characters/);
+    });
+
+    test("the limits come from the column definitions", () => {
+        expect(profileService.PROFILE_FIELDS.name.maxLength).toBe(255);
+        expect(profileService.PROFILE_FIELDS.phone.maxLength).toBe(20);
+        expect(profileService.PROFILE_FIELDS.city.maxLength).toBe(100);
+        expect(profileService.PROFILE_FIELDS.zip.maxLength).toBe(20);
+    });
+
+    test("a nonsense phone number is refused", async () => {
+        await expect(
+            profileService.updateProfile(USER, { phone: "not a phone" })
+        ).rejects.toThrow(/valid phone/i);
+    });
+
+    test("an ordinary phone number is accepted", async () => {
+        stubUpdateThenRead();
+
+        await expect(
+            profileService.updateProfile(USER, { phone: "+91 98765 43210" })
+        ).resolves.toBeDefined();
+    });
+
+    test("a javascript: avatar is refused", async () => {
+        await expect(
+            profileService.updateProfile(USER, {
+                // eslint-disable-next-line no-script-url
+                avatar: "javascript:alert(1)"
+            })
+        ).rejects.toThrow(/http\(s\) URL or an image data URL/i);
+    });
+
+    test("an https avatar is accepted", async () => {
+        stubUpdateThenRead();
+
+        await expect(
+            profileService.updateProfile(USER, {
+                avatar: "https://cdn.example.com/a.png"
+            })
+        ).resolves.toBeDefined();
+    });
+
+    test("an image data URL is accepted, because that is what the file picker produces", async () => {
+        stubUpdateThenRead();
+
+        await expect(
+            profileService.updateProfile(USER, {
+                avatar: "data:image/png;base64,iVBORw0KGgo="
+            })
+        ).resolves.toBeDefined();
+    });
+
+    test("a non-image data URL is refused", async () => {
+        await expect(
+            profileService.updateProfile(USER, {
+                avatar: "data:text/html;base64,PHNjcmlwdD4="
+            })
+        ).rejects.toThrow(/http\(s\) URL or an image data URL/i);
+    });
+});
+
+// ----------------------------------------------------------------------
+// The HTTP surface
+// ----------------------------------------------------------------------
+
+describe("authController profile handlers", () => {
+    const { getProfile, updateProfile } = require("../controllers/authController");
+
+    function mockRes() {
+        return {
+            statusCode: null,
+            body: null,
+            status(code) {
+                this.statusCode = code;
+                return this;
+            },
+            json(payload) {
+                this.body = payload;
+                return this;
+            }
+        };
+    }
+
+    test("GET returns the profile", async () => {
+        db.query.mockResolvedValue([[STORED_ROW]]);
+
+        const res = mockRes();
+
+        await getProfile({ user: { id: USER } }, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.profile.email).toBe("ishwari@example.com");
+    });
+
+    test("PUT saves and answers with what was stored", async () => {
+        stubUpdateThenRead();
+
+        const res = mockRes();
+
+        await updateProfile(
+            { user: { id: USER }, body: { name: "Ishwari D" } },
+            res
+        );
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.profile.name).toBe("Ishwari D");
+    });
+
+    test("a refused field comes back as a 400 with its code", async () => {
+        const res = mockRes();
+
+        await updateProfile(
+            { user: { id: USER }, body: { email: "new@example.com" } },
+            res
+        );
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.code).toBe("FIELD_NOT_EDITABLE");
+    });
+
+    test("an unexpected failure is a 500 with nothing leaked", async () => {
+        db.query.mockRejectedValue(new Error("ER_LOCK_WAIT_TIMEOUT: table users"));
+
+        const res = mockRes();
+
+        await getProfile({ user: { id: USER } }, res);
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body.message).not.toMatch(/ER_LOCK_WAIT_TIMEOUT/);
+    });
+
+    test("an unauthenticated caller is a 401", async () => {
+        const res = mockRes();
+
+        await getProfile({}, res);
+
+        expect(res.statusCode).toBe(401);
+    });
+});

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -420,6 +420,8 @@
 
                 <form id="settings-form">
 
+                    <label for="settings-name">Full Name</label>
+
                     <input
                         type="text"
                         id="settings-name"
@@ -427,11 +429,32 @@
                         required
                     >
 
+                    <label for="settings-email">Email Address</label>
+
+                    <!-- Read-only. Changing the address on an account is an
+                         identity change and goes through verification, not
+                         through a profile save (#1548). -->
                     <input
                         type="email"
                         id="settings-email"
                         placeholder="Email Address"
-                        required
+                        readonly
+                        aria-readonly="true"
+                    >
+
+                    <small class="settings-hint">
+
+                        Your email address cannot be changed here.
+
+                    </small>
+
+                    <label for="settings-phone">Phone Number</label>
+
+                    <input
+                        type="tel"
+                        id="settings-phone"
+                        placeholder="Phone Number"
+                        autocomplete="tel"
                     >
 
                     <button type="submit">

--- a/frontend/scripts/dashboard-settings.js
+++ b/frontend/scripts/dashboard-settings.js
@@ -1,3 +1,17 @@
+// The dashboard settings tab (#1548).
+//
+// This wrote the form straight into the cached `user` object in localStorage
+// and reported success. Nothing was sent anywhere, so the change was gone on
+// the next device -- and because the profile page wrote a different key with a
+// different field set, editing your name here did not change it there either.
+//
+// Worse, `email` went into that cached object. It is the identity the rest of
+// the frontend reads, so the UI started showing an address the account could
+// not be signed in with, while the real address was untouched. The API refuses
+// an email change for exactly that reason, and the field is read-only here.
+//
+// Both editors now speak to the same endpoint and hold the same profile.
+
 // dashboard settings elements
 const dashboardSettingsElements = {
     settingsForm:
@@ -13,117 +27,281 @@ const dashboardSettingsElements = {
     settingsEmail:
         document.getElementById(
             "settings-email"
+        ),
+
+    settingsPhone:
+        document.getElementById(
+            "settings-phone"
         )
 };
 
 // validate profile
+//
+// A courtesy check only. profileService validates every field again against
+// the actual `users` column widths, because a browser is not somewhere a
+// constraint can live.
 function validateDashboardProfile(
-    name,
-    email
+    name
 ) {
     if (
-        !name ||
-        !email
+        !name
     ) {
         notify(
-            "All profile fields are required",
+            "Name is required",
             "error"
         );
         return false;
     }
-
-    const emailRegex =
-        /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
     if (
-        !emailRegex.test(
-            email
-        )
+        name.length < 2
     ) {
         notify(
-            "Invalid email address",
+            "Name must be at least 2 characters",
             "error"
         );
         return false;
     }
+
     return true;
 }
 
-// save profile
-function saveDashboardProfile(
-    event
-) {
-    event.preventDefault();
-    const user =
-        AppUtils.getJSON(
-            "user",
-            {}
-        );
+/**
+ * The email field is read-only.
+ *
+ * Editing it used to "save" a new address locally while the account kept the
+ * old one. Changing an account's email is an identity change and belongs with
+ * the verification flow, so the field says so rather than inviting an edit
+ * that cannot land.
+ */
+function lockDashboardEmailField() {
+    const field =
+        dashboardSettingsElements.settingsEmail;
 
-    const updatedUser = {
-        ...user,
-
-        name:
-            dashboardSettingsElements
-                .settingsName
-                ?.value
-                .trim(),
-
-        email:
-            dashboardSettingsElements
-                .settingsEmail
-                ?.value
-                .trim()
-    };
-
-    const valid =
-        validateDashboardProfile(
-            updatedUser.name,
-            updatedUser.email
-        );
-
-    if (!valid) {
+    if (!field) {
         return;
     }
 
-    AppUtils.setJSON(
-        "user",
-        updatedUser
+    field.readOnly = true;
+    field.setAttribute(
+        "aria-readonly",
+        "true"
     );
+    field.title =
+        "Your email address cannot be changed here";
+}
 
-    // update dashboard UI
+/**
+ * Show the profile the server holds.
+ *
+ * The dashboard used to fill these fields from the cached `user` object, which
+ * is a copy of the session and carries no phone number at all.
+ */
+function applyDashboardProfile(
+    profile
+) {
+    if (!profile) {
+        return;
+    }
+
+    if (
+        dashboardSettingsElements.settingsName
+    ) {
+        dashboardSettingsElements.settingsName.value =
+            profile.name || "";
+    }
+
+    if (
+        dashboardSettingsElements.settingsEmail
+    ) {
+        dashboardSettingsElements.settingsEmail.value =
+            profile.email || "";
+    }
+
+    if (
+        dashboardSettingsElements.settingsPhone
+    ) {
+        dashboardSettingsElements.settingsPhone.value =
+            profile.phone || "";
+    }
+
     if (
         dashboardElements?.userName
     ) {
         dashboardElements.userName.innerText =
-            updatedUser.name;
+            profile.name || "User";
     }
 
     if (
         dashboardElements?.userEmail
     ) {
         dashboardElements.userEmail.innerText =
-            updatedUser.email;
+            profile.email || "";
+    }
+}
+
+// load profile
+async function loadDashboardProfile() {
+    if (
+        !dashboardSettingsElements.settingsForm
+    ) {
+        return;
     }
 
-    notify(
-        "Profile updated successfully!",
-        "success"
-    );
+    try {
+        const response =
+            await AppUtils.apiRequest(
+                "/auth/profile"
+            );
+
+        if (
+            response
+            &&
+            response.success
+        ) {
+            applyDashboardProfile(
+                response.profile
+            );
+        }
+    } catch (error) {
+        // The tab is still usable from the cached session copy, so this is a
+        // console note rather than a toast on a panel the shopper may not even
+        // have opened.
+        console.error(
+            "Failed to load profile:",
+            error
+        );
+    }
+}
+
+// save profile
+async function saveDashboardProfile(
+    event
+) {
+    event.preventDefault();
+
+    const name =
+        dashboardSettingsElements
+            .settingsName
+            ?.value
+            .trim();
+
+    const phone =
+        dashboardSettingsElements
+            .settingsPhone
+            ?.value
+            .trim();
+
+    if (
+        !validateDashboardProfile(name)
+    ) {
+        return;
+    }
+
+    const submitButton =
+        dashboardSettingsElements
+            .settingsForm
+            ?.querySelector(
+                "button[type='submit']"
+            );
+
+    if (submitButton) {
+        submitButton.disabled = true;
+    }
+
+    try {
+        // `email` is deliberately absent: the API refuses it, and sending it
+        // would fail the whole save rather than being quietly dropped.
+        // `phone` is only sent when the field exists on the page.
+        const payload = { name };
+
+        if (
+            dashboardSettingsElements.settingsPhone
+        ) {
+            payload.phone = phone;
+        }
+
+        const response =
+            await AppUtils.apiRequest(
+                "/auth/profile",
+                {
+                    method: "PUT",
+                    body: JSON.stringify(payload)
+                }
+            );
+
+        if (
+            !response
+            ||
+            !response.success
+        ) {
+            throw new Error(
+                (response && response.message)
+                || "Profile could not be saved"
+            );
+        }
+
+        // Rendered from what the server stored, not from what was typed. A
+        // success message about a request that never landed is the defect this
+        // replaces.
+        applyDashboardProfile(
+            response.profile
+        );
+
+        // The name is on the navbar, so the cached session copy moves with it.
+        // The email is not touched -- the server did not change it.
+        const cachedUser =
+            AppUtils.getJSON("user", {}) || {};
+
+        AppUtils.setJSON(
+            "user",
+            {
+                ...cachedUser,
+                name: response.profile?.name || name
+            }
+        );
+
+        notify(
+            "Profile updated",
+            "success"
+        );
+    } catch (error) {
+        console.error(
+            "Failed to save profile:",
+            error
+        );
+
+        notify(
+            error.message
+            || "Failed to save profile. Please try again.",
+            "error"
+        );
+    } finally {
+        if (submitButton) {
+            submitButton.disabled = false;
+        }
+    }
 }
 
 // bind form
 if (
     dashboardSettingsElements.settingsForm
 ) {
+    lockDashboardEmailField();
+
     dashboardSettingsElements
         .settingsForm
         .addEventListener(
             "submit",
             saveDashboardProfile
         );
+
+    loadDashboardProfile();
 }
 
 // expose globally
 window.saveDashboardProfile =
     saveDashboardProfile;
+
+window.loadDashboardProfile =
+    loadDashboardProfile;

--- a/frontend/scripts/profile.js
+++ b/frontend/scripts/profile.js
@@ -1,10 +1,25 @@
+// The profile page (#1548).
+//
+// This used to be a `localStorage` editor. `saveProfile` wrote a
+// `profile_<email>` key, `loadProfile` read it straight back, and the success
+// toast fired without a single request leaving the browser -- so the change
+// was gone on any other device, gone after clearing site data, and invisible
+// to the dashboard settings tab, which kept its own separate copy under a
+// different key.
+//
+// The server owns the profile now. `localStorage` is kept as a first-paint
+// cache so the page is not blank while the request is in flight, and it is
+// only ever written from what the server confirmed it stored.
+
 const currentUser = AppUtils.getJSON("user");
 
 if (!currentUser) {
     window.location.href = "signin.html";
 }
 
-const PROFILE_KEY = `profile_${currentUser.email}`;
+// Read on first paint, written only from a server response. Never the source
+// of truth.
+const PROFILE_CACHE_KEY = `profile_${currentUser?.email}`;
 const MAX_AVATAR_SIZE = 5 * 1024 * 1024;
 const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 let hasUnsavedChanges = false;
@@ -71,6 +86,9 @@ function hideError() {
     }
 }
 
+// Client-side validation is a courtesy, not the rule. profileService checks
+// every one of these again against the actual column widths, because a browser
+// is not somewhere a constraint can live.
 function validateInputs(name, phone, address, bio) {
     const errors = [];
 
@@ -96,46 +114,113 @@ function validateInputs(name, phone, address, bio) {
     return errors;
 }
 
-function loadProfile() {
+/**
+ * Paint a profile object onto the page.
+ *
+ * Split out of `loadProfile` because the same rendering runs twice: once from
+ * the cache on first paint, once from the server's answer.
+ */
+function renderProfile(profile) {
+    if (profileElements.sidebarName) {
+        profileElements.sidebarName.textContent = profile.name;
+    }
+    if (profileElements.sidebarEmail) {
+        profileElements.sidebarEmail.textContent = profile.email;
+    }
+    if (profileElements.profilePreview) {
+        profileElements.profilePreview.src = profile.avatar;
+        profileElements.profilePreview.alt = `${profile.name}'s avatar`;
+    }
+
+    if (profileElements.viewName) profileElements.viewName.textContent = profile.name;
+    if (profileElements.viewEmail) profileElements.viewEmail.textContent = profile.email;
+    if (profileElements.viewPhone) profileElements.viewPhone.textContent = profile.phone || "-";
+    if (profileElements.viewAddress) profileElements.viewAddress.textContent = profile.address || "-";
+    if (profileElements.viewBio) profileElements.viewBio.textContent = profile.bio || "-";
+
+    if (profileElements.profileName) profileElements.profileName.value = profile.name;
+    if (profileElements.profileEmail) profileElements.profileEmail.value = profile.email;
+    if (profileElements.profilePhone) profileElements.profilePhone.value = profile.phone;
+    if (profileElements.profileAddress) profileElements.profileAddress.value = profile.address;
+    if (profileElements.profileBio) profileElements.profileBio.value = profile.bio;
+}
+
+/**
+ * Fill in the fields the API does not carry.
+ *
+ * `bio` has never had a column; it stays local until one exists, and is marked
+ * here rather than silently posted to an endpoint that would reject it as an
+ * unknown field.
+ */
+function toViewModel(apiProfile, cached = {}) {
+    return {
+        name: apiProfile.name || currentUser?.name || "User",
+        email: apiProfile.email || currentUser?.email || "",
+        phone: apiProfile.phone || "",
+        address: apiProfile.address || "",
+        bio: cached.bio || "",
+        avatar:
+            apiProfile.avatar
+            || cached.avatar
+            || currentUser?.image
+            || currentUser?.photoURL
+            || getDefaultAvatar(apiProfile.name || currentUser?.name)
+    };
+}
+
+/**
+ * The email field is read-only.
+ *
+ * It was editable, and "saving" it wrote the typed address into the cached
+ * `user` object -- the identity the rest of the frontend reads -- while the
+ * account kept the old one. The UI then showed an address the shopper could
+ * not sign in with. Changing an account's email is an identity change and
+ * belongs with the verification flow, so the API refuses it and the field says
+ * so rather than inviting an edit that cannot land.
+ */
+function lockEmailField() {
+    const field = profileElements.profileEmail;
+
+    if (!field) return;
+
+    field.readOnly = true;
+    field.setAttribute("aria-readonly", "true");
+    field.title = "Your email address cannot be changed here";
+}
+
+async function loadProfile() {
     try {
         hideError();
         showLoading();
 
-        const savedProfile = AppUtils.getJSON(PROFILE_KEY) || {};
+        // First paint from the cache so the page is not blank while the
+        // request is in flight. This is a mirror, not the record.
+        const cached = AppUtils.getJSON(PROFILE_CACHE_KEY) || {};
 
-        const profile = {
-            name: savedProfile.name || currentUser.name || "User",
-            email: savedProfile.email || currentUser.email || "",
-            phone: savedProfile.phone || "",
-            address: savedProfile.address || "",
-            bio: savedProfile.bio || "",
-            avatar: savedProfile.avatar || currentUser.image || currentUser.photoURL || getDefaultAvatar(currentUser.name)
-        };
-
-        if (profileElements.sidebarName) {
-            profileElements.sidebarName.textContent = profile.name;
-        }
-        if (profileElements.sidebarEmail) {
-            profileElements.sidebarEmail.textContent = profile.email;
-        }
-        if (profileElements.profilePreview) {
-            profileElements.profilePreview.src = profile.avatar;
-            profileElements.profilePreview.alt = `${profile.name}'s avatar`;
+        if (cached.name) {
+            renderProfile(toViewModel(cached, cached));
         }
 
-        if (profileElements.viewName) profileElements.viewName.textContent = profile.name;
-        if (profileElements.viewEmail) profileElements.viewEmail.textContent = profile.email;
-        if (profileElements.viewPhone) profileElements.viewPhone.textContent = profile.phone || "-";
-        if (profileElements.viewAddress) profileElements.viewAddress.textContent = profile.address || "-";
-        if (profileElements.viewBio) profileElements.viewBio.textContent = profile.bio || "-";
+        const response = await AppUtils.apiRequest("/auth/profile");
 
-        if (profileElements.profileName) profileElements.profileName.value = profile.name;
-        if (profileElements.profileEmail) profileElements.profileEmail.value = profile.email;
-        if (profileElements.profilePhone) profileElements.profilePhone.value = profile.phone;
-        if (profileElements.profileAddress) profileElements.profileAddress.value = profile.address;
-        if (profileElements.profileBio) profileElements.profileBio.value = profile.bio;
+        if (!response || !response.success || !response.profile) {
+            throw new Error(
+                (response && response.message) || "Profile could not be loaded"
+            );
+        }
 
-        const hasProfileData = savedProfile.name || savedProfile.phone || savedProfile.address || savedProfile.bio;
+        const profile = toViewModel(response.profile, cached);
+
+        renderProfile(profile);
+        AppUtils.setJSON(PROFILE_CACHE_KEY, profile);
+
+        // A profile with nothing filled in opens in edit mode, which is what
+        // it did before -- a page of dashes invites nothing.
+        const hasProfileData =
+            response.profile.phone
+            || response.profile.address
+            || profile.bio;
+
         if (hasProfileData) {
             showViewMode();
         } else {
@@ -143,21 +228,26 @@ function loadProfile() {
         }
 
         hideLoading();
-
     } catch (error) {
         console.error("Error loading profile:", error);
         hideLoading();
-        showError("Failed to load profile. Please refresh the page.");
+        showError(
+            error.message || "Failed to load profile. Please refresh the page."
+        );
     }
 }
 
-function saveProfile() {
+async function saveProfile() {
+    const submitButton = profileElements.profileForm?.querySelector(
+        "button[type='submit']"
+    );
+
     try {
         const name = profileElements.profileName.value.trim();
-        const email = profileElements.profileEmail.value.trim();
         const phone = profileElements.profilePhone.value.trim();
         const address = profileElements.profileAddress.value.trim();
         const bio = profileElements.profileBio.value.trim();
+        const avatar = profileElements.profilePreview.src;
 
         const errors = validateInputs(name, phone, address, bio);
         if (errors.length > 0) {
@@ -165,26 +255,48 @@ function saveProfile() {
             return;
         }
 
-        const profile = {
-            name: name,
-            email: email,
-            phone: phone,
-            address: address,
-            bio: bio,
-            avatar: profileElements.profilePreview.src
-        };
+        if (submitButton) submitButton.disabled = true;
 
-        AppUtils.setJSON(PROFILE_KEY, profile);
-        loadProfile();
-        AppUtils.notify("Profile saved successfully!", "success");
+        // `email` is deliberately absent. The API refuses it, and sending it
+        // would fail the whole save rather than being quietly dropped.
+        // `bio` has no column yet, so it stays out of the request and in the
+        // local cache.
+        const response = await AppUtils.apiRequest("/auth/profile", {
+            method: "PUT",
+            body: JSON.stringify({ name, phone, address, avatar })
+        });
 
-        setTimeout(() => {
-            window.location.href = "index.html";
-        }, 1000);
+        if (!response || !response.success) {
+            throw new Error(
+                (response && response.message) || "Profile could not be saved"
+            );
+        }
 
+        // Cached from the server's answer, not from what was typed. A save
+        // that reports success on a request that never landed is the whole
+        // defect this replaces.
+        const stored = toViewModel(response.profile, { bio, avatar });
+
+        renderProfile(stored);
+        AppUtils.setJSON(PROFILE_CACHE_KEY, stored);
+
+        // The name is on the navbar, so the cached session copy moves with it.
+        // The email is not touched: the API did not change it.
+        const cachedUser = AppUtils.getJSON("user", {}) || {};
+        AppUtils.setJSON("user", { ...cachedUser, name: stored.name });
+
+        hasUnsavedChanges = false;
+        showViewMode();
+
+        AppUtils.notify("Profile saved", "success");
     } catch (error) {
         console.error("Error saving profile:", error);
-        AppUtils.notify("Failed to save profile. Please try again.", "error");
+        AppUtils.notify(
+            error.message || "Failed to save profile. Please try again.",
+            "error"
+        );
+    } finally {
+        if (submitButton) submitButton.disabled = false;
     }
 }
 
@@ -263,6 +375,7 @@ window.addEventListener("beforeunload", (event) => {
 });
 
 document.addEventListener("DOMContentLoaded", () => {
+    lockEmailField();
     loadProfile();
     setupFormTracking();
 });
@@ -276,5 +389,8 @@ export {
     getDefaultAvatar,
     validateInputs,
     handleAvatarUpload,
-    setupFormTracking
+    setupFormTracking,
+    renderProfile,
+    toViewModel,
+    lockEmailField
 };


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

Editing your profile did nothing.

`profile.js` wrote a `profile_<email>` key to `localStorage`. `dashboard-settings.js` wrote the cached `user` object. Both then fired a success toast. Not a single request left the browser — and there was nothing to send one to: `routes/index.js` mounts nineteen routers and none of them serves a profile, and `authRoutes.js` has signup, login, logout, OTP, password reset and session management, with no `GET` or `PUT` for the signed-in user.

What that cost:

- **The change was gone on any other device**, and gone after clearing site data. No error, no warning — the toast said it worked.
- **The two editors disagreed.** Different keys, different field sets, so a name changed on the profile page did not appear in the dashboard settings tab.
- **The email field was worse than useless.** `dashboard-settings.js` wrote the typed address into the cached `user` object — the identity the rest of the frontend reads — while the account kept the old one. The UI then showed an address the shopper could not sign in with.
- `users.phone`, `.address`, `.city`, `.state`, `.zip`, `.country` and `.avatar` have been in the schema since the baseline and were written by nothing but signup.

Same shape of defect as #1459 (the newsletter form that validated, waited, and thanked you, with nothing behind it).

### What changed

**`backend/services/profileService.js`** — new. The rules live here rather than in the controller, because the columns *are* the constraint:

- **Partial updates.** Only fields present in the body are written, so `{name}` does not blank the phone number. Same rule the address book uses.
- **Email, password, role and id are refused with a reason**, and the whole save fails rather than quietly dropping them. Silently ignoring an email change is how the frontend came to believe it had made one.
- **An unknown field is a 400 that lists what is allowed** — a client sending one believes it is saving something.
- **The widths come from the column definitions** (`name` 255, `phone` 20, `city` 100, …), so nothing that passes here can be truncated on the way in.
- **An avatar must be an `http(s)` URL or an image `data:` URL.** The value ends up in an `<img src>`; a `javascript:` one there is stored XSS, and the repo has already had one class of that (#1276).
- **The stored profile is re-read and returned**, so the client renders what the server holds rather than what it hoped it sent.

**`GET /api/auth/profile`** and **`PUT /api/auth/profile`**, both behind `authMiddleware`. Distinct from `/auth/me`, which returns the four fields a session needs. Documented in the OpenAPI spec with `Profile`, `ProfileSuccess` and `ProfileUpdateRequest` schemas.

**Both editors now call it** and hold the same profile. `localStorage` stays as a first-paint cache so the page is not blank while the request is in flight, and it is only ever written from what the server confirmed it stored. Failures surface — a save that did not reach the server no longer reports success.

**The email field is read-only in both**, with the reason on the page. Changing an account's address is an identity change and belongs with the verification flow.

**The dashboard settings tab gains the phone field** it never had, plus `<label>`s for the inputs it was rendering as bare placeholders.

---

## 🔗 Related Issue

Closes: #1548

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] New feature
- [x] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Documentation update
- [x] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 🧪 Tests

New suite, `backend/tests/profile.test.js` — 38 cases.

**Reading** — returns the columns a profile page edits; never returns the password hash (asserted on the response *and* on the SQL); unset fields come back as `null` rather than `""`; scoped to the caller and skipping deleted accounts; unknown account is a 404; deactivated account is a 403 matching `getMe`; no user id is a 401 rather than a query.

**Writing** — writes only the fields that were sent; a partial save does not blank the rest; all eight fields when all are sent; an explicitly emptied optional field clears to `NULL`; the update is scoped to the caller; returns what the server stored, re-read after the write; a vanished account is a 404.

**Refused fields** — email refused with a reason; the reason explains what to do instead; **email refused even alongside allowed fields, with nothing written**; role, password and id refused; an unknown field errors and lists what is allowed; an empty body errors rather than succeeding as a no-op; a non-object body is refused.

**Validation** — name cannot be emptied and has a minimum length; a value wider than its column is refused rather than truncated; the limits match the column definitions; a nonsense phone is refused and an ordinary one accepted; a `javascript:` avatar is refused; `https:` and image `data:` URLs accepted; a `data:text/html` avatar refused.

**The HTTP surface** — `GET` returns the profile; `PUT` saves and answers with what was stored; a refused field is a 400 carrying its code; an unexpected failure is a 500 with the driver error not leaked; an unauthenticated caller is a 401.

Local run:

```
Test Suites: 87 passed, 87 total
Tests:       1954 passed, 1954 total
```

Plus `check:syntax`, `check:boot`, `check:modules`, `check:sitemap`, `check:a11y` — all green.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Two things left deliberately out of scope**, both worth their own issue:

1. **`bio` has no column.** The profile page has the field, so it stays in the local cache and is not sent — rather than being posted to an endpoint that would (correctly) reject it as unknown. Adding `users.bio` is a migration and belongs with a change that exercises it.
2. **Changing your email.** Refused here on purpose. It needs the existing verification flow, not a profile save.

`/auth/me` is untouched — it is what the session bootstrap reads, and narrowing or widening it was not needed.
