### PR TITLE
fix(saga): handle corrupted JSON parsing in idempotency cache lookup

### DIFF
--- a/backend/services/sagaOrchestratorService.js
+++ b/backend/services/sagaOrchestratorService.js
@@ -51,9 +51,14 @@ class SagaOrchestrator extends EventEmitter {
                 console.log(`🔄 Duplicate saga request ignored (Idempotency Key: ${idempotencyKey})`);
                 const cachedStr = await redis.get(cacheKey);
                 if (cachedStr && cachedStr !== 'pending') {
-                    const cachedData = JSON.parse(cachedStr);
-                    this.sagas.set(cachedData.id, cachedData);
-                    return cachedData;
+                    try {
+                        const cachedData = JSON.parse(cachedStr);
+                        this.sagas.set(cachedData.id, cachedData);
+                        return cachedData;
+                    } catch (parseError) {
+                        console.error(`Malformed saga idempotency cache for key ${cacheKey}:`, parseError);
+                        await redis.del(cacheKey);
+                    }
                 }
                 // It's still pending/running. Generate a dummy saga to satisfy downstream
                 const mockSaga = { id: this.generateSagaId(), status: SAGA_STATUS.RUNNING, isDuplicate: true, steps: [] };

--- a/backend/tests/sagaIdempotency.test.js
+++ b/backend/tests/sagaIdempotency.test.js
@@ -1,0 +1,46 @@
+const { SagaOrchestrator, SAGA_STATUS } = require('../services/sagaOrchestratorService');
+const redis = require('../config/redis');
+
+jest.mock('../config/redis', () => ({
+    set: jest.fn(),
+    get: jest.fn(),
+    del: jest.fn()
+}));
+
+describe('SagaOrchestrator - Idempotency JSON Parsing Resilience', () => {
+    let orchestrator;
+
+    beforeEach(() => {
+        orchestrator = new SagaOrchestrator();
+        jest.clearAllMocks();
+        jest.spyOn(orchestrator, 'storeSaga').mockResolvedValue();
+    });
+
+    test('should return parsed cached saga data when JSON in Redis is valid', async () => {
+        redis.set.mockResolvedValue(null); // setnx returned false (duplicate key)
+        redis.get.mockResolvedValue(JSON.stringify({
+            id: 'cached-saga-1',
+            status: SAGA_STATUS.COMPLETED,
+            workflow: 'checkout'
+        }));
+
+        const workflow = { name: 'checkout', steps: [] };
+        const result = await orchestrator.createSaga(workflow, { idempotencyKey: 'key-123' });
+
+        expect(result).toBeDefined();
+        expect(result.id).toBe('cached-saga-1');
+        expect(result.status).toBe(SAGA_STATUS.COMPLETED);
+    });
+
+    test('should catch SyntaxError on corrupted JSON in Redis and delete corrupted key', async () => {
+        redis.set.mockResolvedValue(null);
+        redis.get.mockResolvedValue('invalid-non-json-string{corrupted');
+
+        const workflow = { name: 'checkout', steps: [] };
+        const result = await orchestrator.createSaga(workflow, { idempotencyKey: 'key-corrupt' });
+
+        expect(result).toBeDefined();
+        expect(result.isDuplicate).toBe(true);
+        expect(redis.del).toHaveBeenCalledWith('saga:idempotency:key-corrupt');
+    });
+});


### PR DESCRIPTION
## Description
Fixes unhandled \SyntaxError\ crashes when parsing corrupted or non-JSON payloads stored under Redis idempotency keys in \ackend/services/sagaOrchestratorService.js\.

## Related Issue
Closes #1558

## Clean Architecture & Changes
- Wrapped \JSON.parse(cachedStr)\ inside a \	ry...catch\ block.
- On JSON parse error, log error context and automatically purge the corrupted Redis key via \wait redis.del(cacheKey)\.
- Added unit tests in \ackend/tests/sagaIdempotency.test.js\ verifying graceful handling and purge of malformed cache entries.

## Verification
- Run \
px jest tests/sagaIdempotency.test.js\ (All unit tests passing cleanly).