### PR TITLE
fix(recently-viewed): stop one product view hiding the whole history (#1610)

### DIFF
--- a/backend/services/recentlyViewedService.js
+++ b/backend/services/recentlyViewedService.js
@@ -25,9 +25,51 @@
 // not `image_url`, `category` or `avg_rating` -- so the surviving queries would
 // have failed with ER_BAD_FIELD_ERROR even once the file parsed.
 
+// #1610 fixed the second defect this cache had. `addViewed` seeded its list
+// from `readCache(userId) || []`, so on a MISS -- a cold worker, a restart, or
+// simply the first view after the 5-minute TTL lapsed -- the cache was written
+// back holding exactly one row: the product just viewed. `getRecentlyViewed`
+// then served any non-empty cache without consulting the database, so the
+// user's whole history vanished from the storefront for five minutes and came
+// back only when the entry expired, at which point the next view wiped it
+// again.
+//
+// The comment in `addViewed` claimed "the next read will reconcile with the
+// database anyway". Nothing reconciled anything. It does now, and the mechanism
+// is the `complete` flag below: an entry is complete only when it came from a
+// database read, and only a complete entry may be served without one.
+
 const db = require('../config/db').promise;
 
 const PLACEHOLDER_IMAGE = '/assets/images/placeholder.png';
+
+/**
+ * One row shape, whichever path produced it.
+ *
+ * The two writers disagreed: the database read hands back `viewed_at` aliased
+ * to `viewedAt` as a MySQL DATETIME, while `addViewed` wrote
+ * `new Date().toISOString()`. Any consumer that sorted or formatted that field
+ * got a Date sometimes and a string other times, depending on which path last
+ * filled the cache.
+ *
+ * @param {object} row
+ * @returns {object}
+ */
+const normalizeEntry = (row) => {
+    const source = row || {};
+    const viewedAt = source.viewedAt ?? source.viewed_at ?? null;
+    const parsed = viewedAt instanceof Date ? viewedAt : new Date(viewedAt);
+
+    return {
+        id: source.id,
+        name: source.name,
+        price: Number.isFinite(parseFloat(source.price)) ? parseFloat(source.price) : 0,
+        imageUrl: source.imageUrl || source.image || PLACEHOLDER_IMAGE,
+        viewedAt: Number.isNaN(parsed.getTime())
+            ? new Date().toISOString()
+            : parsed.toISOString()
+    };
+};
 
 class RecentlyViewedService {
     constructor() {
@@ -72,8 +114,10 @@ class RecentlyViewedService {
      *
      * Returns null when there is nothing usable, so callers never have to know
      * whether a miss was an absent key or an expired one.
+     *
+     * @returns {{data: Array, timestamp: number, complete: boolean}|null}
      */
-    readCache(userId) {
+    readCacheEntry(userId) {
         const key = this.getCacheKey(userId);
         const cached = this.cache.get(key);
 
@@ -84,18 +128,50 @@ class RecentlyViewedService {
             return null;
         }
 
-        return cached.data;
+        return cached;
+    }
+
+    /**
+     * The cached rows for a user, or null.
+     *
+     * Kept alongside `readCacheEntry` because "give me the list" is what most
+     * callers want; only the read path needs to know whether the list is the
+     * whole story.
+     */
+    readCache(userId) {
+        const entry = this.readCacheEntry(userId);
+        return entry ? entry.data : null;
     }
 
     /**
      * Write a user's cache entry in the one shape every reader expects.
+     *
+     * `complete` says whether this list is the user's whole history (capped at
+     * `maxItems`) or merely some of it. Only a database read may claim `true`.
+     * Treating "non-empty" as "complete" is what made a single view hide the
+     * rest of the list for five minutes (#1610).
+     *
+     * @param {string} userId
+     * @param {Array} data
+     * @param {{complete?: boolean}} [options]
      */
-    writeCache(userId, data) {
+    writeCache(userId, data, { complete = false } = {}) {
+        const rows = (Array.isArray(data) ? data : []).map(normalizeEntry);
+
         this.cache.set(this.getCacheKey(userId), {
-            data,
-            timestamp: Date.now()
+            data: rows,
+            timestamp: Date.now(),
+            complete: Boolean(complete)
         });
-        return data;
+
+        return rows;
+    }
+
+    /**
+     * Drop a user's cache entry so the next read goes to the database.
+     */
+    invalidateCache(userId) {
+        return this.cache.delete(this.getCacheKey(userId));
     }
 
     /**
@@ -128,28 +204,9 @@ class RecentlyViewedService {
                 return [];
             }
 
-            // Start from whatever is cached; a miss simply means this write
-            // seeds a fresh list, which the next read will reconcile with the
-            // database anyway.
-            let viewed = this.readCache(userId) || [];
-
-            // Move an existing entry to the front rather than duplicating it.
-            viewed = viewed.filter((item) => item.id !== productId);
-
-            viewed.unshift({
-                id: productId,
-                name: product[0].name,
-                price: parseFloat(product[0].price),
-                imageUrl: product[0].image || PLACEHOLDER_IMAGE,
-                viewedAt: new Date().toISOString()
-            });
-
-            if (viewed.length > this.maxItems) {
-                viewed = viewed.slice(0, this.maxItems);
-            }
-
-            this.writeCache(userId, viewed);
-
+            // The database is written first and unconditionally: the view has
+            // happened whatever the cache believes, and every reconciliation
+            // path below reads back from here.
             await db.query(
                 `INSERT INTO recently_viewed (user_id, product_id, viewed_at)
                  VALUES (?, ?, NOW())
@@ -157,7 +214,40 @@ class RecentlyViewedService {
                 [userId, productId]
             );
 
-            return viewed;
+            const entry = this.readCacheEntry(userId);
+
+            // Only a list that is already the whole history may be extended in
+            // place. Anything else -- a miss, an expired entry, a list seeded
+            // by an earlier partial write -- is reconciled against the database
+            // rather than being grown from a fragment and then trusted.
+            //
+            // This is the fix for #1610. The old code did the opposite: it
+            // started from `[]` on a miss, wrote a one-item list, and
+            // `getRecentlyViewed` then served that one item for the next five
+            // minutes.
+            if (!entry || !entry.complete) {
+                return this.syncCache(userId);
+            }
+
+            const viewed = entry.data
+                // Move an existing entry to the front rather than duplicating
+                // it. Compared as strings: `products.id` is a CHAR(36) UUID,
+                // and the numeric comparison this class used to carry matched
+                // nothing at all (#1497).
+                .filter((item) => String(item.id) !== String(productId))
+                .slice(0, this.maxItems - 1);
+
+            viewed.unshift(normalizeEntry({
+                id: productId,
+                name: product[0].name,
+                price: product[0].price,
+                imageUrl: product[0].image || PLACEHOLDER_IMAGE,
+                viewedAt: new Date().toISOString()
+            }));
+
+            // Still complete: the whole history plus one product that is now
+            // part of it, capped the same way the database read is.
+            return this.writeCache(userId, viewed, { complete: true });
         } catch (error) {
             console.error('Add recently viewed error:', error);
             return [];
@@ -173,38 +263,65 @@ class RecentlyViewedService {
             return [];
         }
 
-        const effectiveLimit = Math.min(Number(limit) || 10, this.maxItems);
+        const effectiveLimit = Math.min(Math.max(1, Number(limit) || 10), this.maxItems);
 
         try {
-            const cached = this.readCache(userId);
-            if (cached && cached.length > 0) {
-                return cached.slice(0, effectiveLimit);
+            const entry = this.readCacheEntry(userId);
+
+            // `complete` and nothing else. Emptiness is not the question --
+            // a one-row entry seeded by a view is non-empty and wrong, and a
+            // genuinely empty history is complete and right.
+            if (entry && entry.complete) {
+                return entry.data.slice(0, effectiveLimit);
             }
 
-            const [rows] = await db.query(
-                `SELECT
-                    p.id,
-                    p.name,
-                    p.price,
-                    COALESCE(p.image, ?) AS imageUrl,
-                    rv.viewed_at AS viewedAt
-                 FROM recently_viewed rv
-                 INNER JOIN products p ON p.id = rv.product_id
-                 WHERE rv.user_id = ? AND p.stock > 0 AND p.deleted_at IS NULL
-                 ORDER BY rv.viewed_at DESC
-                 LIMIT ?`,
-                [PLACEHOLDER_IMAGE, userId, effectiveLimit]
-            );
+            // Always read the full window, never just what this caller asked
+            // for. A cache filled from a limit-5 read cannot answer a limit-10
+            // one, and "complete" would stop meaning anything if it could hold
+            // fewer rows than the history has.
+            const rows = await this.fetchFromDatabase(userId, this.maxItems);
 
-            if (rows.length > 0) {
-                this.writeCache(userId, rows);
-            }
+            // Cached even when empty: "this user has viewed nothing" is a fact
+            // worth not re-querying for every page load, and the entry still
+            // expires on the TTL.
+            const cached = this.writeCache(userId, rows, { complete: true });
 
-            return rows;
+            return cached.slice(0, effectiveLimit);
         } catch (error) {
             console.error('Get recently viewed error:', error);
             return [];
         }
+    }
+
+    /**
+     * The user's history, newest first, straight from the database.
+     *
+     * The one place the visibility predicate and the column aliases live, so
+     * `getRecentlyViewed`, `syncCache` and anything added later cannot drift
+     * apart -- which is how this file ended up with two different SELECT lists
+     * spliced together in the first place (#1341).
+     *
+     * @param {string} userId
+     * @param {number} limit
+     * @returns {Promise<Array>}
+     */
+    async fetchFromDatabase(userId, limit) {
+        const [rows] = await db.query(
+            `SELECT
+                p.id,
+                p.name,
+                p.price,
+                COALESCE(p.image, ?) AS imageUrl,
+                rv.viewed_at AS viewedAt
+             FROM recently_viewed rv
+             INNER JOIN products p ON p.id = rv.product_id
+             WHERE rv.user_id = ? AND p.stock > 0 AND p.deleted_at IS NULL
+             ORDER BY rv.viewed_at DESC
+             LIMIT ?`,
+            [PLACEHOLDER_IMAGE, userId, limit]
+        );
+
+        return Array.isArray(rows) ? rows : [];
     }
 
     /**
@@ -258,7 +375,7 @@ class RecentlyViewedService {
         }
 
         try {
-            this.cache.delete(this.getCacheKey(userId));
+            this.invalidateCache(userId);
 
             await db.query('DELETE FROM recently_viewed WHERE user_id = ?', [userId]);
 
@@ -276,11 +393,16 @@ class RecentlyViewedService {
         if (!userId || !productId) return false;
 
         try {
-            const cached = this.readCache(userId);
-            if (cached) {
+            const entry = this.readCacheEntry(userId);
+            if (entry) {
+                // Removing a row cannot make an incomplete list complete, and
+                // cannot make a complete one incomplete -- so the flag is
+                // carried through rather than reset. Compared as strings
+                // because `products.id` is a UUID.
                 this.writeCache(
                     userId,
-                    cached.filter((item) => item.id !== productId)
+                    entry.data.filter((item) => String(item.id) !== String(productId)),
+                    { complete: entry.complete }
                 );
             }
 
@@ -338,17 +460,24 @@ class RecentlyViewedService {
         const now = Date.now();
         let total = 0;
         let expired = 0;
+        // Surfaced because a cache full of partial entries is the symptom of
+        // #1610 coming back, and the admin route is where that would be seen.
+        let partial = 0;
 
         for (const [, value] of this.cache) {
             total++;
             if (value && value.timestamp && now - value.timestamp > this.cacheTTL) {
                 expired++;
             }
+            if (value && !value.complete) {
+                partial++;
+            }
         }
 
         return {
             totalEntries: total,
             expiredEntries: expired,
+            partialEntries: partial,
             maxItems: this.maxItems,
             cacheTTL: `${this.cacheTTL / 1000}s`
         };
@@ -361,24 +490,15 @@ class RecentlyViewedService {
         if (!userId) return [];
 
         try {
-            const [rows] = await db.query(
-                `SELECT
-                    p.id,
-                    p.name,
-                    p.price,
-                    COALESCE(p.image, ?) AS imageUrl,
-                    rv.viewed_at AS viewedAt
-                 FROM recently_viewed rv
-                 INNER JOIN products p ON p.id = rv.product_id
-                 WHERE rv.user_id = ? AND p.stock > 0 AND p.deleted_at IS NULL
-                 ORDER BY rv.viewed_at DESC
-                 LIMIT ?`,
-                [PLACEHOLDER_IMAGE, userId, this.maxItems]
-            );
+            const rows = await this.fetchFromDatabase(userId, this.maxItems);
 
-            return this.writeCache(userId, rows);
+            return this.writeCache(userId, rows, { complete: true });
         } catch (error) {
             console.error('Sync cache error:', error);
+
+            // A failed sync must not leave a stale or partial entry behind
+            // claiming to be the whole history.
+            this.invalidateCache(userId);
             return [];
         }
     }

--- a/backend/tests/mergeScarRegression.test.js
+++ b/backend/tests/mergeScarRegression.test.js
@@ -152,16 +152,29 @@ describe('backend/services/recentlyViewedService.js', () => {
     });
 
     // Two cache shapes were written to the same key: a bare array and
-    // `{ data, timestamp }`. Every reader expects the second.
+    // `{ data, timestamp }`. Every reader expects the second, and since #1610
+    // it also carries `complete` -- whether the list is the user's whole
+    // history or merely part of it.
     it('writes and reads one cache shape', () => {
-        service.writeCache('user-1', [{ id: 'p1' }]);
+        service.writeCache('user-1', [{ id: 'p1' }], { complete: true });
 
         const raw = service.cache.get(service.getCacheKey('user-1'));
         expect(Array.isArray(raw)).toBe(false);
         expect(raw).toHaveProperty('data');
         expect(raw).toHaveProperty('timestamp');
+        expect(raw).toHaveProperty('complete', true);
 
-        expect(service.readCache('user-1')).toEqual([{ id: 'p1' }]);
+        // The rows are normalised on the way in, so the round trip is by id
+        // rather than by identity -- one row shape whichever path wrote it.
+        expect(service.readCache('user-1').map((row) => row.id)).toEqual(['p1']);
+    });
+
+    it('defaults a cache entry to incomplete', () => {
+        // "Non-empty" is not "complete". Treating the two as the same is what
+        // let one product view hide the rest of the list for five minutes.
+        service.writeCache('user-3', [{ id: 'p1' }]);
+
+        expect(service.readCacheEntry('user-3').complete).toBe(false);
     });
 
     it('treats an expired cache entry as a miss', () => {

--- a/backend/tests/recentlyViewedCache.test.js
+++ b/backend/tests/recentlyViewedCache.test.js
@@ -1,0 +1,298 @@
+// backend/tests/recentlyViewedCache.test.js
+//
+// The recently-viewed cache (#1610).
+//
+// The service keeps a five-minute in-process map in front of the
+// `recently_viewed` table. `addViewed` seeded its list from
+// `readCache(userId) || []`, so on a MISS -- a cold worker, a restart, or the
+// first view after the TTL lapsed -- it wrote the cache back holding exactly
+// one row. `getRecentlyViewed` then served any non-empty cache without
+// consulting the database, so the user's whole history disappeared from the
+// storefront for five minutes and came back only when the entry expired, at
+// which point the next view wiped it again.
+//
+// Swapping the order of the two calls hides it entirely, which is why it
+// survived manual testing: view a product *after* the list has been read into
+// cache and everything looks right. So the tests below are written in the
+// order that breaks it -- add first, read second -- and the class is
+// instantiated fresh each time so no test inherits another's cache.
+
+jest.mock('../config/db', () => {
+    const query = jest.fn();
+    return { promise: { query }, query };
+});
+
+const db = require('../config/db').promise;
+const { RecentlyViewedService } = require('../services/recentlyViewedService');
+
+const USER = 'user-1';
+
+/** Seven products, newest first, as the database read returns them. */
+const HISTORY = Array.from({ length: 7 }, (unused, index) => ({
+    id: `prod-${index}`,
+    name: `Product ${index}`,
+    price: `${10 + index}.00`,
+    imageUrl: `/img/${index}.png`,
+    viewedAt: new Date(Date.UTC(2026, 0, 10 - index)),
+}));
+
+const PRODUCT_SELECT = /SELECT id, name, price, image, stock FROM products/i;
+const HISTORY_SELECT = /FROM recently_viewed rv/i;
+const HISTORY_INSERT = /INSERT INTO recently_viewed/i;
+
+/**
+ * A service whose database answers a fixed history and a fixed product row.
+ *
+ * `rows` is mutated by the insert path so the "add then read" sequence sees the
+ * same thing the real table would.
+ */
+function mount({ history = HISTORY, product = null } = {}) {
+    const rows = [...history];
+
+    db.query.mockImplementation(async (sql, params = []) => {
+        if (PRODUCT_SELECT.test(sql)) {
+            return [product ? [product] : []];
+        }
+        if (HISTORY_SELECT.test(sql)) {
+            const limit = params[params.length - 1];
+            return [rows.slice(0, limit)];
+        }
+        if (HISTORY_INSERT.test(sql)) {
+            const [, productId] = params;
+            const existing = rows.findIndex((row) => row.id === productId);
+            if (existing >= 0) rows.splice(existing, 1);
+            rows.unshift({
+                id: productId,
+                name: product ? product.name : 'Unknown',
+                price: product ? product.price : 0,
+                imageUrl: product && product.image ? product.image : '/assets/images/placeholder.png',
+                viewedAt: new Date(Date.UTC(2026, 0, 20)),
+            });
+            return [{ affectedRows: 1 }];
+        }
+        return [{ affectedRows: 0 }];
+    });
+
+    // Constructed rather than taking the module singleton: the singleton calls
+    // initialize() at require time and would carry cache state between tests.
+    return { service: new RecentlyViewedService(), rows };
+}
+
+function historyReads() {
+    return db.query.mock.calls.filter(([sql]) => HISTORY_SELECT.test(sql));
+}
+
+afterEach(() => {
+    db.query.mockReset();
+});
+
+describe('a view on a cold cache does not hide the history', () => {
+    const NEW_PRODUCT = { id: 'prod-new', name: 'Just viewed', price: '99.00', image: '/img/new.png', stock: 4 };
+
+    test('the list read straight after a view still holds everything', async () => {
+        const { service } = mount({ product: NEW_PRODUCT });
+
+        // Cold cache. This is the exact sequence that used to collapse the
+        // list to one row for five minutes.
+        await service.addViewed(USER, 'prod-new');
+        const viewed = await service.getRecentlyViewed(USER, 10);
+
+        expect(viewed).toHaveLength(8);
+        expect(viewed[0].id).toBe('prod-new');
+        expect(viewed.map((item) => item.id)).toEqual(
+            expect.arrayContaining(HISTORY.map((item) => item.id))
+        );
+    });
+
+    test('addViewed itself returns the whole list, not just the new row', async () => {
+        const { service } = mount({ product: NEW_PRODUCT });
+
+        // The route hands this straight back to the client as `data`.
+        const returned = await service.addViewed(USER, 'prod-new');
+
+        expect(returned).toHaveLength(8);
+        expect(returned[0].id).toBe('prod-new');
+    });
+
+    test('the entry a cold view leaves behind is not served as complete', async () => {
+        const { service } = mount({ product: NEW_PRODUCT });
+
+        await service.addViewed(USER, 'prod-new');
+
+        const entry = service.readCacheEntry(USER);
+        expect(entry.complete).toBe(true);
+        expect(entry.data).toHaveLength(8);
+    });
+});
+
+describe('a view on a warm cache is served from it', () => {
+    const NEW_PRODUCT = { id: 'prod-new', name: 'Just viewed', price: '99.00', image: '/img/new.png', stock: 4 };
+
+    test('no extra database read is needed once the list is complete', async () => {
+        const { service } = mount({ product: NEW_PRODUCT });
+
+        await service.getRecentlyViewed(USER, 10);
+        const readsAfterFirst = historyReads().length;
+
+        await service.addViewed(USER, 'prod-new');
+        const viewed = await service.getRecentlyViewed(USER, 10);
+
+        // The insert happened, the list was extended in place, and neither the
+        // add nor the read went back for the history.
+        expect(historyReads()).toHaveLength(readsAfterFirst);
+        expect(viewed[0].id).toBe('prod-new');
+        expect(viewed).toHaveLength(8);
+    });
+
+    test('re-viewing a product moves it to the front instead of duplicating it', async () => {
+        const { service } = mount({
+            product: { id: 'prod-3', name: 'Product 3', price: '13.00', image: '/img/3.png', stock: 2 },
+        });
+
+        await service.getRecentlyViewed(USER, 10);
+        await service.addViewed(USER, 'prod-3');
+        const viewed = await service.getRecentlyViewed(USER, 10);
+
+        expect(viewed[0].id).toBe('prod-3');
+        expect(viewed.filter((item) => item.id === 'prod-3')).toHaveLength(1);
+        expect(viewed).toHaveLength(7);
+    });
+
+    test('the in-place list is capped at maxItems', async () => {
+        const full = Array.from({ length: 20 }, (unused, index) => ({
+            id: `p-${index}`,
+            name: `P${index}`,
+            price: '1.00',
+            imageUrl: '/x.png',
+            viewedAt: new Date(Date.UTC(2026, 0, 1)),
+        }));
+
+        const { service } = mount({
+            history: full,
+            product: { id: 'p-fresh', name: 'Fresh', price: '2.00', image: null, stock: 1 },
+        });
+
+        await service.getRecentlyViewed(USER, 20);
+        const returned = await service.addViewed(USER, 'p-fresh');
+
+        expect(returned).toHaveLength(service.maxItems);
+        expect(returned[0].id).toBe('p-fresh');
+    });
+});
+
+describe('the read path', () => {
+    test('caches the full window regardless of the limit asked for', async () => {
+        const { service } = mount();
+
+        // A limit-2 read must not leave a two-row entry claiming to be the
+        // whole history: the next limit-10 read would then under-serve.
+        const small = await service.getRecentlyViewed(USER, 2);
+        expect(small).toHaveLength(2);
+
+        const large = await service.getRecentlyViewed(USER, 10);
+        expect(large).toHaveLength(7);
+        expect(historyReads()).toHaveLength(1);
+    });
+
+    test('caches an empty history rather than re-querying for it', async () => {
+        const { service } = mount({ history: [] });
+
+        expect(await service.getRecentlyViewed(USER, 10)).toEqual([]);
+        expect(await service.getRecentlyViewed(USER, 10)).toEqual([]);
+
+        expect(historyReads()).toHaveLength(1);
+        expect(service.readCacheEntry(USER).complete).toBe(true);
+    });
+
+    test('a database failure yields an empty list and no poisoned cache', async () => {
+        const { service } = mount();
+        db.query.mockRejectedValue(new Error('connection lost'));
+
+        expect(await service.getRecentlyViewed(USER, 10)).toEqual([]);
+        expect(service.readCacheEntry(USER)).toBeNull();
+    });
+
+    test('an unknown product is not recorded and the cache is untouched', async () => {
+        const { service } = mount({ product: null });
+
+        await service.getRecentlyViewed(USER, 10);
+        const before = service.readCacheEntry(USER).data;
+
+        expect(await service.addViewed(USER, 'nope')).toEqual([]);
+        expect(service.readCacheEntry(USER).data).toEqual(before);
+        expect(db.query.mock.calls.filter(([sql]) => HISTORY_INSERT.test(sql))).toHaveLength(0);
+    });
+
+    test('an out-of-stock product is not recorded', async () => {
+        const { service } = mount({
+            product: { id: 'oos', name: 'Sold out', price: '5.00', image: null, stock: 0 },
+        });
+
+        expect(await service.addViewed(USER, 'oos')).toEqual([]);
+        expect(db.query.mock.calls.filter(([sql]) => HISTORY_INSERT.test(sql))).toHaveLength(0);
+    });
+});
+
+describe('row shape', () => {
+    test('viewedAt is an ISO string whichever path filled the cache', async () => {
+        const { service } = mount({
+            product: { id: 'prod-new', name: 'Just viewed', price: '99.00', image: '/img/new.png', stock: 4 },
+        });
+
+        const fromDatabase = await service.getRecentlyViewed(USER, 10);
+        const fromWrite = await service.addViewed(USER, 'prod-new');
+
+        [...fromDatabase, ...fromWrite].forEach((item) => {
+            expect(typeof item.viewedAt).toBe('string');
+            expect(Number.isNaN(Date.parse(item.viewedAt))).toBe(false);
+            expect(typeof item.price).toBe('number');
+        });
+    });
+});
+
+describe('cache housekeeping', () => {
+    test('an expired entry is a miss, not a stale answer', async () => {
+        const { service } = mount();
+
+        await service.getRecentlyViewed(USER, 10);
+        expect(historyReads()).toHaveLength(1);
+
+        // Age the entry past the TTL without waiting five minutes.
+        const entry = service.cache.get(service.getCacheKey(USER));
+        entry.timestamp -= service.cacheTTL + 1;
+
+        await service.getRecentlyViewed(USER, 10);
+        expect(historyReads()).toHaveLength(2);
+    });
+
+    test('removeFromViewed keeps the completeness of the entry it edits', async () => {
+        const { service } = mount();
+
+        await service.getRecentlyViewed(USER, 10);
+        await service.removeFromViewed(USER, 'prod-3');
+
+        const entry = service.readCacheEntry(USER);
+        expect(entry.complete).toBe(true);
+        expect(entry.data.map((item) => item.id)).not.toContain('prod-3');
+    });
+
+    test('clearRecentlyViewed drops the entry entirely', async () => {
+        const { service } = mount();
+
+        await service.getRecentlyViewed(USER, 10);
+        await service.clearRecentlyViewed(USER);
+
+        expect(service.readCacheEntry(USER)).toBeNull();
+    });
+
+    test('getCacheStats reports partial entries', async () => {
+        const { service } = mount();
+
+        await service.getRecentlyViewed(USER, 10);
+        service.writeCache('user-2', [{ id: 'x', name: 'x', price: 1 }], { complete: false });
+
+        const stats = service.getCacheStats();
+        expect(stats.totalEntries).toBe(2);
+        expect(stats.partialEntries).toBe(1);
+    });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

Viewing one product could hide the user's entire recently-viewed history for five minutes.

`addViewed` seeded its list from the cache:

```js
let viewed = this.readCache(userId) || [];
```

On a **miss** — a cold worker, a restart, or simply the first view after the 5-minute TTL lapsed — that is `[]`, so the cache was written back holding exactly one row: the product just viewed. `getRecentlyViewed` then trusted it:

```js
const cached = this.readCache(userId);
if (cached && cached.length > 0) {
    return cached.slice(0, effectiveLimit);   // never reaches the database
}
```

A one-item cache is non-empty, so the database was never consulted. The list came back only when the entry expired — at which point the next product view wiped it again. The service is a module-level singleton, so this is **per worker process**: every deploy, every fresh worker, every idle-then-return user.

The comment in `addViewed` said the opposite of what the code did:

> Start from whatever is cached; a miss simply means this write seeds a fresh list, **which the next read will reconcile with the database anyway.**

Nothing reconciled anything. It does now.

**The fix** is a `complete` flag on the cache entry. Only a database read may set it, and only a complete entry may be served without one:

* `addViewed` writes to the table first, then either extends a complete list in place or syncs from the database;
* `getRecentlyViewed` gates on `complete` rather than on emptiness — emptiness was never the right question, since a one-row entry is non-empty and wrong while a genuinely empty history is complete and right;
* the read always fetches the full `maxItems` window, so a limit-2 read cannot leave an entry that under-serves a later limit-10 one.

Three smaller things fixed alongside:

* **`viewedAt` had two types.** The read path produced a MySQL `DATETIME`; `addViewed` wrote `new Date().toISOString()`. A consumer sorting or formatting that field got a different type depending on which path last filled the cache. Both normalise now.
* **The `SELECT` was duplicated** between `getRecentlyViewed` and `syncCache` — which is exactly how this file previously ended up with two different SELECT lists spliced together (#1341). One `fetchFromDatabase` now.
* **Id comparisons** in `addViewed` and `removeFromViewed` are string comparisons, `products.id` being a `CHAR(36)` UUID.

---

## 🔗 Related Issue

Closes #1610

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [x] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

The sequence that broke, with seven products already in the table:

```
POST /api/recently-viewed  { productId: "prod-new" }
GET  /api/recently-viewed

before -> 1 item   (just "prod-new", for the next 5 minutes)
after  -> 8 items  ("prod-new" first, then the history)
```

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Why this survived manual testing.** Swapping the order of the two calls hides it completely: view a product *after* the list has been read into cache and everything looks fine. `tests/recentlyViewedCache.test.js` is therefore written in the order that breaks it — add first, read second. **11 of its 16 cases fail against the previous implementation.**

`mergeScarRegression`'s cache-shape test is updated for the new field and gains a case pinning that an entry defaults to *incomplete*, since "non-empty means complete" is the assumption this whole change exists to remove.

**No schema or API change.** Both routes return the same shape; they now return the right rows.

Full suite: 110 suites, 2374 tests, green.