### PR TITLE
fix: CORS whitelist does not include the production frontend URL

### DIFF
--- a/backend/config/appConfig.js
+++ b/backend/config/appConfig.js
@@ -16,6 +16,7 @@ const ALLOWED_ORIGINS = [
     "http://172.18.208.1:5501",
     "http://172.18.208.1:5502",
     FRONTEND_URL,
+    "https://ecommerce.vercel.app",
     "https://e-commerce-git-main-bhuvanshs-projects.vercel.app",
     "https://www.bhuvansh.xyz",
     "https://e-commerce-production-d546.up.railway.app"

--- a/backend/middleware/corsMiddleware.js
+++ b/backend/middleware/corsMiddleware.js
@@ -23,6 +23,7 @@ const allowedOrigins = [
   FRONTEND_URL,
 
   // production
+  "https://ecommerce.vercel.app",
   "https://e-commerce-git-main-bhuvanshs-projects.vercel.app",
   "https://www.bhuvansh.xyz",
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -221,6 +221,7 @@ app.use(logCompletionMiddleware);
 app.use(standardizeResponse);
 
 // Security, tracing, and logging middlewares
+app.use(corsMiddleware);
 app.use(helmetMiddleware);
 app.use(traceRequest);
 app.use(accessLogger);

--- a/backend/tests/corsProduction.test.js
+++ b/backend/tests/corsProduction.test.js
@@ -1,0 +1,65 @@
+const express = require('express');
+const supertest = require('supertest');
+const corsMiddleware = require('../middleware/corsMiddleware');
+const appConfig = require('../config/appConfig');
+
+describe('Production CORS Whitelist Integration', () => {
+    const PRODUCTION_ORIGIN = 'https://ecommerce.vercel.app';
+
+    test('allowedOrigins list in appConfig contains production origin', () => {
+        expect(appConfig.allowedOrigins).toContain(PRODUCTION_ORIGIN);
+    });
+
+    test('allows requests from production origin https://ecommerce.vercel.app', async () => {
+        const app = express();
+        app.use(corsMiddleware);
+        app.get('/api/test-cors', (req, res) => {
+            res.status(200).json({ success: true, message: 'CORS OK' });
+        });
+
+        const response = await supertest(app)
+            .get('/api/test-cors')
+            .set('Origin', PRODUCTION_ORIGIN);
+
+        expect(response.status).toBe(200);
+        expect(response.headers['access-control-allow-origin']).toBe(PRODUCTION_ORIGIN);
+        expect(response.headers['access-control-allow-credentials']).toBe('true');
+    });
+
+    test('allows OPTIONS preflight requests from production origin https://ecommerce.vercel.app', async () => {
+        const app = express();
+        app.use(corsMiddleware);
+        app.options('/api/test-cors', (req, res) => {
+            res.sendStatus(204);
+        });
+
+        const response = await supertest(app)
+            .options('/api/test-cors')
+            .set('Origin', PRODUCTION_ORIGIN)
+            .set('Access-Control-Request-Method', 'GET');
+
+        expect(response.headers['access-control-allow-origin']).toBe(PRODUCTION_ORIGIN);
+    });
+
+    test('rejects requests from unallowed origin', async () => {
+        const app = express();
+        app.use(corsMiddleware);
+        app.get('/api/test-cors', (req, res) => {
+            res.status(200).json({ success: true });
+        });
+        // Error handler for CORS rejection
+        app.use((err, req, res, next) => {
+            if (err.message === 'CORS not allowed') {
+                return res.status(403).json({ success: false, message: err.message });
+            }
+            next(err);
+        });
+
+        const response = await supertest(app)
+            .get('/api/test-cors')
+            .set('Origin', 'https://unallowed-malicious-site.com');
+
+        expect(response.status).toBe(403);
+        expect(response.headers['access-control-allow-origin']).toBeUndefined();
+    });
+});


### PR DESCRIPTION
I have added the production frontend URL to the CORS whitelist and verified CORS behavior:

Configured Allowed Origins: Added https://ecommerce.vercel.app to ALLOWED_ORIGINS in backend/config/appConfig.js and allowedOrigins in backend/middleware/corsMiddleware.js
.
Server Middleware: Mounted corsMiddleware in backend/server.js under security middlewares.
Integration Testing: Created backend/tests/corsProduction.test.js
. Ran npx jest tests/corsProduction.test.js and confirmed that standard & OPTIONS preflight requests from https://ecommerce.vercel.app succeed with Access-Control-Allow-Origin: https://ecommerce.vercel.app and Access-Control-Allow-Credentials: true.


closes #1601