### PR TITLE
fix: Missing sanitisation of user‑generated SVG filenames

### DIFF
--- a/backend/middleware/assetSecurityMiddleware.js
+++ b/backend/middleware/assetSecurityMiddleware.js
@@ -1,0 +1,45 @@
+// backend/middleware/assetSecurityMiddleware.js
+const path = require('path');
+const express = require('express');
+
+const ALLOWED_FILENAME_REGEX = /^[a-zA-Z0-9_-]+\.svg$/;
+const assetsDir = path.resolve(__dirname, '../../frontend/assets');
+const staticMiddleware = express.static(assetsDir);
+
+/**
+ * Middleware to safely serve SVG assets and protect against path traversal
+ * and invalid filename requests.
+ */
+function assetSecurityMiddleware(req, res, next) {
+    let decodedPath = req.path;
+    try {
+        decodedPath = decodeURIComponent(req.path);
+    } catch (err) {
+        return res.status(403).json({
+            success: false,
+            message: 'Forbidden: Invalid path encoding'
+        });
+    }
+
+    // Guard against path traversal attacks
+    if (decodedPath.includes('..') || decodedPath.includes('\\')) {
+        return res.status(403).json({
+            success: false,
+            message: 'Forbidden: Path traversal detected'
+        });
+    }
+
+    const filename = path.basename(decodedPath);
+
+    // Whitelist check: only alphanumeric, hyphens, underscores, .svg
+    if (!filename || !ALLOWED_FILENAME_REGEX.test(filename)) {
+        return res.status(403).json({
+            success: false,
+            message: 'Forbidden: Invalid asset filename'
+        });
+    }
+
+    return staticMiddleware(req, res, next);
+}
+
+module.exports = assetSecurityMiddleware;

--- a/backend/server.js
+++ b/backend/server.js
@@ -258,6 +258,10 @@ app.use((req, res, next) => {
 const webhookRoutes = require('./routes/webhookRoutes');
 app.use('/api/webhooks', webhookRoutes);
 
+// Static asset serving with filename whitelist & path-traversal security check
+const assetSecurityMiddleware = require('./middleware/assetSecurityMiddleware');
+app.use('/assets', assetSecurityMiddleware);
+
 // JSON and URL-encoded body parsers
 app.use(express.json({ limit: appConfig.bodyLimit }));
 app.use(cookieParser());

--- a/backend/tests/assetSecurity.test.js
+++ b/backend/tests/assetSecurity.test.js
@@ -1,0 +1,64 @@
+const express = require('express');
+const supertest = require('supertest');
+const assetSecurityMiddleware = require('../middleware/assetSecurityMiddleware');
+
+describe('Asset Security Middleware', () => {
+    let app;
+
+    beforeEach(() => {
+        app = express();
+        app.use('/assets', assetSecurityMiddleware);
+    });
+
+    test('should allow valid SVG filenames (alphanumeric, hyphens, underscores, .svg)', async () => {
+        const response = await supertest(app).get('/assets/images/user.svg');
+        // user.svg is valid, so it should not return 403 Forbidden
+        expect(response.status).not.toBe(403);
+    });
+
+    test('should allow another valid SVG filename with hyphens and numbers', async () => {
+        const response = await supertest(app).get('/assets/images/mega-laptop.svg');
+        expect(response.status).not.toBe(403);
+    });
+
+    test('should reject path traversal attempts (../../../../etc/passwd.svg) with 403 Forbidden', async () => {
+        const response = await supertest(app).get('/assets/images/../../../../etc/passwd.svg');
+        expect(response.status).toBe(403);
+        expect(response.body).toEqual({
+            success: false,
+            message: expect.stringMatching(/Forbidden/)
+        });
+    });
+
+    test('should reject encoded path traversal attempts with 403 Forbidden', async () => {
+        const response = await supertest(app).get('/assets/images/..%2f..%2fetc%2fpasswd.svg');
+        expect(response.status).toBe(403);
+        expect(response.body.success).toBe(false);
+    });
+
+    test('should reject non-SVG file extensions with 403 Forbidden', async () => {
+        const response = await supertest(app).get('/assets/images/passwd.png');
+        expect(response.status).toBe(403);
+        expect(response.body).toEqual({
+            success: false,
+            message: 'Forbidden: Invalid asset filename'
+        });
+    });
+
+    test('should reject executable or script filenames with 403 Forbidden', async () => {
+        const response = await supertest(app).get('/assets/images/script.js');
+        expect(response.status).toBe(403);
+        expect(response.body.success).toBe(false);
+    });
+
+    test('should reject filenames with special characters (spaces, dollar signs, semicolons)', async () => {
+        const res1 = await supertest(app).get('/assets/images/invalid$file.svg');
+        expect(res1.status).toBe(403);
+
+        const res2 = await supertest(app).get('/assets/images/bad%20name.svg');
+        expect(res2.status).toBe(403);
+
+        const res3 = await supertest(app).get('/assets/images/test;calc.svg');
+        expect(res3.status).toBe(403);
+    });
+});


### PR DESCRIPTION
I have implemented the SVG asset sanitization and security wrapper:

Asset Security Middleware: Created backend/middleware/assetSecurityMiddleware.js, which:
Validates asset filenames against a whitelist (/^[a-zA-Z0-9_-]+\.svg$/ allowing only alphanumeric characters, hyphens, underscores, and .svg extension).
Detects and rejects path traversal attempts (such as ../ or encoded traversal sequences).
Responds with 403 Forbidden whenever filename validation or security checks fail.
Server Integration: Mounted the security wrapper on /assets in backend/server.js.
Unit Tests: Created backend/tests/assetSecurity.test.js to test that valid SVG filenames are served while path-traversal attempts and invalid filenames are rejected with 403 Forbidden.

closes #1598