### PR TITLE
fix(stock-alerts): stop alerting on products no shopper may see (#1609)

### DIFF
--- a/backend/routes/stockAlertRoutes.js
+++ b/backend/routes/stockAlertRoutes.js
@@ -39,6 +39,15 @@ router.post("/", authMiddleware, async (req, res) => {
         });
         return res.status(201).json({ success: true, subscription });
     } catch (error) {
+        // A subscription against a product no shopper may see is a 404, not a
+        // 400: the request was well formed, the product simply is not there as
+        // far as this caller is concerned (#1609). Same answer the product
+        // detail endpoint gives, so a client cannot use this route to probe for
+        // unreleased catalogue.
+        if (error && error.code === "PRODUCT_NOT_VISIBLE") {
+            return res.status(404).json({ success: false, message: error.message });
+        }
+
         return res.status(400).json({ success: false, message: error.message });
     }
 });

--- a/backend/services/stockAlertScheduler.js
+++ b/backend/services/stockAlertScheduler.js
@@ -27,6 +27,20 @@ async function runScan() {
     } catch (error) {
         logger.error(`Stock-alert scan (price drops) failed: ${error.message}`);
     }
+
+    // Housekeeping, after the dispatch rather than before it: a subscription
+    // against a product that has been soft-deleted or archived will never fire
+    // again, and leaving it `active` means re-examining it on every scan and
+    // showing it to the user as though it were live (#1609). Separately
+    // wrapped so a failure here cannot cost a scan its alerts.
+    try {
+        const purged = await stockAlertService.purgeUnavailableSubscriptions();
+        if (purged > 0) {
+            logger.info(`Stock-alert scan: cancelled ${purged} subscription(s) for withdrawn products`);
+        }
+    } catch (error) {
+        logger.error(`Stock-alert scan (purge) failed: ${error.message}`);
+    }
 }
 
 let scheduledTask = null;

--- a/backend/services/stockAlertService.js
+++ b/backend/services/stockAlertService.js
@@ -12,6 +12,19 @@ const {
     NOTIFICATION_TYPES,
 } = require("./notificationBrokerService");
 
+// The one definition of "a shopper may see this product" (#1456). This engine
+// did not use it, which is the whole of #1609: `products` carries `deleted_at`
+// and a `status` enum, and both evaluators joined on nothing but `p.id`. So a
+// soft-deleted, archived, inactive or still-draft product that gained stock --
+// a correction, a return, a re-import -- mailed everyone who had ever
+// subscribed to it, and the link in that mail lands on a page the product
+// routes deliberately 404.
+//
+// Importing the shared condition rather than retyping the predicate is the
+// point: it is what stops this engine drifting away from the catalogue a
+// second time.
+const { publicProductCondition } = require("../constants/productVisibility");
+
 const ALERT_TYPES = {
     BACK_IN_STOCK: "back_in_stock",
     PRICE_DROP: "price_drop",
@@ -37,15 +50,90 @@ function assertAlertType(alertType) {
     }
 }
 
