### PR TITLE
fix(saga): track compensation errors and set partial status on rollback failures

### DIFF
--- a/backend/services/sagaOrchestratorService.js
+++ b/backend/services/sagaOrchestratorService.js
@@ -233,6 +233,8 @@ class SagaOrchestrator extends EventEmitter {
         // Execute compensations in reverse order
         const compensationSteps = saga.compensations.reverse();
 
+        let hasCompensationFailure = false;
+
         for (const compensation of compensationSteps) {
             try {
                 console.log(`🔄 Executing compensation for: ${compensation.step}`);
@@ -245,8 +247,16 @@ class SagaOrchestrator extends EventEmitter {
                 });
 
             } catch (error) {
+                hasCompensationFailure = true;
+                compensation.executed = false;
+                compensation.error = error.message;
+                saga.errors.push({
+                    step: compensation.step,
+                    phase: 'compensation',
+                    error: error.message,
+                    timestamp: new Date().toISOString()
+                });
                 console.error(`Compensation failed for step: ${compensation.step}`, error);
-                // Log compensation failure but continue
                 this.emit('compensation.failed', {
                     sagaId: saga.id,
                     step: compensation.step,
@@ -255,10 +265,14 @@ class SagaOrchestrator extends EventEmitter {
             }
         }
 
-        saga.status = SAGA_STATUS.COMPENSATED;
+        saga.status = hasCompensationFailure ? SAGA_STATUS.PARTIAL : SAGA_STATUS.COMPENSATED;
         saga.updatedAt = new Date().toISOString();
 
-        this.emit('saga.compensated', { sagaId: saga.id });
+        if (hasCompensationFailure) {
+            this.emit('saga.compensation_partial', { sagaId: saga.id, errors: saga.errors });
+        } else {
+            this.emit('saga.compensated', { sagaId: saga.id });
+        }
 
         await this.storeSaga(saga);
     }

--- a/backend/tests/sagaCompensation.test.js
+++ b/backend/tests/sagaCompensation.test.js
@@ -1,0 +1,50 @@
+const { SagaOrchestrator, SAGA_STATUS } = require('../services/sagaOrchestratorService');
+
+describe('SagaOrchestrator - Compensation Error Handling', () => {
+    let orchestrator;
+
+    beforeEach(() => {
+        orchestrator = new SagaOrchestrator();
+        jest.spyOn(orchestrator, 'storeSaga').mockResolvedValue();
+    });
+
+    test('should set status to COMPENSATED when all compensation steps succeed', async () => {
+        const handlerMock = jest.fn().mockResolvedValue();
+        const saga = {
+            id: 'saga-1',
+            status: SAGA_STATUS.FAILED,
+            context: {},
+            compensations: [
+                { step: 'releaseInventory', handler: handlerMock, data: {} }
+            ],
+            errors: []
+        };
+
+        await orchestrator.compensateSaga(saga, 0);
+        expect(saga.status).toBe(SAGA_STATUS.COMPENSATED);
+        expect(handlerMock).toHaveBeenCalledTimes(1);
+        expect(saga.errors.length).toBe(0);
+    });
+
+    test('should set status to PARTIAL and record errors when compensation step throws', async () => {
+        const failingHandler = jest.fn().mockRejectedValue(new Error('Gateway timeout on refund'));
+        const saga = {
+            id: 'saga-2',
+            status: SAGA_STATUS.FAILED,
+            context: {},
+            compensations: [
+                { step: 'refundPayment', handler: failingHandler, data: {} }
+            ],
+            errors: []
+        };
+
+        await orchestrator.compensateSaga(saga, 0);
+        expect(saga.status).toBe(SAGA_STATUS.PARTIAL);
+        expect(saga.errors.length).toBe(1);
+        expect(saga.errors[0]).toEqual(expect.objectContaining({
+            step: 'refundPayment',
+            phase: 'compensation',
+            error: 'Gateway timeout on refund'
+        }));
+    });
+});


### PR DESCRIPTION
## Description
Fixes error suppression during saga compensation rollback in \ackend/services/sagaOrchestratorService.js\. Previously, when any compensation step threw an error, the error was only logged, and the saga was still erroneously marked as \COMPENSATED\.

## Related Issue
Closes #1556

## Clean Architecture & Changes
- In \compensateSaga()\, capture compensation exceptions, record failure context in \saga.errors\, and set \saga.status = SAGA_STATUS.PARTIAL\ on failures.
- Emit \saga.compensation_partial\ event for operator awareness.
- Added unit tests in \ackend/tests/sagaCompensation.test.js\ validating full vs partial compensation status transitions.

## Verification
- Run \
px jest tests/sagaCompensation.test.js\ (All unit tests passing cleanly).