### PR TITLE
fix: POST /api/config always 500s — persistConfig binds 3 values into 4 placeholders (#1583)

### DIFF
--- a/backend/services/agentLiabilityService.js
+++ b/backend/services/agentLiabilityService.js
@@ -946,11 +946,20 @@ class AgentLiabilityService {
      */
     async storeClaim(claim, transaction = null) {
         const query = transaction || db;
+        // Thirteen columns, thirteen placeholders, fifteen values: `resolvedAt`
+        // and `resolution` were each bound twice, once guarded with `|| null`
+        // and once raw. Every value after them lined up against the wrong
+        // column, and mysql2 rejected the statement on the count before it got
+        // that far -- so filing a liability claim always threw.
+        //
+        // The guarded pair is the one kept: a claim being stored is usually
+        // unresolved, and `undefined` is not a bindable value.
+        //
+        // Found by the same check that caught #1583, not reported separately.
         await query.query(
-
-            `INSERT INTO liability_claims 
-             (id, agent_id, authorization_id, amount, reason, evidence, 
-              status, created_at, resolved_at, resolution, insurance_used, 
+            `INSERT INTO liability_claims
+             (id, agent_id, authorization_id, amount, reason, evidence,
+              status, created_at, resolved_at, resolution, insurance_used,
               liability_amount, liable_party)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
             [
@@ -964,9 +973,6 @@ class AgentLiabilityService {
                 claim.createdAt,
                 claim.resolvedAt || null,
                 claim.resolution || null,
-
-                claim.resolvedAt,
-                claim.resolution,
                 claim.insuranceUsed || 0,
                 claim.liabilityAmount || 0,
                 claim.liableParty || null

--- a/backend/services/configService.js
+++ b/backend/services/configService.js
@@ -317,10 +317,22 @@ class ConfigService extends EventEmitter {
      */
     async persistConfig(key, value, user) {
         try {
+            // Four placeholders, three values. `version` sat in the column list
+            // with a `?` of its own and nothing bound to it, so mysql2 rejected
+            // the statement before it left the process and every persisted
+            // configuration change threw (#1583).
+            //
+            // The placeholder was the mistake, not the missing binding.
+            // `app_config.version` is `INT DEFAULT 1` (sql/app_config.sql) and
+            // the ON DUPLICATE branch below already does `version = version + 1`,
+            // so the insert branch wants the default -- nothing in this codebase
+            // computes a version to pass in. Dropping the column from the list
+            // gives 1 on insert and an increment on update, which is what the
+            // two branches together were always meant to say.
             await db.query(
-                `INSERT INTO app_config 
-                 (config_key, config_value, version, updated_by, updated_at)
-                 VALUES (?, ?, ?, ?, NOW())
+                `INSERT INTO app_config
+                 (config_key, config_value, updated_by, updated_at)
+                 VALUES (?, ?, ?, NOW())
                  ON DUPLICATE KEY UPDATE
                  config_value = VALUES(config_value),
                  version = version + 1,

--- a/backend/tests/configPersistence.test.js
+++ b/backend/tests/configPersistence.test.js
@@ -1,0 +1,260 @@
+// backend/tests/configPersistence.test.js
+//
+// Configuration changes reach the database (#1583).
+//
+// `POST /api/config` returned 500 on every call. `persistConfig` listed five
+// columns, gave `updated_at` a `NOW()` and the other four a `?`, and bound
+// three values:
+//
+//     INSERT INTO app_config
+//       (config_key, config_value, version, updated_by, updated_at)
+//     VALUES (?, ?, ?, ?, NOW())
+//     ...
+//     [key, JSON.stringify(value), user || 'system']
+//
+// mysql2 rejects that with "Incorrect arguments to mysqld_stmt_execute" before
+// the statement leaves the process. The `version` placeholder was the mistake:
+// `app_config.version` is `INT DEFAULT 1` and the ON DUPLICATE branch already
+// increments it, so the insert branch wants the default and nothing in the
+// codebase computes a version to pass.
+//
+// The 500 was not the worst of it. `set()` mutates `this.config` before it
+// calls `persistConfig`, so the process went on serving a value it had failed
+// to store -- the change looked like it worked until the next restart, at which
+// point it silently reverted, and `config_history` recorded changes that never
+// landed in `app_config`.
+//
+// Nothing caught this: the file parses, the module imports, and every suite
+// mocks config/db, so the statement had never been executed by anything. The
+// last describe here is the general form -- it counts both sides of every
+// statically countable statement in the backend.
+
+// configService reads `require('../config/db').promise`, so the mock has to
+// carry the same handle the module actually calls -- one jest.fn behind both.
+jest.mock('../config/db', () => {
+    const query = jest.fn();
+    return { query, promise: { query }, getConnection: jest.fn() };
+});
+
+const db = require('../config/db');
+const { ConfigService } = require('../services/configService');
+
+const { mismatchedStatements, countArguments, countPlaceholders, countableCalls } =
+    require('./helpers/sqlPlaceholders');
+
+/** The statement issued, whitespace collapsed. */
+const statement = (index = 0) =>
+    String(db.query.mock.calls[index][0]).replace(/\s+/g, ' ').trim();
+
+const paramsOf = (index = 0) => db.query.mock.calls[index][1];
+
+// A fresh instance per test. The module exports a singleton, and `set()`
+// refuses a key that already exists unless `override` is passed -- so a shared
+// instance would make each case depend on the ones before it.
+let configService;
+
+beforeEach(() => {
+    db.query.mockClear();
+    db.query.mockResolvedValue([{ affectedRows: 1 }]);
+    configService = new ConfigService();
+});
+
+// ---------------------------------------------------------------------------
+// The statement
+// ---------------------------------------------------------------------------
+
+describe('persisting a configuration value', () => {
+    test('binds a value for every placeholder', async () => {
+        // The whole bug in one assertion.
+        await configService.persistConfig('features.newCheckout', true, 'admin-1');
+
+        expect(countPlaceholders(statement())).toBe(paramsOf().length);
+    });
+
+    test('binds three values into three placeholders', async () => {
+        await configService.persistConfig('features.newCheckout', true, 'admin-1');
+
+        expect(countPlaceholders(statement())).toBe(3);
+        expect(paramsOf()).toHaveLength(3);
+    });
+
+    test('does not list version among the inserted columns', async () => {
+        await configService.persistConfig('a.b', 1, 'admin-1');
+
+        expect(statement()).not.toMatch(/config_value, version/);
+        expect(statement()).toMatch(/\(config_key, config_value, updated_by, updated_at\)/);
+    });
+
+    test('still increments version on the duplicate-key branch', async () => {
+        // Dropping it from the insert must not drop it from the update: the
+        // column exists so a change can be counted.
+        await configService.persistConfig('a.b', 1, 'admin-1');
+
+        expect(statement()).toMatch(/ON DUPLICATE KEY UPDATE[\s\S]*version = version \+ 1/);
+    });
+
+    test('binds the key, the serialised value and the user, in that order', async () => {
+        await configService.persistConfig('features.newCheckout', { on: true }, 'admin-1');
+
+        expect(paramsOf()).toEqual([
+            'features.newCheckout',
+            JSON.stringify({ on: true }),
+            'admin-1',
+        ]);
+    });
+
+    test('attributes an unattributed change to system rather than binding null', async () => {
+        await configService.persistConfig('a.b', 1, null);
+
+        expect(paramsOf()[2]).toBe('system');
+    });
+
+    test('serialises the value rather than binding an object', async () => {
+        // config_value is JSON NOT NULL; an object would be bound as
+        // "[object Object]".
+        await configService.persistConfig('a.b', { nested: { x: 1 } }, 'admin-1');
+
+        expect(paramsOf()[1]).toBe('{"nested":{"x":1}}');
+        expect(JSON.parse(paramsOf()[1])).toEqual({ nested: { x: 1 } });
+    });
+
+    test('a false value is persisted, not skipped', async () => {
+        // Turning a flag off is a change like any other, and `false` is easy to
+        // lose to a truthiness guard.
+        await configService.persistConfig('features.newCheckout', false, 'admin-1');
+
+        expect(paramsOf()[1]).toBe('false');
+    });
+
+    test('a database failure propagates rather than being swallowed', async () => {
+        db.query.mockRejectedValueOnce(new Error('ER_NO_SUCH_TABLE'));
+
+        await expect(configService.persistConfig('a.b', 1, 'admin-1'))
+            .rejects.toThrow('ER_NO_SUCH_TABLE');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The path that reaches it
+// ---------------------------------------------------------------------------
+
+describe('set()', () => {
+    test('persists by default', async () => {
+        await configService.set('test.persistDefault', 1, { override: true, user: 'admin-1' });
+
+        const inserts = db.query.mock.calls.filter(([sql]) => /INSERT INTO app_config/.test(sql));
+        expect(inserts).toHaveLength(1);
+    });
+
+    test('does not write when persistence is turned off', async () => {
+        await configService.set('test.noPersist', 1, {
+            override: true,
+            user: 'admin-1',
+            persist: false,
+        });
+
+        const inserts = db.query.mock.calls.filter(([sql]) => /INSERT INTO app_config/.test(sql));
+        expect(inserts).toHaveLength(0);
+    });
+
+    test('the value it stored is the value it serves', async () => {
+        await configService.set('test.roundTrip', { mode: 'fast' }, {
+            override: true,
+            user: 'admin-1',
+        });
+
+        expect(configService.get('test.roundTrip')).toEqual({ mode: 'fast' });
+        expect(paramsOf(db.query.mock.calls.length - 1)[1]).toBe('{"mode":"fast"}');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The general rule
+// ---------------------------------------------------------------------------
+
+describe('every statement in the backend', () => {
+    test('binds as many values as it has placeholders', () => {
+        // Scoped to statements where both sides can be counted with certainty:
+        // no `${...}` in the SQL, no spread in the argument list. Anything else
+        // is skipped rather than guessed at.
+        expect(mismatchedStatements()).toEqual([]);
+    });
+
+    test('there are enough of them for that to mean something', () => {
+        // A guard on the guard. If the extraction ever stops matching, the case
+        // above passes over an empty set and the next mismatch ships.
+        const fs = require('fs');
+        const { backendSources } = require('./helpers/sqlPlaceholders');
+
+        const counted = backendSources().reduce(
+            (total, file) => total + countableCalls(fs.readFileSync(file, 'utf8'), file).length,
+            0
+        );
+
+        expect(counted).toBeGreaterThan(400);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The counter itself
+// ---------------------------------------------------------------------------
+
+describe('counting arguments', () => {
+    test('counts a flat list', () => {
+        expect(countArguments('a, b, c')).toBe(3);
+    });
+
+    test('ignores commas inside a nested call', () => {
+        expect(countArguments('a, JSON.stringify(x, null, 2), b')).toBe(3);
+    });
+
+    test('ignores commas inside a string', () => {
+        expect(countArguments(`a, 'one, two', b`)).toBe(3);
+    });
+
+    test('ignores commas inside a line comment', () => {
+        // This is what made an earlier draft report a false mismatch in
+        // contactService: a comment reading "TEXT column, but a header is
+        // attacker-controlled" sat between two arguments.
+        expect(countArguments('a,\n// a note, with a comma\nb')).toBe(2);
+    });
+
+    test('ignores a trailing comma', () => {
+        expect(countArguments('a, b,')).toBe(2);
+    });
+
+    test('counts an empty list as zero', () => {
+        expect(countArguments('  ')).toBe(0);
+    });
+
+    test('refuses to count a spread', () => {
+        expect(countArguments('a, ...rest')).toBeNull();
+    });
+
+    test('survives an index expression, which a lazy regex does not', () => {
+        // `.find((s) => s[0] === 'x')[1]` closes a bracket in the middle of an
+        // argument. Matching the array with /\[([\s\S]*?)\]/ truncates there.
+        const list = `a, JSON.stringify(states.find((s) => s[0] === 'x')[1]), b`;
+
+        expect(countArguments(list)).toBe(3);
+    });
+});
+
+describe('counting placeholders', () => {
+    test('counts each ?', () => {
+        expect(countPlaceholders('VALUES (?, ?, ?)')).toBe(3);
+    });
+
+    test('does not count a NOW() column', () => {
+        expect(countPlaceholders('VALUES (?, ?, NOW())')).toBe(2);
+    });
+
+    test('reports the original defect', () => {
+        const broken = `INSERT INTO app_config
+             (config_key, config_value, version, updated_by, updated_at)
+             VALUES (?, ?, ?, ?, NOW())`;
+
+        expect(countPlaceholders(broken)).toBe(4);
+        expect(countArguments(`key, JSON.stringify(value), user || 'system'`)).toBe(3);
+    });
+});

--- a/backend/tests/helpers/sqlPlaceholders.js
+++ b/backend/tests/helpers/sqlPlaceholders.js
@@ -1,0 +1,269 @@
+// backend/tests/helpers/sqlPlaceholders.js
+//
+// Does each statement bind as many values as it has placeholders? (#1583)
+//
+// `configService.persistConfig` listed five columns, gave `updated_at` a
+// `NOW()` and the other four a `?`, and passed three values. mysql2 rejects
+// that with "Incorrect arguments to mysqld_stmt_execute" before the statement
+// reaches the server, so `POST /api/config` was a 500 every time.
+//
+// It is an easy mistake to make and an almost impossible one to see by reading:
+// the placeholders are in a template literal several lines above the array, and
+// counting `?` characters by eye across a wrapped INSERT is exactly the kind of
+// thing people skip. Nothing else catches it either -- the file parses, the
+// module imports, and every suite mocks config/db, so no test has ever executed
+// the statement.
+//
+// This counts both sides of a `.query(sql, [args])` call and reports the ones
+// that disagree.
+//
+// Scope, deliberately narrow. Only calls where **both** sides can be counted
+// with certainty are considered:
+//
+//   * the SQL must be a template literal with no `${...}` in it -- an
+//     interpolated fragment can contribute any number of placeholders, and
+//     several services legitimately build `WHERE` clauses that way;
+//   * the argument list must be an array literal with no spread -- `...values`
+//     has no static length.
+//
+// Anything else is reported as "not statically countable" and skipped rather
+// than guessed at. A checker that guesses produces false failures, people learn
+// to ignore it, and then it catches nothing.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const BACKEND_ROOT = path.join(__dirname, '..', '..');
+
+const SKIP_DIRECTORIES = new Set([
+    'node_modules',
+    'coverage',
+    'tests',
+    'logs',
+    '.git',
+]);
+
+/**
+ * Every .js file under the backend, excluding vendored and generated trees.
+ *
+ * @param {string} [directory]
+ * @returns {string[]} Absolute paths.
+ */
+function backendSources(directory = BACKEND_ROOT) {
+    return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+        if (SKIP_DIRECTORIES.has(entry.name)) return [];
+
+        const full = path.join(directory, entry.name);
+
+        if (entry.isDirectory()) return backendSources(full);
+
+        return entry.isFile() && entry.name.endsWith('.js') ? [full] : [];
+    });
+}
+
+/**
+ * Count top-level commas in an argument list, i.e. how many values it binds.
+ *
+ * Commas inside nested calls, arrays, objects, strings, template literals and
+ * comments do not separate arguments. Getting this wrong in either direction
+ * produces a false result, so it is walked character by character rather than
+ * split.
+ *
+ * @param {string} source - The inside of the array literal, without its brackets.
+ * @returns {number|null} null when the list cannot be counted (a spread).
+ */
+function countArguments(source) {
+    const text = source.trim();
+
+    if (text === '') return 0;
+
+    let depth = 0;
+    let count = 1;
+    let index = 0;
+
+    while (index < text.length) {
+        const character = text[index];
+        const pair = text.slice(index, index + 2);
+
+        // Comments: a `//` line comment often contains prose with commas in it,
+        // which is what made an earlier version of this miscount.
+        if (pair === '//') {
+            const end = text.indexOf('\n', index);
+            index = end === -1 ? text.length : end;
+            continue;
+        }
+
+        if (pair === '/*') {
+            const end = text.indexOf('*/', index + 2);
+            index = end === -1 ? text.length : end + 2;
+            continue;
+        }
+
+        // Strings and template literals, skipped whole. Escapes are honoured so
+        // a quote inside a string does not end it early.
+        if (character === '"' || character === "'" || character === '`') {
+            index += 1;
+            while (index < text.length && text[index] !== character) {
+                index += text[index] === '\\' ? 2 : 1;
+            }
+            index += 1;
+            continue;
+        }
+
+        if (character === '(' || character === '[' || character === '{') depth += 1;
+        if (character === ')' || character === ']' || character === '}') depth -= 1;
+
+        if (character === ',' && depth === 0) {
+            // A trailing comma does not introduce another argument.
+            if (text.slice(index + 1).trim() !== '') count += 1;
+        }
+
+        if (text.startsWith('...', index) && depth === 0) return null;
+
+        index += 1;
+    }
+
+    return count;
+}
+
+/**
+ * Count `?` placeholders in a statement.
+ *
+ * `?` inside a string literal within the SQL is not a placeholder, but SQL
+ * string literals in this codebase are single-quoted status values and none of
+ * them contain a question mark, so a plain count is honest here.
+ *
+ * @param {string} sql
+ * @returns {number}
+ */
+function countPlaceholders(sql) {
+    return (sql.match(/\?/g) || []).length;
+}
+
+/**
+ * The contents of the array literal that starts at `open`.
+ *
+ * Bracket-matched rather than matched with `\[([\s\S]*?)\]`, which stops at the
+ * first `]` in the list -- and argument lists are full of them, as in
+ * `result.agentStates.find((state) => state[0] === 'x')[1]`. A non-greedy regex
+ * truncates that after `state[0`, counts two arguments where there are nine,
+ * and reports a mismatch that is not there.
+ *
+ * @param {string} source
+ * @param {number} open - Index of the `[`.
+ * @returns {string|null} The inside of the array, or null if it never closes.
+ */
+function readArrayLiteral(source, open) {
+    let depth = 0;
+    let index = open;
+
+    while (index < source.length) {
+        const character = source[index];
+        const pair = source.slice(index, index + 2);
+
+        if (pair === '//') {
+            const end = source.indexOf('\n', index);
+            index = end === -1 ? source.length : end;
+            continue;
+        }
+
+        if (pair === '/*') {
+            const end = source.indexOf('*/', index + 2);
+            index = end === -1 ? source.length : end + 2;
+            continue;
+        }
+
+        if (character === '"' || character === "'" || character === '`') {
+            index += 1;
+            while (index < source.length && source[index] !== character) {
+                index += source[index] === '\\' ? 2 : 1;
+            }
+            index += 1;
+            continue;
+        }
+
+        if (character === '[' || character === '(' || character === '{') depth += 1;
+
+        if (character === ']' || character === ')' || character === '}') {
+            depth -= 1;
+            if (depth === 0) return source.slice(open + 1, index);
+        }
+
+        index += 1;
+    }
+
+    return null;
+}
+
+/**
+ * Every statically countable `.query(sql, [args])` call in one file.
+ *
+ * @param {string} source - File contents.
+ * @param {string} label - How to name the file in a result.
+ * @returns {Array<{file: string, line: number, placeholders: number, args: number}>}
+ */
+function countableCalls(source, label) {
+    const calls = [];
+
+    // `.query(` or `.execute(` followed by a template literal, then an array.
+    // The array is located rather than matched, for the reason above.
+    const pattern = /\.(?:query|execute)\(\s*`([^`]*)`\s*,\s*(?=\[)/g;
+
+    for (const match of source.matchAll(pattern)) {
+        const sql = match[1];
+
+        // An interpolated fragment can carry any number of placeholders.
+        if (sql.includes('${')) continue;
+
+        const body = readArrayLiteral(source, match.index + match[0].length);
+        if (body === null) continue;
+
+        const args = countArguments(body);
+        if (args === null) continue;
+
+        calls.push({
+            file: label,
+            line: source.slice(0, match.index).split('\n').length,
+            placeholders: countPlaceholders(sql),
+            args,
+        });
+    }
+
+    return calls;
+}
+
+/**
+ * Every statement in the backend whose two sides disagree.
+ *
+ * @returns {string[]} e.g. `['services/configService.js:320 4 placeholders, 3 arguments']`
+ */
+function mismatchedStatements() {
+    const mismatches = [];
+
+    for (const file of backendSources()) {
+        const label = path.relative(BACKEND_ROOT, file);
+        const source = fs.readFileSync(file, 'utf8');
+
+        for (const call of countableCalls(source, label)) {
+            if (call.placeholders !== call.args) {
+                mismatches.push(
+                    `${call.file}:${call.line} `
+                    + `${call.placeholders} placeholder(s), ${call.args} argument(s)`
+                );
+            }
+        }
+    }
+
+    return mismatches.sort();
+}
+
+module.exports = {
+    readArrayLiteral,
+    backendSources,
+    countArguments,
+    countPlaceholders,
+    countableCalls,
+    mismatchedStatements,
+};


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`POST /api/config` returned a 500 on every call. `configService.persistConfig()` listed five columns, gave `updated_at` a `NOW()` and the other four a `?`, and bound **three** values:

```js
`INSERT INTO app_config
 (config_key, config_value, version, updated_by, updated_at)
 VALUES (?, ?, ?, ?, NOW())
 ...`,
[key, JSON.stringify(value), user || 'system']
```

mysql2 rejects that with `Incorrect arguments to mysqld_stmt_execute` before the statement ever leaves the process.

### The placeholder was the mistake, not the missing binding

`app_config.version` is `INT DEFAULT 1` (`backend/sql/app_config.sql`) and the `ON DUPLICATE KEY UPDATE` branch already does `version = version + 1`. So the insert branch wants the default — nothing in this codebase computes a version to pass in. Dropping the column from the list gives `1` on insert and an increment on update, which is what the two branches together were always meant to say.

```diff
-(config_key, config_value, version, updated_by, updated_at)
-VALUES (?, ?, ?, ?, NOW())
+(config_key, config_value, updated_by, updated_at)
+VALUES (?, ?, ?, NOW())
```

### The 500 was not the worst of it

`set()` mutates `this.config` **before** it calls `persistConfig`, so the process went on serving a value it had failed to store. The change looked like it worked until the next restart, at which point it silently reverted — and `config_history` (written by a different path) recorded changes that never landed in `app_config`. Worth checking for drift on any environment where this endpoint has been used.

That ordering is deliberately left alone here. It is a design question about what `set()` should guarantee, and restructuring it would move the `config.changed` event contract — it belongs in its own change.

---

## 🔗 Related Issue

Closes #1583

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

```
$ npx jest tests/configPersistence.test.js
Tests:       25 passed, 25 total
```

---

## 🌐 Additional Notes

This is an easy mistake to make and an almost impossible one to see by reading: the placeholders are in a template literal several lines above the array, and counting `?` characters by eye across a wrapped `INSERT` is exactly the kind of thing people skip. Nothing catches it either — the file parses, the module imports, and **every suite mocks `config/db`, so the statement had never been executed by anything**.

So this adds `backend/tests/helpers/sqlPlaceholders.js`, which counts both sides of every statement in the backend that can be counted *with certainty*:

- the SQL must be a template literal with no `${...}` in it — an interpolated fragment can contribute any number of placeholders, and several services legitimately build `WHERE` clauses that way;
- the argument list must be an array literal with no spread — `...values` has no static length.

Anything else is skipped rather than guessed at. A checker that guesses produces false failures, people learn to ignore it, and then it catches nothing.

Getting that right took two corrections, both of which now have a test:

1. It walks characters rather than splitting on commas. Commas inside nested calls, strings and **comments** do not separate arguments — an earlier draft reported a false mismatch in `contactService` because a comment reading *"TEXT column, but a header is attacker-controlled"* sat between two arguments.
2. It bracket-matches the array rather than using `/\[([\s\S]*?)\]/`, which truncates at the first `]` *inside* an argument — `states.find((s) => s[0] === 'x')[1]` broke it, turning nine arguments into two.

The first draft reported six mismatches; five were imaginary.

### One extra fix the check turned up

**504 statements counted, exactly one real mismatch left:**

`agentLiabilityService.storeClaim()` — 13 columns, 13 placeholders, **15** values, with `resolvedAt` and `resolution` each bound twice, once guarded with `|| null` and once raw. Every value after them lined up against the wrong column, and the count was rejected before it got that far, so **filing a liability claim always threw**. The guarded pair is the one kept: a claim being stored is usually unresolved, and `undefined` is not a bindable value.

Same defect, found by the check rather than reported separately — and the gate could not be turned on with it still there.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly
