### PR TITLE
fix: next() on error paths

### DIFF
--- a/backend/routes/v2/index.js
+++ b/backend/routes/v2/index.js
@@ -10,8 +10,15 @@ const router = express.Router();
 const sharedRoutes = require('../index');
 
 router.use((req, res, next) => {
-    res.setHeader('X-API-Version', 'v2');
-    next();
+    try {
+        if (res.headersSent) {
+            return next();
+        }
+        res.setHeader('X-API-Version', 'v2');
+        next();
+    } catch (err) {
+        next(err);
+    }
 });
 
 for (const [path, routeHandler] of Object.entries(sharedRoutes)) {

--- a/backend/tests/v2Router.test.js
+++ b/backend/tests/v2Router.test.js
@@ -1,0 +1,47 @@
+const v2Router = require('../routes/v2/index');
+
+describe('v2 Router Header Middleware', () => {
+    let req, res, next;
+
+    beforeEach(() => {
+        req = {};
+        res = {
+            headersSent: false,
+            setHeader: jest.fn()
+        };
+        next = jest.fn();
+    });
+
+    test('should set X-API-Version header to v2 and call next()', () => {
+        // Find the middleware function registered on the router
+        const middlewareLayer = v2Router.stack.find(layer => layer.name === '<anonymous>');
+        expect(middlewareLayer).toBeDefined();
+
+        middlewareLayer.handle(req, res, next);
+
+        expect(res.setHeader).toHaveBeenCalledWith('X-API-Version', 'v2');
+        expect(next).toHaveBeenCalledWith();
+    });
+
+    test('should skip setting header and call next() if headers are already sent', () => {
+        res.headersSent = true;
+
+        const middlewareLayer = v2Router.stack.find(layer => layer.name === '<anonymous>');
+        middlewareLayer.handle(req, res, next);
+
+        expect(res.setHeader).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalledWith();
+    });
+
+    test('should call next(err) if setHeader throws an error', () => {
+        const error = new Error('Cannot set headers after they are sent');
+        res.setHeader.mockImplementation(() => {
+            throw error;
+        });
+
+        const middlewareLayer = v2Router.stack.find(layer => layer.name === '<anonymous>');
+        middlewareLayer.handle(req, res, next);
+
+        expect(next).toHaveBeenCalledWith(error);
+    });
+});


### PR DESCRIPTION
I have updated backend/routes/v2/index.js to address the issue:

Header Guard: Added if (res.headersSent) return next(); before setting the X-API-Version header.
Error Handling: Wrapped the middleware logic in a try...catch block to forward any exceptions using next(err) without executing res.setHeader.
Unit Testing: Added unit test coverage in backend/tests/v2Router.test.js
 to verify header setting, res.headersSent guard, and error forwarding.

closes #1597