### PR TITLE
fix(repositories): sum orders.total, and make delivered the fulfilled state (#1568)

### DIFF
--- a/backend/repositories/orderRepository.js
+++ b/backend/repositories/orderRepository.js
@@ -1,9 +1,65 @@
 // backend/repositories/orderRepository.js
 const BaseRepository = require('./baseRepository');
 
+// The states `orders.status` can actually hold
+// (0001_baseline_schema.sql:287). Declared here so `findByStatus` can reject a
+// value the column has no room for instead of returning an empty list: MySQL
+// matches no rows when an ENUM is compared against something outside its set,
+// which is how `getCompleted()` came to report "no completed orders" on a store
+// full of delivered ones (#1568).
+const ORDER_STATUSES = Object.freeze([
+    'pending',
+    'processing',
+    'shipped',
+    'delivered',
+    'cancelled',
+    'refunded',
+    'on_hold'
+]);
+
+// The fulfilled terminal state. There is no 'completed' in this schema -- see
+// also #769, which tracks the same vocabulary drift across other files.
+const FULFILLED_STATUS = 'delivered';
+
+// Orders that are over. Cancelling one of these is not a cancellation, it is
+// an overwrite: it would move a delivered order into 'cancelled', or reset
+// `cancelled_at` on an order already cancelled and lose when that happened.
+const UNCANCELLABLE_STATUSES = Object.freeze(['delivered', 'cancelled', 'refunded']);
+
+// States whose money is not revenue. `getStats` excluded only 'cancelled', so
+// refunded orders were still counted in the total.
+const NON_REVENUE_STATUSES = Object.freeze(['cancelled', 'refunded']);
+
+// Orders a read is allowed to see. `orders.deleted_at` exists and nothing in
+// this file consulted it, so soft-deleted orders were returned to customers and
+// counted in revenue.
+const LIVE = 'deleted_at IS NULL';
+
+/** The same predicate, where the table carries an alias. */
+const liveOn = (alias) => `${alias}.deleted_at IS NULL`;
+
+/**
+ * Refuse a status the column cannot hold.
+ *
+ * @param {any} status
+ * @returns {string} the status, normalised
+ */
+const assertStatus = (status) => {
+    const value = String(status ?? '').trim().toLowerCase();
+
+    if (!ORDER_STATUSES.includes(value)) {
+        throw new Error(
+            `Unknown order status: ${JSON.stringify(status)}. `
+            + `Expected one of ${ORDER_STATUSES.join(', ')}.`
+        );
+    }
+
+    return value;
+};
+
 class OrderRepository extends BaseRepository {
     constructor() {
-        super('orders', 'id');
+        super('orders', 'id', { softDeleteColumn: 'deleted_at' });
     }
 
     /**
@@ -12,12 +68,12 @@ class OrderRepository extends BaseRepository {
     async findByUser(userId, options = {}) {
         const { limit = 20, offset = 0, status } = options;
 
-        let query = `SELECT * FROM ${this.tableName} WHERE user_id = ?`;
+        let query = `SELECT * FROM ${this.tableName} WHERE user_id = ? AND ${LIVE}`;
         const params = [userId];
 
         if (status) {
             query += ' AND status = ?';
-            params.push(status);
+            params.push(assertStatus(status));
         }
 
         query += ' ORDER BY created_at DESC LIMIT ? OFFSET ?';
@@ -32,7 +88,7 @@ class OrderRepository extends BaseRepository {
      */
     async findWithItems(id) {
         const order = await this.findById(id);
-        if (!order) return null;
+        if (!order || order.deleted_at) return null;
 
         const [items] = await this.db.query(
             `SELECT oi.*, p.name as product_name, p.price as product_price
@@ -49,12 +105,22 @@ class OrderRepository extends BaseRepository {
     }
 
     /**
-     * Get orders by status
+     * Get orders by status.
+     *
+     * The status is checked against the ENUM before it reaches SQL. Comparing
+     * the column to a value outside its set matches nothing and raises nothing,
+     * so an unknown status used to come back as a plausible empty list rather
+     * than as the mistake it is.
+     *
+     * @param {string} status one of ORDER_STATUSES
+     * @returns {Promise<object[]>}
      */
     async findByStatus(status) {
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} WHERE status = ? ORDER BY created_at DESC`,
-            [status]
+            `SELECT * FROM ${this.tableName}
+              WHERE status = ? AND ${LIVE}
+              ORDER BY created_at DESC`,
+            [assertStatus(status)]
         );
 
         return rows;
@@ -65,8 +131,10 @@ class OrderRepository extends BaseRepository {
      */
     async updateStatus(id, status) {
         const [result] = await this.db.query(
-            `UPDATE ${this.tableName} SET status = ?, updated_at = NOW() WHERE id = ?`,
-            [status, id]
+            `UPDATE ${this.tableName}
+                SET status = ?, updated_at = NOW()
+              WHERE id = ? AND ${LIVE}`,
+            [assertStatus(status), id]
         );
 
         this.cache.delete(id);
@@ -74,20 +142,38 @@ class OrderRepository extends BaseRepository {
     }
 
     /**
-     * Get order statistics
+     * Get order statistics.
+     *
+     * The aggregate is over `total`. There is no `orders.total_amount` column
+     * and no migration adds one -- the name appears in
+     * migrations/0047_gift_card_order_settlement.sql only inside a comment
+     * describing what the table would need. So this statement threw
+     * ER_BAD_FIELD_ERROR and never produced a figure, for a single customer or
+     * for the store (#1568).
+     *
+     * Refunded orders are excluded alongside cancelled ones; their money is not
+     * revenue. `payment_status` is deliberately not consulted, so these figures
+     * are orders booked rather than cash collected -- a distinction worth
+     * keeping explicit, since the two diverge for every unpaid COD order.
+     *
+     * @param {string|null} [userId] restrict to one customer
+     * @returns {Promise<object|null>}
      */
     async getStats(userId = null) {
+        const excluded = NON_REVENUE_STATUSES.map(() => '?').join(', ');
+
         let query = `
-            SELECT 
-                COUNT(*) as total_orders,
-                SUM(total_amount) as total_revenue,
-                AVG(total_amount) as avg_order_value,
-                MIN(total_amount) as min_order,
-                MAX(total_amount) as max_order
+            SELECT
+                COUNT(*)   as total_orders,
+                SUM(total) as total_revenue,
+                AVG(total) as avg_order_value,
+                MIN(total) as min_order,
+                MAX(total) as max_order
             FROM ${this.tableName}
-            WHERE status != 'cancelled'
+            WHERE status NOT IN (${excluded})
+              AND ${LIVE}
         `;
-        const params = [];
+        const params = [...NON_REVENUE_STATUSES];
 
         if (userId) {
             query += ' AND user_id = ?';
@@ -106,6 +192,7 @@ class OrderRepository extends BaseRepository {
             `SELECT o.*, u.name as user_name, u.email as user_email
              FROM ${this.tableName} o
              LEFT JOIN users u ON o.user_id = u.id
+             WHERE ${liveOn('o')}
              ORDER BY o.created_at DESC
              LIMIT ?`,
             [limit]
@@ -119,8 +206,8 @@ class OrderRepository extends BaseRepository {
      */
     async getByDateRange(startDate, endDate) {
         const [rows] = await this.db.query(
-            `SELECT * FROM ${this.tableName} 
-             WHERE created_at BETWEEN ? AND ? 
+            `SELECT * FROM ${this.tableName}
+             WHERE created_at BETWEEN ? AND ? AND ${LIVE}
              ORDER BY created_at DESC`,
             [startDate, endDate]
         );
@@ -129,17 +216,30 @@ class OrderRepository extends BaseRepository {
     }
 
     /**
-     * Cancel order
+     * Cancel order.
+     *
+     * Guarded on the states an order can still be cancelled from. Without the
+     * guard this moved a delivered order into 'cancelled' and reset
+     * `cancelled_at` on one already cancelled -- and reported both as success,
+     * because `affectedRows > 0` is true for an overwrite.
+     *
+     * @param {string} id
+     * @param {string} reason
+     * @returns {Promise<boolean>} whether the order was cancelled
      */
     async cancel(id, reason) {
+        const blocked = UNCANCELLABLE_STATUSES.map(() => '?').join(', ');
+
         const [result] = await this.db.query(
-            `UPDATE ${this.tableName} 
-             SET status = 'cancelled', 
+            `UPDATE ${this.tableName}
+             SET status = 'cancelled',
                  cancellation_reason = ?,
                  cancelled_at = NOW(),
                  updated_at = NOW()
-             WHERE id = ?`,
-            [reason, id]
+             WHERE id = ?
+               AND status NOT IN (${blocked})
+               AND ${LIVE}`,
+            [reason, id, ...UNCANCELLABLE_STATUSES]
         );
 
         this.cache.delete(id);
@@ -161,11 +261,23 @@ class OrderRepository extends BaseRepository {
     }
 
     /**
-     * Get completed orders
+     * Get fulfilled orders.
+     *
+     * `'completed'` is not one of the seven states `orders.status` can hold, so
+     * this returned an empty array on a store with any number of delivered
+     * orders -- silently, which read as "none yet" rather than as a bug, and
+     * which its two working siblings above made look plausible (#1568).
      */
     async getCompleted() {
-        return this.findByStatus('completed');
+        return this.findByStatus(FULFILLED_STATUS);
     }
 }
 
-module.exports = new OrderRepository();
+const orderRepository = new OrderRepository();
+
+// Exported off the instance so callers can name a status without restating the
+// ENUM, which is how 'completed' got written in the first place.
+orderRepository.ORDER_STATUSES = ORDER_STATUSES;
+orderRepository.FULFILLED_STATUS = FULFILLED_STATUS;
+
+module.exports = orderRepository;

--- a/backend/tests/orderRepository.test.js
+++ b/backend/tests/orderRepository.test.js
@@ -1,0 +1,236 @@
+// backend/tests/orderRepository.test.js
+//
+// Two independent faults, one loud and one silent (#1568).
+//
+// getStats() aggregated `total_amount`. orders has subtotal, total and
+// final_amount (0001_baseline_schema.sql:186-190) and no total_amount -- the
+// name appears in migrations/0047 only inside a comment. So the statement threw
+// ER_BAD_FIELD_ERROR and the store never got a revenue figure at all.
+//
+// getCompleted() filtered on 'completed', which is not one of the seven states
+// orders.status can hold. That one raised nothing: MySQL matches no rows when
+// an ENUM is compared against a value outside its set, so it returned [] on a
+// store full of delivered orders, and its two working siblings made that look
+// like a true answer.
+
+jest.mock('../config/db', () => ({
+    promise: { query: jest.fn() },
+    withTransaction: jest.fn()
+}));
+
+const orderRepo = require('../repositories/orderRepository');
+
+const ORDER_ID = '7c9e6679-7425-40de-944b-e07fc1f90ae7';
+const USER_ID = '9f8b7a60-1c2d-4e3f-8a9b-0c1d2e3f4a5b';
+
+/** Every statement sent, whitespace collapsed for matching. */
+const allSql = () =>
+    orderRepo.db.query.mock.calls.map(([sql]) =>
+        String(sql).replace(/\s+/g, ' ').trim());
+
+const lastSql = () => allSql()[allSql().length - 1];
+
+const lastParams = () => {
+    const calls = orderRepo.db.query.mock.calls;
+    return calls[calls.length - 1][1];
+};
+
+beforeEach(() => {
+    orderRepo.db = { query: jest.fn().mockResolvedValue([[], []]) };
+    orderRepo.clearCache();
+});
+
+describe('getStats aggregates a column that exists', () => {
+    beforeEach(() => {
+        orderRepo.db.query.mockResolvedValue([[{ total_orders: 2 }], []]);
+    });
+
+    test('it sums total, not total_amount', async () => {
+        await orderRepo.getStats();
+
+        expect(lastSql()).toMatch(/SUM\(total\) as total_revenue/i);
+        expect(lastSql()).not.toMatch(/total_amount/i);
+    });
+
+    test('every aggregate moves together', async () => {
+        await orderRepo.getStats();
+
+        for (const fn of ['SUM', 'AVG', 'MIN', 'MAX']) {
+            expect(lastSql()).toMatch(new RegExp(`${fn}\\(total\\)`, 'i'));
+        }
+    });
+
+    test('refunded money is not counted as revenue', async () => {
+        await orderRepo.getStats();
+
+        expect(lastSql()).toMatch(/status NOT IN \(\?, \?\)/i);
+        expect(lastParams().slice(0, 2)).toEqual(['cancelled', 'refunded']);
+    });
+
+    test('it can still be scoped to one customer', async () => {
+        await orderRepo.getStats(USER_ID);
+
+        expect(lastSql()).toMatch(/AND user_id = \?/i);
+        expect(lastParams()).toEqual(['cancelled', 'refunded', USER_ID]);
+    });
+
+    test('soft-deleted orders are not counted', async () => {
+        await orderRepo.getStats();
+
+        expect(lastSql()).toMatch(/deleted_at IS NULL/i);
+    });
+
+    test('it returns null rather than undefined when there is no row', async () => {
+        orderRepo.db.query.mockResolvedValue([[], []]);
+
+        await expect(orderRepo.getStats()).resolves.toBeNull();
+    });
+});
+
+describe('the fulfilled state is delivered, not completed', () => {
+    test('getCompleted asks for delivered orders', async () => {
+        await orderRepo.getCompleted();
+
+        expect(lastSql()).toMatch(/WHERE status = \?/i);
+        expect(lastParams()[0]).toBe('delivered');
+    });
+
+    test('and never for a status the ENUM has no room for', async () => {
+        await orderRepo.getCompleted();
+
+        expect(lastParams()[0]).not.toBe('completed');
+    });
+
+    test('its working siblings are unchanged', async () => {
+        await orderRepo.getPending();
+        expect(lastParams()[0]).toBe('pending');
+
+        await orderRepo.getProcessing();
+        expect(lastParams()[0]).toBe('processing');
+    });
+
+    test('the fulfilled status is exported so callers need not restate it', () => {
+        // Restating the vocabulary by hand is how 'completed' got written.
+        expect(orderRepo.FULFILLED_STATUS).toBe('delivered');
+        expect(orderRepo.ORDER_STATUSES).toContain('delivered');
+        expect(orderRepo.ORDER_STATUSES).not.toContain('completed');
+    });
+});
+
+describe('an unknown status fails loudly', () => {
+    test('findByStatus refuses it', async () => {
+        // Previously an empty list, which is indistinguishable from a true
+        // "none in that state" answer.
+        await expect(orderRepo.findByStatus('completed'))
+            .rejects.toThrow(/Unknown order status/i);
+
+        expect(orderRepo.db.query).not.toHaveBeenCalled();
+    });
+
+    test('the message names what was expected', async () => {
+        await expect(orderRepo.findByStatus('shipped_out'))
+            .rejects.toThrow(/pending, processing, shipped, delivered/i);
+    });
+
+    test('updateStatus refuses it too', async () => {
+        await expect(orderRepo.updateStatus(ORDER_ID, 'complete'))
+            .rejects.toThrow(/Unknown order status/i);
+    });
+
+    test('findByUser refuses it when filtering', async () => {
+        await expect(orderRepo.findByUser(USER_ID, { status: 'done' }))
+            .rejects.toThrow(/Unknown order status/i);
+    });
+
+    test('a valid status in the wrong case is accepted and normalised', async () => {
+        await orderRepo.findByStatus('Delivered');
+
+        expect(lastParams()[0]).toBe('delivered');
+    });
+
+    test('findByUser without a status filter is unaffected', async () => {
+        await orderRepo.findByUser(USER_ID);
+
+        expect(lastSql()).not.toMatch(/AND status = \?/i);
+    });
+});
+
+describe('cancel does not overwrite an order that is over', () => {
+    test('it excludes delivered, cancelled and refunded orders', async () => {
+        orderRepo.db.query.mockResolvedValue([{ affectedRows: 1 }, []]);
+
+        await orderRepo.cancel(ORDER_ID, 'changed my mind');
+
+        expect(lastSql()).toMatch(/status NOT IN \(\?, \?, \?\)/i);
+        expect(lastParams()).toEqual([
+            'changed my mind', ORDER_ID, 'delivered', 'cancelled', 'refunded'
+        ]);
+    });
+
+    test('it reports false when nothing was cancellable', async () => {
+        // affectedRows > 0 was true for an overwrite, so the old version
+        // reported re-cancelling a delivered order as a success.
+        orderRepo.db.query.mockResolvedValue([{ affectedRows: 0 }, []]);
+
+        await expect(orderRepo.cancel(ORDER_ID, 'too late')).resolves.toBe(false);
+    });
+
+    test('it still records the reason and the time', async () => {
+        orderRepo.db.query.mockResolvedValue([{ affectedRows: 1 }, []]);
+
+        await orderRepo.cancel(ORDER_ID, 'changed my mind');
+
+        expect(lastSql()).toMatch(/cancellation_reason = \?/i);
+        expect(lastSql()).toMatch(/cancelled_at = NOW\(\)/i);
+    });
+});
+
+describe('soft-deleted orders stay out of the reads', () => {
+    const readsThatMustFilter = [
+        ['findByUser', () => orderRepo.findByUser(USER_ID)],
+        ['findByStatus', () => orderRepo.findByStatus('pending')],
+        ['getByDateRange', () => orderRepo.getByDateRange('2026-01-01', '2026-02-01')],
+        ['getStats', () => orderRepo.getStats()]
+    ];
+
+    test.each(readsThatMustFilter)('%s excludes them', async (_name, run) => {
+        orderRepo.db.query.mockResolvedValue([[{}], []]);
+
+        await run();
+
+        expect(lastSql()).toMatch(/deleted_at IS NULL/i);
+    });
+
+    test('getRecent excludes them on the aliased table', async () => {
+        await orderRepo.getRecent();
+
+        expect(lastSql()).toMatch(/o\.deleted_at IS NULL/i);
+    });
+
+    test('findWithItems refuses a deleted order', async () => {
+        orderRepo.db.query.mockResolvedValue([
+            [{ id: ORDER_ID, deleted_at: new Date() }], []
+        ]);
+
+        await expect(orderRepo.findWithItems(ORDER_ID)).resolves.toBeNull();
+        // It must not go on to fetch the items.
+        expect(orderRepo.db.query).toHaveBeenCalledTimes(1);
+    });
+
+    test('findWithItems still returns a live order with its items', async () => {
+        orderRepo.db.query
+            .mockResolvedValueOnce([[{ id: ORDER_ID, deleted_at: null }], []])
+            .mockResolvedValueOnce([[{ id: 1, name: 'Shirt' }], []]);
+
+        const result = await orderRepo.findWithItems(ORDER_ID);
+
+        expect(result.id).toBe(ORDER_ID);
+        expect(result.items).toEqual([{ id: 1, name: 'Shirt' }]);
+    });
+
+    test('the repository declares the soft-delete column', () => {
+        // Without it, BaseRepository.delete() hard-deletes the order and
+        // cascades order_items away with it.
+        expect(orderRepo.softDeleteColumn).toBe('deleted_at');
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

Two independent faults in `orderRepository`, one loud and one silent.

**1. `getStats()` aggregated a column that does not exist.** `orders` has `subtotal`, `total` and `final_amount` (`migrations/0001_baseline_schema.sql:186-190`). There is no `total_amount` and no migration adds one — the name appears in `migrations/0047_gift_card_order_settlement.sql` only inside a comment describing what the table *would* need. `SUM(total_amount)` threw `ER_BAD_FIELD_ERROR`, so the store never got a revenue figure at all, for one customer or in aggregate. Now aggregates `total`.

**2. `getCompleted()` filtered on a status the ENUM does not contain.** `orders.status` is `ENUM('pending','processing','shipped','delivered','cancelled','refunded','on_hold')`; `'completed'` is not one of them, and the fulfilled state here is `'delivered'`.

This one is worse than an error because it does not raise one. MySQL matches no rows when an ENUM is compared against a value outside its set, so `getCompleted()` returned `[]` on a store full of delivered orders — and `getPending()`/`getProcessing()` sitting next to it name real states and work, which made the empty result read as "none yet" rather than as a bug. Another instance of the vocabulary drift #769 tracks, in a file that issue does not list.

`findByStatus`, `updateStatus` and `findByUser` now validate the status against the ENUM before it reaches SQL, so an unknown value fails by name instead of returning a plausible empty list. The vocabulary is exported off the instance as `ORDER_STATUSES` / `FULFILLED_STATUS`, since restating it by hand is how `'completed'` got written in the first place.

**Alongside those:**

- `getStats()` excluded only `'cancelled'`, so **refunded money was still counted as revenue**. Now excludes both.
- **No read filtered `orders.deleted_at`**, so soft-deleted orders were returned to customers and counted in the totals. `findByUser`, `findByStatus`, `getRecent`, `getByDateRange`, `getStats` and `findWithItems` all filter now, and the repository declares `deleted_at` as its soft-delete column so `BaseRepository.delete()` stops hard-deleting an order and cascading `order_items` away with it.
- **`cancel()` had no status guard**, so it moved a delivered order into `'cancelled'` and reset `cancelled_at` on one already cancelled — reporting both as success, because `affectedRows > 0` is true for an overwrite.

---

## 🔗 Related Issue

Closes #1568

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Backend-only; no UI surface.

Before, against a migrated database with a delivered order:

```
await orderRepo.getStats();
  Error: ER_BAD_FIELD_ERROR: Unknown column 'total_amount' in 'field list'

await orderRepo.getCompleted();
  → []      # silently; the delivered order is not returned
```

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Tests** — `backend/tests/orderRepository.test.js`, 27 new cases: the corrected aggregate, the delivered-vs-completed status, the validation path and its message, the `cancel()` guard, and soft-delete coverage across six reads including `findWithItems` refusing to fetch items for a deleted order.

```
Test Suites: 90 passed, 90 total
Tests:       2032 passed, 2032 total
```

**Deliberately not changed** — `payment_status` is still not consulted by `getStats()`. These figures are orders *booked* rather than cash *collected*, and the two diverge for every unpaid COD order. That seemed worth making an explicit, documented decision rather than leaving it an accident, but it is a genuine product question and I am happy to split revenue into booked/collected if that is the preference.

**Behaviour change worth flagging** — `findByStatus('completed')` now throws instead of returning `[]`. Any caller relying on the empty result will surface immediately, which is the point; a `grep` for `'completed'` against this repository found none in the backend, but it is worth a reviewer's eye.

**Scope** — only `repositories/orderRepository.js` is touched, so this does not overlap with the four sibling repository fixes (#1564–#1567) and can merge in any order relative to them.
