### PR TITLE
bug:  Rate‑limit configuration for auth endpoints is too permissive

### DIFF
--- a/backend/config/appConfig.js
+++ b/backend/config/appConfig.js
@@ -32,5 +32,9 @@ module.exports = {
     compression: {
         level: 6,
         threshold: 1024
+    },
+    authRateLimit: {
+        windowMs: 15 * 60 * 1000,
+        max: 20
     }
 };

--- a/backend/middleware/authLimiter.js
+++ b/backend/middleware/authLimiter.js
@@ -1,11 +1,12 @@
 const rateLimit = require("express-rate-limit");
+const appConfig = require("../config/appConfig");
 
 // =====================
 // AUTH LIMITER - For login/register (20 requests per 15 min)
 // =====================
 const authLimiter = rateLimit({
-    windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 20, // 20 requests
+    windowMs: appConfig.authRateLimit?.windowMs || 15 * 60 * 1000, // 15 minutes
+    max: appConfig.authRateLimit?.max || 20, // 20 requests
     standardHeaders: true,
     legacyHeaders: false,
     message: {

--- a/backend/server.js
+++ b/backend/server.js
@@ -289,11 +289,7 @@ app.use(detectAgenticFraud);
 
 // 8. Global Rate Limiting
 app.use("/api", apiLimiter);
-app.use("/api/auth/login", authLimiter);
-app.use("/api/auth/signup", authLimiter);
-app.use("/api/auth/forgot-password", authLimiter);
-app.use("/api/auth/reset-password", authLimiter);
-app.use("/api/auth/refresh-token", authLimiter);
+app.use("/api/auth", authLimiter);
 app.use("/api/admin", adminLimiter);
 app.use("/api/mcp", mcpLimiter);
 

--- a/backend/tests/authRateLimit.test.js
+++ b/backend/tests/authRateLimit.test.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const supertest = require('supertest');
+const { authLimiter } = require('../middleware/authLimiter');
+const appConfig = require('../config/appConfig');
+
+describe('Auth Rate Limiter Configuration and Behavior', () => {
+    test('appConfig defines auth rate limit max as 20 requests per 15 minutes', () => {
+        expect(appConfig.authRateLimit).toBeDefined();
+        expect(appConfig.authRateLimit.max).toBe(20);
+        expect(appConfig.authRateLimit.windowMs).toBe(15 * 60 * 1000);
+    });
+
+    test('returns HTTP 429 response after 20 attempts on auth routes', async () => {
+        const app = express();
+        app.use('/auth', authLimiter);
+        app.get('/auth/login', (req, res) => {
+            res.status(200).json({ success: true, message: 'Login endpoint' });
+        });
+
+        // First 20 requests should pass
+        for (let i = 0; i < 20; i++) {
+            const res = await supertest(app).get('/auth/login');
+            expect(res.status).toBe(200);
+        }
+
+        // The 21st request must trigger a 429 Too Many Requests response
+        const rateLimitedResponse = await supertest(app).get('/auth/login');
+        expect(rateLimitedResponse.status).toBe(429);
+        expect(rateLimitedResponse.body).toEqual(expect.objectContaining({
+            success: false,
+            errorCode: 'AUTH_RATE_LIMIT_EXCEEDED'
+        }));
+    });
+});


### PR DESCRIPTION
I have updated the rate-limiting configuration for authentication endpoints:

Configured Rate Limit Values: Added authRateLimit in backend/config/appConfig.js with max: 20 requests per windowMs: 15 * 60 * 1000 (15 minutes).
Updated Limiter Middleware: Updated authLimiter in backend/middleware/authLimiter.js to consume the appConfig.authRateLimit settings.
Applied to Auth Routes: Updated backend/server.js to apply authLimiter to all /api/auth endpoints.
Unit Tests: Created backend/tests/authRateLimit.test.js, asserting that 20 requests are permitted and the 21st request receives an HTTP 429 (Too Many Requests) response.

closes #1600