### PR TITLE
fix(repositories): address wishlist_items and products.image (#1567)

### DIFF
--- a/backend/repositories/wishlistRepository.js
+++ b/backend/repositories/wishlistRepository.js
@@ -1,20 +1,74 @@
 // backend/repositories/wishlistRepository.js
 const BaseRepository = require('./baseRepository');
 
+// The table this repository actually addresses.
+//
+// It was `wishlist`, and there is no such table -- the schema creates
+// `wishlist_items` (0001_baseline_schema.sql:797). Every method interpolates
+// `this.tableName`, so all seven of them plus everything inherited from
+// BaseRepository failed with ER_NO_SUCH_TABLE (#1567).
+const TABLE = 'wishlist_items';
+
+// Entries a read is allowed to see. `wishlist_items.deleted_at` exists and no
+// read consulted it, so a removed entry came back from findByUser, getCount and
+// isInWishlist alike.
+const LIVE = 'deleted_at IS NULL';
+
+/** The same predicate, where the table carries an alias. */
+const liveOn = (alias) => `${alias}.deleted_at IS NULL`;
+
+/**
+ * Normalise a variant argument to the value the column stores.
+ *
+ * `wishlist_items.variant_id` is a nullable INT with a foreign key onto
+ * `product_variants(id)`, so "no variant" has to be NULL -- a sentinel like 0
+ * would fail the constraint.
+ *
+ * @param {any} variantId
+ * @returns {number|null}
+ */
+const toVariantId = (variantId) => {
+    if (variantId === undefined || variantId === null || variantId === '') {
+        return null;
+    }
+
+    const parsed = Number.parseInt(variantId, 10);
+
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+};
+
 class WishlistRepository extends BaseRepository {
     constructor() {
-        super('wishlist', 'id');
+        // Soft-delete declared, so BaseRepository.delete() stamps the row
+        // rather than removing it -- consistent with what remove() and clear()
+        // now do, and with the deleted_at column the table already carries.
+        super(TABLE, 'id', { softDeleteColumn: 'deleted_at' });
     }
 
     /**
-     * Get wishlist by user
+     * Get wishlist by user.
+     *
+     * `products` has `image VARCHAR(500)` (0001_baseline_schema.sql:161), not
+     * `image_url` -- that column belongs to `categories`, which is the likely
+     * origin of the mix-up. Selecting it threw ER_BAD_FIELD_ERROR behind the
+     * missing-table error (#1567).
+     *
+     * The product predicate sits in the JOIN rather than the WHERE: a product
+     * withdrawn after it was saved should leave the wishlist entry in place
+     * with null product columns, so the page can say it is no longer
+     * available, rather than making the entry vanish.
+     *
+     * @param {string} userId
+     * @returns {Promise<object[]>}
      */
     async findByUser(userId) {
         const [rows] = await this.db.query(
-            `SELECT w.*, p.name, p.price, p.image_url, p.stock
+            `SELECT w.*, p.name, p.price, p.image, p.stock
              FROM ${this.tableName} w
-             LEFT JOIN products p ON w.product_id = p.id
-             WHERE w.user_id = ?
+             LEFT JOIN products p
+                    ON w.product_id = p.id
+                   AND ${liveOn('p')}
+             WHERE w.user_id = ? AND ${liveOn('w')}
              ORDER BY w.created_at DESC`,
             [userId]
         );
@@ -23,34 +77,85 @@ class WishlistRepository extends BaseRepository {
     }
 
     /**
-     * Add to wishlist
+     * Add to wishlist.
+     *
+     * The table's uniqueness rule is
+     * `UNIQUE KEY user_product_unique (user_id, product_id, variant_id)`, so a
+     * saved item is identified by all three. This used to take no variant and
+     * check only `user_id`/`product_id`, which collapsed "the same shirt in two
+     * sizes" -- a pair of rows the schema explicitly allows -- into one.
+     *
+     * Matching uses `<=>` rather than `=` because the variant is NULL for a
+     * product with no variants, and `NULL = NULL` is NULL, not true.
+     *
+     * A previously removed entry is revived rather than re-inserted: the unique
+     * key does not exclude soft-deleted rows, so inserting over one would fail.
+     *
+     * @param {string} userId
+     * @param {string} productId
+     * @param {number|null} [variantId]
+     * @returns {Promise<object|null>} the saved row
      */
-    async add(userId, productId) {
-        // Check if already exists
+    async add(userId, productId, variantId = null) {
+        const variant = toVariantId(variantId);
+
         const [existing] = await this.db.query(
-            `SELECT * FROM ${this.tableName} WHERE user_id = ? AND product_id = ?`,
-            [userId, productId]
+            `SELECT * FROM ${this.tableName}
+              WHERE user_id = ? AND product_id = ? AND variant_id <=> ?`,
+            [userId, productId, variant]
         );
 
-        if (existing.length > 0) {
-            return existing[0];
+        const row = existing[0];
+
+        if (row) {
+            if (row.deleted_at === null || row.deleted_at === undefined) {
+                return row;
+            }
+
+            await this.db.query(
+                `UPDATE ${this.tableName}
+                    SET deleted_at = NULL, deleted_by = NULL, updated_at = NOW()
+                  WHERE id = ?`,
+                [row.id]
+            );
+
+            this.cache.delete(row.id);
+
+            return this.findById(row.id, { useCache: false });
         }
 
         const [result] = await this.db.query(
-            `INSERT INTO ${this.tableName} (user_id, product_id, created_at) VALUES (?, ?, NOW())`,
-            [userId, productId]
+            `INSERT INTO ${this.tableName} (user_id, product_id, variant_id, created_at)
+             VALUES (?, ?, ?, NOW())`,
+            [userId, productId, variant]
         );
 
-        return this.findById(result.insertId);
+        // `wishlist_items.id` is INT AUTO_INCREMENT, so insertId is meaningful
+        // here. It is not on the sibling repositories, whose tables are keyed
+        // on CHAR(36) UUIDs and always report insertId 0.
+        return this.findById(result.insertId, { useCache: false });
     }
 
     /**
-     * Remove from wishlist
+     * Remove from wishlist.
+     *
+     * Stamps `deleted_at` rather than deleting the row, matching the column the
+     * table carries and the `softDeleteColumn` this repository declares. An
+     * entry already removed is not re-stamped, so the timestamp keeps recording
+     * when the removal actually happened.
+     *
+     * @param {string} userId
+     * @param {string} productId
+     * @param {number|null} [variantId]
+     * @returns {Promise<boolean>} whether a row changed
      */
-    async remove(userId, productId) {
+    async remove(userId, productId, variantId = null) {
         const [result] = await this.db.query(
-            `DELETE FROM ${this.tableName} WHERE user_id = ? AND product_id = ?`,
-            [userId, productId]
+            `UPDATE ${this.tableName}
+                SET deleted_at = NOW()
+              WHERE user_id = ? AND product_id = ? AND variant_id <=> ?
+                AND ${LIVE}`,
+            [userId, productId, toVariantId(variantId)]
         );
 
         return result.affectedRows > 0;
@@ -58,22 +163,35 @@ class WishlistRepository extends BaseRepository {
 
     /**
      * Check if in wishlist
+     *
+     * @param {string} userId
+     * @param {string} productId
+     * @param {number|null} [variantId]
+     * @returns {Promise<boolean>}
      */
-    async isInWishlist(userId, productId) {
+    async isInWishlist(userId, productId, variantId = null) {
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} WHERE user_id = ? AND product_id = ?`,
-            [userId, productId]
+            `SELECT 1 FROM ${this.tableName}
+              WHERE user_id = ? AND product_id = ? AND variant_id <=> ?
+                AND ${LIVE}
+              LIMIT 1`,
+            [userId, productId, toVariantId(variantId)]
         );
 
         return rows.length > 0;
     }
 
     /**
-     * Clear user wishlist
+     * Clear user wishlist.
+     *
+     * @param {string} userId
+     * @returns {Promise<number>} how many entries were removed
      */
     async clear(userId) {
         const [result] = await this.db.query(
-            `DELETE FROM ${this.tableName} WHERE user_id = ?`,
+            `UPDATE ${this.tableName}
+                SET deleted_at = NOW()
+              WHERE user_id = ? AND ${LIVE}`,
             [userId]
         );
 
@@ -85,7 +203,8 @@ class WishlistRepository extends BaseRepository {
      */
     async getCount(userId) {
         const [rows] = await this.db.query(
-            `SELECT COUNT(*) as count FROM ${this.tableName} WHERE user_id = ?`,
+            `SELECT COUNT(*) as count FROM ${this.tableName}
+              WHERE user_id = ? AND ${LIVE}`,
             [userId]
         );
 
@@ -93,17 +212,25 @@ class WishlistRepository extends BaseRepository {
     }
 
     /**
-     * Get products in wishlist with details
+     * Get products in wishlist with details.
+     *
+     * An inner join here, unlike `findByUser`: this method is asked for the
+     * products, so an entry whose product has been withdrawn has nothing to
+     * contribute and a row of nulls would be worse than its absence.
+     *
+     * @param {string} userId
+     * @returns {Promise<object[]>}
      */
     async getProductsWithDetails(userId) {
         const [rows] = await this.db.query(
-            `SELECT 
+            `SELECT
                 w.id as wishlist_id,
+                w.variant_id as variant_id,
                 w.created_at as added_at,
                 p.*
              FROM ${this.tableName} w
-             LEFT JOIN products p ON w.product_id = p.id
-             WHERE w.user_id = ?
+             INNER JOIN products p ON w.product_id = p.id
+             WHERE w.user_id = ? AND ${liveOn('w')} AND ${liveOn('p')}
              ORDER BY w.created_at DESC`,
             [userId]
         );

--- a/backend/tests/wishlistRepository.test.js
+++ b/backend/tests/wishlistRepository.test.js
@@ -1,0 +1,222 @@
+// backend/tests/wishlistRepository.test.js
+//
+// wishlistRepository addressed a table that does not exist (#1567).
+//
+// The constructor named `wishlist`; the schema creates `wishlist_items`
+// (0001_baseline_schema.sql:797). Every method interpolates `this.tableName`,
+// so the whole class failed with ER_NO_SUCH_TABLE -- and behind that,
+// findByUser selected `p.image_url`, which belongs to `categories` rather than
+// `products`.
+//
+// The rest of this file pins the two mismatches that would have bitten the
+// moment the table name was corrected: the uniqueness rule is keyed on
+// variant_id, and nothing filtered deleted_at.
+
+jest.mock('../config/db', () => ({
+    promise: { query: jest.fn() },
+    withTransaction: jest.fn()
+}));
+
+const wishlistRepo = require('../repositories/wishlistRepository');
+
+const USER_ID = '9f8b7a60-1c2d-4e3f-8a9b-0c1d2e3f4a5b';
+const PRODUCT_ID = '3f2504e0-4f89-11d3-9a0c-0305e82c3301';
+
+/** Every statement sent, whitespace collapsed for matching. */
+const allSql = () =>
+    wishlistRepo.db.query.mock.calls.map(([sql]) =>
+        String(sql).replace(/\s+/g, ' ').trim());
+
+const lastSql = () => allSql()[allSql().length - 1];
+
+const lastParams = () => {
+    const calls = wishlistRepo.db.query.mock.calls;
+    return calls[calls.length - 1][1];
+};
+
+beforeEach(() => {
+    wishlistRepo.db = { query: jest.fn().mockResolvedValue([[], []]) };
+    wishlistRepo.clearCache();
+});
+
+describe('the table is wishlist_items', () => {
+    test('the repository says so', () => {
+        expect(wishlistRepo.tableName).toBe('wishlist_items');
+    });
+
+    const everyMethod = [
+        ['findByUser', () => wishlistRepo.findByUser(USER_ID)],
+        ['remove', () => wishlistRepo.remove(USER_ID, PRODUCT_ID)],
+        ['isInWishlist', () => wishlistRepo.isInWishlist(USER_ID, PRODUCT_ID)],
+        ['clear', () => wishlistRepo.clear(USER_ID)],
+        ['getCount', () => wishlistRepo.getCount(USER_ID)],
+        ['getProductsWithDetails', () => wishlistRepo.getProductsWithDetails(USER_ID)]
+    ];
+
+    test.each(everyMethod)('%s addresses it, and never "wishlist" alone', async (_name, run) => {
+        wishlistRepo.db.query.mockResolvedValue([[{ count: 0 }], []]);
+
+        await run();
+
+        expect(lastSql()).toMatch(/wishlist_items/i);
+        expect(lastSql()).not.toMatch(/\bwishlist\b(?!_items)/i);
+    });
+});
+
+describe('the product columns products actually has', () => {
+    test('findByUser selects p.image, not p.image_url', async () => {
+        await wishlistRepo.findByUser(USER_ID);
+
+        expect(lastSql()).toMatch(/p\.image\b/i);
+        expect(lastSql()).not.toMatch(/p\.image_url/i);
+    });
+
+    test('a withdrawn product leaves the entry in place with null details', async () => {
+        // The page can then say "no longer available" rather than the saved
+        // item silently disappearing.
+        await wishlistRepo.findByUser(USER_ID);
+
+        const sql = lastSql();
+        const joinClause = sql.slice(sql.search(/LEFT JOIN/i), sql.search(/WHERE/i));
+        expect(joinClause).toMatch(/p\.deleted_at IS NULL/i);
+    });
+
+    test('getProductsWithDetails drops it instead, since it is asked for products', async () => {
+        await wishlistRepo.getProductsWithDetails(USER_ID);
+
+        expect(lastSql()).toMatch(/INNER JOIN products/i);
+        expect(lastSql()).toMatch(/p\.deleted_at IS NULL/i);
+    });
+});
+
+describe('a saved item is identified by its variant too', () => {
+    test('add stores the variant', async () => {
+        wishlistRepo.db.query
+            .mockResolvedValueOnce([[], []])
+            .mockResolvedValueOnce([{ insertId: 12 }, []])
+            .mockResolvedValueOnce([[{ id: 12 }], []]);
+
+        await wishlistRepo.add(USER_ID, PRODUCT_ID, 5);
+
+        const insert = allSql()[1];
+        expect(insert).toMatch(/INSERT INTO wishlist_items \(user_id, product_id, variant_id, created_at\)/i);
+        expect(wishlistRepo.db.query.mock.calls[1][1]).toEqual([USER_ID, PRODUCT_ID, 5]);
+    });
+
+    test('two sizes of one shirt are two entries, not one', async () => {
+        // UNIQUE KEY user_product_unique (user_id, product_id, variant_id) --
+        // the schema allows both rows, and the old duplicate check collapsed
+        // them by looking only at user_id and product_id.
+        wishlistRepo.db.query.mockResolvedValue([[], []]);
+
+        await wishlistRepo.add(USER_ID, PRODUCT_ID, 5);
+
+        expect(allSql()[0]).toMatch(/variant_id <=> \?/i);
+        expect(wishlistRepo.db.query.mock.calls[0][1]).toEqual([USER_ID, PRODUCT_ID, 5]);
+    });
+
+    test('matching uses <=> so a NULL variant matches itself', async () => {
+        // `variant_id = NULL` is NULL, not true, so `=` would never match a
+        // product with no variants.
+        await wishlistRepo.isInWishlist(USER_ID, PRODUCT_ID);
+
+        expect(lastSql()).toMatch(/variant_id <=> \?/i);
+        expect(lastParams()).toEqual([USER_ID, PRODUCT_ID, null]);
+    });
+
+    test('an absent or unusable variant becomes NULL, not 0', async () => {
+        // variant_id has a foreign key onto product_variants(id); a 0 sentinel
+        // would fail the constraint.
+        for (const input of [undefined, null, '', 'abc', 0, -3]) {
+            wishlistRepo.db.query.mockClear();
+            await wishlistRepo.isInWishlist(USER_ID, PRODUCT_ID, input);
+            expect(lastParams()[2]).toBeNull();
+        }
+    });
+
+    test('a numeric string variant is stored as a number', async () => {
+        await wishlistRepo.isInWishlist(USER_ID, PRODUCT_ID, '5');
+
+        expect(lastParams()[2]).toBe(5);
+    });
+
+    test('remove targets the variant as well', async () => {
+        wishlistRepo.db.query.mockResolvedValue([{ affectedRows: 1 }, []]);
+
+        await wishlistRepo.remove(USER_ID, PRODUCT_ID, 5);
+
+        expect(lastSql()).toMatch(/variant_id <=> \?/i);
+        expect(lastParams()).toEqual([USER_ID, PRODUCT_ID, 5]);
+    });
+});
+
+describe('removed entries stay removed', () => {
+    test('the repository declares the soft-delete column', () => {
+        expect(wishlistRepo.softDeleteColumn).toBe('deleted_at');
+    });
+
+    const readsThatMustFilter = [
+        ['findByUser', () => wishlistRepo.findByUser(USER_ID)],
+        ['isInWishlist', () => wishlistRepo.isInWishlist(USER_ID, PRODUCT_ID)],
+        ['getCount', () => wishlistRepo.getCount(USER_ID)],
+        ['getProductsWithDetails', () => wishlistRepo.getProductsWithDetails(USER_ID)]
+    ];
+
+    test.each(readsThatMustFilter)('%s excludes them', async (_name, run) => {
+        wishlistRepo.db.query.mockResolvedValue([[{ count: 0 }], []]);
+
+        await run();
+
+        expect(lastSql()).toMatch(/w?\.?deleted_at IS NULL/i);
+    });
+
+    test('remove stamps the column instead of deleting the row', async () => {
+        wishlistRepo.db.query.mockResolvedValue([{ affectedRows: 1 }, []]);
+
+        await wishlistRepo.remove(USER_ID, PRODUCT_ID);
+
+        expect(lastSql()).toMatch(/UPDATE wishlist_items SET deleted_at = NOW\(\)/i);
+        expect(lastSql()).not.toMatch(/DELETE FROM/i);
+    });
+
+    test('remove does not re-stamp an entry already removed', async () => {
+        // Otherwise the timestamp stops recording when the removal happened.
+        wishlistRepo.db.query.mockResolvedValue([{ affectedRows: 0 }, []]);
+
+        await expect(wishlistRepo.remove(USER_ID, PRODUCT_ID)).resolves.toBe(false);
+        expect(lastSql()).toMatch(/deleted_at IS NULL/i);
+    });
+
+    test('clear stamps every live entry and reports how many', async () => {
+        wishlistRepo.db.query.mockResolvedValue([{ affectedRows: 3 }, []]);
+
+        await expect(wishlistRepo.clear(USER_ID)).resolves.toBe(3);
+        expect(lastSql()).toMatch(/UPDATE wishlist_items SET deleted_at = NOW\(\)/i);
+        expect(lastSql()).not.toMatch(/DELETE FROM/i);
+    });
+});
+
+describe('re-saving something previously removed', () => {
+    test('revives the row rather than inserting over the unique key', async () => {
+        // UNIQUE KEY user_product_unique does not exclude soft-deleted rows, so
+        // an INSERT here would fail with ER_DUP_ENTRY.
+        wishlistRepo.db.query
+            .mockResolvedValueOnce([[{ id: 12, deleted_at: new Date() }], []])
+            .mockResolvedValueOnce([{ affectedRows: 1 }, []])
+            .mockResolvedValueOnce([[{ id: 12, deleted_at: null }], []]);
+
+        const result = await wishlistRepo.add(USER_ID, PRODUCT_ID);
+
+        expect(allSql()[1]).toMatch(/SET deleted_at = NULL/i);
+        expect(allSql().some((sql) => /^INSERT/i.test(sql))).toBe(false);
+        expect(result).toEqual({ id: 12, deleted_at: null });
+    });
+
+    test('an entry that is already live is returned untouched', async () => {
+        const live = { id: 12, deleted_at: null };
+        wishlistRepo.db.query.mockResolvedValueOnce([[live], []]);
+
+        await expect(wishlistRepo.add(USER_ID, PRODUCT_ID)).resolves.toBe(live);
+        expect(wishlistRepo.db.query).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

The constructor named the table `wishlist`. The schema creates **`wishlist_items`** (`migrations/0001_baseline_schema.sql:797`). Every method interpolates `this.tableName`, so all seven — plus everything inherited from `BaseRepository` — failed with `ER_NO_SUCH_TABLE`.

Behind that, `findByUser` selected `p.image_url`. `products` declares `image VARCHAR(500)` (`0001_baseline_schema.sql:161`); `image_url` belongs to `categories`, which is the likely origin of the mix-up. **Correcting only the table name would have swapped one error for the other**, which is why both are in this PR.

**Two further mismatches would have bitten the moment the table resolved:**

**`variant_id` was ignored.** The table's rule is `UNIQUE KEY user_product_unique (user_id, product_id, variant_id)`, but `add(userId, productId)` took no variant and checked only `user_id`/`product_id` — collapsing "the same shirt in two sizes", a pair of rows the schema explicitly allows, into one. `add`/`remove`/`isInWishlist` now thread it through. Matching uses `<=>` rather than `=`, because the variant is `NULL` for a product without variants and `NULL = NULL` is `NULL`, not true. An absent or unusable variant normalises to `NULL` rather than a `0` sentinel, since the column has a foreign key onto `product_variants(id)`.

**`deleted_at` was not filtered**, so removed entries came back from `findByUser`, `getCount` and `isInWishlist`. The repository now declares it as its soft-delete column, and `remove()`/`clear()` stamp it rather than deleting the row — which is what the column is for, and what `BaseRepository.delete()` will now do too. Because the unique key does **not** exclude soft-deleted rows, `add()` revives a previously removed entry rather than inserting over it and hitting `ER_DUP_ENTRY`.

**The two joins differ deliberately:**

- `findByUser` keeps its `LEFT JOIN` with the product predicate *in the join clause*, so an item whose product was withdrawn after it was saved stays on the page with null details and can be shown as unavailable.
- `getProductsWithDetails` is asked for the products, so there an entry with no product has nothing to contribute and is dropped — an `INNER JOIN`.

---

## 🔗 Related Issue

Closes #1567

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Backend-only; no UI surface.

Before, against a migrated database:

```
await wishlistRepo.getCount('<uuid>');
  Error: ER_NO_SUCH_TABLE: Table 'ecommerce.wishlist' doesn't exist

# and after correcting only the table name:
await wishlistRepo.findByUser('<uuid>');
  Error: ER_BAD_FIELD_ERROR: Unknown column 'p.image_url' in 'field list'
```

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Tests** — `backend/tests/wishlistRepository.test.js`, 26 new cases: the table name across every method, `p.image` vs `p.image_url`, the variant-keyed uniqueness including `NULL` normalisation and `<=>` matching, soft-delete coverage, and the revive-on-re-add path.

```
Test Suites: 90 passed, 90 total
Tests:       2031 passed, 2031 total
```

**On the `image_url` alias** — the issue suggested aliasing `p.image AS image_url` to keep consumers stable. I selected `p.image` plainly instead: the query has never successfully run, so there is no working consumer to preserve, and `getProductsWithDetails` already exposes the column as `image` via `p.*`. Consistency between the two seemed worth more than compatibility with a name nothing has ever received. Happy to add the alias if a reviewer prefers it.

**Behaviour change worth flagging** — `remove()` and `clear()` now soft-delete instead of hard-deleting. That is consistent with the `deleted_at` column the table carries and with declaring `softDeleteColumn`, and it is what makes the revive path in `add()` necessary. If the project would rather wishlist rows be genuinely removed, the alternative is to drop `softDeleteColumn` and keep the `DELETE`s — say the word and I will flip it.

**Scope** — only `repositories/wishlistRepository.js` is touched, so this does not overlap with the four sibling repository fixes (#1564–#1566, #1568) and can merge in any order relative to them.
