### PR TITLE
fix(contact): support numeric admin IDs and validate status transitions

### DIFF
--- a/backend/services/contactService.js
+++ b/backend/services/contactService.js
@@ -350,7 +350,7 @@ async function getMessage(id) {
 async function updateStatus(id, status, adminId) {
     const messageId = Math.trunc(safeNumber(id));
     const next = sanitizeString(status).toLowerCase();
-    const actor = safeUUID(adminId);
+    const actor = safeUUID(adminId) || (Number.isInteger(Number(adminId)) && Number(adminId) > 0 ? Number(adminId) : null);
 
     if (messageId < 1) {
         throw new ContactError('Invalid message ID', 400, 'INVALID_ID');

--- a/backend/tests/contactAdmin.test.js
+++ b/backend/tests/contactAdmin.test.js
@@ -1,0 +1,43 @@
+const contactService = require('../services/contactService');
+const db = require('../config/db');
+
+jest.mock('../config/db', () => ({
+    query: jest.fn()
+}));
+
+describe('ContactService - Admin Status Updates', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should accept numeric integer adminId for status updates', async () => {
+        db.query
+            .mockResolvedValueOnce([[{ id: 5 }]]) // existing message check
+            .mockResolvedValueOnce([{}])          // update query
+            .mockResolvedValueOnce([[{ id: 5, status: 'resolved', name: 'John', email: 'j@example.com', subject: 'Help', message: 'Hello' }]]) // getMessage detail
+            .mockResolvedValueOnce([[]]);         // getMessage history
+
+        const result = await contactService.updateStatus(5, 'resolved', 1);
+        expect(result).toBeDefined();
+        expect(result.status).toBe('resolved');
+        expect(db.query).toHaveBeenCalledTimes(4);
+    });
+
+    test('should reject invalid status string with 400 error', async () => {
+        await expect(contactService.updateStatus(5, 'invalid_status_value', 1))
+            .rejects
+            .toMatchObject({
+                status: 400,
+                code: 'INVALID_STATUS'
+            });
+    });
+
+    test('should reject missing admin authentication', async () => {
+        await expect(contactService.updateStatus(5, 'resolved', null))
+            .rejects
+            .toMatchObject({
+                status: 401,
+                code: 'UNAUTHENTICATED'
+            });
+    });
+});


### PR DESCRIPTION
## Description
Fixes actor validation in \updateStatus\ under \ackend/services/contactService.js\. Previously, only UUID-format admin IDs were accepted via \safeUUID\, rejecting valid numeric MySQL auto-increment admin IDs and causing false 401 \UNAUTHENTICATED\ errors during status updates.

## Related Issue
Closes #1557

## Clean Architecture & Changes
- Supported both numeric integer IDs and UUID actor representations in \updateStatus()\.
- Preserved strict status ENUM whitelist validation.
- Added unit tests in \ackend/tests/contactAdmin.test.js\ validating numeric admin ID transitions and input rejection.

## Verification
- Run \
px jest tests/contactAdmin.test.js\ (All unit tests passing cleanly).