### PR TITLE
fix(repositories): read the user columns the schema has — is_active, no user_profiles (#1566)

### DIFF
--- a/backend/repositories/userRepository.js
+++ b/backend/repositories/userRepository.js
@@ -1,9 +1,69 @@
 // backend/repositories/userRepository.js
 const BaseRepository = require('./baseRepository');
 
+// Accounts a read is allowed to see. `users.deleted_at` exists
+// (0001_baseline_schema.sql:47) and nothing in this file consulted it, so a
+// deactivated account was still searchable, still listed by role and still
+// counted in the admin statistics (#1566).
+const LIVE = 'deleted_at IS NULL';
+
+// The profile fields `users` actually carries. `findWithProfile` used to read
+// them from a `user_profiles` table that does not exist in any migration; these
+// are the columns the same information is really stored in
+// (0001_baseline_schema.sql:24-58).
+const PROFILE_COLUMNS = Object.freeze([
+    'avatar',
+    'phone',
+    'address',
+    'city',
+    'state',
+    'zip',
+    'country'
+]);
+
+/**
+ * Escape the characters that are metacharacters inside a LIKE pattern.
+ *
+ * Parameterising the term stops injection but not this: `%` and `_` keep their
+ * wildcard meaning once the driver has substituted the value, so an admin
+ * searching users for `%` matched the entire table. Backslash first, or it
+ * would escape the escapes added after it.
+ *
+ * @param {any} value
+ * @returns {string}
+ */
+const escapeLike = (value) =>
+    String(value ?? '').replace(/[\\%_]/g, (character) => `\\${character}`);
+
+/**
+ * Read an "is this account enabled" argument in the forms callers use.
+ *
+ * `updateStatus` was written against a `status` ENUM this schema never had, so
+ * its existing callers pass strings. The column is `is_active TINYINT(1)`, and
+ * both spellings map onto it cleanly. Anything that is neither is rejected
+ * rather than silently coerced to 0, which would deactivate the account.
+ *
+ * @param {any} value
+ * @returns {0|1}
+ */
+const toIsActive = (value) => {
+    if (value === true || value === 1 || value === '1') return 1;
+    if (value === false || value === 0 || value === '0') return 0;
+
+    const text = String(value ?? '').trim().toLowerCase();
+
+    if (text === 'active') return 1;
+    if (text === 'inactive' || text === 'suspended' || text === 'disabled') return 0;
+
+    throw new Error(
+        `Unrecognised account status: ${JSON.stringify(value)}. `
+        + `Expected a boolean, or one of "active", "inactive", "suspended", "disabled".`
+    );
+};
+
 class UserRepository extends BaseRepository {
     constructor() {
-        super('users', 'id');
+        super('users', 'id', { softDeleteColumn: 'deleted_at' });
     }
 
     /**
@@ -11,7 +71,7 @@ class UserRepository extends BaseRepository {
      */
     async findByEmail(email) {
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} WHERE email = ?`,
+            `SELECT * FROM ${this.tableName} WHERE email = ? AND ${LIVE}`,
             [email]
         );
 
@@ -19,20 +79,35 @@ class UserRepository extends BaseRepository {
     }
 
     /**
-     * Find user with profile
+     * Find user with their profile fields.
+     *
+     * This used to read `SELECT * FROM user_profiles`, and there is no such
+     * table in `migrations/` -- so the method threw `ER_NO_SUCH_TABLE` on every
+     * call (#1566). The information it was reaching for is on `users` itself.
+     *
+     * The destructuring was wrong as well, and would have stayed wrong even
+     * against a real table: `db.query()` resolves to `[rows, fields]`, so
+     * `const [profile] = ...` bound `profile` to the rows *array*. `profile ||
+     * null` then kept it, because `[]` is truthy -- reporting a user with no
+     * profile as `profile: []` and one with a profile as `profile: [ {...} ]`.
+     * Neither is an object a caller can read a phone number off.
+     *
+     * @param {string} id user UUID
+     * @returns {Promise<object|null>} the user, with a `profile` object
      */
     async findWithProfile(id) {
         const user = await this.findById(id);
         if (!user) return null;
 
-        const [profile] = await this.db.query(
-            `SELECT * FROM user_profiles WHERE user_id = ?`,
-            [id]
-        );
+        const profile = {};
+
+        for (const column of PROFILE_COLUMNS) {
+            profile[column] = user[column] ?? null;
+        }
 
         return {
             ...user,
-            profile: profile || null
+            profile
         };
     }
 
@@ -41,20 +116,28 @@ class UserRepository extends BaseRepository {
      */
     async updateLastLogin(id) {
         await this.db.query(
-            `UPDATE ${this.tableName} SET last_login = NOW() WHERE id = ?`,
+            `UPDATE ${this.tableName} SET last_login = NOW() WHERE id = ? AND ${LIVE}`,
             [id]
         );
         this.cache.delete(id);
     }
 
     /**
-     * Get active users
+     * Get users who signed in within the last `days`.
+     *
+     * `users` has no `status` column -- the flag is `is_active TINYINT(1)`
+     * (0001_baseline_schema.sql:37). `status = 'active'` threw
+     * `ER_BAD_FIELD_ERROR` (#1566).
+     *
+     * @param {number} [days=30]
+     * @returns {Promise<object[]>}
      */
     async getActive(days = 30) {
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} 
+            `SELECT * FROM ${this.tableName}
              WHERE last_login > DATE_SUB(NOW(), INTERVAL ? DAY)
-             AND status = 'active'`,
+               AND is_active = 1
+               AND ${LIVE}`,
             [days]
         );
 
@@ -66,7 +149,7 @@ class UserRepository extends BaseRepository {
      */
     async findByRole(role) {
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} WHERE role = ?`,
+            `SELECT * FROM ${this.tableName} WHERE role = ? AND ${LIVE}`,
             [role]
         );
 
@@ -74,12 +157,26 @@ class UserRepository extends BaseRepository {
     }
 
     /**
-     * Update user status
+     * Enable or disable an account.
+     *
+     * Writes `is_active`, for the same reason as `getActive`. Callers written
+     * against the imagined `status` ENUM keep working: "active" and
+     * "inactive"/"suspended"/"disabled" both map onto the flag, and anything
+     * unrecognised throws rather than being coerced to 0 -- silently
+     * deactivating an account is the worst available reading of a typo.
+     *
+     * @param {string} id
+     * @param {boolean|string} status
+     * @returns {Promise<boolean>} whether a row changed
      */
     async updateStatus(id, status) {
+        const isActive = toIsActive(status);
+
         const [result] = await this.db.query(
-            `UPDATE ${this.tableName} SET status = ?, updated_at = NOW() WHERE id = ?`,
-            [status, id]
+            `UPDATE ${this.tableName}
+                SET is_active = ?, updated_at = NOW()
+              WHERE id = ? AND ${LIVE}`,
+            [isActive, id]
         );
 
         this.cache.delete(id);
@@ -87,34 +184,58 @@ class UserRepository extends BaseRepository {
     }
 
     /**
-     * Get user statistics
+     * Get user statistics.
+     *
+     * `status` took the whole statement down, not just the one column it
+     * appeared in, so this returned nothing at all rather than a partly wrong
+     * figure (#1566).
+     *
+     * `logged_in_today` was `COUNT(DISTINCT last_login)`, which counts distinct
+     * login *timestamps* across all time. `last_login` is a DATETIME stamped to
+     * the second, so that was close to a plain row count and had no
+     * relationship to today. It now counts accounts whose last sign-in was
+     * today, which is what the column name claims.
+     *
+     * @returns {Promise<object|null>}
      */
     async getStats() {
         const [rows] = await this.db.query(
-            `SELECT 
+            `SELECT
                 COUNT(*) as total_users,
-                SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) as active_users,
+                SUM(CASE WHEN is_active = 1 THEN 1 ELSE 0 END) as active_users,
                 SUM(CASE WHEN role = 'admin' THEN 1 ELSE 0 END) as admins,
                 SUM(CASE WHEN created_at > DATE_SUB(NOW(), INTERVAL 7 DAY) THEN 1 ELSE 0 END) as new_users,
-                COUNT(DISTINCT last_login) as logged_in_today
-             FROM ${this.tableName}`
+                SUM(CASE WHEN DATE(last_login) = CURDATE() THEN 1 ELSE 0 END) as logged_in_today
+             FROM ${this.tableName}
+             WHERE ${LIVE}`
         );
 
         return rows[0] || null;
     }
 
     /**
-     * Search users
+     * Search users by name or email.
+     *
+     * The term is escaped before it is wrapped in wildcards. Parameterising it
+     * stops injection but not the wildcards themselves, which keep their
+     * meaning inside the substituted value -- so an admin searching for `%`
+     * listed every account in the store.
+     *
+     * @param {string} query
+     * @param {{limit?: number, offset?: number}} [options]
+     * @returns {Promise<object[]>}
      */
     async search(query, options = {}) {
         const { limit = 20, offset = 0 } = options;
+        const term = `%${escapeLike(query)}%`;
 
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} 
-             WHERE name LIKE ? OR email LIKE ? 
-             ORDER BY created_at DESC 
+            `SELECT * FROM ${this.tableName}
+             WHERE (name LIKE ? ESCAPE '\\\\' OR email LIKE ? ESCAPE '\\\\')
+               AND ${LIVE}
+             ORDER BY created_at DESC
              LIMIT ? OFFSET ?`,
-            [`%${query}%`, `%${query}%`, limit, offset]
+            [term, term, limit, offset]
         );
 
         return rows;

--- a/backend/tests/userRepository.test.js
+++ b/backend/tests/userRepository.test.js
@@ -1,0 +1,233 @@
+// backend/tests/userRepository.test.js
+//
+// userRepository queried a `users.status` column and a `user_profiles` table,
+// and the schema has neither (#1566).
+//
+// `users` carries `is_active TINYINT(1)` (0001_baseline_schema.sql:37); there is
+// no `status`, and no `CREATE TABLE user_profiles` anywhere in migrations/. So
+// getActive, updateStatus, getStats and findWithProfile all threw before
+// returning -- four of the nine methods in the class, including the one the
+// admin dashboard reads its numbers from.
+
+jest.mock('../config/db', () => ({
+    promise: { query: jest.fn() },
+    withTransaction: jest.fn()
+}));
+
+const userRepo = require('../repositories/userRepository');
+
+const USER_ID = '9f8b7a60-1c2d-4e3f-8a9b-0c1d2e3f4a5b';
+
+/** The statement most recently sent, whitespace collapsed for matching. */
+const lastSql = () => {
+    const calls = userRepo.db.query.mock.calls;
+    return String(calls[calls.length - 1][0]).replace(/\s+/g, ' ').trim();
+};
+
+/** The parameters of the statement most recently sent. */
+const lastParams = () => {
+    const calls = userRepo.db.query.mock.calls;
+    return calls[calls.length - 1][1];
+};
+
+beforeEach(() => {
+    userRepo.db = { query: jest.fn().mockResolvedValue([[], []]) };
+    userRepo.clearCache();
+});
+
+describe('the account flag is is_active, not status', () => {
+    test('getActive filters on is_active', async () => {
+        await userRepo.getActive(30);
+
+        expect(lastSql()).toMatch(/is_active = 1/i);
+        expect(lastSql()).not.toMatch(/status = 'active'/i);
+    });
+
+    test('getStats aggregates is_active', async () => {
+        userRepo.db.query.mockResolvedValue([[{ total_users: 3 }], []]);
+
+        await userRepo.getStats();
+
+        expect(lastSql()).toMatch(/WHEN is_active = 1 THEN 1/i);
+        expect(lastSql()).not.toMatch(/WHEN status = 'active'/i);
+    });
+
+    test('updateStatus writes is_active', async () => {
+        userRepo.db.query.mockResolvedValue([{ affectedRows: 1 }, []]);
+
+        await userRepo.updateStatus(USER_ID, 'active');
+
+        expect(lastSql()).toMatch(/SET is_active = \?/i);
+        expect(lastParams()).toEqual([1, USER_ID]);
+    });
+
+    test('updateStatus still understands the old status vocabulary', async () => {
+        userRepo.db.query.mockResolvedValue([{ affectedRows: 1 }, []]);
+
+        for (const [input, expected] of [
+            ['active', 1],
+            ['inactive', 0],
+            ['suspended', 0],
+            ['disabled', 0],
+            [true, 1],
+            [false, 0],
+            [1, 1],
+            [0, 0]
+        ]) {
+            await userRepo.updateStatus(USER_ID, input);
+            expect(lastParams()[0]).toBe(expected);
+        }
+    });
+
+    test('updateStatus refuses a value it does not recognise', async () => {
+        // Coercing an unknown string to 0 would silently deactivate the
+        // account, which is the worst available reading of a typo.
+        await expect(userRepo.updateStatus(USER_ID, 'actve'))
+            .rejects.toThrow(/Unrecognised account status/i);
+
+        expect(userRepo.db.query).not.toHaveBeenCalled();
+    });
+
+    test('updateStatus reports whether a row changed', async () => {
+        userRepo.db.query.mockResolvedValue([{ affectedRows: 0 }, []]);
+
+        await expect(userRepo.updateStatus(USER_ID, 'active')).resolves.toBe(false);
+    });
+});
+
+describe('findWithProfile', () => {
+    const user = {
+        id: USER_ID,
+        name: 'Someone',
+        email: 'someone@example.com',
+        phone: '9876543210',
+        city: 'Pune',
+        state: 'Maharashtra',
+        zip: '411001',
+        country: 'India',
+        address: '12 Example Road',
+        avatar: null
+    };
+
+    test('does not query a user_profiles table', async () => {
+        userRepo.db.query.mockResolvedValue([[user], []]);
+
+        await userRepo.findWithProfile(USER_ID);
+
+        const statements = userRepo.db.query.mock.calls.map(([sql]) => String(sql));
+        expect(statements.some((sql) => /user_profiles/i.test(sql))).toBe(false);
+    });
+
+    test('returns the profile as an object, not an array', async () => {
+        // The old destructuring bound `profile` to the rows array, and `[]` is
+        // truthy -- so a user with no profile was reported as `profile: []`.
+        userRepo.db.query.mockResolvedValue([[user], []]);
+
+        const result = await userRepo.findWithProfile(USER_ID);
+
+        expect(Array.isArray(result.profile)).toBe(false);
+        expect(result.profile).toEqual({
+            avatar: null,
+            phone: '9876543210',
+            address: '12 Example Road',
+            city: 'Pune',
+            state: 'Maharashtra',
+            zip: '411001',
+            country: 'India'
+        });
+    });
+
+    test('keeps the user fields alongside it', async () => {
+        userRepo.db.query.mockResolvedValue([[user], []]);
+
+        const result = await userRepo.findWithProfile(USER_ID);
+
+        expect(result.id).toBe(USER_ID);
+        expect(result.email).toBe('someone@example.com');
+    });
+
+    test('reports absent profile fields as null rather than undefined', async () => {
+        userRepo.db.query.mockResolvedValue([[{ id: USER_ID, name: 'Someone' }], []]);
+
+        const result = await userRepo.findWithProfile(USER_ID);
+
+        expect(result.profile.phone).toBeNull();
+        expect(result.profile.city).toBeNull();
+    });
+
+    test('returns null for a user who does not exist', async () => {
+        userRepo.db.query.mockResolvedValue([[], []]);
+
+        await expect(userRepo.findWithProfile(USER_ID)).resolves.toBeNull();
+    });
+});
+
+describe('logged_in_today means today', () => {
+    test('it counts accounts whose last sign-in was today', async () => {
+        userRepo.db.query.mockResolvedValue([[{ logged_in_today: 2 }], []]);
+
+        await userRepo.getStats();
+
+        expect(lastSql()).toMatch(/DATE\(last_login\) = CURDATE\(\)/i);
+    });
+
+    test('and no longer counts distinct timestamps across all time', async () => {
+        userRepo.db.query.mockResolvedValue([[{}], []]);
+
+        await userRepo.getStats();
+
+        expect(lastSql()).not.toMatch(/COUNT\(DISTINCT last_login\)/i);
+    });
+});
+
+describe('deactivated accounts stay out of the reads', () => {
+    const readsThatMustFilter = [
+        ['findByEmail', () => userRepo.findByEmail('someone@example.com')],
+        ['findByRole', () => userRepo.findByRole('admin')],
+        ['getActive', () => userRepo.getActive()],
+        ['search', () => userRepo.search('someone')],
+        ['getStats', () => userRepo.getStats()]
+    ];
+
+    test.each(readsThatMustFilter)('%s excludes soft-deleted rows', async (_name, run) => {
+        userRepo.db.query.mockResolvedValue([[{}], []]);
+
+        await run();
+
+        expect(lastSql()).toMatch(/deleted_at IS NULL/i);
+    });
+
+    test('the repository declares the soft-delete column', () => {
+        // Without this, BaseRepository.delete() hard-deletes the row and takes
+        // every order, review and address that cascades off it.
+        expect(userRepo.softDeleteColumn).toBe('deleted_at');
+    });
+});
+
+describe('search terms are not read as LIKE patterns', () => {
+    test('a percent sign is escaped', async () => {
+        await userRepo.search('%');
+
+        expect(lastParams()[0]).toBe('%\\%%');
+        expect(lastSql()).toMatch(/ESCAPE/i);
+    });
+
+    test('an underscore is escaped', async () => {
+        await userRepo.search('a_b');
+
+        expect(lastParams()[0]).toBe('%a\\_b%');
+    });
+
+    test('an ordinary term is unchanged', async () => {
+        await userRepo.search('someone');
+
+        expect(lastParams()[0]).toBe('%someone%');
+    });
+
+    test('name and email get the same escaped term', async () => {
+        await userRepo.search('%');
+
+        const [name, email] = lastParams();
+        expect(name).toBe(email);
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`userRepository` queried a `users.status` column and a `user_profiles` table. Neither exists. `users` carries `is_active TINYINT(1)` (`migrations/0001_baseline_schema.sql:37`), and there is no `CREATE TABLE user_profiles` anywhere in `migrations/`. Four of the nine methods threw before returning:

| Method | Failure |
|---|---|
| `getActive` | `AND status = 'active'` → `ER_BAD_FIELD_ERROR` |
| `updateStatus` | `SET status = ?` → `ER_BAD_FIELD_ERROR` |
| `getStats` | `SUM(CASE WHEN status = 'active' …)` → `ER_BAD_FIELD_ERROR`, which takes the **whole** statement down rather than one column |
| `findWithProfile` | `SELECT * FROM user_profiles` → `ER_NO_SUCH_TABLE` |

**`findWithProfile` had a second, independent fault** that would have survived a correct table name:

```js
const [profile] = await this.db.query(`SELECT * FROM user_profiles WHERE user_id = ?`, [id]);
return { ...user, profile: profile || null };
```

`db.query()` resolves to `[rows, fields]`, so `profile` bound to the **rows array**, and `profile || null` kept it because `[]` is truthy. A user with no profile was reported as `profile: []` and one with a profile as `profile: [ {...} ]` — neither an object a caller can read a phone number off. It now builds the profile from the columns `users` already holds (`avatar`, `phone`, `address`, `city`, `state`, `zip`, `country`), as a single object with `null` for anything unset.

**`updateStatus` stays compatible with its callers.** They were written against the imagined ENUM, so `"active"` and `"inactive"`/`"suspended"`/`"disabled"` both map onto the flag, as do booleans and `0`/`1`. An unrecognised value throws rather than coercing to `0` — silently deactivating an account is the worst available reading of a typo.

**`getStats().logged_in_today` was not "today".** It was `COUNT(DISTINCT last_login)` — distinct login *timestamps* across all time, which for a `DATETIME` stamped to the second is close to a plain row count. Now `SUM(CASE WHEN DATE(last_login) = CURDATE() …)`.

**Two more, both reachable from the admin screens:**

- No read filtered `users.deleted_at`, so deactivated accounts were searchable, listed by role and counted in the statistics. The repository now also declares `deleted_at` as its soft-delete column, so `BaseRepository.delete()` stops hard-deleting a user and everything that cascades off them.
- `search()` wrapped the caller's term in wildcards without escaping it. Parameterising stops injection but not the wildcards — searching for `%` listed every account in the store.

---

## 🔗 Related Issue

Closes #1566

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Backend-only; no UI surface.

Before, against a migrated database:

```
await userRepo.getStats();
  Error: ER_BAD_FIELD_ERROR: Unknown column 'status' in 'field list'

await userRepo.findWithProfile('<uuid>');
  Error: ER_NO_SUCH_TABLE: Table 'ecommerce.user_profiles' doesn't exist
```

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Tests** — `backend/tests/userRepository.test.js`, 23 new cases: the `is_active` corrections, the full `updateStatus` vocabulary table plus the rejection path, `findWithProfile` returning an object rather than an array, `logged_in_today`, soft-delete coverage across five reads, and LIKE escaping.

```
Test Suites: 90 passed, 90 total
Tests:       2028 passed, 2028 total
```

**Marked as a security fix** for the `search()` wildcard behaviour — an admin search for `%` returning the entire user table is an unintended disclosure of scope, even though the term is parameterised and there is no injection here.

**Scope** — only `repositories/userRepository.js` is touched, so this does not overlap with the four sibling repository fixes (#1564, #1565, #1567, #1568) and can merge in any order relative to them.

**Note on the CI flake** — `tests/authMiddleware.test.js` failed once during a full run on this branch and passed on re-run and in isolation (37/37). It is a pre-existing timing flake; nothing in this PR is on its import path.
