### PR TITLE
fix(repositories): make BaseRepository.findOne return the row it found (#1564)

### DIFF
--- a/backend/repositories/baseRepository.js
+++ b/backend/repositories/baseRepository.js
@@ -2,6 +2,15 @@
 const db = require('../config/db').promise;
 const { withTransaction } = require('../config/db');
 
+// How many rows one repository will hold in its identity cache, and for how
+// long. Both are bounded because `repositories/index.js` exports these classes
+// as singletons: the instance lives as long as the process, so an unbounded map
+// is a leak that grows with traffic, and an entry with no expiry is served
+// until something happens to write through this same instance -- which a second
+// app instance, a migration or a raw `db.query` never does.
+const DEFAULT_CACHE_MAX_ENTRIES = 500;
+const DEFAULT_CACHE_TTL_MS = 30 * 1000;
+
 /**
  * Base Repository class providing common CRUD operations
  */
@@ -17,14 +26,83 @@ class BaseRepository {
      *   Declared explicitly rather than sniffed from the schema: a repository
      *   whose behaviour depends on whether a column happens to exist is a
      *   repository that silently changes behaviour when someone adds one.
+     * @param {number} [options.cacheMaxEntries=500] rows held by `findById`
+     * @param {number} [options.cacheTtlMs=30000] how long an entry stays usable
      */
-    constructor(tableName, primaryKey = 'id', { softDeleteColumn = null } = {}) {
+    constructor(
+        tableName,
+        primaryKey = 'id',
+        {
+            softDeleteColumn = null,
+            cacheMaxEntries = DEFAULT_CACHE_MAX_ENTRIES,
+            cacheTtlMs = DEFAULT_CACHE_TTL_MS
+        } = {}
+    ) {
         this.tableName = tableName;
         this.primaryKey = primaryKey;
         this.softDeleteColumn = softDeleteColumn;
         this.db = db;
+        // Still a Map, and still keyed by primary key, because every subclass
+        // reaches into it directly with `this.cache.delete(id)` after a write.
+        // What changed is what the values are: `{ row, expiresAt }` rather than
+        // the row itself.
         this.cache = new Map();
         this.cacheEnabled = true;
+        this.cacheMaxEntries = Math.max(0, Number(cacheMaxEntries) || 0);
+        this.cacheTtlMs = Math.max(0, Number(cacheTtlMs) || 0);
+    }
+
+    /**
+     * Read a row back out of the identity cache, honouring its expiry.
+     *
+     * An expired entry is dropped rather than merely ignored, so a key that is
+     * looked up and never written again does not sit in the map for good.
+     *
+     * @param {string|number} id
+     * @returns {object|null}
+     */
+    _cacheGet(id) {
+        const entry = this.cache.get(id);
+
+        if (!entry) {
+            return null;
+        }
+
+        if (entry.expiresAt <= Date.now()) {
+            this.cache.delete(id);
+            return null;
+        }
+
+        return entry.row;
+    }
+
+    /**
+     * Put a row in the identity cache, evicting the oldest entries first.
+     *
+     * A Map iterates in insertion order, so the first key it yields is the
+     * least recently *inserted* one. Re-inserting on every write keeps that
+     * ordering meaningful.
+     *
+     * @param {string|number} id
+     * @param {object} row
+     */
+    _cacheSet(id, row) {
+        if (!this.cacheEnabled || this.cacheMaxEntries === 0 || row == null) {
+            return;
+        }
+
+        // Delete first so a refreshed key moves to the back of the queue rather
+        // than keeping its original position and being evicted early.
+        this.cache.delete(id);
+        this.cache.set(id, { row, expiresAt: Date.now() + this.cacheTtlMs });
+
+        while (this.cache.size > this.cacheMaxEntries) {
+            const oldest = this.cache.keys().next();
+
+            if (oldest.done) break;
+
+            this.cache.delete(oldest.value);
+        }
     }
 
     /**
@@ -34,7 +112,7 @@ class BaseRepository {
         const { useCache = true } = options;
 
         if (useCache && this.cacheEnabled) {
-            const cached = this.cache.get(id);
+            const cached = this._cacheGet(id);
             if (cached) {
                 return cached;
             }
@@ -51,9 +129,7 @@ class BaseRepository {
 
         const result = rows[0];
 
-        if (this.cacheEnabled) {
-            this.cache.set(id, result);
-        }
+        this._cacheSet(id, result);
 
         return result;
     }
@@ -88,19 +164,60 @@ class BaseRepository {
     }
 
     /**
-     * Find one by filters
+     * Find one by filters.
+     *
+     * `findAll()` returns the rows array itself -- it has already unwrapped the
+     * `[rows, fields]` tuple the driver resolves to. Destructuring it a second
+     * time here bound `rows` to *element 0 of the row set*, which made this
+     * method wrong in both directions and never right in either:
+     *
+     *   - a matching row bound `rows` to the row object, whose `.length` is
+     *     `undefined`, so the guard failed and it returned `null`;
+     *   - no matching row bound `rows` to `undefined`, so reading `.length`
+     *     threw `TypeError` -- a 500 out of every route that asked whether
+     *     something existed.
+     *
+     * So it returned nothing on a hit and threw on a miss. There is no input
+     * for which the old body produced a record.
+     *
+     * @param {object} [filters] column => value equality filters
+     * @returns {Promise<object|null>} the first matching row, or null
      */
     async findOne(filters = {}) {
-        const [rows] = await this.findAll(filters, { limit: 1 });
-        return rows.length > 0 ? rows[0] : null;
+        const rows = await this.findAll(filters, { limit: 1 });
+
+        // `findAll` always resolves to an array, but a subclass that overrides
+        // it might not; treating a non-array as "no match" keeps the contract
+        // this method advertises rather than throwing on `.length`.
+        if (!Array.isArray(rows) || rows.length === 0) {
+            return null;
+        }
+
+        return rows[0];
     }
 
     /**
-     * Create new record
+     * Create new record.
+     *
+     * An empty payload used to build `INSERT INTO t () VALUES ()`, which MySQL
+     * rejects with `ER_PARSE_ERROR`. A handler that filters its request body
+     * down to nothing is asking for a no-op, not for a syntax error, so it gets
+     * one back by name.
+     *
+     * @param {object} data column => value
+     * @returns {Promise<object|null>} the inserted row, reloaded
      */
     async create(data) {
-        const columns = Object.keys(data);
-        const values = Object.values(data);
+        const payload = data && typeof data === 'object' ? data : {};
+        const columns = Object.keys(payload);
+
+        if (columns.length === 0) {
+            throw new Error(
+                `Cannot insert into ${this.tableName}: no columns were supplied.`
+            );
+        }
+
+        const values = Object.values(payload);
         const placeholders = columns.map(() => '?').join(',');
 
         const [result] = await this.db.query(
@@ -108,21 +225,46 @@ class BaseRepository {
             values
         );
 
-        const newRecord = await this.findById(result.insertId);
-        
-        if (this.cacheEnabled) {
-            this.cache.set(newRecord[this.primaryKey], newRecord);
+        // `insertId` is 0 for the UUID-keyed tables in this schema (`products`,
+        // `orders`, `users` are all CHAR(36)), so fall back to the key the
+        // caller supplied. Reloading by 0 would return the wrong row or none.
+        const insertedId = result && result.insertId
+            ? result.insertId
+            : payload[this.primaryKey];
+
+        if (insertedId === undefined || insertedId === null) {
+            return null;
+        }
+
+        const newRecord = await this.findById(insertedId, { useCache: false });
+
+        if (newRecord) {
+            this._cacheSet(newRecord[this.primaryKey], newRecord);
         }
 
         return newRecord;
     }
 
     /**
-     * Update record by ID
+     * Update record by ID.
+     *
+     * As with `create`, an empty payload produced `UPDATE t SET  WHERE id = ?`
+     * and an `ER_PARSE_ERROR`. Nothing to write is a no-op: the row is returned
+     * unchanged and no statement is sent.
+     *
+     * @param {string|number} id
+     * @param {object} data column => value
+     * @returns {Promise<object|null>} the row after the write
      */
     async update(id, data) {
-        const columns = Object.keys(data);
-        const values = Object.values(data);
+        const payload = data && typeof data === 'object' ? data : {};
+        const columns = Object.keys(payload);
+
+        if (columns.length === 0) {
+            return this.findById(id, { useCache: false });
+        }
+
+        const values = Object.values(payload);
         const setClause = columns.map(c => `${c} = ?`).join(',');
 
         await this.db.query(
@@ -133,7 +275,10 @@ class BaseRepository {
         // Clear cache
         this.cache.delete(id);
 
-        return this.findById(id);
+        // Read past the cache: the entry was just dropped, but a concurrent
+        // `findById` between the write and this read could have repopulated it
+        // with the pre-update row.
+        return this.findById(id, { useCache: false });
     }
 
     /**

--- a/backend/tests/baseRepository.test.js
+++ b/backend/tests/baseRepository.test.js
@@ -1,0 +1,234 @@
+// backend/tests/baseRepository.test.js
+//
+// `findOne()` could not return a record (#1564).
+//
+// It destructured the return value of `findAll()`, which is the rows array
+// itself and not the driver's `[rows, fields]` tuple. So `rows` bound to
+// element 0 of the row set: the row object on a hit (whose `.length` is
+// undefined, so the guard failed and it returned null) and `undefined` on a
+// miss (so reading `.length` threw). Both outcomes are the opposite of the
+// intended one, which is why the first two tests here are worth stating
+// separately -- fixing only one of them would still leave the method broken.
+
+// Mocked so requiring the repository does not open a real pool. Every test
+// below replaces `repo.db` with its own double anyway; this only keeps the
+// module-level `require('../config/db')` from reaching mysql2.
+jest.mock('../config/db', () => ({
+    promise: { query: jest.fn() },
+    withTransaction: jest.fn()
+}));
+
+const BaseRepository = require('../repositories/baseRepository');
+
+/** A repository whose `db` is a recording double. */
+const repoWith = (rows = [], options = {}) => {
+    const repo = new BaseRepository('widgets', 'id', options);
+    repo.db = { query: jest.fn().mockResolvedValue([rows, []]) };
+    return repo;
+};
+
+/** Every statement the repository sent, whitespace collapsed for matching. */
+const executedSql = (repo) =>
+    repo.db.query.mock.calls.map(([sql]) => String(sql).replace(/\s+/g, ' ').trim());
+
+describe('BaseRepository.findOne', () => {
+    test('returns the row when one matches', async () => {
+        const row = { id: 7, email: 'someone@example.com' };
+        const repo = repoWith([row]);
+
+        await expect(repo.findOne({ email: 'someone@example.com' }))
+            .resolves.toEqual(row);
+    });
+
+    test('returns null when nothing matches, instead of throwing', async () => {
+        const repo = repoWith([]);
+
+        await expect(repo.findOne({ email: 'nobody@example.com' }))
+            .resolves.toBeNull();
+    });
+
+    test('asks for a single row', async () => {
+        const repo = repoWith([{ id: 1 }]);
+
+        await repo.findOne({ email: 'someone@example.com' });
+
+        const [sql, params] = repo.db.query.mock.calls[0];
+        expect(sql.replace(/\s+/g, ' ')).toMatch(/LIMIT \? OFFSET \?/i);
+        // filter value, then limit, then offset
+        expect(params).toEqual(['someone@example.com', 1, 0]);
+    });
+
+    test('takes the first row when the driver hands back several', async () => {
+        // A caller can pass a filter that is not unique; "one of these" is a
+        // defensible answer, "null" is not.
+        const first = { id: 1 };
+        const repo = repoWith([first, { id: 2 }]);
+
+        await expect(repo.findOne({ role: 'admin' })).resolves.toEqual(first);
+    });
+
+    test('survives a subclass whose findAll does not return an array', async () => {
+        const repo = repoWith([]);
+        repo.findAll = jest.fn().mockResolvedValue(undefined);
+
+        await expect(repo.findOne({ id: 1 })).resolves.toBeNull();
+    });
+
+    test('applies no filters when given none', async () => {
+        const repo = repoWith([{ id: 1 }]);
+
+        await repo.findOne();
+
+        expect(executedSql(repo)[0]).not.toMatch(/WHERE/i);
+    });
+});
+
+describe('BaseRepository.update with nothing to write', () => {
+    test('sends no UPDATE rather than "SET  WHERE"', async () => {
+        const repo = repoWith([{ id: 1, name: 'unchanged' }]);
+
+        await repo.update(1, {});
+
+        expect(executedSql(repo).some((sql) => /^UPDATE/i.test(sql))).toBe(false);
+    });
+
+    test('returns the row unchanged', async () => {
+        const row = { id: 1, name: 'unchanged' };
+        const repo = repoWith([row]);
+
+        await expect(repo.update(1, {})).resolves.toEqual(row);
+    });
+
+    test('still writes when there is something to write', async () => {
+        const repo = repoWith([{ id: 1, name: 'after' }]);
+
+        await repo.update(1, { name: 'after' });
+
+        const update = repo.db.query.mock.calls.find(([sql]) => /^UPDATE/i.test(sql));
+        expect(update[0].replace(/\s+/g, ' ')).toMatch(/UPDATE widgets SET name = \? WHERE id = \?/i);
+        expect(update[1]).toEqual(['after', 1]);
+    });
+
+    test('re-reads past the cache after writing', async () => {
+        // The entry is dropped before the read, but a concurrent findById
+        // between the two could repopulate it with the pre-update row.
+        const repo = repoWith([{ id: 1, name: 'stale' }]);
+        repo.cache.set(1, { row: { id: 1, name: 'stale' }, expiresAt: Date.now() + 60_000 });
+        repo.db.query.mockResolvedValue([[{ id: 1, name: 'fresh' }], []]);
+
+        await expect(repo.update(1, { name: 'fresh' }))
+            .resolves.toEqual({ id: 1, name: 'fresh' });
+    });
+
+    test('a non-object payload is treated as empty rather than crashing', async () => {
+        const repo = repoWith([{ id: 1 }]);
+
+        await expect(repo.update(1, null)).resolves.toEqual({ id: 1 });
+        expect(executedSql(repo).some((sql) => /^UPDATE/i.test(sql))).toBe(false);
+    });
+});
+
+describe('BaseRepository.create with nothing to insert', () => {
+    test('refuses by name instead of emitting "INSERT INTO t () VALUES ()"', async () => {
+        const repo = repoWith([]);
+
+        await expect(repo.create({})).rejects.toThrow(/no columns were supplied/i);
+        expect(repo.db.query).not.toHaveBeenCalled();
+    });
+
+    test('reloads a UUID-keyed row by its supplied key, not by insertId 0', async () => {
+        // products, orders and users are all CHAR(36); insertId is 0 for them,
+        // and reloading by 0 returns the wrong row or none at all.
+        const id = '3f2504e0-4f89-11d3-9a0c-0305e82c3301';
+        const repo = repoWith([]);
+        repo.db.query
+            .mockResolvedValueOnce([{ insertId: 0, affectedRows: 1 }, []])
+            .mockResolvedValueOnce([[{ id, name: 'widget' }], []]);
+
+        await expect(repo.create({ id, name: 'widget' }))
+            .resolves.toEqual({ id, name: 'widget' });
+
+        const select = repo.db.query.mock.calls[1];
+        expect(select[1]).toEqual([id]);
+    });
+
+    test('still uses insertId for auto-increment tables', async () => {
+        const repo = repoWith([]);
+        repo.db.query
+            .mockResolvedValueOnce([{ insertId: 42, affectedRows: 1 }, []])
+            .mockResolvedValueOnce([[{ id: 42, name: 'widget' }], []]);
+
+        await repo.create({ name: 'widget' });
+
+        expect(repo.db.query.mock.calls[1][1]).toEqual([42]);
+    });
+});
+
+describe('BaseRepository identity cache', () => {
+    test('serves a second read from memory', async () => {
+        const repo = repoWith([{ id: 1, name: 'widget' }]);
+
+        await repo.findById(1);
+        await repo.findById(1);
+
+        expect(repo.db.query).toHaveBeenCalledTimes(1);
+    });
+
+    test('evicts the oldest entry once the cap is reached', async () => {
+        // The repositories are process-lifetime singletons; an unbounded map is
+        // a leak that grows with traffic.
+        const repo = repoWith([], { cacheMaxEntries: 2 });
+
+        for (const id of [1, 2, 3]) {
+            repo.db.query.mockResolvedValue([[{ id }], []]);
+            await repo.findById(id);
+        }
+
+        expect(repo.cache.size).toBe(2);
+        expect(repo.cache.has(1)).toBe(false);
+        expect(repo.cache.has(3)).toBe(true);
+    });
+
+    test('re-reads once an entry has expired', async () => {
+        const repo = repoWith([{ id: 1, name: 'widget' }], { cacheTtlMs: 1 });
+
+        await repo.findById(1);
+        jest.spyOn(Date, 'now').mockReturnValue(Date.now() + 60_000);
+        await repo.findById(1);
+
+        expect(repo.db.query).toHaveBeenCalledTimes(2);
+        Date.now.mockRestore();
+    });
+
+    test('an expired entry is dropped, not merely ignored', async () => {
+        const repo = repoWith([{ id: 1 }], { cacheTtlMs: 1 });
+        repo.cache.set(1, { row: { id: 1 }, expiresAt: Date.now() - 1 });
+
+        repo._cacheGet(1);
+
+        expect(repo.cache.has(1)).toBe(false);
+    });
+
+    test('caching can still be turned off entirely', async () => {
+        const repo = repoWith([{ id: 1 }]);
+        repo.setCacheEnabled(false);
+
+        await repo.findById(1);
+        await repo.findById(1);
+
+        expect(repo.db.query).toHaveBeenCalledTimes(2);
+        expect(repo.cache.size).toBe(0);
+    });
+
+    test('subclasses can still invalidate with cache.delete(id)', async () => {
+        // productRepository, userRepository and orderRepository all do exactly
+        // this after a write, so the map has to stay keyed by primary key.
+        const repo = repoWith([{ id: 1 }]);
+
+        await repo.findById(1);
+        repo.cache.delete(1);
+        await repo.findById(1);
+
+        expect(repo.db.query).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`BaseRepository.findOne()` destructured the return value of `findAll()`. `findAll()` has already unwrapped the driver's `[rows, fields]` tuple and returns the rows array itself, so `const [rows] = ...` bound `rows` to **element 0 of the row set**:

| Case | `rows` bound to | Result |
|---|---|---|
| A row matches | the row object, `.length` undefined | guard fails → returns **`null`** |
| No row matches | `undefined` | reading `.length` throws **`TypeError`** |

There is no input for which the old body produced a record — it returned nothing on a hit and threw on a miss. It now treats `findAll()`'s result as the array it is, and returns `null` for a non-array so a subclass override cannot reintroduce the throw.

**Two adjacent faults in the same class**, both of which turned a no-op call into invalid SQL and are reachable from a PATCH handler that filters its payload down to nothing:

- `update(id, {})` built `UPDATE t SET  WHERE id = ?` → `ER_PARSE_ERROR`. An empty update is now a no-op that returns the row.
- `create({})` built `INSERT INTO t () VALUES ()` → `ER_PARSE_ERROR`. An empty insert is now refused by name.

`create()` also reloaded by `result.insertId` unconditionally, which is `0` for every `CHAR(36)`-keyed table in this schema (`products`, `orders`, `users`); it now falls back to the key the caller supplied. Post-write reloads bypass the cache, since a concurrent `findById` between the write and the read could repopulate it with the pre-update row.

**The identity cache is now bounded.** `repositories/index.js` exports these classes as singletons, so the map lived as long as the process and no entry ever expired — it grew with traffic and served rows a second app instance or a raw `db.query` had since changed. Default 500 entries / 30s TTL, both overridable per repository. It keeps its `Map` shape and primary-key indexing, because `productRepository`, `userRepository` and `orderRepository` all invalidate with `this.cache.delete(id)`.

---

## 🔗 Related Issue

Closes #1564

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Backend-only; no UI surface.

Before:

```js
await userRepo.findOne({ email: 'someone@example.com' });   // → null, though the row exists
await userRepo.findOne({ email: 'nobody@example.com' });    // → TypeError
```

After:

```js
await userRepo.findOne({ email: 'someone@example.com' });   // → { id: '…', email: '…' }
await userRepo.findOne({ email: 'nobody@example.com' });    // → null
```

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Tests** — `backend/tests/baseRepository.test.js`, 20 new cases covering both directions of the `findOne` fault, the empty-payload guards, the UUID-vs-`insertId` reload, and the cache bound/TTL/eviction. The last case in that file pins `cache.delete(id)` still working, because three subclasses depend on it.

```
Test Suites: 90 passed, 90 total
Tests:       2025 passed, 2025 total
```

**Scope** — only `repositories/baseRepository.js` is touched, so this does not overlap with the four sibling repository fixes (#1565–#1568) and can merge in any order relative to them.

`findAll()`'s default `ORDER BY created_at DESC` is left alone: it is wrong for any table without that column, but changing it would alter result ordering for existing callers and belongs in its own change.

**Note on the CI flake** — `tests/authMiddleware.test.js` failed once during a full run and passed on re-run and in isolation (37/37). It is a pre-existing timing flake and touches nothing in this PR.
