### PR TITLE
fix: cart line checkboxes do nothing — add the bulk-select markup, CSS and bindings (#1584)

### DIFF
--- a/backend/tests/cartBulkSelection.test.js
+++ b/backend/tests/cartBulkSelection.test.js
@@ -1,0 +1,487 @@
+// backend/tests/cartBulkSelection.test.js
+//
+// Cart bulk selection, driven for real in jsdom (#1584).
+//
+// `cart.js` rendered a checkbox on every cart line and ticking one did nothing
+// at all. The state (`selectedItems`), the operations (`bulkRemove`,
+// `bulkSaveForLater`), the undo integration and the per-item checkbox had all
+// shipped. What had not:
+//
+//   * `#bulk-actions`, `#selected-count`, `#select-all`, `#cart-item-count` and
+//     `#saved-for-later-container` were not in cart.html, so every one of them
+//     cached as null and `updateBulkActions` -- guarded on
+//     `if (bulkActions && selectedCount)` -- was a no-op;
+//   * nothing called `toggleSelectItem`, `toggleSelectAll`, `bulkRemove` or
+//     `bulkSaveForLater`. The delegated click handler matched `.increase-qty`,
+//     `.remove-btn` and four others, and nothing for the checkboxes;
+//   * the markup's `onchange="window.toggleSelectItem(...)"` could not have
+//     worked either: cart.js is an IIFE and assigns nothing to `window`, and
+//     the id was interpolated unquoted, which for a CHAR(36) UUID is not valid
+//     syntax;
+//   * `toggleSelectAll` did `parseInt(checkbox.dataset.itemId)`, and product
+//     ids are UUIDs, so every row collapsed onto a single NaN key.
+//
+// None of that is visible to grep -- the functions are all there, correctly
+// written. The question is whether anything reaches them, so these cases load
+// the real cart.html and the real cart.js and click things.
+
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const FRONTEND = path.join(REPO_ROOT, 'frontend');
+
+const CART_HTML = fs.readFileSync(path.join(FRONTEND, 'cart.html'), 'utf8');
+const CART_JS = fs.readFileSync(path.join(FRONTEND, 'scripts', 'cart.js'), 'utf8');
+const CART_CSS = fs.readFileSync(path.join(FRONTEND, 'styles', 'cart.css'), 'utf8');
+
+// UUIDs, because that is what product ids are and it is what broke the
+// selection. Integers here would let `parseInt` pass.
+const LINES = [
+    { id: 'a3f1b2c4-0000-4000-8000-000000000001', name: 'Linen Shirt', price: 1200, qty: 1, img: 'a.png' },
+    { id: 'a3f1b2c4-0000-4000-8000-000000000002', name: 'Denim Jacket', price: 3400, qty: 2, img: 'b.png' },
+    { id: 'a3f1b2c4-0000-4000-8000-000000000003', name: 'Cotton Hoodie', price: 2100, qty: 1, img: 'c.png' },
+];
+
+// The delegated click handler in cart.js reads `decreaseBtn` at a point where
+// its `const` is commented out, so every click on the cart page that is not on
+// the "+" button throws a ReferenceError. That is #1535, it is assigned, and it
+// is not this change's to fix -- the bulk buttons here are bound directly to
+// their elements rather than through that handler, so they work regardless.
+//
+// Filtered out by name rather than by ignoring errors wholesale, so a *new*
+// error still fails these cases, and so this stops filtering anything the day
+// #1535 lands.
+const KNOWN_UNRELATED = [/decreaseBtn is not defined/];
+
+const unexpected = (errors) =>
+    errors.filter((message) => !KNOWN_UNRELATED.some((known) => known.test(message)));
+
+const settle = async (dom, ms = 60) => {
+    await new Promise((resolve) => dom.window.setTimeout(resolve, ms));
+    await new Promise((resolve) => setImmediate(resolve));
+};
+
+/**
+ * Load the real cart page with a cart in it.
+ *
+ * @param {object} [options]
+ * @param {Array} [options.lines] the cart contents.
+ * @param {number} [options.expiresInDays] seeds the expiry key when given.
+ * @returns {object} handles onto the page.
+ */
+const mountCart = async ({ lines = LINES, expiresInDays = null } = {}) => {
+    const dom = new JSDOM(CART_HTML, {
+        url: 'http://localhost:5500/cart.html',
+        runScripts: 'outside-only',
+        pretendToBeVisual: true,
+    });
+
+    const { window } = dom;
+    const errors = [];
+    const notices = [];
+
+    window.addEventListener('error', (event) => errors.push(event.message));
+
+    let stored = JSON.parse(JSON.stringify(lines));
+
+    if (expiresInDays !== null) {
+        window.localStorage.setItem(
+            'cartExpiry',
+            new Date(Date.now() + expiresInDays * 86400000).toISOString()
+        );
+    }
+
+    window.AppUtils = {
+        CART_UPDATED_EVENT: 'cart:updated',
+        getCart: () => JSON.parse(JSON.stringify(stored)),
+        saveCart: (next) => {
+            stored = JSON.parse(JSON.stringify(next));
+            return JSON.parse(JSON.stringify(stored));
+        },
+        getJSON: (_key, fallback) => fallback,
+        setJSON: () => {},
+        escapeHTML: (value) =>
+            String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;'),
+        formatPrice: (value) => `₹${value}`,
+        defaultImage: (value) => value || 'placeholder.png',
+        notify: (message) => notices.push(message),
+        safeInteger: (value, fallback) =>
+            Number.isFinite(Number(value)) ? Number(value) : fallback,
+        safeNumber: (value, fallback) => Number(value) || fallback,
+        fetchCartQuote: async () => ({
+            subtotal: 0, tax: 0, shipping: 0, discount: 0, total: 0,
+            freeShipping: {}, currency: { symbol: '₹' },
+        }),
+        calculateCartTotals: async () => ({
+            subtotal: 0, tax: 0, shipping: 0, discount: 0, total: 0, freeShipping: {},
+        }),
+        formatFreeShippingProgress: () => '',
+        validateCoupon: async () => ({ valid: false, message: '' }),
+        getWishlist: () => [],
+        saveWishlist: () => {},
+        getToken: () => null,
+    };
+
+    window.eval(CART_JS);
+    window.document.dispatchEvent(new window.Event('DOMContentLoaded', { bubbles: true }));
+    await settle(dom);
+
+    const byId = (id) => window.document.getElementById(id);
+
+    return {
+        dom,
+        window,
+        document: window.document,
+        errors,
+        notices,
+        storedCart: () => stored,
+        rows: () => window.document.querySelectorAll('.cart-item'),
+        boxes: () => [...window.document.querySelectorAll('.cart-item-select')],
+        bulkBar: () => byId('bulk-actions'),
+        selectedCount: () => byId('selected-count'),
+        selectAll: () => byId('select-all'),
+        itemCount: () => byId('cart-item-count'),
+        expiryWarning: () => byId('cart-expiry-warning'),
+        savedContainer: () => byId('saved-for-later-container'),
+        tick: async (index, checked = true) => {
+            const box = window.document.querySelectorAll('.cart-item-select')[index];
+            box.checked = checked;
+            box.dispatchEvent(new window.Event('change', { bubbles: true }));
+            await settle(dom);
+        },
+        toggleAll: async (checked = true) => {
+            const box = byId('select-all');
+            box.checked = checked;
+            box.dispatchEvent(new window.Event('change', { bubbles: true }));
+            await settle(dom);
+        },
+        clickBulk: async (id) => {
+            byId(id).click();
+            await settle(dom);
+        },
+    };
+};
+
+// ---------------------------------------------------------------------------
+// The markup that was missing
+// ---------------------------------------------------------------------------
+
+describe('cart.html carries the elements cart.js caches', () => {
+    test.each([
+        'bulk-actions',
+        'bulk-remove-btn',
+        'bulk-save-later-btn',
+        'select-all',
+        'selected-count',
+        'cart-item-count',
+        'saved-for-later-container',
+        'cart-expiry-warning',
+    ])('#%s is in the page', (id) => {
+        expect(CART_HTML).toMatch(new RegExp(`id="${id}"`));
+    });
+
+    test('the bulk toolbar and expiry notice start hidden', () => {
+        // Both are revealed by script. Shipping them visible would put an empty
+        // "0 items selected" bar above every cart.
+        expect(CART_HTML).toMatch(/id="bulk-actions"[\s\S]{0,220}style="display: none;"/);
+        expect(CART_HTML).toMatch(/id="cart-expiry-warning"[\s\S]{0,220}style="display: none;"/);
+    });
+
+    test('cart.css styles them', () => {
+        for (const selector of [
+            '.bulk-actions', '.bulk-action-btn', '.selected-count',
+            '.select-all-label', '.cart-item-count', '.cart-expiry-warning',
+            '#saved-for-later-section',
+        ]) {
+            expect(CART_CSS).toContain(selector);
+        }
+    });
+
+    test('cart.css does not fight the script for display', () => {
+        // updateBulkActions and updateExpiryWarning set `display` inline. A
+        // `display` in the rule as well would mean two owners for one property.
+        const rule = /\.bulk-actions\s*\{([^}]*)\}/.exec(CART_CSS);
+
+        expect(rule).not.toBeNull();
+        expect(rule[1]).not.toMatch(/(^|[;\s])display\s*:/);
+    });
+
+    test('there is a dark-theme rule for the new toolbar', () => {
+        expect(CART_CSS).toMatch(/body\.dark-theme \.bulk-actions/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The wiring
+// ---------------------------------------------------------------------------
+
+describe('a cart with three lines', () => {
+    test('renders a checkbox per line', async () => {
+        const cart = await mountCart();
+
+        expect(cart.rows()).toHaveLength(3);
+        expect(cart.boxes()).toHaveLength(3);
+    });
+
+    test('loads without throwing', async () => {
+        // showUndoToast was called from three places and declared in none of
+        // them; it is restored by this change. See KNOWN_UNRELATED above for
+        // the one error still expected here.
+        const cart = await mountCart();
+
+        expect(unexpected(cart.errors)).toEqual([]);
+    });
+
+    test('keeps the whole UUID on the checkbox', async () => {
+        // parseInt on this is NaN, which is what collapsed the selection.
+        const cart = await mountCart();
+
+        expect(cart.boxes()[0].dataset.itemId)
+            .toBe('a3f1b2c4-0000-4000-8000-000000000001');
+    });
+
+    test('does not put handlers on the global object', async () => {
+        // The markup used to call window.toggleSelectItem, which this file
+        // never defined -- cart.js is an IIFE and assigns nothing to window.
+        // Asserted against the rendered DOM rather than the source, so a
+        // comment mentioning the old form does not fail the case.
+        const cart = await mountCart();
+
+        expect(cart.document.querySelector('#cart-items').innerHTML)
+            .not.toMatch(/window\./);
+        expect(cart.window.toggleSelectItem).toBeUndefined();
+        expect(cart.window.updateQuantity).toBeUndefined();
+        expect(cart.window.updateItemNote).toBeUndefined();
+    });
+
+    test('shows the item count, summed over quantities', async () => {
+        const cart = await mountCart();
+
+        // 1 + 2 + 1
+        expect(cart.itemCount().textContent).toBe('4 items');
+    });
+
+    test('says "1 item" rather than "1 items"', async () => {
+        const cart = await mountCart({ lines: [{ ...LINES[0], qty: 1 }] });
+
+        expect(cart.itemCount().textContent).toBe('1 item');
+    });
+
+    test('hides the bulk bar until something is selected', async () => {
+        const cart = await mountCart();
+
+        expect(cart.bulkBar().style.display).toBe('none');
+    });
+});
+
+describe('selecting lines', () => {
+    test('ticking one reveals the bar with a count', async () => {
+        const cart = await mountCart();
+
+        await cart.tick(0);
+
+        expect(cart.bulkBar().style.display).toBe('flex');
+        expect(cart.selectedCount().textContent).toBe('1 item selected');
+    });
+
+    test('ticking a second updates the count', async () => {
+        const cart = await mountCart();
+
+        await cart.tick(0);
+        await cart.tick(1);
+
+        expect(cart.selectedCount().textContent).toBe('2 items selected');
+    });
+
+    test('unticking the last one hides the bar again', async () => {
+        const cart = await mountCart();
+
+        await cart.tick(0);
+        await cart.tick(0, false);
+
+        expect(cart.bulkBar().style.display).toBe('none');
+    });
+
+    test('select-all is indeterminate on a partial selection', async () => {
+        const cart = await mountCart();
+
+        await cart.tick(0);
+
+        expect(cart.selectAll().indeterminate).toBe(true);
+        expect(cart.selectAll().checked).toBe(false);
+    });
+
+    test('select-all is checked once every line is picked', async () => {
+        const cart = await mountCart();
+
+        await cart.tick(0);
+        await cart.tick(1);
+        await cart.tick(2);
+
+        expect(cart.selectAll().checked).toBe(true);
+        expect(cart.selectAll().indeterminate).toBe(false);
+    });
+
+    test('select-all ticks every box and counts them all', async () => {
+        // This is the case parseInt broke: three UUIDs became one NaN, so the
+        // count said 1.
+        const cart = await mountCart();
+
+        await cart.toggleAll(true);
+
+        expect(cart.boxes().filter((box) => box.checked)).toHaveLength(3);
+        expect(cart.selectedCount().textContent).toBe('3 items selected');
+    });
+
+    test('unticking select-all clears the selection', async () => {
+        const cart = await mountCart();
+
+        await cart.toggleAll(true);
+        await cart.toggleAll(false);
+
+        expect(cart.bulkBar().style.display).toBe('none');
+        expect(cart.boxes().filter((box) => box.checked)).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The operations
+// ---------------------------------------------------------------------------
+
+describe('save selected for later', () => {
+    test('moves the selected lines out of the cart', async () => {
+        const cart = await mountCart();
+
+        await cart.tick(0);
+        await cart.clickBulk('bulk-save-later-btn');
+
+        expect(cart.rows()).toHaveLength(2);
+        expect(cart.storedCart().map((item) => item.name))
+            .toEqual(['Denim Jacket', 'Cotton Hoodie']);
+    });
+
+    test('renders them into the saved-for-later container', async () => {
+        const cart = await mountCart();
+
+        await cart.tick(0);
+        await cart.clickBulk('bulk-save-later-btn');
+
+        const saved = cart.savedContainer();
+        expect(saved.children).toHaveLength(1);
+        expect(saved.textContent).toContain('Linen Shirt');
+        expect(saved.textContent).toContain('Saved for Later (1)');
+    });
+
+    test('says how many, with the right noun', async () => {
+        const cart = await mountCart();
+
+        await cart.tick(0);
+        await cart.clickBulk('bulk-save-later-btn');
+
+        expect(cart.notices).toContain('Saved 1 item for later');
+    });
+
+    test('clears the selection and hides the bar', async () => {
+        const cart = await mountCart();
+
+        await cart.tick(0);
+        await cart.clickBulk('bulk-save-later-btn');
+
+        expect(cart.bulkBar().style.display).toBe('none');
+    });
+
+    test('emptying the cart this way still renders the saved items', async () => {
+        const cart = await mountCart();
+
+        await cart.toggleAll(true);
+        await cart.clickBulk('bulk-save-later-btn');
+
+        expect(cart.rows()).toHaveLength(0);
+        expect(cart.savedContainer().textContent).toContain('Saved for Later (3)');
+        expect(unexpected(cart.errors)).toEqual([]);
+    });
+});
+
+describe('remove selected', () => {
+    test('takes the selected lines out immediately', async () => {
+        const cart = await mountCart();
+
+        await cart.tick(0);
+        await cart.tick(1);
+        await cart.clickBulk('bulk-remove-btn');
+
+        expect(cart.rows()).toHaveLength(1);
+    });
+
+    test('offers an undo', async () => {
+        const cart = await mountCart();
+
+        await cart.tick(0);
+        await cart.clickBulk('bulk-remove-btn');
+
+        const toast = cart.document.getElementById('undo-toast');
+        expect(toast).not.toBeNull();
+        expect(toast.textContent).toContain('Removing 1 item from cart');
+    });
+
+    test('undo puts them back', async () => {
+        const cart = await mountCart();
+
+        await cart.tick(0);
+        await cart.clickBulk('bulk-remove-btn');
+        expect(cart.rows()).toHaveLength(2);
+
+        cart.document.querySelector('#undo-toast .undo-btn').click();
+        await settle(cart.dom);
+
+        expect(cart.rows()).toHaveLength(3);
+    });
+
+    test('clears the selection so the bar goes away', async () => {
+        const cart = await mountCart();
+
+        await cart.tick(0);
+        await cart.clickBulk('bulk-remove-btn');
+
+        expect(cart.bulkBar().style.display).toBe('none');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The rest of the markup that had nowhere to render
+// ---------------------------------------------------------------------------
+
+describe('the expiry notice', () => {
+    test('warns when the cart is nearly out of time', async () => {
+        const cart = await mountCart({ expiresInDays: 2 });
+
+        expect(cart.expiryWarning().style.display).toBe('block');
+        expect(cart.expiryWarning().textContent).toContain('expire in 2 days');
+        expect(cart.expiryWarning().className).toContain('urgent');
+    });
+
+    test('is softer when there is more time left', async () => {
+        const cart = await mountCart({ expiresInDays: 4 });
+
+        expect(cart.expiryWarning().className).toContain('warning');
+        expect(cart.expiryWarning().className).not.toContain('urgent');
+    });
+
+    test('stays hidden when the cart has plenty of time', async () => {
+        const cart = await mountCart({ expiresInDays: 6 });
+
+        expect(cart.expiryWarning().style.display).toBe('none');
+    });
+
+    test('stays hidden when no expiry has been set', async () => {
+        const cart = await mountCart();
+
+        expect(cart.expiryWarning().style.display).toBe('none');
+    });
+});

--- a/frontend/cart.html
+++ b/frontend/cart.html
@@ -147,13 +147,94 @@
 
         <div class="cart-items-container">
 
-            <h2>
+            <!--
+                Expiry notice. cart.js has computed the days remaining from
+                CART_CONFIG.EXPIRY_DAYS since the feature landed, but had
+                nowhere to write it (#1584). Hidden until updateExpiryWarning
+                decides otherwise.
+            -->
+            <div
+                id="cart-expiry-warning"
+                class="cart-expiry-warning"
+                role="status"
+                aria-live="polite"
+                style="display: none;"
+            ></div>
 
-                Cart Items
+            <div class="cart-items-header">
 
-            </h2>
+                <h2>
+
+                    Cart Items
+
+                </h2>
+
+                <div class="cart-items-header__tools">
+
+                    <label class="select-all-label" for="select-all">
+                        <input
+                            type="checkbox"
+                            id="select-all"
+                            class="select-all-checkbox"
+                        >
+                        Select all
+                    </label>
+
+                    <span id="cart-item-count" class="cart-item-count">0 items</span>
+
+                </div>
+
+            </div>
+
+            <!--
+                Bulk actions. bulkRemove() and bulkSaveForLater() have been in
+                cart.js all along with nothing to trigger them, and
+                updateBulkActions() opens with `if (bulkActions && selectedCount)`
+                so it was a no-op. Revealed by updateBulkActions once at least
+                one line is selected.
+            -->
+            <div
+                id="bulk-actions"
+                class="bulk-actions"
+                role="region"
+                aria-label="Actions for selected items"
+                style="display: none;"
+            >
+
+                <span id="selected-count" class="selected-count">0 items selected</span>
+
+                <div class="bulk-actions__buttons">
+
+                    <button
+                        type="button"
+                        id="bulk-save-later-btn"
+                        class="bulk-action-btn bulk-action-btn--secondary"
+                    >
+                        <i class="fas fa-bookmark" aria-hidden="true"></i>
+                        Save for later
+                    </button>
+
+                    <button
+                        type="button"
+                        id="bulk-remove-btn"
+                        class="bulk-action-btn bulk-action-btn--danger"
+                    >
+                        <i class="fas fa-trash" aria-hidden="true"></i>
+                        Remove selected
+                    </button>
+
+                </div>
+
+            </div>
 
             <div id="cart-items"></div>
+
+            <!--
+                Saved for later. renderCart() builds this section itself when
+                there is something in it, so this is the container it renders
+                into rather than markup of its own.
+            -->
+            <div id="saved-for-later-container"></div>
 
         </div>
 

--- a/frontend/scripts/cart.js
+++ b/frontend/scripts/cart.js
@@ -32,10 +32,15 @@ const elements = {
     couponForm: document.getElementById("coupon-form"),
     couponCode: document.getElementById("coupon-code"),
     couponMessage: document.getElementById("coupon-message"),
-    // New elements for enhanced features
+    // Selection, bulk actions, saved-for-later and the expiry notice. Every one
+    // of these resolved to null until #1584 added the markup to cart.html: the
+    // code behind them shipped, the elements it needed did not.
     bulkActions: document.getElementById("bulk-actions"),
+    bulkRemoveBtn: document.getElementById("bulk-remove-btn"),
+    bulkSaveLaterBtn: document.getElementById("bulk-save-later-btn"),
     selectAll: document.getElementById("select-all"),
     selectedCount: document.getElementById("selected-count"),
+    cartItemCount: document.getElementById("cart-item-count"),
     savedForLaterContainer: document.getElementById("saved-for-later-container"),
     cartExpiryWarning: document.getElementById("cart-expiry-warning")
 };
@@ -140,6 +145,67 @@ function renderEmptyCart() {
     updateCartTotals(
         0
     );
+}
+
+// Show the undo toast for a destructive action.
+//
+// Called from three places -- single-item remove, empty cart, and the bulk
+// remove this change wires up -- and declared in none of them. It was dropped
+// by the same merge that recommented the `decreaseBtn` declaration (#1535), and
+// went unnoticed because that ReferenceError fires first on the two paths that
+// already existed. `bulkRemove` cannot work without it, so it comes back here,
+// as it stood in 49e3b64.
+//
+// The contract the three call sites rely on: `onConfirm` runs when the window
+// closes (timeout, or the shopper dismissing the toast) and `onUndo` runs if
+// they take it back, with only one of the two ever running.
+//
+// @param {string} message
+// @param {Function} onUndo
+// @param {Function} onConfirm
+function showUndoToast(message, onUndo, onConfirm) {
+    const toast = document.getElementById('undo-toast');
+    if (!toast) {
+        createUndoToast();
+        return showUndoToast(message, onUndo, onConfirm);
+    }
+
+    toast.querySelector('.toast-message').textContent = message;
+    toast.classList.add('show');
+
+    // A second action while one is pending: settle the first rather than
+    // leaving its timeout to fire against a cart that has moved on.
+    if (undoAction) {
+        clearTimeout(undoAction.timeout);
+        if (undoAction.onConfirm) {
+            undoAction.onConfirm();
+        }
+    }
+
+    undoAction = {
+        onUndo,
+        onConfirm,
+        timeout: setTimeout(() => {
+            if (onConfirm) {
+                onConfirm();
+            }
+            hideUndoToast();
+            undoAction = null;
+        }, CART_CONFIG.UNDO_TIMEOUT)
+    };
+
+    const undoBtn = toast.querySelector('.undo-btn');
+    undoBtn.onclick = () => {
+        if (!undoAction) return;
+
+        clearTimeout(undoAction.timeout);
+        if (undoAction.onUndo) {
+            undoAction.onUndo();
+        }
+        hideUndoToast();
+        undoAction = null;
+        AppUtils.notify('Action undone', 'success');
+    };
 }
 
 function createUndoToast() {
@@ -279,11 +345,13 @@ async function updateCartTotals() {
         elements.totalElement.innerText = AppUtils.formatPrice(totals.total, currency);
     }
     
-    // Update cart item count
+    // Update cart item count. The element is cached with the rest rather than
+    // looked up again on every totals refresh; #cart-item-count was not in
+    // cart.html at all, so this had never written anywhere (#1584).
     const itemCount = cart.reduce((sum, item) => sum + (item.qty || 1), 0);
-    const countElement = document.getElementById('cart-item-count');
-    if (countElement) {
-        countElement.textContent = `${itemCount} items`;
+    if (elements.cartItemCount) {
+        elements.cartItemCount.textContent =
+            `${itemCount} ${itemCount === 1 ? 'item' : 'items'}`;
     }
     
     // Update expiry warning
@@ -386,101 +454,165 @@ function removeSavedItem(index) {
 }
 
 // ==================== BULK OPERATIONS ====================
+//
+// The selection is keyed by product id, and product ids are CHAR(36) UUIDs
+// (AGENTS.md: users, products and orders all use them). `parseInt` on one is
+// NaN, so every row collapsed onto a single key and "select all" reported one
+// item selected however many there were (#1584). Ids are kept as strings here
+// and compared with String(), which is what the rest of this file already does.
+const itemKey = (value) => String(value);
+
+/** Is this cart line currently selected? */
+function isSelected(item) {
+    return selectedItems.has(itemKey(item?.id));
+}
+
+/**
+ * Drop anything from the selection that is no longer in the cart.
+ *
+ * Removing a selected line used to leave its id in `selectedItems`, so the
+ * count kept including it and a later bulk action operated on a set that no
+ * longer matched what was on screen.
+ */
+function pruneSelection() {
+    const present = new Set(cart.map((item) => itemKey(item.id)));
+
+    for (const key of [...selectedItems]) {
+        if (!present.has(key)) selectedItems.delete(key);
+    }
+}
+
 function toggleSelectAll() {
     const selectAll = elements.selectAll;
     if (!selectAll) return;
-    
+
     const isChecked = selectAll.checked;
-    
+
     document.querySelectorAll('.cart-item-select').forEach(checkbox => {
         checkbox.checked = isChecked;
-        const itemId = parseInt(checkbox.dataset.itemId);
+        const key = itemKey(checkbox.dataset.itemId);
+
         if (isChecked) {
-            selectedItems.add(itemId);
+            selectedItems.add(key);
         } else {
-            selectedItems.delete(itemId);
+            selectedItems.delete(key);
         }
     });
-    
+
     updateBulkActions();
 }
 
 function toggleSelectItem(itemId) {
-    if (selectedItems.has(itemId)) {
-        selectedItems.delete(itemId);
+    const key = itemKey(itemId);
+
+    if (selectedItems.has(key)) {
+        selectedItems.delete(key);
     } else {
-        selectedItems.add(itemId);
+        selectedItems.add(key);
     }
+
     updateBulkActions();
 }
 
+/**
+ * Reflect the selection in the toolbar.
+ *
+ * `#bulk-actions`, `#selected-count` and `#select-all` were not in cart.html,
+ * so the guard below was false on every call and this did nothing at all -- the
+ * checkboxes rendered, ticked, and led nowhere (#1584).
+ */
 function updateBulkActions() {
     const bulkActions = elements.bulkActions;
     const selectedCount = elements.selectedCount;
-    
+    const selectAll = elements.selectAll;
+    const total = cart.length;
+    const selected = selectedItems.size;
+
     if (bulkActions && selectedCount) {
-        if (selectedItems.size > 0) {
+        if (selected > 0) {
             bulkActions.style.display = 'flex';
-            selectedCount.textContent = `${selectedItems.size} items selected`;
+            selectedCount.textContent =
+                `${selected} ${selected === 1 ? 'item' : 'items'} selected`;
         } else {
             bulkActions.style.display = 'none';
         }
+    }
+
+    if (selectAll) {
+        // Indeterminate rather than checked when only some are picked, so the
+        // control describes the selection instead of guessing at it.
+        selectAll.checked = total > 0 && selected === total;
+        selectAll.indeterminate = selected > 0 && selected < total;
+        selectAll.disabled = total === 0;
     }
 }
 
 function bulkRemove() {
     if (selectedItems.size === 0) return;
-    
-    const removedItems = cart.filter(item => selectedItems.has(item.id));
+
+    // Captured before the cart is filtered. Both callbacks run after
+    // `selectedItems` has been cleared, so one that re-derived the set from it
+    // would act on nothing.
+    const removedItems = cart.filter(isSelected);
     const count = removedItems.length;
-    
+    const noun = count === 1 ? 'item' : 'items';
+
+    // Written through immediately rather than held in memory pending the
+    // toast. `renderCart` opens with `cart = AppUtils.getCart()`, so an
+    // optimistic in-memory filter is discarded by the very render meant to
+    // show it -- the rows would blink out and come straight back. Undo
+    // restores from `removedItems` below, which is what makes this safe.
+    cart = cart.filter((item) => !isSelected(item));
+    selectedItems.clear();
+    saveAndRender(cart);
+
     showUndoToast(
-        `Removing ${count} items from cart`,
+        `Removing ${count} ${noun} from cart`,
         () => {
-            // Undo: restore items
-            cart.push(...removedItems);
-            saveAndRender(cart);
-            selectedItems.clear();
-            updateBulkActions();
+            // Undo: put them back where the cart can see them again.
+            saveAndRender([...cart, ...removedItems]);
         },
         () => {
-            // Confirm: actually remove
-            cart = cart.filter(item => !selectedItems.has(item.id));
-            selectedItems.clear();
-            saveAndRender(cart);
-            updateBulkActions();
-            AppUtils.notify(`Removed ${count} items from cart`, 'success');
+            // Confirm: already durable, so this only reports it.
+            AppUtils.notify(`Removed ${count} ${noun} from cart`, 'success');
         }
     );
-    
-    // Optimistic update
-    cart = cart.filter(item => !selectedItems.has(item.id));
-    renderCart();
-    updateCartTotals();
 }
 
 function bulkSaveForLater() {
     if (selectedItems.size === 0) return;
-    
-    const itemsToSave = cart.filter(item => selectedItems.has(item.id));
+
+    const itemsToSave = cart.filter(isSelected);
     const count = itemsToSave.length;
-    
+
     // Remove from cart
-    cart = cart.filter(item => !selectedItems.has(item.id));
-    
-    // Add to saved for later
-    itemsToSave.forEach(item => {
+    cart = cart.filter((item) => !isSelected(item));
+
+    // Add to saved for later, skipping anything already there so a double
+    // click cannot list the same product twice.
+    itemsToSave.forEach((item) => {
+        const alreadySaved = savedForLater.some(
+            (saved) =>
+                String(saved.id) === String(item.id)
+                && saved.color === item.color
+                && saved.size === item.size
+        );
+
+        if (alreadySaved) return;
+
         savedForLater.push({
             ...item,
             savedAt: new Date().toISOString()
         });
     });
     saveSavedForLater();
-    
+
     selectedItems.clear();
     saveAndRender(cart);
-    updateBulkActions();
-    AppUtils.notify(`Saved ${count} items for later`, 'success');
+    AppUtils.notify(
+        `Saved ${count} ${count === 1 ? 'item' : 'items'} for later`,
+        'success'
+    );
 }
 
 // ==================== ESTIMATED DELIVERY ====================
@@ -512,6 +644,11 @@ function renderCart() {
     loadSavedForLater();
     checkCartExpiry();
 
+    // The cart can change under the selection -- another tab, the drawer, an
+    // expiry sweep -- so anything no longer in it is dropped before the count
+    // is shown, rather than being counted and then acted on as a miss.
+    pruneSelection();
+
     if (!cart.length && !savedForLater.length) {
         renderEmptyCart();
         return;
@@ -531,7 +668,7 @@ function renderCart() {
     cart.forEach((item, index) => {
         const qty = Math.max(1, AppUtils.safeInteger(item.qty, 1));
         const price = AppUtils.safeNumber(item.price, 0);
-        const isSelected = selectedItems.has(item.id);
+        const selected = isSelected(item);
 
         const cartItem = document.createElement("div");
         cartItem.classList.add("cart-item");
@@ -539,11 +676,10 @@ function renderCart() {
 
         cartItem.innerHTML = `
             <div class="cart-item-select-wrapper">
-                <input type="checkbox" class="cart-item-select" 
-                    data-item-id="${item.id}"
-                    ${isSelected ? 'checked' : ''}
-                    onchange="window.toggleSelectItem(${item.id})">
-            </div>
+                <input type="checkbox" class="cart-item-select"
+                    data-item-id="${AppUtils.escapeHTML(String(item.id))}"
+                    aria-label="Select ${AppUtils.escapeHTML(item.name || "Product")}"
+                    ${selected ? 'checked' : ''}></div>
             <img src="${AppUtils.escapeHTML(AppUtils.defaultImage(item.img || item.image))}"
                 alt="${AppUtils.escapeHTML(item.name || "Product")}"
                 loading="lazy">
@@ -556,11 +692,10 @@ function renderCart() {
                 ${item.note ? `<p class="item-note">Note: ${AppUtils.escapeHTML(item.note)}</p>` : ""}
                 
                 <div class="item-notes">
-                    <input type="text" class="note-input" 
-                        placeholder="Add a note..." 
+                    <input type="text" class="note-input"
+                        placeholder="Add a note..."
                         value="${AppUtils.escapeHTML(item.note || '')}"
-                        data-index="${index}"
-                        onchange="window.updateItemNote(${index}, this.value)">
+                        data-index="${index}">
                 </div>
                 
                 <div class="cart-qty-controls" aria-label="Quantity controls">
@@ -568,10 +703,10 @@ function renderCart() {
                             aria-label="Decrease quantity" ${qty <= 1 ? "disabled" : ""}>
                         -
                     </button>
-                    <input type="number" class="qty-input" 
+                    <input type="number" class="qty-input"
                         value="${qty}" min="${CART_CONFIG.MIN_QUANTITY}" max="${CART_CONFIG.MAX_QUANTITY}"
-                        data-index="${index}"
-                        onchange="window.updateQuantity(${index}, parseInt(this.value))">
+                        aria-label="Quantity"
+                        data-index="${index}">
                     <button type="button" data-index="${index}" class="increase-qty" 
                             aria-label="Increase quantity">
                         +
@@ -627,7 +762,16 @@ function renderCart() {
                 `).join('')}
             </div>
         `;
-        fragment.appendChild(savedSection);
+        // Into its own container when the page provides one, so the saved
+        // items sit outside #cart-items and survive a cart re-render intact.
+        // Falls back to the cart fragment on any page that has not got one.
+        if (elements.savedForLaterContainer) {
+            elements.savedForLaterContainer.replaceChildren(savedSection);
+        } else {
+            fragment.appendChild(savedSection);
+        }
+    } else if (elements.savedForLaterContainer) {
+        elements.savedForLaterContainer.replaceChildren();
     }
 
     elements.cartContainer.replaceChildren(fragment);
@@ -658,6 +802,12 @@ function renderEmptyCart() {
     if (elements.emptyCartBtn) {
         elements.emptyCartBtn.disabled = true;
     }
+
+    // Nothing left to have selected. Without this the toolbar would stay on
+    // screen over an empty cart, offering to remove items that are gone.
+    selectedItems.clear();
+    updateBulkActions();
+
     updateCartTotals();
 }
 
@@ -790,6 +940,58 @@ document.addEventListener("click", (event) => {
         return;
     }
 });
+
+// ==================== SELECTION AND BULK ACTIONS ====================
+//
+// The bindings that were missing (#1584). `toggleSelectItem`,
+// `toggleSelectAll`, `bulkRemove` and `bulkSaveForLater` have all been in this
+// file since the feature landed and none of them was called from anywhere:
+// there was no listener on `.cart-item-select` and no `#select-all` or bulk
+// buttons in the page to bind to. Shoppers got a checkbox per line that did
+// nothing when ticked.
+//
+// The rendered markup used to carry `onchange="window.toggleSelectItem(...)"`,
+// which could not have worked either -- this file is an IIFE and assigns
+// nothing to `window`, so the handler was `undefined`, and the id was
+// interpolated unquoted, which for a CHAR(36) UUID is not even valid syntax.
+// The same was true of the quantity and note inputs, whose `onchange` called
+// `window.updateQuantity` and `window.updateItemNote`. All three are delegated
+// here instead, which matches how the rest of this file binds and needs nothing
+// on the global object.
+
+document.addEventListener("change", (event) => {
+    const itemCheckbox = event.target.closest(".cart-item-select");
+
+    if (itemCheckbox) {
+        toggleSelectItem(itemCheckbox.dataset.itemId);
+        return;
+    }
+
+    const qtyInput = event.target.closest(".qty-input");
+
+    if (qtyInput) {
+        updateQuantity(Number(qtyInput.dataset.index), parseInt(qtyInput.value, 10));
+        return;
+    }
+
+    const noteInput = event.target.closest(".note-input");
+
+    if (noteInput) {
+        updateItemNote(Number(noteInput.dataset.index), noteInput.value);
+    }
+});
+
+if (elements.selectAll) {
+    elements.selectAll.addEventListener("change", toggleSelectAll);
+}
+
+if (elements.bulkRemoveBtn) {
+    elements.bulkRemoveBtn.addEventListener("click", bulkRemove);
+}
+
+if (elements.bulkSaveLaterBtn) {
+    elements.bulkSaveLaterBtn.addEventListener("click", bulkSaveForLater);
+}
 
 // ==================== COUPON FORM ====================
 if (elements.couponForm) {

--- a/frontend/styles/cart.css
+++ b/frontend/styles/cart.css
@@ -437,3 +437,410 @@ body.dark-theme .continue-shopping-btn {
 body.dark-theme .continue-shopping-btn:hover {
     background: #088178;
 }
+
+/* ==========================================================================
+   Selection, bulk actions, expiry notice  (#1584)
+
+   cart.js has rendered a checkbox on every cart line for some time and had
+   nowhere to put a toolbar, a select-all, an item count or an expiry notice --
+   none of those elements were in cart.html, so the code behind them was inert.
+   These are the styles for the markup that closes that.
+
+   Colours follow the rest of this file: #088178 for the accent, #0a9b8f as its
+   dark-theme counterpart, and body.dark-theme for the dark rules.
+   ========================================================================== */
+
+.cart-items-header{
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+    padding-bottom: 14px;
+    border-bottom: 1px solid #eee;
+}
+
+.cart-items-header h2{
+    margin: 0;
+}
+
+.cart-items-header__tools{
+    display: flex;
+    align-items: center;
+    gap: 18px;
+}
+
+.select-all-label{
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    color: #444;
+    cursor: pointer;
+    user-select: none;
+}
+
+.select-all-label:has(input:disabled){
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.select-all-checkbox,
+.cart-item-select{
+    width: 18px;
+    height: 18px;
+    accent-color: #088178;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.cart-item-count{
+    font-size: 14px;
+    color: #777;
+    white-space: nowrap;
+}
+
+.cart-item-select-wrapper{
+    display: flex;
+    align-items: center;
+    padding-right: 4px;
+}
+
+/* The toolbar. `display` is owned by updateBulkActions, which sets it to
+   `flex` or `none` -- so no display declaration here, or the inline style and
+   the stylesheet would be arguing about who decides. */
+.bulk-actions{
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin: 16px 0;
+    padding: 12px 16px;
+    background: #e8f5f3;
+    border: 1px solid #b8e0da;
+    border-radius: 8px;
+}
+
+.selected-count{
+    font-size: 14px;
+    font-weight: 600;
+    color: #066a63;
+}
+
+.bulk-actions__buttons{
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.bulk-action-btn{
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 9px 16px;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: 0.25s ease;
+}
+
+.bulk-action-btn:hover{
+    transform: translateY(-1px);
+}
+
+.bulk-action-btn:focus-visible{
+    outline: 2px solid #088178;
+    outline-offset: 2px;
+}
+
+.bulk-action-btn--secondary{
+    background: #fff;
+    border-color: #088178;
+    color: #088178;
+}
+
+.bulk-action-btn--secondary:hover{
+    background: #088178;
+    color: #fff;
+}
+
+.bulk-action-btn--danger{
+    background: #fff;
+    border-color: #d64545;
+    color: #d64545;
+}
+
+.bulk-action-btn--danger:hover{
+    background: #d64545;
+    color: #fff;
+}
+
+/* Expiry notice. `display` is owned by updateExpiryWarning for the same reason
+   as the toolbar above. */
+.cart-expiry-warning{
+    gap: 10px;
+    margin-bottom: 18px;
+    padding: 12px 16px;
+    border-radius: 8px;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.cart-expiry-warning i{
+    margin-right: 6px;
+}
+
+.cart-expiry-warning a{
+    color: inherit;
+    font-weight: 600;
+    text-decoration: underline;
+}
+
+.cart-expiry-warning.warning{
+    background: #fff8e6;
+    border: 1px solid #f0d68a;
+    color: #85610a;
+}
+
+.cart-expiry-warning.urgent{
+    background: #fdecec;
+    border: 1px solid #f3bcbc;
+    color: #a12626;
+}
+
+/* Saved for later, in its own container outside #cart-items so a cart
+   re-render leaves it alone. */
+#saved-for-later-section{
+    margin-top: 28px;
+    padding-top: 22px;
+    border-top: 1px solid #eee;
+}
+
+#saved-for-later-section h3{
+    margin: 0 0 16px;
+    font-size: 18px;
+}
+
+.saved-items-container{
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.saved-item{
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 14px;
+    background: #fafafa;
+    border: 1px solid #eee;
+    border-radius: 8px;
+}
+
+.saved-item img{
+    width: 64px;
+    height: 64px;
+    object-fit: cover;
+    border-radius: 6px;
+    flex-shrink: 0;
+}
+
+.saved-item-info{
+    flex: 1;
+    min-width: 0;
+}
+
+.saved-item-info h4{
+    margin: 0 0 4px;
+    font-size: 15px;
+}
+
+.saved-item-info p{
+    margin: 0 0 2px;
+    color: #088178;
+    font-weight: 600;
+}
+
+.saved-item-info small{
+    color: #999;
+}
+
+.saved-item-actions{
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+.move-to-cart-btn,
+.remove-saved-btn{
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border: 1px solid #088178;
+    border-radius: 6px;
+    background: #fff;
+    color: #088178;
+    font-size: 13px;
+    cursor: pointer;
+    transition: 0.25s ease;
+}
+
+.move-to-cart-btn:hover{
+    background: #088178;
+    color: #fff;
+}
+
+.remove-saved-btn{
+    border-color: #ddd;
+    color: #888;
+    padding: 8px 11px;
+}
+
+.remove-saved-btn:hover{
+    border-color: #d64545;
+    color: #d64545;
+}
+
+/* On a phone the toolbar stacks and its buttons go full width, so neither is a
+   target you have to aim for. */
+@media (max-width: 640px){
+
+    .cart-items-header{
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .cart-items-header__tools{
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .bulk-actions{
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .bulk-actions__buttons{
+        width: 100%;
+    }
+
+    .bulk-action-btn{
+        flex: 1;
+        justify-content: center;
+    }
+
+    .saved-item{
+        align-items: flex-start;
+        flex-wrap: wrap;
+    }
+
+    .saved-item-actions{
+        width: 100%;
+        justify-content: flex-end;
+    }
+
+}
+
+/* Dark Mode */
+body.dark-theme .cart-items-header{
+    border-bottom-color: #2a2a3e;
+}
+
+body.dark-theme .select-all-label{
+    color: #ccc;
+}
+
+body.dark-theme .select-all-checkbox,
+body.dark-theme .cart-item-select{
+    accent-color: #0a9b8f;
+}
+
+body.dark-theme .cart-item-count{
+    color: #999;
+}
+
+body.dark-theme .bulk-actions{
+    background: #16323040;
+    border-color: #0a9b8f;
+}
+
+body.dark-theme .selected-count{
+    color: #4fd1c5;
+}
+
+body.dark-theme .bulk-action-btn--secondary{
+    background: transparent;
+    border-color: #0a9b8f;
+    color: #4fd1c5;
+}
+
+body.dark-theme .bulk-action-btn--secondary:hover{
+    background: #0a9b8f;
+    color: #fff;
+}
+
+body.dark-theme .bulk-action-btn--danger{
+    background: transparent;
+    border-color: #e07070;
+    color: #e07070;
+}
+
+body.dark-theme .bulk-action-btn--danger:hover{
+    background: #d64545;
+    color: #fff;
+}
+
+body.dark-theme .cart-expiry-warning.warning{
+    background: #2e2611;
+    border-color: #6b5518;
+    color: #e8c766;
+}
+
+body.dark-theme .cart-expiry-warning.urgent{
+    background: #331a1a;
+    border-color: #7a2f2f;
+    color: #f0a0a0;
+}
+
+body.dark-theme #saved-for-later-section{
+    border-top-color: #2a2a3e;
+}
+
+body.dark-theme .saved-item{
+    background: #1a1a2e;
+    border-color: #2a2a3e;
+}
+
+body.dark-theme .saved-item-info h4{
+    color: #e0e0e0;
+}
+
+body.dark-theme .saved-item-info p{
+    color: #4fd1c5;
+}
+
+body.dark-theme .saved-item-info small{
+    color: #777;
+}
+
+body.dark-theme .move-to-cart-btn{
+    background: transparent;
+    border-color: #0a9b8f;
+    color: #4fd1c5;
+}
+
+body.dark-theme .move-to-cart-btn:hover{
+    background: #0a9b8f;
+    color: #fff;
+}
+
+body.dark-theme .remove-saved-btn{
+    background: transparent;
+    border-color: #3a3a4e;
+    color: #999;
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

Every cart line renders a checkbox and ticking one does nothing at all. The feature was half-landed: the state (`selectedItems`), the operations (`bulkRemove`, `bulkSaveForLater`), the undo integration and the per-item checkbox all shipped — the markup, the CSS and the event bindings did not.

**What was missing:**

- `#bulk-actions`, `#selected-count`, `#select-all`, `#cart-item-count` and `#saved-for-later-container` were not in `cart.html`, so all five cached as `null`. `updateBulkActions()` is guarded on `if (bulkActions && selectedCount)`, so it was a no-op — as was `updateExpiryWarning()`, which returns at `if (!warningElement) return;`.
- **Nothing called** `toggleSelectItem`, `toggleSelectAll`, `bulkRemove` or `bulkSaveForLater`. The delegated click handler matched `.increase-qty`, `.remove-btn` and four others, and nothing for the checkboxes.
- The markup carried `onchange="window.toggleSelectItem(...)"`, which could not have worked either: `cart.js` is an IIFE and assigns nothing to `window`, so the handler was `undefined` — and the id was interpolated **unquoted**, which for a `CHAR(36)` UUID is not even valid syntax. The same was true of the quantity and note inputs (`window.updateQuantity`, `window.updateItemNote`).
- `toggleSelectAll` did `parseInt(checkbox.dataset.itemId)`. Product ids are UUIDs (`AGENTS.md`), so `parseInt` gave `NaN` and **every row collapsed onto one key** — "select all" would have reported a single item selected however many there were.

### The change

**`cart.html`** — the expiry banner, a list header carrying `#select-all` and `#cart-item-count`, the `#bulk-actions` bar with its count and two buttons, and `#saved-for-later-container`. The bar and the banner ship hidden: their `display` is owned by the script, which is also why neither has a `display` in its CSS rule (there is a test for that — two owners for one property is how this kind of thing drifts).

**`cart.js`** — a delegated `change` listener for `.cart-item-select`, `.qty-input` and `.note-input`, replacing all three inline handlers, plus direct bindings for `#select-all` and the two bulk buttons. Ids are kept as strings throughout and compared with `String()`, matching what the rest of the file already does. Added `pruneSelection()` so a line removed in another tab cannot linger in the count, and `#select-all` now goes **indeterminate** on a partial selection rather than guessing.

**`cart.css`** — follows the rest of the file: `#088178` accent, `#0a9b8f` under `body.dark-theme`, a 640px breakpoint that stacks the toolbar and gives its buttons full width, and dark-theme rules throughout.

### Two things this turned up on the way

1. **`showUndoToast` is called from three places and declared in none of them.** It was dropped by the same merge that recommented the `decreaseBtn` declaration, and went unnoticed because *that* ReferenceError fires first on both of the older paths. `bulkRemove` cannot work without it, so it is restored as it stood in `49e3b64`.

2. **`bulkRemove` filtered the cart in memory and called `renderCart()`** — which opens with `cart = AppUtils.getCart()`, so the optimistic change was discarded by the very render meant to show it, and the rows would blink out and come straight back. It writes through now and restores from the captured items on undo. *The single-item remove path has the same flaw*; it is unreachable until #1535 lands and belongs with that change.

### On #1535

**Deliberately not touched here** — it is assigned to someone else. Its `decreaseBtn is not defined` ReferenceError still fires on any click on this page, which is exactly why the new buttons are bound **directly to their elements** rather than through that delegated handler: the bulk actions work regardless of it.

The test suite filters that one error **by name** rather than ignoring errors wholesale, so a *new* error still fails the cases — and the filter stops doing anything the day #1535 lands.

---

## 🔗 Related Issue

Closes #1584

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [x] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Driven in jsdom against the real `cart.html` + `cart.js`, three lines with UUID ids:

```
cart rows        : 3
checkboxes       : 3
data-item-id[0]  : a3f1b2c4-0000-4000-8000-000000000001   (whole UUID, not NaN)
item count text  : 4 items                                 (1 + 2 + 1)
expiry warning   : block | "Your cart will expire in 2 days."
bulk initially   : none
after 1 tick     : flex | "1 item selected"  | select-all indeterminate = true
after select all : flex | "3 items selected" | checked boxes = 3
after bulk save  : rows = 0 | saved container populated | "Saved 3 items for later"
bulk after       : none
```

```
$ npx jest tests/cartBulkSelection.test.js
Tests:       39 passed, 39 total

$ npx jest                      # whole backend suite, unchanged
Test Suites: 99 passed, 99 total
Tests:       2154 passed, 2154 total
```

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

The suite drives the real page rather than grepping, because none of this is visible in the source — the functions are all there and correctly written; the question was whether anything ever reached them. It covers the markup being present and shipping hidden, the CSS not fighting the script for `display`, selection and select-all (including the indeterminate state and the UUID case `parseInt` broke), both bulk operations, the undo toast and its restore, and all four states of the expiry notice.

One thing I noticed and left alone: `renderEmptyCart()` is declared twice in `cart.js`, ~540 lines apart. Declarations hoist, so the second wins and the first — the `#continue-shopping-btn` version from #1206 — is unreachable. The surviving one uses a plain `<a href="shop.html">`, which is arguably the better implementation of #1206 anyway, so this is dead code rather than a live bug. Worth its own tidy-up rather than folding into this.
