### PR TITLE
fix(agent): add ownership and role authorization checks on agent query routes

### DIFF
--- a/backend/controllers/agentController.js
+++ b/backend/controllers/agentController.js
@@ -1,3 +1,4 @@
+const AgentIdentity = require('../models/AgentIdentity');
 const AgentIdentityService = require('../services/agentIdentityService');
 const TrustScoringService = require('../services/trustScoringService');
 const ReputationService = require('../services/reputationService');
@@ -62,16 +63,24 @@ exports.getAgent = async (req, res) => {
     try {
         const { agentId } = req.params;
 
-        const agent = await AgentIdentityService.getAgentIdentity(agentId);
+        const agentData = await AgentIdentityService.getAgentIdentity(agentId);
+        if (!agentData || !agentData.agent) {
+            return res.status(404).json({ error: "Agent not found" });
+        }
+
+        if (req.user.role !== 'admin' && String(agentData.agent.ownerId) !== String(req.user.id)) {
+            return res.status(403).json({ error: "Access denied. You do not own this agent." });
+        }
 
         res.status(200).json({
             success: true,
-            data: agent
+            data: agentData
         });
     } catch (error) {
         console.error("Get agent error:", error);
-        res.status(500).json({
-            error: "Failed to get agent"
+        const status = error.message === 'Agent not found' ? 404 : 500;
+        res.status(status).json({
+            error: error.message || "Failed to get agent"
         });
     }
 };
@@ -82,6 +91,15 @@ exports.getAgent = async (req, res) => {
 exports.getTrustScore = async (req, res) => {
     try {
         const { agentId } = req.params;
+
+        const agent = await AgentIdentity.findOne({ agentId });
+        if (!agent) {
+            return res.status(404).json({ error: "Agent not found" });
+        }
+
+        if (req.user.role !== 'admin' && String(agent.ownerId) !== String(req.user.id)) {
+            return res.status(403).json({ error: "Access denied. You do not own this agent." });
+        }
 
         const score = await TrustScoringService.getTrustScoreDetails(agentId);
 
@@ -104,6 +122,15 @@ exports.getReputation = async (req, res) => {
     try {
         const { agentId } = req.params;
 
+        const agent = await AgentIdentity.findOne({ agentId });
+        if (!agent) {
+            return res.status(404).json({ error: "Agent not found" });
+        }
+
+        if (req.user.role !== 'admin' && String(agent.ownerId) !== String(req.user.id)) {
+            return res.status(403).json({ error: "Access denied. You do not own this agent." });
+        }
+
         const reputation = await ReputationService.getAgentReputation(agentId);
 
         res.status(200).json({
@@ -125,6 +152,15 @@ exports.getTransactions = async (req, res) => {
     try {
         const { agentId } = req.params;
         const { limit = 50 } = req.query;
+
+        const agent = await AgentIdentity.findOne({ agentId });
+        if (!agent) {
+            return res.status(404).json({ error: "Agent not found" });
+        }
+
+        if (req.user.role !== 'admin' && String(agent.ownerId) !== String(req.user.id)) {
+            return res.status(403).json({ error: "Access denied. You do not own this agent." });
+        }
 
         const transactions = await AgentTransaction.find({ agentId })
             .sort({ timestamp: -1 })

--- a/backend/tests/agentAuth.test.js
+++ b/backend/tests/agentAuth.test.js
@@ -1,0 +1,74 @@
+const agentController = require('../controllers/agentController');
+const AgentIdentity = require('../models/AgentIdentity');
+const AgentIdentityService = require('../services/agentIdentityService');
+const TrustScoringService = require('../services/trustScoringService');
+const ReputationService = require('../services/reputationService');
+const AgentTransaction = require('../models/AgentTransaction');
+
+jest.mock('../models/AgentIdentity');
+jest.mock('../services/agentIdentityService');
+jest.mock('../services/trustScoringService');
+jest.mock('../services/reputationService');
+jest.mock('../models/AgentTransaction');
+
+describe('Agent Controller Authorization Checks', () => {
+    let req;
+    let res;
+
+    beforeEach(() => {
+        req = {
+            params: { agentId: 'agent-123' },
+            query: {},
+            user: { id: 'user-1', role: 'customer' }
+        };
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn()
+        };
+        jest.clearAllMocks();
+    });
+
+    test('getAgent should return 403 when user does not own the agent', async () => {
+        AgentIdentityService.getAgentIdentity.mockResolvedValue({
+            agent: { agentId: 'agent-123', ownerId: 'user-2' },
+            trustScore: { score: 95 }
+        });
+
+        await agentController.getAgent(req, res);
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            error: expect.stringContaining('Access denied')
+        }));
+    });
+
+    test('getAgent should return 200 when user is the owner', async () => {
+        AgentIdentityService.getAgentIdentity.mockResolvedValue({
+            agent: { agentId: 'agent-123', ownerId: 'user-1' },
+            trustScore: { score: 95 }
+        });
+
+        await agentController.getAgent(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            success: true
+        }));
+    });
+
+    test('getAgent should return 200 when user is an admin', async () => {
+        req.user = { id: 'admin-user', role: 'admin' };
+        AgentIdentityService.getAgentIdentity.mockResolvedValue({
+            agent: { agentId: 'agent-123', ownerId: 'user-2' },
+            trustScore: { score: 95 }
+        });
+
+        await agentController.getAgent(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    test('getTransactions should return 403 when user does not own the agent', async () => {
+        AgentIdentity.findOne.mockResolvedValue({ agentId: 'agent-123', ownerId: 'user-2' });
+
+        await agentController.getTransactions(req, res);
+        expect(res.status).toHaveBeenCalledWith(403);
+    });
+});


### PR DESCRIPTION
## Description
Fixes missing ownership and authorization verification on AI Agent query routes (\getAgent\, \getTrustScore\, \getReputation\, \getTransactions\) in \ackend/controllers/agentController.js\. Previously, any authenticated user could inspect any other user's private agent details and transaction history.

## Related Issue
Closes #1555

## Clean Architecture & Changes
- Added agent ownership verification (\eq.user.role === 'admin' || String(agent.ownerId) === String(req.user.id)\) across all agent query endpoints.
- Added comprehensive unit tests in \ackend/tests/agentAuth.test.js\ covering owner access, admin elevation, and non-owner 403 Forbidden rejection.

## Verification
- Run \
px jest tests/agentAuth.test.js\ (All 4 tests passing cleanly).