### PR TITLE
fix: remove dead Firebase script tags from signin/signup and add an asset-reference gate (#1580)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,14 @@ jobs:
       - name: Check every page has a skip link, a main landmark and an h1
         run: node scripts/check-a11y-landmarks.js
 
+      # Dependency-free as well. Nothing in this repository parses HTML, so a
+      # <script src> or a stylesheet pointing at a deleted file stays green
+      # through every other gate and surfaces only as a 404 in a console nobody
+      # has open -- which is how two dead Firebase tags survived on signin.html
+      # and signup.html, the two pages every visitor passes through (#1580).
+      - name: Check every local asset a page references exists
+        run: node scripts/check-assets.js
+
   backend-tests:
     name: Backend tests
     runs-on: ubuntu-latest

--- a/backend/tests/frontendAssets.test.js
+++ b/backend/tests/frontendAssets.test.js
@@ -1,0 +1,227 @@
+// backend/tests/frontendAssets.test.js
+//
+// Every local asset a page references has to exist (#1580).
+//
+// signin.html and signup.html each carried four script tags for a Firebase
+// integration that had been deleted:
+//
+//   <script src="scripts/runtime-config.js"></script>   -> 404
+//   <script src=".../firebase-app-compat.js"></script>  -> ~180 KB, unused
+//   <script src=".../firebase-auth-compat.js"></script> -> ~70 KB, unused
+//   <script src="scripts/firebase.js"></script>         -> 404
+//
+// Nothing in the repository referenced `firebase`, `runtime-config` or any
+// Google sign-in handler, and dashboard.html pointed at an avatar
+// (assets/images/user.png) that had never been committed at all. All three
+// survived because nothing here reads HTML: the syntax gate parses .js, the
+// boot gate requires server.js, and neither has any opinion about a <script>
+// tag.
+//
+// scripts/check-assets.js holds the rules; this suite runs it over every page so
+// a broken reference fails with the rest of the test output, and pins the
+// specific regressions that motivated it.
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const FRONTEND_DIR = path.join(REPO_ROOT, 'frontend');
+
+const {
+    auditPage,
+    extractReferences,
+    isExternal,
+    resolveReference,
+} = require(path.join(REPO_ROOT, 'scripts', 'check-assets.js'));
+
+const pages = fs
+    .readdirSync(FRONTEND_DIR)
+    .filter((name) => name.endsWith('.html'))
+    .sort();
+
+/**
+ * Read one page.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function read(name) {
+    return fs.readFileSync(path.join(FRONTEND_DIR, name), 'utf8');
+}
+
+describe('every frontend page', () => {
+    test('there are pages to check', () => {
+        // A guard on the glob: an empty list would make every case below pass
+        // over nothing.
+        expect(pages.length).toBeGreaterThan(20);
+    });
+
+    test.each(pages)('%s only references assets that exist', (name) => {
+        expect(auditPage(read(name), FRONTEND_DIR)).toEqual([]);
+    });
+
+    test.each(pages)('%s references at least one local asset', (name) => {
+        // Every page in this project loads at least a stylesheet. A page that
+        // suddenly references nothing means the extraction stopped matching,
+        // not that the page got simpler -- and a gate that finds nothing to
+        // check passes silently.
+        expect(extractReferences(read(name)).length).toBeGreaterThan(0);
+    });
+});
+
+describe('the dead Firebase integration', () => {
+    const authPages = ['signin.html', 'signup.html'];
+
+    test.each(authPages)('%s no longer loads the Firebase compat SDK', (name) => {
+        expect(read(name)).not.toMatch(/firebasejs/);
+    });
+
+    test.each(authPages)('%s no longer loads the deleted local scripts', (name) => {
+        const source = read(name);
+
+        expect(source).not.toMatch(/scripts\/firebase\.js/);
+        expect(source).not.toMatch(/scripts\/runtime-config\.js/);
+    });
+
+    test.each(authPages)('%s still loads the auth client it actually uses', (name) => {
+        // The point of the removal is that it changes no behaviour: sign-in on
+        // both pages runs through scripts/auth.js against our own /api/auth
+        // endpoints, and always did.
+        expect(read(name)).toMatch(/src="scripts\/auth\.js"/);
+    });
+
+    test('neither file was left behind anywhere else in the frontend', () => {
+        expect(fs.existsSync(path.join(FRONTEND_DIR, 'scripts', 'firebase.js'))).toBe(false);
+        expect(fs.existsSync(path.join(FRONTEND_DIR, 'scripts', 'runtime-config.js'))).toBe(false);
+
+        const referencing = pages.filter((name) => /firebase|runtime-config/i.test(read(name)));
+        expect(referencing).toEqual([]);
+    });
+});
+
+describe('the dashboard avatar', () => {
+    test('resolves to a file that is in the tree', () => {
+        const source = read('dashboard.html');
+        const match = /<img[^>]*id="profile-avatar"[^>]*>/.exec(source);
+
+        expect(match).not.toBeNull();
+
+        const src = /\bsrc\s*=\s*"([^"]*)"/.exec(match[0]);
+        expect(src).not.toBeNull();
+        expect(fs.existsSync(resolveReference(src[1], FRONTEND_DIR))).toBe(true);
+    });
+});
+
+describe('reference extraction', () => {
+    test('picks up scripts, stylesheets, images and sources', () => {
+        const found = extractReferences(`
+            <link rel="stylesheet" href="styles/base.css">
+            <script src="scripts/utils.js"></script>
+            <img src="assets/images/1.png" alt="">
+            <source src="assets/videos/hero.mp4" type="video/mp4">
+        `);
+
+        expect(found.map((entry) => entry.kind).sort()).toEqual([
+            'image',
+            'link',
+            'script',
+            'source',
+        ]);
+    });
+
+    test('ignores links that carry a URL rather than a file', () => {
+        // preconnect and canonical both use href and neither names anything on
+        // disk. Checking them would report the whole of the internet missing.
+        const found = extractReferences(`
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+            <link rel="canonical" href="/shop.html">
+            <link rel="dns-prefetch" href="//cdn.example.com">
+        `);
+
+        expect(found).toEqual([]);
+    });
+
+    test('ignores inline scripts, which have no src to resolve', () => {
+        expect(extractReferences('<script>console.log(1)</script>')).toEqual([]);
+    });
+});
+
+describe('what counts as external', () => {
+    test.each([
+        'https://cdn.example.com/a.js',
+        'http://cdn.example.com/a.js',
+        '//cdn.example.com/a.js',
+        'data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=',
+        'mailto:support@example.com',
+        '#main-content',
+        '${product.image}',
+        '{{ product.image }}',
+        '',
+    ])('%s is not checked against the filesystem', (reference) => {
+        expect(isExternal(reference)).toBe(true);
+    });
+
+    test.each([
+        'scripts/utils.js',
+        './scripts/utils.js',
+        '../styles/base.css',
+        '/assets/images/1.png',
+        'styles/base.css?v=3',
+    ])('%s is checked against the filesystem', (reference) => {
+        expect(isExternal(reference)).toBe(false);
+    });
+});
+
+describe('reference resolution', () => {
+    test('treats a leading slash as the deployment root', () => {
+        // vercel.json serves frontend/ as the root, so /styles/base.css is
+        // frontend/styles/base.css regardless of which page asked for it.
+        expect(resolveReference('/styles/base.css', path.join(FRONTEND_DIR, 'anywhere')))
+            .toBe(path.join(FRONTEND_DIR, 'styles', 'base.css'));
+    });
+
+    test('resolves a relative reference against the referencing page', () => {
+        expect(resolveReference('scripts/utils.js', FRONTEND_DIR))
+            .toBe(path.join(FRONTEND_DIR, 'scripts', 'utils.js'));
+    });
+
+    test('strips a cache-busting query before resolving', () => {
+        expect(resolveReference('styles/base.css?v=3', FRONTEND_DIR))
+            .toBe(path.join(FRONTEND_DIR, 'styles', 'base.css'));
+    });
+
+    test('strips an SVG sprite fragment before resolving', () => {
+        expect(resolveReference('assets/sprite.svg#cart', FRONTEND_DIR))
+            .toBe(path.join(FRONTEND_DIR, 'assets', 'sprite.svg'));
+    });
+});
+
+describe('the gate itself', () => {
+    test('reports a reference that does not resolve', () => {
+        const problems = auditPage(
+            '<script src="scripts/definitely-not-here.js"></script>',
+            FRONTEND_DIR
+        );
+
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain('definitely-not-here.js');
+        expect(problems[0]).toContain('no such file');
+    });
+
+    test('reports every broken reference on a page, not just the first', () => {
+        const problems = auditPage(
+            `<script src="scripts/gone-a.js"></script>
+             <link rel="stylesheet" href="styles/gone-b.css">
+             <img src="assets/images/gone-c.png" alt="">`,
+            FRONTEND_DIR
+        );
+
+        expect(problems).toHaveLength(3);
+    });
+
+    test('passes a page whose references all resolve', () => {
+        expect(
+            auditPage('<script src="scripts/utils.js"></script>', FRONTEND_DIR)
+        ).toEqual([]);
+    });
+});

--- a/frontend/assets/images/user.svg
+++ b/frontend/assets/images/user.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Default avatar for a signed-in user with no picture of their own.
+
+  dashboard.html pointed at assets/images/user.png, which is not in the tree and
+  is not in the history either, so every visit to the dashboard rendered a broken
+  image in the sidebar (#1580). SVG rather than a raster file: it is a flat
+  two-tone glyph, so it costs under a kilobyte, stays sharp on any display, and
+  is text in the diff rather than an opaque blob.
+
+  currentColor is deliberately avoided -- this is an <img>, not an inline SVG, so
+  it does not inherit the page's colour. The greys below sit acceptably against
+  both the light and the dark dashboard card.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="img" aria-label="Default user avatar">
+  <circle cx="64" cy="64" r="64" fill="#e2e5ea"/>
+  <circle cx="64" cy="49" r="23" fill="#9aa3af"/>
+  <path d="M64 80c-22.4 0-40.6 14.2-43.6 32.6A64 64 0 0 0 64 128a64 64 0 0 0 43.6-15.4C104.6 94.2 86.4 80 64 80Z" fill="#9aa3af"/>
+</svg>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -139,7 +139,7 @@
 
                     <img
                         id="profile-avatar"
-                        src="assets/images/user.png"
+                        src="assets/images/user.svg"
                         alt="User Avatar"
                         loading="lazy"
                     >

--- a/frontend/signin.html
+++ b/frontend/signin.html
@@ -248,12 +248,6 @@
         src="scripts/components.js"
     ></script>
 
-    <!-- Firebase -->
-    <script src="scripts/runtime-config.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/10.13.0/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/10.13.0/firebase-auth-compat.js"></script>
-    <script src="scripts/firebase.js"></script>
-    
     <!-- Auth Script -->
     <script
         defer

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -267,12 +267,6 @@
         src="scripts/components.js"
     ></script>
 
-    <!-- Firebase -->
-    <script src="scripts/runtime-config.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/10.13.0/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/10.13.0/firebase-auth-compat.js"></script>
-    <script src="scripts/firebase.js"></script>
-
     <!-- Auth Script -->
     <script
         defer

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "sitemap": "node scripts/generate-sitemap.js",
     "check:sitemap": "node scripts/generate-sitemap.js --check",
     "check:a11y": "node scripts/check-a11y-landmarks.js",
-    "test": "npm run check:syntax && npm run check:boot && npm run check:modules && npm run test:backend",
+    "check:assets": "node scripts/check-assets.js",
+    "test": "npm run check:syntax && npm run check:assets && npm run check:boot && npm run check:modules && npm run test:backend",
     "test:backend": "npm --prefix backend test",
     "start": "npm --prefix backend start",
     "dev": "npm --prefix backend run dev"

--- a/scripts/check-assets.js
+++ b/scripts/check-assets.js
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+//
+// scripts/check-assets.js
+//
+// Every local asset a page references has to exist. Addresses #1580.
+//
+// The three gates that already run -- syntax, boot, modules -- are all backend
+// or parse-level. None of them can see this:
+//
+//   <script src="scripts/firebase.js"></script>
+//
+// pointing at a file that was deleted eight commits ago. The tag parses (it is
+// HTML, nothing parses it at all), the server boots fine (it is frontend), and
+// the page still renders, so nothing goes red. The only symptom is a 404 in a
+// console nobody has open, and it survived on signin.html and signup.html --
+// the two pages every visitor passes through -- until someone happened to look.
+//
+// A missing stylesheet is worse than a missing script, because the page renders
+// unstyled rather than not at all, and a missing image is a broken icon on a
+// product card. All three are the same mistake: a reference that outlived what
+// it referenced.
+//
+// What is checked:
+//
+//   <script src>   local paths only
+//   <link href>    only where the link is a stylesheet or an icon; preconnect,
+//                  dns-prefetch and canonical carry URLs, not files
+//   <img src>      local paths only
+//   <source src>   local paths only, for <picture> and <video>
+//
+// What is deliberately not checked:
+//
+//   * absolute URLs (http://, https://, //cdn...) -- resolving those means a
+//     network call, and a gate that needs the network is a gate that fails on
+//     a train
+//   * data: and blob: URIs, which are the content
+//   * fragment-only hrefs (#main-content), which are anchors
+//   * template placeholders (${...}, {{...}}) in pages that build a src at
+//     runtime -- there is nothing on disk to compare them against
+//   * runtime-injected assets: components.js writes the header and footer into
+//     every page, so anything it references is invisible here. That is a real
+//     hole and a JSDOM-level check is the way to close it; this gate covers
+//     what is written in the markup, which is where the dead references were.
+//
+// Query strings and fragments are stripped before resolving, so
+// `styles/main.css?v=3` and `sprite.svg#cart` both resolve to the file.
+//
+// Usage:
+//   node scripts/check-assets.js
+//
+// Exit code 0 when every reference resolves, 1 otherwise.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const FRONTEND_DIR = path.join(REPO_ROOT, 'frontend');
+
+// A `rel` that names a file on disk. Anything else on a <link> -- preconnect,
+// dns-prefetch, canonical, manifest pointing at a route -- is a URL or a hint,
+// and checking it against the filesystem would produce noise, not findings.
+const FILE_BEARING_REL = new Set([
+    'stylesheet',
+    'icon',
+    'shortcut icon',
+    'apple-touch-icon',
+    'mask-icon',
+    'preload',
+]);
+
+/**
+ * References this gate cannot or should not resolve against the filesystem.
+ *
+ * @param {string} reference - The raw attribute value.
+ * @returns {boolean}
+ */
+function isExternal(reference) {
+    const value = reference.trim();
+
+    if (value === '') return true;
+
+    return (
+        /^[a-z][a-z0-9+.-]*:/i.test(value) // http:, https:, data:, blob:, mailto:
+        || value.startsWith('//') // protocol-relative
+        || value.startsWith('#') // in-page anchor
+        || value.includes('${') // template literal built at runtime
+        || value.includes('{{') // handlebars-style placeholder
+    );
+}
+
+/**
+ * Turn a reference into the path on disk it should resolve to.
+ *
+ * A leading slash means the deployment root, which for this project is
+ * `frontend/` -- that is what vercel.json serves and what Live Server opens.
+ * Anything else is relative to the page that carries it.
+ *
+ * @param {string} reference
+ * @param {string} pageDir - Absolute directory of the referencing page.
+ * @returns {string} Absolute path.
+ */
+function resolveReference(reference, pageDir) {
+    const withoutQuery = reference.split('?')[0].split('#')[0];
+
+    return withoutQuery.startsWith('/')
+        ? path.join(FRONTEND_DIR, withoutQuery.slice(1))
+        : path.resolve(pageDir, withoutQuery);
+}
+
+/**
+ * Read the value of one attribute out of a tag.
+ *
+ * @param {string} tag - The full tag text, e.g. `<link rel="icon" href="a.png">`.
+ * @param {string} name
+ * @returns {string|null}
+ */
+function attribute(tag, name) {
+    const match = new RegExp(`\\b${name}\\s*=\\s*["']([^"']*)["']`, 'i').exec(tag);
+    return match ? match[1] : null;
+}
+
+/**
+ * Every local asset one page references, as `{ kind, reference }` pairs.
+ *
+ * Exported so the tests can exercise the extraction without touching disk.
+ *
+ * @param {string} source - The page's HTML.
+ * @returns {Array<{kind: string, reference: string}>}
+ */
+function extractReferences(source) {
+    const found = [];
+
+    const collect = (tagPattern, attributeName, kind, filter) => {
+        for (const match of source.matchAll(tagPattern)) {
+            const tag = match[0];
+            if (filter && !filter(tag)) continue;
+
+            const reference = attribute(tag, attributeName);
+            if (reference === null || isExternal(reference)) continue;
+
+            found.push({ kind, reference });
+        }
+    };
+
+    collect(/<script\b[^>]*>/gi, 'src', 'script');
+    collect(/<img\b[^>]*>/gi, 'src', 'image');
+    collect(/<source\b[^>]*>/gi, 'src', 'source');
+    collect(/<link\b[^>]*>/gi, 'href', 'link', (tag) => {
+        const rel = attribute(tag, 'rel');
+        return rel !== null && FILE_BEARING_REL.has(rel.trim().toLowerCase());
+    });
+
+    return found;
+}
+
+/**
+ * Everything one page references that is not there.
+ *
+ * @param {string} source - The page's HTML.
+ * @param {string} pageDir - Absolute directory of the page.
+ * @returns {string[]} Empty when every reference resolves.
+ */
+function auditPage(source, pageDir) {
+    const problems = [];
+
+    for (const { kind, reference } of extractReferences(source)) {
+        const target = resolveReference(reference, pageDir);
+
+        if (!fs.existsSync(target)) {
+            problems.push(`${kind} ${reference} -> no such file`);
+        }
+    }
+
+    return problems;
+}
+
+function main() {
+    const pages = fs
+        .readdirSync(FRONTEND_DIR)
+        .filter((name) => name.endsWith('.html'))
+        .sort();
+
+    const failures = [];
+    let checked = 0;
+
+    for (const name of pages) {
+        const file = path.join(FRONTEND_DIR, name);
+        const source = fs.readFileSync(file, 'utf8');
+
+        checked += extractReferences(source).length;
+
+        const problems = auditPage(source, path.dirname(file));
+        if (problems.length > 0) failures.push({ name, problems });
+    }
+
+    if (failures.length === 0) {
+        console.log(
+            `✅ asset check passed — ${checked} local reference(s) across ${pages.length} page(s) resolve`
+        );
+        process.exit(0);
+    }
+
+    const broken = failures.reduce((sum, failure) => sum + failure.problems.length, 0);
+
+    console.error(
+        `\n❌ ${broken} broken reference(s) across ${failures.length} of ${pages.length} page(s):\n`
+    );
+    for (const failure of failures) {
+        console.error(`  frontend/${failure.name}`);
+        for (const problem of failure.problems) {
+            console.error(`      ${problem}`);
+        }
+        console.error('');
+    }
+    console.error(
+        'Either restore the file or remove the reference. '
+        + 'Run `npm run check:assets` locally to reproduce.\n'
+    );
+
+    process.exit(1);
+}
+
+module.exports = { extractReferences, isExternal, resolveReference, auditPage };
+
+if (require.main === module) {
+    main();
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`signin.html` and `signup.html` each loaded four script tags for a Firebase auth integration that no longer exists in the repo:

```html
<script src="scripts/runtime-config.js"></script>                                  <!-- 404 -->
<script src="https://www.gstatic.com/firebasejs/10.13.0/firebase-app-compat.js"></script>   <!-- ~180 KB, never called -->
<script src="https://www.gstatic.com/firebasejs/10.13.0/firebase-auth-compat.js"></script>  <!-- ~70 KB, never called -->
<script src="scripts/firebase.js"></script>                                        <!-- 404 -->
```

Grepping the whole frontend for `firebase`, `runtime-config`, `RUNTIME_CONFIG`, `signInWithPopup` or any Google sign-in handler returns **only those eight lines**. `git log --all` shows both local files were tracked once and deleted; the tags outlived them.

Sign-in and sign-up on these pages are handled entirely by `scripts/auth.js` against our own `/api/auth` endpoints, so removing all four changes no behaviour. It just stops two 404s and ~250 KB of unused third-party JS on the two pages every visitor has to pass through.

### Why it survived

Nothing in this repository reads HTML. `check:syntax` parses `.js`, `check:boot` requires `server.js`, `check:modules` imports every backend module — a `<script src>` pointing at nothing is invisible to all three, and CI stays green.

### The gate

`scripts/check-assets.js` walks every page in `frontend/` and resolves each local `<script src>`, file-bearing `<link href>`, `<img src>` and `<source src>` against the filesystem, exiting non-zero with a list of what does not resolve.

Deliberately **not** checked: absolute URLs (a gate that needs the network is a gate that fails on a train), `data:`/`blob:` URIs, fragment-only hrefs, and runtime template placeholders (`${...}`, `{{...}}`). Query strings and SVG sprite fragments are stripped before resolving, so `styles/base.css?v=3` and `sprite.svg#cart` both resolve. `<link rel="preconnect">` / `canonical` / `dns-prefetch` are skipped — they carry URLs, not files.

Known limitation, documented in the header: `components.js` injects the header and footer at runtime, so assets it references are not visible to this gate. Closing that needs a JSDOM-level check; this covers what is written in the markup, which is where the dead references were.

### One extra fix it turned up

Turning the gate on found a third dangling reference: `dashboard.html` pointed at `assets/images/user.png`, which is **not in the tree and not in the history either** — so the sidebar has been rendering a broken image for every user. Added `assets/images/user.svg` as the default avatar and repointed it. SVG rather than a raster file: flat two-tone glyph, under a kilobyte, sharp on any display, and text in the diff rather than an opaque blob. The gate could not be wired into CI while this was still red, so it is fixed here.

**Current state: 577 local references across 30 pages, all resolving.**

---

## 🔗 Related Issue

Closes #1580

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Before, on `signin.html`:

```
GET /scripts/runtime-config.js  net::ERR_ABORTED 404 (Not Found)
GET /scripts/firebase.js        net::ERR_ABORTED 404 (Not Found)
```

After:

```
$ npm run check:assets
✅ asset check passed — 577 local reference(s) across 30 page(s) resolve
```

```
$ npx jest tests/frontendAssets.test.js
Test Suites: 1 passed, 1 total
Tests:       93 passed, 93 total
```

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

`backend/tests/frontendAssets.test.js` runs the gate over every page inside the Jest suite (so a broken reference fails with the rest of the test output) and pins the specific regressions: no `firebasejs` on either auth page, neither local file referenced anywhere, `auth.js` still loaded, and the dashboard avatar resolving. It also covers the extraction and resolution helpers directly — external-vs-local classification, query/fragment stripping, root-relative resolution, and that all broken references on a page are reported rather than just the first.

The gate is wired into the `syntax` job in `ci.yml` rather than a new job, since it is dependency-free and belongs with the other three cheap checks that run before `npm ci`.
