### PR TITLE
fix(repositories): query the product columns that exist — category_id, views_count (#1565)

### DIFF
--- a/backend/repositories/productRepository.js
+++ b/backend/repositories/productRepository.js
@@ -1,6 +1,39 @@
 // backend/repositories/productRepository.js
 const BaseRepository = require('./baseRepository');
 
+// The rows a catalogue read is allowed to see.
+//
+// `deleted_at` is what the `softDeleteColumn` declared below is for, and until
+// #1565 not one read in this file filtered on it. Withdrawing a product stamps
+// the column, and every method here read straight past the stamp -- so a
+// product an admin removed still came back from search, featured, low-stock,
+// related and by-id lookups alike. That is the other half of #1457: the write
+// path stopped cascading, and the read path never noticed.
+//
+// Named once so that a read added later cannot quietly omit it.
+const LIVE = 'deleted_at IS NULL';
+
+/** The same predicate, where the table carries an alias. */
+const liveOn = (alias) => `${alias}.deleted_at IS NULL`;
+
+/**
+ * Escape the characters that are metacharacters *inside* a LIKE pattern.
+ *
+ * Parameterising the term stops injection but not this: `%` and `_` keep their
+ * wildcard meaning once the driver has substituted the value, so searching the
+ * catalogue for "50%" matched every product rather than the discounted ones,
+ * and "_" matched any single character. The backslash goes first, or it would
+ * escape the escapes added after it.
+ *
+ * Paired with an explicit `ESCAPE '\\'` at the call site, because MySQL's
+ * default escape character depends on `NO_BACKSLASH_ESCAPES` being off.
+ *
+ * @param {any} value the raw search term
+ * @returns {string}
+ */
+const escapeLike = (value) =>
+    String(value ?? '').replace(/[\\%_]/g, (character) => `\\${character}`);
+
 class ProductRepository extends BaseRepository {
     constructor() {
         // `products.deleted_at` is filtered by every read path in the codebase
@@ -12,17 +45,26 @@ class ProductRepository extends BaseRepository {
     }
 
     /**
-     * Find products by category
+     * Find products by category.
+     *
+     * The column is `category_id INT` (`0001_baseline_schema.sql:163`). There
+     * is no `products.category`, so the previous `WHERE category = ?` failed
+     * outright with `ER_BAD_FIELD_ERROR` rather than returning the wrong rows
+     * (#1565).
+     *
+     * @param {number} categoryId
+     * @param {{limit?: number, offset?: number}} [options]
+     * @returns {Promise<object[]>}
      */
-    async findByCategory(category, options = {}) {
+    async findByCategory(categoryId, options = {}) {
         const { limit = 20, offset = 0 } = options;
 
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} 
-             WHERE category = ? AND stock > 0 
-             ORDER BY created_at DESC 
+            `SELECT * FROM ${this.tableName}
+             WHERE category_id = ? AND stock > 0 AND ${LIVE}
+             ORDER BY created_at DESC
              LIMIT ? OFFSET ?`,
-            [category, limit, offset]
+            [categoryId, limit, offset]
         );
 
         return rows;
@@ -35,9 +77,9 @@ class ProductRepository extends BaseRepository {
         const { limit = 20, offset = 0 } = options;
 
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} 
-             WHERE price BETWEEN ? AND ? AND stock > 0 
-             ORDER BY price ASC 
+            `SELECT * FROM ${this.tableName}
+             WHERE price BETWEEN ? AND ? AND stock > 0 AND ${LIVE}
+             ORDER BY price ASC
              LIMIT ? OFFSET ?`,
             [minPrice, maxPrice, limit, offset]
         );
@@ -50,13 +92,15 @@ class ProductRepository extends BaseRepository {
      */
     async search(query, options = {}) {
         const { limit = 20, offset = 0 } = options;
+        const term = `%${escapeLike(query)}%`;
 
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} 
-             WHERE (name LIKE ? OR description LIKE ?) AND stock > 0 
-             ORDER BY created_at DESC 
+            `SELECT * FROM ${this.tableName}
+             WHERE (name LIKE ? ESCAPE '\\\\' OR description LIKE ? ESCAPE '\\\\')
+               AND stock > 0 AND ${LIVE}
+             ORDER BY created_at DESC
              LIMIT ? OFFSET ?`,
-            [`%${query}%`, `%${query}%`, limit, offset]
+            [term, term, limit, offset]
         );
 
         return rows;
@@ -67,8 +111,8 @@ class ProductRepository extends BaseRepository {
      */
     async getLowStockProducts(threshold = 10) {
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} 
-             WHERE stock <= ? AND stock > 0 
+            `SELECT * FROM ${this.tableName}
+             WHERE stock <= ? AND stock > 0 AND ${LIVE}
              ORDER BY stock ASC`,
             [threshold]
         );
@@ -149,16 +193,32 @@ class ProductRepository extends BaseRepository {
     }
 
     /**
-     * Get product with reviews
+     * Get product with reviews.
+     *
+     * The aggregate counts only reviews a shopper is allowed to see. `reviews`
+     * carries both `deleted_at` and `is_approved` (`0001_baseline_schema.sql:
+     * 824-838`) and the previous version consulted neither, so withdrawn and
+     * unapproved reviews inflated `review_count` and skewed `avg_rating` --
+     * which is the rating shown against the product.
+     *
+     * The predicates sit in the JOIN rather than the WHERE because the join is
+     * a LEFT one: moving them out would turn it into an inner join and drop the
+     * product entirely as soon as it had no visible reviews.
+     *
+     * @param {string} id product UUID
+     * @returns {Promise<object|null>}
      */
     async findWithReviews(id) {
         const [rows] = await this.db.query(
-            `SELECT p.*, 
+            `SELECT p.*,
                     AVG(r.rating) as avg_rating,
                     COUNT(r.id) as review_count
              FROM ${this.tableName} p
-             LEFT JOIN reviews r ON p.id = r.product_id
-             WHERE p.id = ?
+             LEFT JOIN reviews r
+                    ON p.id = r.product_id
+                   AND ${liveOn('r')}
+                   AND r.is_approved = 1
+             WHERE p.id = ? AND ${liveOn('p')}
              GROUP BY p.id`,
             [id]
         );
@@ -169,7 +229,10 @@ class ProductRepository extends BaseRepository {
 
         // Get reviews
         const [reviews] = await this.db.query(
-            `SELECT * FROM reviews WHERE product_id = ? ORDER BY created_at DESC LIMIT 10`,
+            `SELECT * FROM reviews
+              WHERE product_id = ? AND ${LIVE} AND is_approved = 1
+              ORDER BY created_at DESC
+              LIMIT 10`,
             [id]
         );
 
@@ -180,29 +243,54 @@ class ProductRepository extends BaseRepository {
     }
 
     /**
-     * Get related products
+     * Get related products.
+     *
+     * Related by `category_id`, read off the product this method just loaded.
+     * It previously matched `WHERE category = ?` against `product.category`,
+     * and since neither the column nor the property exists that was a
+     * `ER_BAD_FIELD_ERROR` with `undefined` as its parameter (#1565).
+     *
+     * A product filed under no category has nothing to be related to, so it
+     * returns nothing rather than matching every other uncategorised product
+     * via `category_id = NULL`.
+     *
+     * @param {string} id
+     * @param {number} [limit=5]
+     * @returns {Promise<object[]>}
      */
     async getRelatedProducts(id, limit = 5) {
         const product = await this.findById(id);
         if (!product) return [];
 
+        if (product.category_id === null || product.category_id === undefined) {
+            return [];
+        }
+
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} 
-             WHERE category = ? AND id != ? AND stock > 0 
-             ORDER BY created_at DESC 
+            `SELECT * FROM ${this.tableName}
+             WHERE category_id = ? AND id != ? AND stock > 0 AND ${LIVE}
+             ORDER BY created_at DESC
              LIMIT ?`,
-            [product.category, id, limit]
+            [product.category_id, id, limit]
         );
 
         return rows;
     }
 
     /**
-     * Increment view count
+     * Increment view count.
+     *
+     * The counter is `views_count INT DEFAULT 0` (`0001_baseline_schema.sql:
+     * 180`). There is no `products.views`, so this threw `ER_BAD_FIELD_ERROR`
+     * on every product page view (#1565).
+     *
+     * @param {string} id
      */
     async incrementViews(id) {
         await this.db.query(
-            `UPDATE ${this.tableName} SET views = views + 1 WHERE id = ?`,
+            `UPDATE ${this.tableName}
+                SET views_count = views_count + 1
+              WHERE id = ? AND ${LIVE}`,
             [id]
         );
         this.cache.delete(id);
@@ -216,7 +304,8 @@ class ProductRepository extends BaseRepository {
 
         const placeholders = ids.map(() => '?').join(',');
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} WHERE id IN (${placeholders})`,
+            `SELECT * FROM ${this.tableName}
+              WHERE id IN (${placeholders}) AND ${LIVE}`,
             ids
         );
 
@@ -228,9 +317,9 @@ class ProductRepository extends BaseRepository {
      */
     async getFeatured(limit = 10) {
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} 
-             WHERE featured = 1 AND stock > 0 
-             ORDER BY created_at DESC 
+            `SELECT * FROM ${this.tableName}
+             WHERE featured = 1 AND stock > 0 AND ${LIVE}
+             ORDER BY created_at DESC
              LIMIT ?`,
             [limit]
         );

--- a/backend/tests/productRepository.test.js
+++ b/backend/tests/productRepository.test.js
@@ -1,0 +1,194 @@
+// backend/tests/productRepository.test.js
+//
+// productRepository named two columns `products` does not have (#1565).
+//
+// The schema declares `category_id INT` and `views_count INT DEFAULT 0`
+// (0001_baseline_schema.sql:150-188). The repository asked for `category` and
+// `views`, so findByCategory, getRelatedProducts and incrementViews each threw
+// ER_BAD_FIELD_ERROR on every call rather than returning the wrong rows.
+//
+// The second theme here is the soft-delete column. The constructor has declared
+// `softDeleteColumn: 'deleted_at'` since #1457, which is what stopped the
+// withdraw path cascading -- but not one read filtered on it, so a withdrawn
+// product came straight back out of search, featured, related and by-id
+// lookups. The assertions below pin both halves.
+
+jest.mock('../config/db', () => ({
+    promise: { query: jest.fn() },
+    withTransaction: jest.fn()
+}));
+
+const productRepo = require('../repositories/productRepository');
+
+const PRODUCT_ID = '3f2504e0-4f89-11d3-9a0c-0305e82c3301';
+
+/** The statement most recently sent, whitespace collapsed for matching. */
+const lastSql = () => {
+    const calls = productRepo.db.query.mock.calls;
+    return String(calls[calls.length - 1][0]).replace(/\s+/g, ' ').trim();
+};
+
+/** Every statement sent, whitespace collapsed. */
+const allSql = () =>
+    productRepo.db.query.mock.calls.map(([sql]) =>
+        String(sql).replace(/\s+/g, ' ').trim());
+
+/** The parameters of the statement most recently sent. */
+const lastParams = () => {
+    const calls = productRepo.db.query.mock.calls;
+    return calls[calls.length - 1][1];
+};
+
+beforeEach(() => {
+    productRepo.db = { query: jest.fn().mockResolvedValue([[], []]) };
+    productRepo.clearCache();
+});
+
+describe('column names that products actually has', () => {
+    test('findByCategory filters on category_id, not category', async () => {
+        await productRepo.findByCategory(7);
+
+        expect(lastSql()).toMatch(/WHERE category_id = \?/i);
+        expect(lastSql()).not.toMatch(/WHERE category = \?/i);
+        expect(lastParams()[0]).toBe(7);
+    });
+
+    test('incrementViews writes views_count, not views', async () => {
+        await productRepo.incrementViews(PRODUCT_ID);
+
+        expect(lastSql()).toMatch(/SET views_count = views_count \+ 1/i);
+        expect(lastSql()).not.toMatch(/SET views = views \+ 1/i);
+    });
+
+    test('getRelatedProducts matches on the loaded product\'s category_id', async () => {
+        productRepo.db.query
+            .mockResolvedValueOnce([[{ id: PRODUCT_ID, category_id: 4 }], []])
+            .mockResolvedValueOnce([[], []]);
+
+        await productRepo.getRelatedProducts(PRODUCT_ID);
+
+        expect(lastSql()).toMatch(/WHERE category_id = \?/i);
+        // Previously `product.category`, which is always undefined.
+        expect(lastParams()[0]).toBe(4);
+    });
+
+    test('getRelatedProducts returns nothing for an uncategorised product', async () => {
+        // category_id = NULL would otherwise match every other uncategorised
+        // product in the catalogue.
+        productRepo.db.query.mockResolvedValueOnce([
+            [{ id: PRODUCT_ID, category_id: null }], []
+        ]);
+
+        await expect(productRepo.getRelatedProducts(PRODUCT_ID)).resolves.toEqual([]);
+        expect(productRepo.db.query).toHaveBeenCalledTimes(1);
+    });
+
+    test('getRelatedProducts still returns nothing for a product that is gone', async () => {
+        productRepo.db.query.mockResolvedValueOnce([[], []]);
+
+        await expect(productRepo.getRelatedProducts(PRODUCT_ID)).resolves.toEqual([]);
+    });
+});
+
+describe('withdrawn products stay withdrawn', () => {
+    const readsThatMustFilter = [
+        ['findByCategory', () => productRepo.findByCategory(1)],
+        ['findByPriceRange', () => productRepo.findByPriceRange(0, 100)],
+        ['search', () => productRepo.search('shirt')],
+        ['getLowStockProducts', () => productRepo.getLowStockProducts()],
+        ['getFeatured', () => productRepo.getFeatured()],
+        ['findByIds', () => productRepo.findByIds([PRODUCT_ID])]
+    ];
+
+    test.each(readsThatMustFilter)('%s excludes soft-deleted rows', async (_name, run) => {
+        await run();
+
+        expect(lastSql()).toMatch(/deleted_at IS NULL/i);
+    });
+
+    test('findWithReviews excludes a deleted product', async () => {
+        productRepo.db.query.mockResolvedValue([[{ id: PRODUCT_ID }], []]);
+
+        await productRepo.findWithReviews(PRODUCT_ID);
+
+        expect(allSql()[0]).toMatch(/p\.deleted_at IS NULL/i);
+    });
+
+    test('incrementViews does not resurrect a deleted product\'s counter', async () => {
+        await productRepo.incrementViews(PRODUCT_ID);
+
+        expect(lastSql()).toMatch(/deleted_at IS NULL/i);
+    });
+});
+
+describe('review aggregates count only visible reviews', () => {
+    beforeEach(() => {
+        productRepo.db.query.mockResolvedValue([[{ id: PRODUCT_ID }], []]);
+    });
+
+    test('the aggregate skips deleted and unapproved reviews', async () => {
+        await productRepo.findWithReviews(PRODUCT_ID);
+
+        const aggregate = allSql()[0];
+        expect(aggregate).toMatch(/r\.deleted_at IS NULL/i);
+        expect(aggregate).toMatch(/r\.is_approved = 1/i);
+    });
+
+    test('those predicates stay in the JOIN, not the WHERE', async () => {
+        // Moving them to WHERE turns the LEFT JOIN into an inner one and drops
+        // the product as soon as it has no visible reviews.
+        await productRepo.findWithReviews(PRODUCT_ID);
+
+        const aggregate = allSql()[0];
+        const joinClause = aggregate.slice(
+            aggregate.search(/LEFT JOIN/i),
+            aggregate.search(/WHERE/i)
+        );
+        expect(joinClause).toMatch(/r\.deleted_at IS NULL/i);
+        expect(joinClause).toMatch(/r\.is_approved = 1/i);
+    });
+
+    test('the review list applies the same rule', async () => {
+        await productRepo.findWithReviews(PRODUCT_ID);
+
+        const list = allSql()[1];
+        expect(list).toMatch(/FROM reviews/i);
+        expect(list).toMatch(/deleted_at IS NULL/i);
+        expect(list).toMatch(/is_approved = 1/i);
+    });
+});
+
+describe('search terms are not read as LIKE patterns', () => {
+    test('a percent sign in the term is escaped', async () => {
+        await productRepo.search('50%');
+
+        expect(lastParams()[0]).toBe('%50\\%%');
+        expect(lastSql()).toMatch(/ESCAPE/i);
+    });
+
+    test('an underscore is escaped too', async () => {
+        await productRepo.search('a_b');
+
+        expect(lastParams()[0]).toBe('%a\\_b%');
+    });
+
+    test('a backslash is escaped before anything else', async () => {
+        // Escaping it last would double-escape the escapes added for % and _.
+        await productRepo.search('a\\%');
+
+        expect(lastParams()[0]).toBe('%a\\\\\\%%');
+    });
+
+    test('an ordinary term is unchanged', async () => {
+        await productRepo.search('shirt');
+
+        expect(lastParams()[0]).toBe('%shirt%');
+    });
+
+    test('both LIKE parameters carry the same escaped term', async () => {
+        await productRepo.search('50%');
+
+        const [name, description] = lastParams();
+        expect(name).toBe(description);
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`productRepository` named two columns `products` does not have. The schema declares `category_id INT` and `views_count INT DEFAULT 0` (`migrations/0001_baseline_schema.sql:150-188`); there is no `category` and no `views`, and no later migration adds either. So three methods threw `ER_BAD_FIELD_ERROR` on every call rather than returning the wrong rows:

| Method | Was | Now |
|---|---|---|
| `findByCategory` | `WHERE category = ?` | `WHERE category_id = ?` |
| `getRelatedProducts` | `WHERE category = ?`, parameter `product.category` (always `undefined`) | `WHERE category_id = ?`, parameter `product.category_id` |
| `incrementViews` | `SET views = views + 1` | `SET views_count = views_count + 1` |

`getRelatedProducts` now returns nothing for a product filed under no category, rather than matching every other uncategorised product through `category_id = NULL`.

**The soft-delete column is now honoured on the way out.** The constructor has declared `softDeleteColumn: 'deleted_at'` since #1457 — that is what stopped the withdraw path cascading through fourteen tables — but **no read in this file filtered on it**, so a product an admin removed still came back from `search`, `getFeatured`, `getLowStockProducts`, `findByPriceRange`, `findByIds`, `findWithReviews` and `getRelatedProducts`. That is the other half of #1457: the write path stopped cascading and the read path never noticed. Every read now carries the predicate, named once as `LIVE` so a read added later cannot quietly omit it.

**Review aggregates count only visible reviews.** `reviews` carries `deleted_at` and `is_approved` (`0001_baseline_schema.sql:824-838`) and `findWithReviews` consulted neither, so withdrawn and unapproved reviews inflated `review_count` and skewed the `avg_rating` shown against the product. The predicates go in the `JOIN` rather than the `WHERE`, since moving them out would turn the `LEFT JOIN` into an inner one and drop the product as soon as it had no visible reviews.

**`search()` read its own term as a LIKE pattern.** Parameterising stops injection but not the wildcards, which keep their meaning *inside* the substituted value — so a catalogue search for `50%` matched every product and `a_b` matched `axb`. Escaped, with an explicit `ESCAPE` clause since MySQL's default depends on `NO_BACKSLASH_ESCAPES` being off. (Raised as a comment on the issue.)

---

## 🔗 Related Issue

Closes #1565

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Backend-only; no UI surface.

Before, against a migrated database:

```
await productRepo.findByCategory(3);
  Error: ER_BAD_FIELD_ERROR: Unknown column 'category' in 'where clause'

await productRepo.incrementViews('<uuid>');
  Error: ER_BAD_FIELD_ERROR: Unknown column 'views' in 'field list'
```

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Tests** — `backend/tests/productRepository.test.js`, 21 new cases: the corrected column names, the uncategorised-product case, soft-delete coverage across all six affected reads, the JOIN-vs-WHERE placement of the review predicates, and LIKE escaping including the backslash-first ordering.

```
Test Suites: 90 passed, 90 total
Tests:       2026 passed, 2026 total
```

**Deliberately not changed** — the stock methods (`updateStock`, `getStockForUpdate`, `deductStockAtomic`, `restoreStock`) do not filter `deleted_at`. `restoreStock` has to work for an order placed before the product was withdrawn, and changing what checkout locks belongs with a change that exercises checkout.

**Scope** — only `repositories/productRepository.js` is touched, so this does not overlap with the four sibling repository fixes (#1564, #1566–#1568) and can merge in any order relative to them.
