### PR TITLE
fix: coupon effectiveness metric reads promo_codes instead of the dormant coupons table (#1581)

### DIFF
--- a/backend/services/metricsAggregationService.js
+++ b/backend/services/metricsAggregationService.js
@@ -379,6 +379,7 @@ class MetricsAggregationService extends EventEmitter {
         // exist.
         let conditions = `
             c.created_at BETWEEN ? AND ?
+            AND c.is_deleted = 0
             AND c.usage_count > 0
         `;
 
@@ -387,19 +388,40 @@ class MetricsAggregationService extends EventEmitter {
             params.push(filters.couponType);
         }
 
+        // Two things this query used to get wrong about where a coupon lives.
+        //
         // `orders.coupon_code` does not exist. The order path writes the code
         // it applied to `promo_code` and `discount_code` (`order.service`).
+        //
+        // And `coupons` is the wrong table (#1581). It is a baseline table with
+        // no writer anywhere in the codebase, and it names its columns `type`,
+        // `value` and `used_count` -- so `c.discount_type`, `c.discount_value`
+        // and `c.usage_count` were all ER_BAD_FIELD_ERROR and this metric could
+        // not return a row under any filter. Those three names are exactly the
+        // ones on `promo_codes` (migrations/0002_promo_schema.sql), which is
+        // the table `promo.service` validates against and the one whose `code`
+        // the join above is matching `orders.promo_code` to. The query was
+        // written for `promo_codes` and pointed at its dormant namesake.
+        //
+        // `is_deleted` is how the rest of the promo path filters this table; a
+        // withdrawn code should not appear in an effectiveness report.
+        //
+        // The COUNT is aliased `redemption_count` rather than `usage_count`:
+        // the latter is also a real column on `c`, and having the same name
+        // mean the lifetime counter in the WHERE clause and the in-period
+        // total in the select list is what made the mismatch hard to see. The
+        // response key below is unchanged.
         const query = `
             SELECT
                 c.code,
                 c.discount_type,
                 c.discount_value,
-                COUNT(o.id) as usage_count,
+                COUNT(o.id) as redemption_count,
                 COALESCE(SUM(${ORDER_VALUE}), 0) as revenue_generated,
                 COALESCE(AVG(${ORDER_VALUE}), 0) as avg_order_value,
                 (COALESCE(SUM(${ORDER_VALUE}), 0) / NULLIF(COUNT(o.id), 0))
                     - c.discount_value as net_value
-            FROM coupons c
+            FROM promo_codes c
             LEFT JOIN orders o
                 ON o.promo_code = c.code
                 AND ${REVENUE_ORDERS}
@@ -415,7 +437,7 @@ class MetricsAggregationService extends EventEmitter {
                 code: row.code,
                 discountType: row.discount_type,
                 discountValue: parseFloat(row.discount_value),
-                usageCount: parseInt(row.usage_count || 0),
+                usageCount: parseInt(row.redemption_count || 0, 10),
                 revenueGenerated: parseFloat(row.revenue_generated || 0),
                 avgOrderValue: parseFloat(row.avg_order_value || 0),
                 netValue: parseFloat(row.net_value || 0)

--- a/backend/tests/couponEffectiveness.test.js
+++ b/backend/tests/couponEffectiveness.test.js
@@ -1,0 +1,238 @@
+// backend/tests/couponEffectiveness.test.js
+//
+// Which table a coupon lives in, and whether the columns a query names exist
+// (#1581).
+//
+// `GET /api/metrics/coupon-effectiveness` returned 500 on every call. The query
+// read `c.discount_type`, `c.discount_value` and `c.usage_count` off `coupons`,
+// and `coupons` (migrations/0001_baseline_schema.sql) names those columns
+// `type`, `value` and `used_count`. There is no filter that avoids them:
+// `c.usage_count > 0` is unconditional and the other two are in the select list
+// and in the `net_value` expression.
+//
+// The names were not invented. `discount_type`, `discount_value` and
+// `usage_count` are precisely the columns on `promo_codes`
+// (migrations/0002_promo_schema.sql), and the join reads
+// `o.promo_code = c.code` -- `orders.promo_code` is written by `order.service`
+// from the code `promo.service` resolved out of `promo_codes`. The query was
+// written for `promo_codes` and pointed at `coupons`, a baseline table with no
+// writer anywhere in the codebase; even with the column names corrected it
+// would have joined to nothing and returned an empty report.
+//
+// businessMetrics.test.js already covers what this metric sums and who may read
+// it. This suite covers where it reads from, and generalises: the last case
+// checks every qualified column reference in the statement against the schema
+// in migrations/, so the next rename fails here rather than in production.
+
+jest.mock('../config/db', () => {
+    const query = jest.fn();
+    return { query, promise: { query }, getConnection: jest.fn() };
+});
+
+const db = require('../config/db');
+const {
+    MetricsAggregationService,
+    TIME_PERIODS,
+} = require('../services/metricsAggregationService');
+
+const { columnsOf, unknownColumns } = require('./helpers/migrationSchema');
+
+/** The statement issued, whitespace collapsed. */
+const statement = (index = 0) =>
+    String(db.query.mock.calls[index][0]).replace(/\s+/g, ' ').trim();
+
+const paramsOf = (index = 0) => db.query.mock.calls[index][1];
+
+let metrics;
+
+beforeEach(() => {
+    db.query.mockReset();
+    db.query.mockResolvedValue([[]]);
+    // A fresh instance per test: the service caches by metric and period, and a
+    // cached answer issues no statement to assert on.
+    metrics = new MetricsAggregationService();
+});
+
+// ---------------------------------------------------------------------------
+// The two tables, as the migrations define them
+// ---------------------------------------------------------------------------
+
+describe('what the migrations say', () => {
+    test('coupons does not have the columns the query was naming', () => {
+        const coupons = columnsOf('coupons');
+
+        expect(coupons.has('discount_type')).toBe(false);
+        expect(coupons.has('discount_value')).toBe(false);
+        expect(coupons.has('usage_count')).toBe(false);
+    });
+
+    test('coupons calls them type, value and used_count', () => {
+        const coupons = columnsOf('coupons');
+
+        expect(coupons.has('type')).toBe(true);
+        expect(coupons.has('value')).toBe(true);
+        expect(coupons.has('used_count')).toBe(true);
+    });
+
+    test('promo_codes has every column the query names', () => {
+        const promos = columnsOf('promo_codes');
+
+        for (const column of ['code', 'discount_type', 'discount_value', 'usage_count', 'is_deleted', 'created_at']) {
+            expect(promos.has(column)).toBe(true);
+        }
+    });
+
+    test('orders carries the code the join matches on', () => {
+        expect(columnsOf('orders').has('promo_code')).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The query
+// ---------------------------------------------------------------------------
+
+describe('coupon effectiveness reads promo_codes', () => {
+    test('selects from promo_codes, not coupons', async () => {
+        await metrics.getCouponEffectiveness(TIME_PERIODS.WEEK);
+
+        expect(statement()).toMatch(/FROM promo_codes c/);
+        expect(statement()).not.toMatch(/FROM coupons/);
+    });
+
+    test('still joins orders on the column the order path writes', async () => {
+        await metrics.getCouponEffectiveness(TIME_PERIODS.WEEK);
+
+        expect(statement()).toMatch(/o\.promo_code = c\.code/);
+        expect(statement()).not.toMatch(/coupon_code/);
+    });
+
+    test('excludes withdrawn codes', async () => {
+        // is_deleted is how the rest of the promo path filters this table. A
+        // code that has been pulled should not appear in an effectiveness
+        // report alongside live ones.
+        await metrics.getCouponEffectiveness(TIME_PERIODS.WEEK);
+
+        expect(statement()).toMatch(/c\.is_deleted = 0/);
+    });
+
+    test('keeps the type filter parameterised and in the WHERE clause', async () => {
+        await metrics.getCouponEffectiveness(TIME_PERIODS.WEEK, {
+            couponType: 'percentage',
+        });
+
+        expect(statement()).toMatch(/WHERE[\s\S]*discount_type = \?[\s\S]*GROUP BY/);
+        expect(statement()).not.toMatch(/ORDER BY[\s\S]*AND c\.discount_type/);
+        expect(paramsOf()).toContain('percentage');
+    });
+
+    test('does not alias the COUNT over a real column of the same table', async () => {
+        // `usage_count` is a column on promo_codes and was also the alias for
+        // COUNT(o.id). One name meaning the lifetime counter in the WHERE
+        // clause and the in-period total in the select list is what made the
+        // original mismatch hard to see.
+        await metrics.getCouponEffectiveness(TIME_PERIODS.WEEK);
+
+        expect(statement()).toMatch(/COUNT\(o\.id\) as redemption_count/);
+        expect(statement()).not.toMatch(/as usage_count/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The shape that reaches the route
+// ---------------------------------------------------------------------------
+
+describe('the report it returns', () => {
+    test('maps a row onto the documented keys', async () => {
+        db.query.mockResolvedValueOnce([[
+            {
+                code: 'SUMMER20',
+                discount_type: 'percentage',
+                discount_value: '20.00',
+                redemption_count: 14,
+                revenue_generated: '18400.50',
+                avg_order_value: '1314.32',
+                net_value: '1294.32',
+            },
+        ]]);
+
+        const report = await metrics.getCouponEffectiveness(TIME_PERIODS.WEEK);
+
+        expect(report.metric).toBe('coupon_effectiveness');
+        expect(report.coupons).toHaveLength(1);
+        expect(report.coupons[0]).toMatchObject({
+            code: 'SUMMER20',
+            discountType: 'percentage',
+            discountValue: 20,
+            usageCount: 14,
+            revenueGenerated: 18400.5,
+        });
+    });
+
+    test('the response key stayed usageCount when the SQL alias changed', async () => {
+        // Renaming the alias is an internal change; anything reading this
+        // endpoint should not have to notice.
+        db.query.mockResolvedValueOnce([[
+            { code: 'A', discount_type: 'fixed', discount_value: '5', redemption_count: 3 },
+        ]]);
+
+        const report = await metrics.getCouponEffectiveness(TIME_PERIODS.WEEK);
+
+        expect(report.coupons[0].usageCount).toBe(3);
+    });
+
+    test('totals across the rows it got', async () => {
+        db.query.mockResolvedValueOnce([[
+            { code: 'A', discount_value: '5', redemption_count: 1, revenue_generated: '100.00' },
+            { code: 'B', discount_value: '5', redemption_count: 2, revenue_generated: '250.50' },
+        ]]);
+
+        const report = await metrics.getCouponEffectiveness(TIME_PERIODS.WEEK);
+
+        expect(report.totalCoupons).toBe(2);
+        expect(report.totalRevenue).toBeCloseTo(350.5, 2);
+    });
+
+    test('an empty window is an empty report, not a failure', async () => {
+        const report = await metrics.getCouponEffectiveness(TIME_PERIODS.WEEK);
+
+        expect(report.coupons).toEqual([]);
+        expect(report.totalCoupons).toBe(0);
+        expect(report.totalRevenue).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The general rule, so the next one fails here
+// ---------------------------------------------------------------------------
+
+describe('every column the statement names', () => {
+    test('exists in the migration schema', async () => {
+        await metrics.getCouponEffectiveness(TIME_PERIODS.WEEK, {
+            couponType: 'percentage',
+        });
+
+        // Stating the alias map here rather than parsing it out of the SQL is
+        // deliberate: it documents which table this query is meant to be
+        // reading, which is the thing that was wrong.
+        expect(
+            unknownColumns(statement(), { c: 'promo_codes', o: 'orders' })
+        ).toEqual([]);
+    });
+
+    test('would have caught the bug this suite exists for', () => {
+        // A guard on the guard. If unknownColumns ever stops resolving, the
+        // case above passes over nothing and the next rename ships.
+        const broken = `
+            SELECT c.discount_type, c.discount_value
+            FROM coupons c
+            LEFT JOIN orders o ON o.promo_code = c.code
+            WHERE c.usage_count > 0
+        `;
+
+        expect(unknownColumns(broken, { c: 'coupons', o: 'orders' }).sort()).toEqual([
+            'c.discount_type is not a column of coupons',
+            'c.discount_value is not a column of coupons',
+            'c.usage_count is not a column of coupons',
+        ]);
+    });
+});

--- a/backend/tests/helpers/migrationSchema.js
+++ b/backend/tests/helpers/migrationSchema.js
@@ -1,0 +1,249 @@
+// backend/tests/helpers/migrationSchema.js
+//
+// What the database actually looks like, read from migrations/ (#1581).
+//
+// A whole family of bugs in this repository has the same shape: a query names a
+// column that is not there, nothing catches it, and the endpoint 500s for
+// everyone until somebody happens to call it.
+//
+//   #1538  admin.service reads is_email_verified; the column is is_verified
+//   #1539  recommendationService reads products.category; it is category_id
+//   #1529  the money metrics summed orders.total_amount; it is orders.total
+//   #1581  coupon effectiveness read coupons.discount_type/discount_value/
+//          usage_count; those are promo_codes columns, and coupons calls them
+//          type/value/used_count
+//
+// Every one of them parses, boots and imports cleanly, so the syntax, boot and
+// module gates all pass. The suites mock config/db, so nothing in the test run
+// touches a real schema either -- which is precisely why the mismatch survives
+// to production.
+//
+// This reads the migration sequence, which is the definition of the schema
+// (AGENTS.md: "Schema comes from the ordered sequence in migrations/"), and
+// gives a test the column set for a table. A test can then assert that the
+// columns a query names are columns that exist, without needing a database.
+//
+// Scope, deliberately: this is a lexical reader, not a SQL engine. It handles
+// CREATE TABLE and the ADD COLUMN forms this repository uses, which covers the
+// sequence as it stands. It does not model DROP COLUMN, CHANGE or RENAME -- if
+// one lands, extend it here rather than working around it in a test, because a
+// dropped column that this helper still reports is a false pass.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const MIGRATIONS_DIR = path.join(__dirname, '..', '..', '..', 'migrations');
+
+// The type keywords a column definition can start with. Matching on these is
+// what separates `code VARCHAR(50) NOT NULL` from `INDEX idx_code (code)` and
+// `CONSTRAINT chk_value CHECK (...)`, which are not columns.
+const TYPES = [
+    'CHAR', 'VARCHAR', 'TINYTEXT', 'TEXT', 'MEDIUMTEXT', 'LONGTEXT',
+    'TINYINT', 'SMALLINT', 'MEDIUMINT', 'INT', 'INTEGER', 'BIGINT',
+    'DECIMAL', 'NUMERIC', 'FLOAT', 'DOUBLE',
+    'DATE', 'DATETIME', 'TIMESTAMP', 'TIME', 'YEAR',
+    'JSON', 'ENUM', 'SET', 'BOOLEAN', 'BOOL',
+    'BLOB', 'TINYBLOB', 'MEDIUMBLOB', 'LONGBLOB', 'BINARY', 'VARBINARY',
+].join('|');
+
+const COLUMN_DEFINITION = new RegExp(`^\`?([a-z_][a-z0-9_]*)\`?\\s+(?:${TYPES})\\b`, 'i');
+
+const CREATE_TABLE = /CREATE TABLE(?:\s+IF NOT EXISTS)?\s+`?(\w+)`?\s*\(([\s\S]*?)\n\s*\)\s*(?:ENGINE|;)/gi;
+const ALTER_TABLE = /ALTER TABLE\s+`?(\w+)`?([\s\S]*?);/gi;
+const ADD_COLUMN = new RegExp(
+    `ADD\\s+(?:COLUMN\\s+)?(?:IF NOT EXISTS\\s+)?\`?([a-z_][a-z0-9_]*)\`?\\s+(?:${TYPES})\\b`,
+    'gi'
+);
+
+let cached = null;
+
+/**
+ * Split a CREATE TABLE body into its top-level entries.
+ *
+ * Splitting on newlines is not enough -- an ENUM lists its members on one line
+ * and a CHECK constraint can span several -- so this tracks parenthesis depth
+ * and breaks only on commas outside them.
+ *
+ * @param {string} body
+ * @returns {string[]}
+ */
+function splitDefinitions(body) {
+    const entries = [];
+    let depth = 0;
+    let current = '';
+
+    for (const character of body) {
+        if (character === '(') depth += 1;
+        if (character === ')') depth -= 1;
+
+        if (character === ',' && depth === 0) {
+            entries.push(current);
+            current = '';
+            continue;
+        }
+
+        current += character;
+    }
+
+    entries.push(current);
+
+    return entries;
+}
+
+/**
+ * Strip comments so a column name inside one is not read as a definition.
+ *
+ * @param {string} sql
+ * @returns {string}
+ */
+function stripComments(sql) {
+    return sql
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/^\s*--.*$/gm, '');
+}
+
+/**
+ * Every table in the migration sequence, with its columns.
+ *
+ * Migrations are applied in filename order and later ones add to earlier ones,
+ * so they are read in that order and the column sets accumulate.
+ *
+ * @returns {Map<string, Set<string>>} Table name (lowercased) to column names.
+ */
+function readSchema() {
+    if (cached) return cached;
+
+    const schema = new Map();
+
+    const columnsFor = (table) => {
+        const key = table.toLowerCase();
+        if (!schema.has(key)) schema.set(key, new Set());
+        return schema.get(key);
+    };
+
+    const files = fs
+        .readdirSync(MIGRATIONS_DIR)
+        .filter((name) => name.endsWith('.sql'))
+        .sort();
+
+    for (const name of files) {
+        const sql = stripComments(
+            fs.readFileSync(path.join(MIGRATIONS_DIR, name), 'utf8')
+        );
+
+        for (const match of sql.matchAll(CREATE_TABLE)) {
+            const columns = columnsFor(match[1]);
+
+            for (const entry of splitDefinitions(match[2])) {
+                const definition = COLUMN_DEFINITION.exec(entry.trim());
+                if (definition) columns.add(definition[1].toLowerCase());
+            }
+        }
+
+        for (const match of sql.matchAll(ALTER_TABLE)) {
+            const columns = columnsFor(match[1]);
+
+            for (const added of match[2].matchAll(ADD_COLUMN)) {
+                columns.add(added[1].toLowerCase());
+            }
+        }
+    }
+
+    cached = schema;
+    return schema;
+}
+
+/**
+ * The columns of one table.
+ *
+ * Throws rather than returning an empty set for a table that is not in the
+ * sequence: "this table has no columns" and "you misspelled the table" should
+ * not look the same to a test.
+ *
+ * @param {string} table
+ * @returns {Set<string>}
+ */
+function columnsOf(table) {
+    const schema = readSchema();
+    const key = String(table).toLowerCase();
+
+    if (!schema.has(key)) {
+        throw new Error(
+            `No CREATE TABLE for "${table}" in migrations/. `
+            + `Known tables: ${[...schema.keys()].sort().join(', ')}`
+        );
+    }
+
+    return schema.get(key);
+}
+
+/**
+ * Does this table define this column?
+ *
+ * @param {string} table
+ * @param {string} column
+ * @returns {boolean}
+ */
+function hasColumn(table, column) {
+    return columnsOf(table).has(String(column).toLowerCase());
+}
+
+/**
+ * Every `alias.column` a statement reads, given what the aliases stand for.
+ *
+ * The caller supplies the alias map because resolving `FROM`/`JOIN` properly
+ * means parsing SQL, and getting that subtly wrong would make the assertion
+ * quieter than no assertion at all. Stating the map in the test also documents
+ * which table the query is expected to be reading.
+ *
+ * @param {string} sql
+ * @param {Object<string, string>} aliases - e.g. `{ c: 'promo_codes', o: 'orders' }`
+ * @returns {Array<{alias: string, table: string, column: string}>}
+ */
+function qualifiedReads(sql, aliases) {
+    const known = new Map(
+        Object.entries(aliases).map(([alias, table]) => [alias.toLowerCase(), table])
+    );
+
+    const reads = [];
+    const seen = new Set();
+
+    for (const match of String(sql).matchAll(/\b([a-z_][a-z0-9_]*)\.([a-z_][a-z0-9_]*)\b/gi)) {
+        const alias = match[1].toLowerCase();
+        const column = match[2].toLowerCase();
+
+        if (!known.has(alias)) continue;
+
+        const key = `${alias}.${column}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        reads.push({ alias, table: known.get(alias), column });
+    }
+
+    return reads;
+}
+
+/**
+ * Every `alias.column` in a statement that the schema does not define.
+ *
+ * @param {string} sql
+ * @param {Object<string, string>} aliases
+ * @returns {string[]} e.g. `['c.discount_type is not a column of coupons']`
+ */
+function unknownColumns(sql, aliases) {
+    return qualifiedReads(sql, aliases)
+        .filter(({ table, column }) => !hasColumn(table, column))
+        .map(({ alias, table, column }) => `${alias}.${column} is not a column of ${table}`);
+}
+
+module.exports = {
+    MIGRATIONS_DIR,
+    readSchema,
+    columnsOf,
+    hasColumn,
+    qualifiedReads,
+    unknownColumns,
+};


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`GET /api/metrics/coupon-effectiveness` returned a 500 on **every** call. `metricsAggregationService.getCouponEffectiveness()` selected `c.discount_type`, `c.discount_value` and `c.usage_count` off `coupons` — and `coupons` (`migrations/0001_baseline_schema.sql`) names those columns `type`, `value` and `used_count`.

There is no filter that avoids the failure: `c.usage_count > 0` is unconditional, and the other two are in the select list *and* in the `net_value` expression.

```
500 { "success": false, "error": "Unknown column 'c.discount_type' in 'field list'" }
```

### It was pointed at the wrong table, not just misspelled

`discount_type`, `discount_value` and `usage_count` are exactly the columns on **`promo_codes`** (`migrations/0002_promo_schema.sql`). The join gives it away too — `o.promo_code = c.code`, and `orders.promo_code` is written by `order.service` from the code `promo.service.validatePromo()` resolved out of `promo_codes`.

`coupons` is a baseline table with **no writer anywhere in the codebase**. Even with the three column names corrected, joining `orders.promo_code` to `coupons.code` would have matched nothing and returned an empty report. So renaming the columns would have swapped a loud 500 for a silent zero — which is worse.

### The change

```diff
-FROM coupons c
+FROM promo_codes c
```

plus `AND c.is_deleted = 0` in the conditions — that is how the rest of the promo path filters this table, and a withdrawn code does not belong in an effectiveness report next to live ones.

One rename beyond the fix: the `COUNT(o.id)` alias moves from `usage_count` to `redemption_count`. `usage_count` is a *real column* on `promo_codes`, and having one name mean the lifetime counter in the `WHERE` clause and the in-period total in the select list is a large part of why this was hard to spot. **The JSON response key stays `usageCount`**, so nothing consuming the endpoint changes.

### Deliberately left alone

The window filters on `c.created_at`, so the report covers codes *created* in the period rather than redemptions *made* in it. That is arguably wrong, but it is a question about what the metric means rather than whether it runs, and changing it silently would move numbers on a dashboard. Worth its own issue.

---

## 🔗 Related Issue

Closes #1581

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

```
$ npx jest tests/couponEffectiveness.test.js tests/businessMetrics.test.js
PASS tests/couponEffectiveness.test.js
PASS tests/businessMetrics.test.js

Test Suites: 2 passed, 2 total
Tests:       46 passed, 46 total
```

The pre-existing `businessMetrics.test.js` suite still passes unchanged.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**This is the fourth bug of this exact shape** — #1538 (`is_email_verified` vs `is_verified`), #1539 (`products.category` vs `category_id`), #1529 (`orders.total_amount` vs `orders.total`), and now this one. Every one of them parses, boots and imports cleanly, so the syntax, boot and module gates all pass. And every suite mocks `config/db`, so nothing in a test run has ever touched a real schema — which is exactly why they survive to production.

So this PR also adds `backend/tests/helpers/migrationSchema.js`: it reads the migration sequence (the definition of the schema, per `AGENTS.md`) and answers "does this table have this column", with no database needed. The last case in the new suite runs *every qualified column reference in the generated statement* through it, with the alias map stated explicitly in the test so it also documents which table the query is meant to read.

There is a guard on the guard too — a case that feeds the original broken SQL through `unknownColumns()` and asserts it reports all three bad columns, so if the helper ever stops resolving, the check does not quietly start passing over nothing.

The helper is deliberately a lexical reader, not a SQL engine: it handles `CREATE TABLE` and the `ADD COLUMN` forms this repository actually uses, and does **not** model `DROP COLUMN` / `CHANGE` / `RENAME`. That limitation is documented in its header, with a note to extend it there rather than work around it in a test — a dropped column it still reports would be a false pass. Reusable by any suite that wants the same assertion.