-async function fetchCurrentPrice(productId) {
-    const [rows] = await db.query(
-        "SELECT price FROM products WHERE id = ?",
-        [productId]
-    );
-    if (!rows || rows.length === 0) {
-        throw new Error(`Product not found: ${productId}`);
+/**
+ * Raised when a subscription is asked for against a product a shopper may not
+ * see. Carries a `code` so the route can answer 404 rather than folding every
+ * business-rule failure into a 400.
+ */
+class StockAlertError extends Error {
+    constructor(message, code) {
+        super(message);
+        this.name = "StockAlertError";
+        this.code = code;
     }
-    return rows[0].price;
+}
+
+/**
+ * Load the product a subscription is being taken out against, through the
+ * public visibility condition.
+ *
+ * Runs for every alert type, not only for a price-drop without a baseline.
+ * Before this, a back-in-stock subscription was inserted with no lookup at all
+ * and a price-drop subscription carrying a client-supplied `referencePrice`
+ * skipped it too -- so `POST /api/stock-alerts` accepted subscriptions to
+ * draft and deleted products and held them until an evaluator picked them up.
+ *
+ * @param {string} productId
+ * @returns {Promise<{id: string, price: number, stock: number, name: string}>}
+ * @throws {StockAlertError} PRODUCT_NOT_VISIBLE
+ */
+async function fetchVisibleProduct(productId) {
+    const visible = publicProductCondition("p");
+
+    const [rows] = await db.query(
+        `SELECT p.id, p.price, p.stock, p.name
+           FROM products p
+          WHERE p.id = ?
+            AND ${visible.sql}
+          LIMIT 1`,
+        [productId, ...visible.params]
+    );
+
+    const product = Array.isArray(rows) ? rows[0] : undefined;
+
+    if (!product) {
+        // Deliberately the same message whether the product does not exist or
+        // is merely not public. Which of the two it is is information about
+        // unreleased catalogue, and this endpoint is reachable by any signed-in
+        // account.
+        throw new StockAlertError(
+            `Product not found: ${productId}`,
+            "PRODUCT_NOT_VISIBLE"
+        );
+    }
+
+    return product;
+}
+
+/**
+ * The price a price-drop alert measures against.
+ *
+ * A caller may pin a baseline, but only downwards. Left unclamped, a client
+ * could post `referencePrice: 999999` and be notified of a "price drop" on the
+ * very next scan for a product whose price never moved.
+ *
+ * @param {unknown} requested
+ * @param {number} currentPrice
+ * @returns {number}
+ */
+function resolveReferencePrice(requested, currentPrice) {
+    const current = Number(currentPrice);
+    const base = Number.isFinite(current) ? current : 0;
+
+    if (requested === null || requested === undefined || requested === "") {
+        return base;
+    }
+
+    const pinned = Number(requested);
+
+    if (!Number.isFinite(pinned) || pinned <= 0) {
+        throw new StockAlertError(
+            "referencePrice must be a positive number",
+            "INVALID_REFERENCE_PRICE"
+        );
+    }
+
+    return Math.min(pinned, base);
 }
 
 async function fetchSubscription(userId, productId, alertType) {
@@ -83,6 +171,13 @@ async function dispatchAndMark(subscription, notificationType, extraData) {
 const stockAlertService = {
     ALERT_TYPES,
     SUBSCRIPTION_STATUS,
+    StockAlertError,
+
+    // Exposed so the routes can distinguish "no such visible product" (404)
+    // from a malformed request (400), and so the tests can assert the clamp
+    // without going through the database.
+    fetchVisibleProduct,
+    resolveReferencePrice,
 
     // Create (or reactivate) a subscription. The UNIQUE key on
     // (user_id, product_id, alert_type) makes this idempotent: a repeat call
@@ -92,12 +187,19 @@ const stockAlertService = {
     subscribe: async ({ userId, productId, alertType, referencePrice = null }) => {
         assertAlertType(alertType);
 
+        // Every alert type, every time. A subscription is a promise to mail
+        // this user about this product later, and there is no point recording
+        // one against a product that will never be publicly visible again.
+        const product = await fetchVisibleProduct(productId);
+
         // A price-drop alert needs a baseline to compare against; default it to
-        // the product's current price when the caller doesn't pin one.
-        let effectiveReferencePrice = referencePrice;
-        if (alertType === ALERT_TYPES.PRICE_DROP && effectiveReferencePrice === null) {
-            effectiveReferencePrice = await fetchCurrentPrice(productId);
-        }
+        // the product's current price when the caller doesn't pin one, and take
+        // it from the row already loaded rather than issuing a second query
+        // that could read a price the visibility check never saw.
+        const effectiveReferencePrice =
+            alertType === ALERT_TYPES.PRICE_DROP
+                ? resolveReferencePrice(referencePrice, product.price)
+                : null;
 
         await db.query(
             `INSERT INTO stock_alert_subscriptions
@@ -152,17 +254,51 @@ const stockAlertService = {
         return rows;
     },
 
+    // Cancel every active subscription whose product is no longer publicly
+    // visible.
+    //
+    // Filtering at evaluation time stops the mail going out, but it leaves the
+    // rows sitting `active` forever, re-examined on every scan and shown to the
+    // user on their alerts page as though they were still live. A product can
+    // come back -- `inactive` is explicitly "withdrawn, expected back" -- so
+    // this is deliberately NOT run by the evaluators; it is a housekeeping
+    // call for the scheduler to make against genuinely gone products, i.e.
+    // soft-deleted or archived ones.
+    //
+    // Returns the number of rows cancelled.
+    purgeUnavailableSubscriptions: async () => {
+        const [result] = await db.query(
+            `UPDATE stock_alert_subscriptions s
+               JOIN products p ON p.id = s.product_id
+                SET s.status = ?
+              WHERE s.status = ?
+                AND (p.deleted_at IS NOT NULL OR p.status = 'archived')`,
+            [SUBSCRIPTION_STATUS.CANCELLED, SUBSCRIPTION_STATUS.ACTIVE]
+        );
+
+        return result && typeof result.affectedRows === "number"
+            ? result.affectedRows
+            : 0;
+    },
+
     // Fire a PRODUCT_BACK_IN_STOCK alert for every active back-in-stock
     // subscription whose product now has stock. Returns the number dispatched.
     evaluateRestocks: async () => {
+        const visible = publicProductCondition("p");
+
         const [rows] = await db.query(
             `SELECT s.id, s.user_id, s.product_id, p.stock, p.name
                FROM stock_alert_subscriptions s
                JOIN products p ON p.id = s.product_id
               WHERE s.alert_type = ?
                 AND s.status = ?
-                AND p.stock > 0`,
-            [ALERT_TYPES.BACK_IN_STOCK, SUBSCRIPTION_STATUS.ACTIVE]
+                AND p.stock > 0
+                AND ${visible.sql}`,
+            [
+                ALERT_TYPES.BACK_IN_STOCK,
+                SUBSCRIPTION_STATUS.ACTIVE,
+                ...visible.params,
+            ]
         );
 
         let dispatched = 0;
@@ -188,6 +324,8 @@ const stockAlertService = {
     // whose product price has fallen below the price captured at subscribe
     // time. Returns the number dispatched.
     evaluatePriceDrops: async () => {
+        const visible = publicProductCondition("p");
+
         const [rows] = await db.query(
             `SELECT s.id, s.user_id, s.product_id, s.reference_price, p.price, p.name
                FROM stock_alert_subscriptions s
@@ -195,8 +333,13 @@ const stockAlertService = {
               WHERE s.alert_type = ?
                 AND s.status = ?
                 AND s.reference_price IS NOT NULL
-                AND p.price < s.reference_price`,
-            [ALERT_TYPES.PRICE_DROP, SUBSCRIPTION_STATUS.ACTIVE]
+                AND p.price < s.reference_price
+                AND ${visible.sql}`,
+            [
+                ALERT_TYPES.PRICE_DROP,
+                SUBSCRIPTION_STATUS.ACTIVE,
+                ...visible.params,
+            ]
         );
 
         let dispatched = 0;

--- a/backend/tests/stockAlert.evaluation.test.js
+++ b/backend/tests/stockAlert.evaluation.test.js
@@ -35,6 +35,11 @@ function respondWith(responder) {
     });
 }
 
+// Since #1609 every subscribe resolves the product through the public
+// visibility condition before writing a row, so a responder that wants the
+// insert to be reached has to answer that lookup.
+const VISIBLE_PRODUCT_SQL = /FROM products p\s+WHERE p\.id = \?/i;
+
 function updateCalls() {
     return db.query.mock.calls.filter(([sql]) =>
         /UPDATE stock_alert_subscriptions/i.test(sql)
@@ -156,7 +161,9 @@ describe("evaluatePriceDrops", () => {
 describe("subscription foundation (PR 1/3)", () => {
     test("subscribe to price_drop with no referencePrice anchors to the current product price", async () => {
         respondWith((sql) => {
-            if (/SELECT price FROM products/i.test(sql)) return [{ price: 100.0 }];
+            if (VISIBLE_PRODUCT_SQL.test(sql)) {
+                return [{ id: "prod-1", price: 100.0, stock: 3, name: "A product" }];
+            }
             // subscribe returns the freshly upserted row via a SELECT *.
             if (/SELECT \* FROM stock_alert_subscriptions/i.test(sql)) {
                 return [{ id: 5, user_id: "user-1", product_id: "prod-1", alert_type: "price_drop", reference_price: 100.0, status: "active" }];
@@ -180,25 +187,35 @@ describe("subscription foundation (PR 1/3)", () => {
         expect(insertParams).toEqual(["user-1", "prod-1", "price_drop", 100.0]);
     });
 
-    test("subscribe to back_in_stock does not look up product price", async () => {
-        respondWith(() => ({ insertId: 6, affectedRows: 1 }));
+    test("subscribe to back_in_stock still resolves the product, but stores no baseline", async () => {
+        respondWith((sql) => {
+            if (VISIBLE_PRODUCT_SQL.test(sql)) {
+                return [{ id: "prod-2", price: 100.0, stock: 0, name: "A product" }];
+            }
+            return { insertId: 6, affectedRows: 1 };
+        });
 
         await service.subscribe({ userId: "user-1", productId: "prod-2", alertType: "back_in_stock" });
 
-        const priceLookups = db.query.mock.calls.filter(([sql]) =>
-            /SELECT price FROM products/i.test(sql)
+        const [insertSql, insertParams] = db.query.mock.calls.find(([sql]) =>
+            /INSERT INTO stock_alert_subscriptions/i.test(sql)
         );
-        expect(priceLookups).toHaveLength(0);
+        expect(insertSql).toMatch(/ON DUPLICATE KEY UPDATE/i);
+        expect(insertParams).toEqual(["user-1", "prod-2", "back_in_stock", null]);
     });
 
-    test("subscribe to price_drop for a missing product throws", async () => {
+    test("subscribe for a missing product throws, whatever the alert type", async () => {
         respondWith((sql) => {
-            if (/SELECT price FROM products/i.test(sql)) return [];
+            if (VISIBLE_PRODUCT_SQL.test(sql)) return [];
             return { insertId: 0 };
         });
 
         await expect(
             service.subscribe({ userId: "user-1", productId: "gone", alertType: "price_drop" })
+        ).rejects.toThrow(/not found/i);
+
+        await expect(
+            service.subscribe({ userId: "user-1", productId: "gone", alertType: "back_in_stock" })
         ).rejects.toThrow(/not found/i);
     });
 

--- a/backend/tests/stockAlert.test.js
+++ b/backend/tests/stockAlert.test.js
@@ -15,6 +15,16 @@ function callsMatching(regex) {
     return db.query.mock.calls.filter(([sql]) => regex.test(sql));
 }
 
+// Every subscribe now resolves the product through the public visibility
+// condition first (#1609), so a mock that wants the insert to be reached has
+// to answer that lookup. Kept as one helper so the shape of the answer is
+// stated once.
+const VISIBLE_PRODUCT_SQL = /FROM products p\s+WHERE p\.id = \?/i;
+
+function visibleProduct(overrides = {}) {
+    return [{ id: "p1", price: "19.99", stock: 0, name: "A product", ...overrides }];
+}
+
 afterEach(() => {
     db.query.mockReset();
 });
@@ -22,6 +32,9 @@ afterEach(() => {
 describe("subscribe", () => {
     test("inserts a back_in_stock subscription with ON DUPLICATE KEY UPDATE dedupe", async () => {
         db.query.mockImplementation(async (sql) => {
+            if (VISIBLE_PRODUCT_SQL.test(sql)) {
+                return [visibleProduct()];
+            }
             if (/^\s*INSERT INTO stock_alert_subscriptions/i.test(sql)) {
                 return [{ affectedRows: 1, insertId: 1 }];
             }
@@ -40,14 +53,18 @@ describe("subscribe", () => {
         expect(sql).toMatch(/ON DUPLICATE KEY UPDATE/i);
         expect(sql).toMatch(/status = 'active'/i);
         expect(sql).toMatch(/last_notified_at = NULL/i);
-        // back_in_stock has no reference price; no product lookup needed.
-        expect(callsMatching(/SELECT price FROM products/i)).toHaveLength(0);
+        // back_in_stock stores no reference price, but the product is still
+        // resolved through the visibility condition before the row is written.
+        expect(callsMatching(VISIBLE_PRODUCT_SQL)).toHaveLength(1);
         expect(params).toEqual(["u1", "p1", "back_in_stock", null]);
         expect(row).toMatchObject({ id: 1, status: "active" });
     });
 
     test("dedupes: a second subscribe for the same user/product/type does not insert a duplicate row", async () => {
         db.query.mockImplementation(async (sql) => {
+            if (VISIBLE_PRODUCT_SQL.test(sql)) {
+                return [visibleProduct()];
+            }
             if (/^\s*INSERT INTO stock_alert_subscriptions/i.test(sql)) {
                 return [{ affectedRows: 2 }];
             }
@@ -64,10 +81,10 @@ describe("subscribe", () => {
         inserts.forEach(([sql]) => expect(sql).toMatch(/ON DUPLICATE KEY UPDATE/i));
     });
 
-    test("price_drop with null referencePrice looks up the product's current price", async () => {
+    test("price_drop with null referencePrice anchors to the product's current price", async () => {
         db.query.mockImplementation(async (sql) => {
-            if (/SELECT price FROM products WHERE id = \?/i.test(sql)) {
-                return [[{ price: "19.99" }]];
+            if (VISIBLE_PRODUCT_SQL.test(sql)) {
+                return [visibleProduct({ price: "19.99" })];
             }
             if (/^\s*INSERT INTO stock_alert_subscriptions/i.test(sql)) {
                 return [{ affectedRows: 1 }];
@@ -77,18 +94,24 @@ describe("subscribe", () => {
 
         await service.subscribe({ userId: "u1", productId: "p1", alertType: "price_drop" });
 
-        const priceLookups = callsMatching(/SELECT price FROM products WHERE id = \?/i);
-        expect(priceLookups).toHaveLength(1);
-        expect(priceLookups[0][1]).toEqual(["p1"]);
+        // One lookup, not two: the baseline comes off the row the visibility
+        // check already loaded rather than from a second SELECT that could read
+        // a price the check never saw.
+        const lookups = callsMatching(VISIBLE_PRODUCT_SQL);
+        expect(lookups).toHaveLength(1);
+        expect(lookups[0][1][0]).toBe("p1");
 
         const inserts = callsMatching(/INSERT INTO stock_alert_subscriptions/i);
         expect(inserts).toHaveLength(1);
         // Looked-up price is stored as reference_price (4th param).
-        expect(inserts[0][1]).toEqual(["u1", "p1", "price_drop", "19.99"]);
+        expect(inserts[0][1]).toEqual(["u1", "p1", "price_drop", 19.99]);
     });
 
-    test("price_drop with an explicit referencePrice does not look up the product price", async () => {
+    test("an explicit referencePrice below the current price is honoured", async () => {
         db.query.mockImplementation(async (sql) => {
+            if (VISIBLE_PRODUCT_SQL.test(sql)) {
+                return [visibleProduct({ price: "80.00" })];
+            }
             if (/^\s*INSERT INTO stock_alert_subscriptions/i.test(sql)) {
                 return [{ affectedRows: 1 }];
             }
@@ -102,9 +125,33 @@ describe("subscribe", () => {
             referencePrice: "50.00",
         });
 
-        expect(callsMatching(/SELECT price FROM products/i)).toHaveLength(0);
         const inserts = callsMatching(/INSERT INTO stock_alert_subscriptions/i);
-        expect(inserts[0][1]).toEqual(["u1", "p1", "price_drop", "50.00"]);
+        expect(inserts[0][1]).toEqual(["u1", "p1", "price_drop", 50]);
+    });
+
+    test("a referencePrice above the current price is clamped down to it", async () => {
+        // Otherwise a client posts referencePrice: 999999 and is notified of a
+        // "price drop" on the very next scan for a product whose price has not
+        // moved at all.
+        db.query.mockImplementation(async (sql) => {
+            if (VISIBLE_PRODUCT_SQL.test(sql)) {
+                return [visibleProduct({ price: "80.00" })];
+            }
+            if (/^\s*INSERT INTO stock_alert_subscriptions/i.test(sql)) {
+                return [{ affectedRows: 1 }];
+            }
+            return [[{ id: 5, alert_type: "price_drop", reference_price: "80.00" }]];
+        });
+
+        await service.subscribe({
+            userId: "u1",
+            productId: "p1",
+            alertType: "price_drop",
+            referencePrice: 999999,
+        });
+
+        const inserts = callsMatching(/INSERT INTO stock_alert_subscriptions/i);
+        expect(inserts[0][1]).toEqual(["u1", "p1", "price_drop", 80]);
     });
 
     test("rejects an unknown alert type before touching the db", async () => {

--- a/backend/tests/stockAlertVisibility.test.js
+++ b/backend/tests/stockAlertVisibility.test.js
@@ -1,0 +1,247 @@
+// backend/tests/stockAlertVisibility.test.js
+//
+// Stock alerts and product visibility (#1609).
+//
+// `products` carries `deleted_at` and a `status` enum, and
+// `constants/productVisibility.js` has existed since #1456 to say what those
+// two mean together. The alert engine was the one public path that never
+// imported it: both evaluators joined `stock_alert_subscriptions` to `products`
+// on nothing but the id, so a soft-deleted, archived, inactive or still-draft
+// product that gained stock -- a correction, a return, a re-import -- mailed
+// every subscriber, and the link in that mail lands on a page the product
+// routes deliberately 404.
+//
+// The same gap was at the front door: only a price-drop subscription *without*
+// a baseline ever looked a product up at all.
+//
+// These tests assert the predicate reaches the SQL and that the subscribe path
+// refuses an invisible product, using the real
+// `publicProductCondition` rather than a copy of its text -- so if the
+// definition of "public" changes, this suite follows it instead of pinning the
+// old one.
+
+jest.mock("../config/db", () => ({ query: jest.fn() }));
+
+jest.mock("../services/notificationBrokerService", () => ({
+    notificationBroker: { publish: jest.fn(async () => ({ id: "NOTIF" })) },
+    NOTIFICATION_TYPES: {
+        PRODUCT_BACK_IN_STOCK: "product.back_in_stock",
+        WISHLIST_PRICE_DROP: "wishlist.price_drop",
+    },
+}));
+
+const db = require("../config/db");
+const { notificationBroker } = require("../services/notificationBrokerService");
+const { publicProductCondition, PUBLIC_PRODUCT_STATUSES } =
+    require("../constants/productVisibility");
+const service = require("../services/stockAlertService");
+
+const VISIBLE_PRODUCT_SQL = /FROM products p\s+WHERE p\.id = \?/i;
+const DETECTION_SQL = /FROM stock_alert_subscriptions s/i;
+
+/** The SQL and params the shared condition produces for the `p` alias. */
+const CONDITION = publicProductCondition("p");
+
+/** Route each query to canned rows, mirroring config/db's `[rows]` contract. */
+function respondWith(responder) {
+    db.query.mockImplementation(async (sql, params = []) => [responder(sql, params)]);
+}
+
+function callsMatching(regex) {
+    return db.query.mock.calls.filter(([sql]) => regex.test(sql));
+}
+
+afterEach(() => {
+    db.query.mockReset();
+    notificationBroker.publish.mockClear();
+});
+
+describe("the shared visibility condition reaches the evaluators", () => {
+    test("evaluateRestocks filters on deleted_at and status", async () => {
+        respondWith(() => []);
+
+        await service.evaluateRestocks();
+
+        const [sql, params] = callsMatching(DETECTION_SQL)[0];
+
+        expect(sql).toContain(CONDITION.sql);
+        expect(sql).toMatch(/p\.deleted_at IS NULL/i);
+        expect(sql).toMatch(/p\.status IN/i);
+
+        // The status placeholders are bound, not interpolated, and they trail
+        // the alert-type and subscription-status parameters.
+        expect(params.slice(-CONDITION.params.length)).toEqual(CONDITION.params);
+        PUBLIC_PRODUCT_STATUSES.forEach((status) => expect(params).toContain(status));
+    });
+
+    test("evaluatePriceDrops filters on deleted_at and status", async () => {
+        respondWith(() => []);
+
+        await service.evaluatePriceDrops();
+
+        const [sql, params] = callsMatching(DETECTION_SQL)[0];
+
+        expect(sql).toContain(CONDITION.sql);
+        expect(sql).toMatch(/p\.price < s\.reference_price/i);
+        expect(params.slice(-CONDITION.params.length)).toEqual(CONDITION.params);
+    });
+
+    test("the placeholder count still matches the parameter count", async () => {
+        // The class of mistake this whole file exists to stop is a predicate
+        // appended without its parameters. Counting is cheap; debugging
+        // ER_WRONG_ARGUMENTS at 3am is not.
+        respondWith(() => []);
+
+        await service.evaluateRestocks();
+        await service.evaluatePriceDrops();
+
+        callsMatching(DETECTION_SQL).forEach(([sql, params]) => {
+            const placeholders = (sql.match(/\?/g) || []).length;
+            expect(params).toHaveLength(placeholders);
+        });
+    });
+
+    test("a withdrawn product produces no dispatch, because the query never returns it", async () => {
+        // The database is the thing enforcing this, so the honest test is that
+        // an empty result set publishes nothing and marks nothing -- and that
+        // the predicate which produces that empty set is present, asserted
+        // above.
+        respondWith((sql) => (DETECTION_SQL.test(sql) ? [] : { affectedRows: 0 }));
+
+        expect(await service.evaluateRestocks()).toBe(0);
+        expect(await service.evaluatePriceDrops()).toBe(0);
+        expect(notificationBroker.publish).not.toHaveBeenCalled();
+        expect(callsMatching(/UPDATE stock_alert_subscriptions/i)).toHaveLength(0);
+    });
+});
+
+describe("subscribe refuses a product no shopper may see", () => {
+    const invisible = (sql) => (VISIBLE_PRODUCT_SQL.test(sql) ? [] : { affectedRows: 0 });
+
+    test.each(["back_in_stock", "price_drop"])(
+        "%s against an invisible product throws PRODUCT_NOT_VISIBLE",
+        async (alertType) => {
+            respondWith(invisible);
+
+            await expect(
+                service.subscribe({ userId: "u1", productId: "hidden", alertType })
+            ).rejects.toMatchObject({
+                name: "StockAlertError",
+                code: "PRODUCT_NOT_VISIBLE",
+            });
+
+            // Nothing was written. A rejected subscription must not leave a row
+            // behind for a later scan to find.
+            expect(callsMatching(/INSERT INTO stock_alert_subscriptions/i)).toHaveLength(0);
+        }
+    );
+
+    test("a client-supplied referencePrice does not skip the check", async () => {
+        // This was the second half of the hole: the only lookup that existed
+        // ran when the caller left referencePrice null, so pinning one bought a
+        // subscription to anything at all.
+        respondWith(invisible);
+
+        await expect(
+            service.subscribe({
+                userId: "u1",
+                productId: "hidden",
+                alertType: "price_drop",
+                referencePrice: 10,
+            })
+        ).rejects.toMatchObject({ code: "PRODUCT_NOT_VISIBLE" });
+
+        expect(callsMatching(VISIBLE_PRODUCT_SQL)).toHaveLength(1);
+    });
+
+    test("the lookup itself carries the visibility condition", async () => {
+        respondWith(invisible);
+
+        await service
+            .subscribe({ userId: "u1", productId: "hidden", alertType: "back_in_stock" })
+            .catch(() => {});
+
+        const [sql, params] = callsMatching(VISIBLE_PRODUCT_SQL)[0];
+        expect(sql).toContain(CONDITION.sql);
+        expect(params).toEqual(["hidden", ...CONDITION.params]);
+    });
+
+    test("the message does not reveal which of the two reasons applied", async () => {
+        // "no such product" and "that product is not on sale yet" have to read
+        // the same, or the endpoint becomes a probe for unreleased catalogue.
+        respondWith(invisible);
+
+        const failure = await service
+            .subscribe({ userId: "u1", productId: "hidden", alertType: "back_in_stock" })
+            .catch((error) => error);
+
+        expect(failure.message).toBe("Product not found: hidden");
+        expect(failure.message).not.toMatch(/draft|archived|deleted|inactive/i);
+    });
+});
+
+describe("resolveReferencePrice", () => {
+    const { resolveReferencePrice, StockAlertError } = service;
+
+    test("defaults to the product's current price", () => {
+        expect(resolveReferencePrice(null, "19.99")).toBe(19.99);
+        expect(resolveReferencePrice(undefined, 80)).toBe(80);
+        expect(resolveReferencePrice("", 80)).toBe(80);
+    });
+
+    test("honours a baseline at or below the current price", () => {
+        expect(resolveReferencePrice(50, 80)).toBe(50);
+        expect(resolveReferencePrice("50.00", 80)).toBe(50);
+        expect(resolveReferencePrice(80, 80)).toBe(80);
+    });
+
+    test("clamps a baseline above the current price", () => {
+        expect(resolveReferencePrice(999999, 80)).toBe(80);
+    });
+
+    test("rejects a baseline that is not a positive number", () => {
+        expect(() => resolveReferencePrice(0, 80)).toThrow(StockAlertError);
+        expect(() => resolveReferencePrice(-5, 80)).toThrow(/positive/i);
+        expect(() => resolveReferencePrice("free", 80)).toThrow(/positive/i);
+    });
+
+    test("survives a product price the column could not give us", () => {
+        expect(resolveReferencePrice(null, null)).toBe(0);
+        expect(resolveReferencePrice(null, "not a price")).toBe(0);
+    });
+});
+
+describe("purgeUnavailableSubscriptions", () => {
+    test("cancels active subscriptions for soft-deleted and archived products", async () => {
+        respondWith(() => ({ affectedRows: 4 }));
+
+        const purged = await service.purgeUnavailableSubscriptions();
+
+        expect(purged).toBe(4);
+
+        const [sql, params] = db.query.mock.calls[0];
+        expect(sql).toMatch(/UPDATE stock_alert_subscriptions s/i);
+        expect(sql).toMatch(/JOIN products p ON p\.id = s\.product_id/i);
+        expect(sql).toMatch(/p\.deleted_at IS NOT NULL OR p\.status = 'archived'/i);
+        expect(params).toEqual(["cancelled", "active"]);
+    });
+
+    test("leaves an inactive product's subscriptions alone", async () => {
+        // `inactive` is explicitly "withdrawn, expected back" in
+        // constants/productVisibility.js, so a subscription against one is
+        // still worth keeping -- it simply must not fire while it is withdrawn.
+        respondWith(() => ({ affectedRows: 0 }));
+
+        await service.purgeUnavailableSubscriptions();
+
+        const [sql] = db.query.mock.calls[0];
+        expect(sql).not.toMatch(/'inactive'/);
+        expect(sql).not.toMatch(/'draft'/);
+    });
+
+    test("reports zero when the driver returns no row count", async () => {
+        respondWith(() => ({}));
+
+        expect(await service.purgeUnavailableSubscriptions()).toBe(0);
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

The stock-alert engine mailed shoppers about products the rest of the storefront refuses to serve.

Both evaluators joined subscriptions to products on nothing but the id:

```sql
JOIN products p ON p.id = s.product_id
WHERE s.alert_type = ? AND s.status = ? AND p.stock > 0
```

`products` carries `deleted_at` and a `status ENUM('draft','active','inactive','archived')`, and **`constants/productVisibility.js` has existed since #1456 to say what those two mean together.** The alert engine is the one public path that never imported it. So a soft-deleted, archived, inactive or still-draft product that gained stock — a correction, a returned unit, a re-import — fanned a notification out to everyone who had ever subscribed to it, and the link in that mail lands on a page the product routes deliberately 404.

Both detection queries now carry `publicProductCondition('p')`. Importing the shared fragment rather than retyping the predicate is the point: it is what stops this engine drifting away from the catalogue a second time.

**The same hole was at the front door.** `subscribe()` looked a product up only for a `price_drop` alert with no `referencePrice`:

```js
if (alertType === ALERT_TYPES.PRICE_DROP && effectiveReferencePrice === null) {
    effectiveReferencePrice = await fetchCurrentPrice(productId);
}
```

A `back_in_stock` subscription was inserted with no check at all, and pinning a `referencePrice` bought a subscription to anything. Every alert type now resolves the product through the same condition, and the route maps the typed `PRODUCT_NOT_VISIBLE` failure to **404** rather than folding it into the blanket 400. The message is identical whether the product is absent or merely not public — which of the two it is is information about unreleased catalogue, and this endpoint is reachable by any signed-in account.

Two more things fixed in passing:

* the price-drop baseline is taken from the row the visibility check already loaded, instead of a second `SELECT` that could read a price the check never saw;
* a caller-supplied `referencePrice` is **clamped** to the current price. Left unclamped, `referencePrice: 999999` earned a "price drop" notification on the very next scan for a product whose price never moved.

`purgeUnavailableSubscriptions()` is new and runs after each scan. Filtering at evaluation time stops the mail, but leaves rows sitting `active` forever — re-examined on every tick and shown on the user's alerts page as though they were live. It cancels **only** soft-deleted and archived products: `inactive` is explicitly "withdrawn, expected back" in `productVisibility.js`, so those subscriptions are kept and simply do not fire.

---

## 🔗 Related Issue

Closes #1609

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Not applicable — backend only. The user-visible change is the absence of a notification.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Behaviour deliberately changed.** `POST /api/stock-alerts` now rejects a product that is not publicly visible. Two cases in the existing suites pinned the old behaviour and are updated rather than worked around — that is the behaviour this PR exists to change, so the assertions move with it:

* `stockAlert.test.js` — "back_in_stock does not look up product price" became "still resolves the product, but stores no baseline";
* `stockAlert.evaluation.test.js` — "price_drop for a missing product throws" became "for a missing product throws, whatever the alert type".

**On the new tests.** `tests/stockAlertVisibility.test.js` asserts against the real `publicProductCondition` rather than a copy of its text, so if the definition of "public" ever changes this suite follows it instead of pinning the old one. It also counts placeholders against parameters on both detection queries — a predicate appended without its parameters is exactly the class of mistake this change could have introduced.

**No schema change.**

Full suite: 110 suites, 2375 tests, green.