### PR TITLE
fix(compare): Remove and Add to Cart were dead on UUID product ids (#1611)

### DIFF
--- a/backend/tests/comparePage.test.js
+++ b/backend/tests/comparePage.test.js
@@ -1,0 +1,318 @@
+// backend/tests/comparePage.test.js
+//
+// The comparison matrix (#1611), driven for real in jsdom.
+//
+// `products.id` is a CHAR(36) UUID and `frontend/scripts/compare.js` identified
+// products with `Number()`:
+//
+//     const removeId = Number(btn.dataset.removeId);              // NaN
+//     compareProductIds.filter((id) => Number(id) !== removeId);  // keeps all
+//
+//     const prodId = Number(btn.dataset.productId);               // NaN
+//     loadedProducts.find((p) => Number(p.id) === prodId);        // matches none
+//
+// NaN is not equal to itself, so the remove filter kept every element and the
+// cart lookup matched nothing -- for every product, not some of them. Add to
+// Cart fell out of `if (targetProd)` and produced no toast, no error and no
+// change: the button was dead and said nothing about it.
+//
+// Reading the source cannot show that. What can is clicking the buttons and
+// looking at localStorage and the cart, which is what these tests do.
+//
+// Same class of defect as #1497 in recentlyViewed.js; compare.js was not part
+// of that change.
+
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const COMPARE_JS = path.join(REPO_ROOT, 'frontend', 'scripts', 'compare.js');
+
+const source = fs.readFileSync(COMPARE_JS, 'utf8');
+
+/** Real UUIDs, because that is the whole point. */
+const IDS = [
+    'f3a0d99c-5509-4619-9634-7ceeb3615921',
+    '0b1e2d3c-4a5b-6c7d-8e9f-a0b1c2d3e4f5',
+    'aa11bb22-cc33-dd44-ee55-ff6677889900'
+];
+
+const PRODUCTS = IDS.map((id, index) => ({
+    id,
+    name: `Product ${index}`,
+    price: 100 + index,
+    rating: 4 - index * 0.5,
+    brand: `Brand ${index}`,
+    category: 'Shirts',
+    num_reviews: 10 * (index + 1),
+    stock: 5,
+    image: `/img/${index}.png`
+}));
+
+const PAGE = `<!doctype html><html><body>
+    <select id="compare-sort-select"><option value="">Default</option></select>
+    <input type="checkbox" id="toggle-diff-checkbox">
+    <button id="clear-compare-btn">Clear</button>
+    <div id="compare-matrix-content"></div>
+</body></html>`;
+
+/** Let the awaited Promise.allSettled and the render settle. */
+const settle = async () => {
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+};
+
+/**
+ * A compare page with the real script running on it.
+ *
+ * The Web Worker is deliberately absent so the main-thread matrix path runs;
+ * jsdom has no Worker and loading `scripts/compare-worker.js` over a file URL
+ * would not work anyway.
+ *
+ * @param {object} [options]
+ * @param {object} [options.storage] initial localStorage contents
+ * @param {string[]} [options.knownIds] ids the fake API will resolve
+ */
+const mountCompare = async ({ storage = {}, knownIds = IDS } = {}) => {
+    const dom = new JSDOM(PAGE, {
+        url: 'https://shop.example/compare.html',
+        runScripts: 'outside-only'
+    });
+
+    const { window } = dom;
+
+    Object.entries(storage).forEach(([key, value]) => {
+        window.localStorage.setItem(key, JSON.stringify(value));
+    });
+
+    const cart = [];
+    const notices = [];
+    const requested = [];
+
+    window.AppUtils = {
+        getJSON: (key, fallback = null) => {
+            try {
+                const raw = window.localStorage.getItem(key);
+                return raw ? JSON.parse(raw) : fallback;
+            } catch (error) {
+                return fallback;
+            }
+        },
+        setJSON: (key, value) => {
+            window.localStorage.setItem(key, JSON.stringify(value));
+            return true;
+        },
+        escapeHTML: (value) => {
+            if (value === null || value === undefined) return '';
+            return String(value)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        },
+        formatPrice: (value) => `INR ${(Number(value) || 0).toFixed(2)}`,
+        notify: (message, level) => notices.push({ message, level }),
+        addCartItem: (product) => cart.push(product),
+        apiRequest: async (url) => {
+            requested.push(url);
+            const id = decodeURIComponent(url.split('/').pop());
+            const product = PRODUCTS.find((candidate) => candidate.id === id);
+            if (!product || !knownIds.includes(id)) {
+                throw new Error('404');
+            }
+            return { product };
+        }
+    };
+
+    // No Worker: exercise the main-thread matrix path.
+    window.Worker = undefined;
+    window.confirm = () => true;
+
+    window.eval(source);
+    await settle();
+
+    const readStored = (key) => JSON.parse(window.localStorage.getItem(key) || 'null');
+
+    return {
+        window,
+        document: window.document,
+        cart,
+        notices,
+        requested,
+        readStored,
+        removeButtons: () => [...window.document.querySelectorAll('.compare-remove-btn')],
+        addButtons: () => [...window.document.querySelectorAll('.add-to-cart-btn')],
+        headerTitles: () =>
+            [...window.document.querySelectorAll('.compare-product-title')].map((el) => el.textContent.trim())
+    };
+};
+
+describe('the matrix renders', () => {
+    it('shows one column per compared product', async () => {
+        const page = await mountCompare({ storage: { compareProducts: IDS } });
+
+        expect(page.headerTitles()).toEqual(['Product 0', 'Product 1', 'Product 2']);
+        expect(page.removeButtons()).toHaveLength(3);
+        expect(page.addButtons()).toHaveLength(3);
+    });
+
+    it('carries the UUID through to the button, unconverted', async () => {
+        const page = await mountCompare({ storage: { compareProducts: IDS } });
+
+        expect(page.removeButtons().map((btn) => btn.dataset.removeId)).toEqual(IDS);
+        expect(page.addButtons().map((btn) => btn.dataset.productId)).toEqual(IDS);
+    });
+});
+
+describe('removing a product', () => {
+    it('takes it out of storage and out of the matrix', async () => {
+        const page = await mountCompare({ storage: { compareProducts: IDS } });
+
+        page.removeButtons()[1].click();
+        await settle();
+
+        expect(page.readStored('compareProducts')).toEqual([IDS[0], IDS[2]]);
+        expect(page.headerTitles()).toEqual(['Product 0', 'Product 2']);
+    });
+
+    it('keeps both storage keys in step', async () => {
+        const page = await mountCompare({ storage: { compareProducts: IDS, comparisonList: IDS } });
+
+        page.removeButtons()[0].click();
+        await settle();
+
+        expect(page.readStored('compareProducts')).toEqual([IDS[1], IDS[2]]);
+        expect(page.readStored('comparisonList')).toEqual([IDS[1], IDS[2]]);
+    });
+
+    it('falls back to the empty state once the last one goes', async () => {
+        const page = await mountCompare({ storage: { compareProducts: [IDS[0]] } });
+
+        page.removeButtons()[0].click();
+        await settle();
+
+        expect(page.readStored('compareProducts')).toEqual([]);
+        expect(page.document.body.textContent).toContain('No Products Selected for Comparison');
+    });
+
+    it('does not re-fetch the surviving products', async () => {
+        const page = await mountCompare({ storage: { compareProducts: IDS } });
+        const before = page.requested.length;
+
+        page.removeButtons()[2].click();
+        await settle();
+
+        expect(page.requested).toHaveLength(before);
+        expect(page.headerTitles()).toHaveLength(2);
+    });
+});
+
+describe('add to cart', () => {
+    it('adds the product the button belongs to', async () => {
+        const page = await mountCompare({ storage: { compareProducts: IDS } });
+
+        page.addButtons()[2].click();
+        await settle();
+
+        expect(page.cart).toHaveLength(1);
+        expect(page.cart[0].id).toBe(IDS[2]);
+        expect(page.notices.map((n) => n.message)).toContain('Added Product 2 to cart');
+    });
+
+    it('adds each product independently', async () => {
+        const page = await mountCompare({ storage: { compareProducts: IDS } });
+
+        page.addButtons()[0].click();
+        page.addButtons()[1].click();
+        await settle();
+
+        expect(page.cart.map((item) => item.id)).toEqual([IDS[0], IDS[1]]);
+    });
+});
+
+describe('reading the stored list', () => {
+    it('falls back to comparisonList when compareProducts is empty', async () => {
+        // `[]` is truthy, so the old `getJSON(a, []) || getJSON(b, [])` could
+        // never reach the second key and this visitor saw the empty state.
+        const page = await mountCompare({ storage: { comparisonList: IDS } });
+
+        expect(page.headerTitles()).toEqual(['Product 0', 'Product 1', 'Product 2']);
+    });
+
+    it('prefers compareProducts when both hold something', async () => {
+        const page = await mountCompare({
+            storage: { compareProducts: [IDS[0]], comparisonList: IDS }
+        });
+
+        expect(page.headerTitles()).toEqual(['Product 0']);
+    });
+
+    it('renders the empty state when neither key holds anything', async () => {
+        const page = await mountCompare({ storage: {} });
+
+        expect(page.document.body.textContent).toContain('No Products Selected for Comparison');
+        expect(page.requested).toHaveLength(0);
+    });
+
+    it('survives a corrupt stored value', async () => {
+        const page = await mountCompare({ storage: { compareProducts: 'not-an-array' } });
+
+        expect(page.document.body.textContent).toContain('No Products Selected for Comparison');
+    });
+
+    it('drops blanks and duplicates without losing order', async () => {
+        const page = await mountCompare({
+            storage: { compareProducts: [IDS[1], '', IDS[1], null, IDS[0], '  '] }
+        });
+
+        expect(page.headerTitles()).toEqual(['Product 1', 'Product 0']);
+    });
+
+    it('prunes an id the catalogue no longer resolves', async () => {
+        const page = await mountCompare({
+            storage: { compareProducts: [...IDS, 'deadbeef-0000-0000-0000-000000000000'] },
+            knownIds: IDS
+        });
+
+        // Otherwise a withdrawn product sits in the list forever, retried on
+        // every visit and counting against the three-product cap.
+        expect(page.readStored('compareProducts')).toEqual(IDS);
+    });
+});
+
+describe('clearing', () => {
+    it('empties both keys and shows the empty state', async () => {
+        const page = await mountCompare({ storage: { compareProducts: IDS, comparisonList: IDS } });
+
+        page.document.getElementById('clear-compare-btn').click();
+        await settle();
+
+        expect(page.readStored('compareProducts')).toEqual([]);
+        expect(page.readStored('comparisonList')).toEqual([]);
+        expect(page.document.body.textContent).toContain('No Products Selected for Comparison');
+    });
+});
+
+describe('sameId', () => {
+    it('compares UUIDs as strings, never as numbers', async () => {
+        const page = await mountCompare({ storage: { compareProducts: IDS } });
+        const { sameId, normalizeIds } = page.window.__compareInternals;
+
+        expect(sameId(IDS[0], IDS[0])).toBe(true);
+        expect(sameId(IDS[0], IDS[1])).toBe(false);
+
+        // The regression itself: Number() of either side is NaN, and NaN
+        // compared to NaN is false in every direction.
+        expect(Number(IDS[0])).toBeNaN();
+
+        // Integer ids from older builds still work.
+        expect(sameId(7, '7')).toBe(true);
+        expect(sameId(' 7 ', 7)).toBe(true);
+
+        expect(normalizeIds([1, '1', 2])).toEqual(['1', '2']);
+        expect(normalizeIds(null)).toEqual([]);
+    });
+});

--- a/backend/tests/comparePage.test.js
+++ b/backend/tests/comparePage.test.js
@@ -67,15 +67,17 @@ const settle = async () => {
 /**
  * A compare page with the real script running on it.
  *
- * The Web Worker is deliberately absent so the main-thread matrix path runs;
+ * By default the Web Worker is absent so the main-thread matrix path runs;
  * jsdom has no Worker and loading `scripts/compare-worker.js` over a file URL
- * would not work anyway.
+ * would not work anyway. Pass `worker` to install a stand-in and exercise the
+ * path a real browser takes instead.
  *
  * @param {object} [options]
  * @param {object} [options.storage] initial localStorage contents
  * @param {string[]} [options.knownIds] ids the fake API will resolve
+ * @param {{messages: Array, reply: Function}} [options.worker] fake worker
  */
-const mountCompare = async ({ storage = {}, knownIds = IDS } = {}) => {
+const mountCompare = async ({ storage = {}, knownIds = IDS, worker = null, brokenWorker = false } = {}) => {
     const dom = new JSDOM(PAGE, {
         url: 'https://shop.example/compare.html',
         runScripts: 'outside-only'
@@ -127,8 +129,34 @@ const mountCompare = async ({ storage = {}, knownIds = IDS } = {}) => {
         }
     };
 
-    // No Worker: exercise the main-thread matrix path.
-    window.Worker = undefined;
+    if (brokenWorker) {
+        // A Worker constructor that throws, the way a blocked or missing worker
+        // script behaves. compare.js catches it and uses the main thread.
+        window.Worker = function BrokenWorker() {
+            throw new Error('worker script blocked');
+        };
+    } else if (worker) {
+        // A stand-in for the real Web Worker. jsdom has none, and the browsers
+        // that shoppers actually use do -- so the worker path is the one most
+        // of them take, and the buttons are bound from the render it drives.
+        window.Worker = function FakeWorker() {
+            worker.instance = this;
+            this.postMessage = (payload) => {
+                worker.messages.push(payload);
+                // The real worker replies asynchronously; so does this.
+                Promise.resolve().then(() => {
+                    if (typeof this.onmessage === 'function') {
+                        this.onmessage({ data: worker.reply(payload) });
+                    }
+                });
+            };
+            this.terminate = () => {};
+        };
+    } else {
+        // No Worker: exercise the main-thread matrix path.
+        window.Worker = undefined;
+    }
+
     window.confirm = () => true;
 
     window.eval(source);
@@ -142,6 +170,7 @@ const mountCompare = async ({ storage = {}, knownIds = IDS } = {}) => {
         cart,
         notices,
         requested,
+        worker,
         readStored,
         removeButtons: () => [...window.document.querySelectorAll('.compare-remove-btn')],
         addButtons: () => [...window.document.querySelectorAll('.add-to-cart-btn')],
@@ -314,5 +343,102 @@ describe('sameId', () => {
 
         expect(normalizeIds([1, '1', 2])).toEqual(['1', '2']);
         expect(normalizeIds(null)).toEqual([]);
+    });
+});
+
+describe('the Web Worker path', () => {
+    // Everything above runs the main-thread fallback, but a real browser has a
+    // Worker and takes this branch -- so the buttons shoppers actually click
+    // are bound from the render the worker drives. The fake below answers the
+    // shape `compare-worker.js` posts back.
+
+    /** A worker double that sorts and builds a matrix the way the real one does. */
+    const fakeWorker = () => ({
+        messages: [],
+        instance: null,
+        reply: ({ products, sortBy }) => {
+            const sorted = [...products];
+            if (sortBy === 'price-desc') {
+                sorted.sort((a, b) => Number(b.price) - Number(a.price));
+            }
+
+            return {
+                action: 'PROCESS_COMPARISON_RESULT',
+                products: sorted,
+                specMatrix: [
+                    {
+                        key: 'price',
+                        label: 'Price',
+                        type: 'currency',
+                        values: sorted.map((p) => p.price),
+                        isDifferent: true,
+                        bestValue: Math.min(...sorted.map((p) => Number(p.price)))
+                    }
+                ]
+            };
+        }
+    });
+
+    it('renders from the worker reply', async () => {
+        const page = await mountCompare({ storage: { compareProducts: IDS }, worker: fakeWorker() });
+
+        expect(page.worker.messages).toHaveLength(1);
+        expect(page.worker.messages[0].action).toBe('PROCESS_COMPARISON');
+        expect(page.headerTitles()).toEqual(['Product 0', 'Product 1', 'Product 2']);
+    });
+
+    it('removes the product the button belongs to', async () => {
+        const page = await mountCompare({ storage: { compareProducts: IDS }, worker: fakeWorker() });
+
+        page.removeButtons()[1].click();
+        await settle();
+
+        expect(page.readStored('compareProducts')).toEqual([IDS[0], IDS[2]]);
+        expect(page.headerTitles()).toEqual(['Product 0', 'Product 2']);
+    });
+
+    it('adds the product the button belongs to', async () => {
+        const page = await mountCompare({ storage: { compareProducts: IDS }, worker: fakeWorker() });
+
+        page.addButtons()[1].click();
+        await settle();
+
+        expect(page.cart.map((item) => item.id)).toEqual([IDS[1]]);
+    });
+
+    it('binds against the order the worker returned, not the order stored', async () => {
+        // The worker sorts; the ids on the buttons come from its reply. If the
+        // handlers had closed over an index rather than reading the id back,
+        // sorting would silently rewire every button.
+        const page = await mountCompare({ storage: { compareProducts: IDS }, worker: fakeWorker() });
+
+        page.document.getElementById('compare-sort-select').innerHTML =
+            '<option value="price-desc" selected>Price high to low</option>';
+        page.document.getElementById('compare-sort-select').dispatchEvent(
+            new page.window.Event('change')
+        );
+        await settle();
+
+        expect(page.headerTitles()).toEqual(['Product 2', 'Product 1', 'Product 0']);
+
+        page.addButtons()[0].click();
+        await settle();
+
+        expect(page.cart.map((item) => item.id)).toEqual([IDS[2]]);
+    });
+
+    it('falls back to the main thread when the worker cannot be created', async () => {
+        // A blocked or missing worker script must not take the page with it --
+        // and the buttons have to work on the fallback render too.
+        const page = await mountCompare({ storage: { compareProducts: IDS }, brokenWorker: true });
+
+        expect(page.headerTitles()).toEqual(['Product 0', 'Product 1', 'Product 2']);
+
+        page.addButtons()[0].click();
+        page.removeButtons()[2].click();
+        await settle();
+
+        expect(page.cart.map((item) => item.id)).toEqual([IDS[0]]);
+        expect(page.readStored('compareProducts')).toEqual([IDS[0], IDS[1]]);
     });
 });

--- a/frontend/scripts/compare.js
+++ b/frontend/scripts/compare.js
@@ -1,10 +1,113 @@
+// frontend/scripts/compare.js
+//
+// The side-by-side comparison matrix (#1611).
+//
+// WHY EVERY ID IS A STRING HERE
+//
+// `products.id` is a CHAR(36) UUID. This file used to identify products with
+// `Number()`:
+//
+//     const removeId = Number(btn.dataset.removeId);                    // NaN
+//     compareProductIds.filter((id) => Number(id) !== removeId);        // keeps all
+//
+//     const prodId = Number(btn.dataset.productId);                     // NaN
+//     loadedProducts.find((p) => Number(p.id) === prodId);              // matches none
+//
+// `Number("f3a0d99c-…")` is NaN and NaN is not equal to itself, so the remove
+// filter kept every element and the cart lookup matched nothing -- for 100% of
+// products, not some of them. Add to Cart failed into `if (targetProd)` and so
+// produced no toast, no console error and no change: the button was simply
+// dead. `recentlyViewed.js` had the identical defect and was fixed in #1497;
+// this file was not part of that change.
+//
+// Ids are therefore compared through `sameId` and normalised to strings on the
+// way in and out of storage. There is no path here that turns one into a
+// number.
+//
+// WHY THE STORAGE READ IS NOT AN `||`
+//
+//     getJSON("compareProducts", []) || getJSON("comparisonList", [])
+//
+// `getJSON(key, [])` returns the default `[]` when the key is absent, and `[]`
+// is truthy -- so the right-hand side was unreachable and a visitor whose list
+// lived under `comparisonList` got the empty state. The fallback is on
+// emptiness now, which is what it was always meant to be.
+
 (() => {
     const compareMatrixContent = document.getElementById("compare-matrix-content");
     const sortSelect = document.getElementById("compare-sort-select");
     const toggleDiffCheckbox = document.getElementById("toggle-diff-checkbox");
     const clearCompareBtn = document.getElementById("clear-compare-btn");
 
-    let compareProductIds = AppUtils.getJSON("compareProducts", []) || AppUtils.getJSON("comparisonList", []);
+    // Both keys are written on every mutation so either can be the source of
+    // truth for a page that only knows about one of them.
+    const STORAGE_KEYS = ["compareProducts", "comparisonList"];
+
+    /**
+     * Are these two ids the same product?
+     *
+     * The one comparison in this file, so no call site can reintroduce a
+     * numeric coercion. String, because that is what a UUID is.
+     *
+     * @param {unknown} a
+     * @param {unknown} b
+     * @returns {boolean}
+     */
+    const sameId = (a, b) => String(a ?? "").trim() === String(b ?? "").trim();
+
+    /**
+     * Clean a stored list into ids we can actually use.
+     *
+     * Trims, drops blanks and de-duplicates while preserving order. Numbers are
+     * accepted and stringified: older builds stored integer ids, and those
+     * lists should keep working rather than silently emptying.
+     *
+     * @param {unknown} value
+     * @returns {string[]}
+     */
+    const normalizeIds = (value) => {
+        if (!Array.isArray(value)) return [];
+
+        const seen = new Set();
+
+        return value.reduce((ids, entry) => {
+            const id = String(entry ?? "").trim();
+            if (!id || seen.has(id)) return ids;
+            seen.add(id);
+            ids.push(id);
+            return ids;
+        }, []);
+    };
+
+    /**
+     * The comparison list as stored.
+     *
+     * Tries each key in turn and takes the first that actually holds
+     * something, rather than the first that returns a truthy value -- an empty
+     * array is truthy, which is what made the second key unreachable.
+     *
+     * @returns {string[]}
+     */
+    const readStoredIds = () => {
+        for (const key of STORAGE_KEYS) {
+            const ids = normalizeIds(AppUtils.getJSON(key, []));
+            if (ids.length) return ids;
+        }
+        return [];
+    };
+
+    /**
+     * Persist the list under every key the storefront reads.
+     *
+     * @param {string[]} ids
+     */
+    const writeStoredIds = (ids) => {
+        const normalized = normalizeIds(ids);
+        STORAGE_KEYS.forEach((key) => AppUtils.setJSON(key, normalized));
+        return normalized;
+    };
+
+    let compareProductIds = readStoredIds();
     let loadedProducts = [];
     let compareWorker = null;
 
@@ -40,12 +143,23 @@
 
         try {
             const results = await Promise.allSettled(
-                compareProductIds.map((id) => AppUtils.apiRequest(`/products/${id}`))
+                compareProductIds.map((id) => AppUtils.apiRequest(`/products/${encodeURIComponent(id)}`))
             );
 
             loadedProducts = results
                 .filter((res) => res.status === "fulfilled" && res.value && res.value.product)
                 .map((res) => res.value.product);
+
+            // A product that no longer resolves -- withdrawn, deleted, or an id
+            // left over from an older build -- is dropped from the stored list
+            // rather than being retried on every visit and counting against the
+            // three-product cap forever.
+            const resolved = normalizeIds(loadedProducts.map((product) => product.id));
+            if (resolved.length !== compareProductIds.length) {
+                compareProductIds = writeStoredIds(
+                    compareProductIds.filter((id) => resolved.some((found) => sameId(found, id)))
+                );
+            }
 
             if (!loadedProducts.length) {
                 renderEmptyState();
@@ -90,7 +204,7 @@
             if (sortBy === "name-asc") sorted.sort((a, b) => String(a.name || "").localeCompare(String(b.name || "")));
 
             const specMatrix = specKeys.map((spec) => {
-                const values = sorted.map((p) => p[spec.key] !== undefined ? p[spec.key] : "N/A");
+                const values = sorted.map((p) => (p[spec.key] !== undefined && p[spec.key] !== null ? p[spec.key] : "N/A"));
                 const isDifferent = values.some((val) => String(val) !== String(values[0]));
                 let bestValue = null;
                 if (spec.type === "currency") {
@@ -123,12 +237,12 @@
                         <th>Specifications</th>
                         ${products.map((p) => `
                             <th class="compare-product-header">
-                                <button type="button" class="compare-remove-btn" data-remove-id="${p.id}" title="Remove product">
+                                <button type="button" class="compare-remove-btn" data-remove-id="${AppUtils.escapeHTML(String(p.id))}" title="Remove product">
                                     <i class="fas fa-times"></i>
                                 </button>
                                 <img src="${AppUtils.escapeHTML(p.image || p.img || '')}" alt="${AppUtils.escapeHTML(p.name)}" class="compare-product-img" onerror="this.src='assets/images/logo.png'">
                                 <div class="compare-product-title">${AppUtils.escapeHTML(p.name)}</div>
-                                <button type="button" class="btn btn-primary add-to-cart-btn" data-product-id="${p.id}" style="padding: 6px 12px; font-size: 0.8rem; border-radius: 6px;">
+                                <button type="button" class="btn btn-primary add-to-cart-btn" data-product-id="${AppUtils.escapeHTML(String(p.id))}" style="padding: 6px 12px; font-size: 0.8rem; border-radius: 6px;">
                                     <i class="fas fa-shopping-cart"></i> Add to Cart
                                 </button>
                             </th>
@@ -140,7 +254,10 @@
                         <tr class="${row.isDifferent ? 'highlight-diff' : ''}">
                             <td>${AppUtils.escapeHTML(row.label)}</td>
                             ${row.values.map((val) => {
-                                const isBest = row.bestValue !== null && row.bestValue !== undefined && Number(val) === Number(row.bestValue);
+                                const isBest = row.bestValue !== null
+                                    && row.bestValue !== undefined
+                                    && Number.isFinite(Number(val))
+                                    && Number(val) === Number(row.bestValue);
                                 let formattedVal = AppUtils.escapeHTML(String(val));
 
                                 if (row.type === 'currency') {
@@ -167,24 +284,45 @@
         // Bind Remove buttons
         compareMatrixContent.querySelectorAll(".compare-remove-btn").forEach((btn) => {
             btn.addEventListener("click", () => {
-                const removeId = Number(btn.dataset.removeId);
-                compareProductIds = compareProductIds.filter((id) => Number(id) !== removeId);
-                AppUtils.setJSON("compareProducts", compareProductIds);
-                AppUtils.setJSON("comparisonList", compareProductIds);
+                const removeId = btn.dataset.removeId;
+
+                compareProductIds = writeStoredIds(
+                    compareProductIds.filter((id) => !sameId(id, removeId))
+                );
+
+                // Drop it from what has already been fetched too, so the
+                // re-render does not have to wait on the network to stop
+                // showing a product the user just removed.
+                loadedProducts = loadedProducts.filter((product) => !sameId(product.id, removeId));
+
                 AppUtils.notify("Product removed from comparison", "info");
-                loadProducts();
+
+                if (!compareProductIds.length) {
+                    renderEmptyState();
+                    return;
+                }
+
+                processMatrix();
             });
         });
 
         // Bind Add to Cart buttons
         compareMatrixContent.querySelectorAll(".add-to-cart-btn").forEach((btn) => {
             btn.addEventListener("click", () => {
-                const prodId = Number(btn.dataset.productId);
-                const targetProd = loadedProducts.find((p) => Number(p.id) === prodId);
-                if (targetProd) {
-                    AppUtils.addCartItem(targetProd);
-                    AppUtils.notify(`Added ${targetProd.name} to cart`, "success");
+                const prodId = btn.dataset.productId;
+                const targetProd = loadedProducts.find((p) => sameId(p.id, prodId));
+
+                if (!targetProd) {
+                    // Reachable only if the render and the loaded set have
+                    // drifted. Silence here is what made the original defect so
+                    // hard to spot, so it says something now.
+                    console.warn("COMPARE: no loaded product for id", prodId);
+                    AppUtils.notify("That product is no longer available", "warning");
+                    return;
                 }
+
+                AppUtils.addCartItem(targetProd);
+                AppUtils.notify(`Added ${targetProd.name} to cart`, "success");
             });
         });
     }
@@ -215,15 +353,29 @@
     if (clearCompareBtn) {
         clearCompareBtn.addEventListener("click", () => {
             if (confirm("Clear all items from comparison matrix?")) {
-                compareProductIds = [];
-                AppUtils.setJSON("compareProducts", []);
-                AppUtils.setJSON("comparisonList", []);
+                compareProductIds = writeStoredIds([]);
+                loadedProducts = [];
                 renderEmptyState();
                 AppUtils.notify("Comparison list cleared", "info");
             }
         });
     }
 
-    // Initialize
-    document.addEventListener("DOMContentLoaded", loadProducts);
+    // Initialize.
+    //
+    // Against readyState rather than a bare DOMContentLoaded listener: the tag
+    // is a plain <script> today, so the event has not fired yet, but a `defer`
+    // or `async` added later would mean the listener is registered after the
+    // event and the page never loads anything at all.
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", loadProducts);
+    } else {
+        loadProducts();
+    }
+
+    // Exposed for tests. The IIFE keeps everything else private; these three are
+    // the pure pieces worth asserting on directly.
+    if (typeof window !== "undefined") {
+        window.__compareInternals = { sameId, normalizeIds, readStoredIds, writeStoredIds };
+    }
 })();


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

On `compare.html`, **Remove (×)** and **Add to Cart** did nothing. Both failed for the same reason.

`products.id` is a `CHAR(36)` UUID, and `compare.js` identified products with `Number()`:

```js
// remove
const removeId = Number(btn.dataset.removeId);                    // NaN
compareProductIds.filter((id) => Number(id) !== removeId);
//                                NaN !== NaN  ->  true, keeps everything

// add to cart
const prodId = Number(btn.dataset.productId);                     // NaN
loadedProducts.find((p) => Number(p.id) === prodId);
//                         NaN === NaN  ->  false, matches nothing
```

`Number("f3a0d99c-5509-4619-9634-7ceeb3615921")` is `NaN`, and `NaN` is not equal to itself. So the remove filter kept every element and the cart lookup matched nothing — for **100% of products**, not some of them. Add to Cart fell out of `if (targetProd)` and produced no toast, no console error and no change: the button was dead and silent about it. The only working control on the page was **Clear all**, because it does not need to identify an individual product.

Same defect class as #1497 in `recentlyViewed.js`; this file was not part of that change. There is now one `sameId` helper doing `String(a) === String(b)`, and no path in the file that turns an id into a number.

**Second bug, line 7:**

```js
AppUtils.getJSON("compareProducts", []) || AppUtils.getJSON("comparisonList", [])
```

`getJSON(key, [])` returns the default `[]` when the key is absent, and `[]` is truthy — so the right-hand side was **unreachable**. The file writes both keys on every mutation precisely so either can be the source of truth, but a visitor whose list lived under `comparisonList` got the empty state. The fallback is on emptiness now, which is what it was always meant to be.

Also in this change:

* stored ids are normalised on read — trimmed, blanks and duplicates dropped, order preserved — so a list written by an older build (integer ids) keeps working rather than silently emptying;
* an id the catalogue no longer resolves is pruned from storage instead of being retried on every visit and counting against the three-product cap forever;
* a failed cart lookup logs and notifies rather than returning silently — that silence is what made the original defect so hard to spot;
* ids are escaped into the `data-` attributes and the product URL is encoded;
* initialisation is against `document.readyState`. The tag is a plain `<script>` today so `DOMContentLoaded` has not fired yet, but adding `defer` or `async` later would register the listener *after* the event and the page would load nothing at all.

---

## 🔗 Related Issue

Closes #1611

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [x] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

With three products compared:

```
                       before            after
click × on column 2    nothing           column removed, storage updated
click Add to Cart      nothing, no       product in cart,
                       toast, no error   "Added Product 2 to cart"
```

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**On the tests.** Reading the source cannot show this bug — the question is what happens when you click the button. `tests/comparePage.test.js` mounts the real script in jsdom with real UUIDs, clicks, and asserts `localStorage` and the cart. It follows the pattern already established by `navbarSearch.test.js` and `recentlyViewed.test.js`.

21 cases in total. 16 drive the main-thread matrix path (jsdom has no `Worker`), of which **11 fail against the previous implementation**. The other 5 install a worker double and drive the path a real browser actually takes — that is the render the buttons a shopper clicks are bound from, and it had no coverage at all. They also pin that the handlers read the id back from the worker's reply rather than closing over a position, since sorting would otherwise rewire every button, and that a blocked worker script falls back to the main thread with working buttons rather than taking the page down. **4 of those 5 fail against the previous implementation too.**

**Scope note.** #1484 (compare only reachable from the homepage) is a separate issue about where the *entry point* lives; this PR is only about the compare page itself being non-functional once you get there. The two do not overlap.

Full suite: 110 suites, 2373 tests, green. Syntax, sitemap, a11y and asset gates all pass.