### PR TITLE
fix(newsletter): a confirmation link followed twice is not an error (#1612)

### DIFF
--- a/backend/controllers/newsletterController.js
+++ b/backend/controllers/newsletterController.js
@@ -70,6 +70,18 @@ const confirm = async (req, res) => {
     try {
         const token = req.body?.token || req.query?.token;
         const result = await newsletterService.confirm(token);
+        const { CONFIRM_OUTCOMES } = newsletterService;
+
+        // A link that has already done its job is not an error. Clicking twice
+        // is ordinary, and a mail security scanner following the link before
+        // the recipient sees it makes the *first* human click the second one
+        // (#1612).
+        if (result.outcome === CONFIRM_OUTCOMES.ALREADY_CONFIRMED) {
+            return res.status(200).json({
+                success: true,
+                message: "You're already subscribed — nothing more to do."
+            });
+        }
 
         if (result.confirmed) {
             return res.status(200).json({
@@ -78,11 +90,24 @@ const confirm = async (req, res) => {
             });
         }
 
-        if (result.reason === 'expired') {
+        // The address asked not to be mailed. Silently re-adding it on the
+        // strength of an old link in an inbox would undo that request, so the
+        // only honest answer is to send them back to the form, where the
+        // double opt-in will ask them again.
+        if (result.outcome === CONFIRM_OUTCOMES.ALREADY_UNSUBSCRIBED) {
+            return res.status(409).json({
+                success: false,
+                message:
+                    'This address has unsubscribed. Sign up again if you would '
+                    + 'like to start receiving the newsletter.'
+            });
+        }
+
+        if (result.outcome === CONFIRM_OUTCOMES.EXPIRED) {
             return res.status(410).json({
                 success: false,
                 message:
-                    'That confirmation link has expired or has already been used. '
+                    'That confirmation link has expired. '
                     + 'Sign up again to get a new one.'
             });
         }

--- a/backend/services/newsletterService.js
+++ b/backend/services/newsletterService.js
@@ -228,14 +228,51 @@ const sendConfirmationEmail = async (email, rawToken) => {
 };
 
 /**
+ * Every answer `confirm` can give.
+ *
+ * Named because the controller branches on them and the tests assert them, and
+ * a set of bare strings scattered across three files is how one of them quietly
+ * stops being produced.
+ */
+const CONFIRM_OUTCOMES = Object.freeze({
+    /** The link worked; this call is what put the address on the list. */
+    CONFIRMED: 'confirmed',
+    /** A link for a subscription that is already live. Not a failure. */
+    ALREADY_CONFIRMED: 'already_confirmed',
+    /** The address has since asked not to be mailed. */
+    ALREADY_UNSUBSCRIBED: 'already_unsubscribed',
+    /** Still pending, but the 48 hours are up. */
+    EXPIRED: 'expired',
+    /** No row has ever carried this digest. */
+    INVALID_TOKEN: 'invalid_token'
+});
+
+/**
  * Redeem a confirmation token.
  *
+ * A spent token stays findable and stops being usable (#1612). The successful
+ * UPDATE moves the digest from `confirm_token` -- the column every write path
+ * matches on -- to `spent_confirm_token`, which no write path matches on at
+ * all. Before this the digest was simply set to NULL, so the lookup below found
+ * nothing and a second click on a working link was reported as invalid.
+ *
+ * That matters more than it sounds: double-clicking a link in a mail client is
+ * ordinary, and several mail security scanners follow links in a message before
+ * the recipient ever opens it. The scanner spends the token; the human is told
+ * their link is broken for a subscription that is live; they submit the form
+ * again, which correctly mails nothing to an already-confirmed address; and the
+ * page stays broken from their point of view forever.
+ *
  * @param {string} token Raw token from the link.
- * @returns {Promise<{confirmed: boolean, reason?: string, unsubscribeToken?: string}>}
+ * @returns {Promise<{confirmed: boolean, outcome: string, reason?: string}>}
  */
 const confirm = async (token) => {
     if (!token || typeof token !== 'string') {
-        return { confirmed: false, reason: 'invalid_token' };
+        return {
+            confirmed: false,
+            outcome: CONFIRM_OUTCOMES.INVALID_TOKEN,
+            reason: CONFIRM_OUTCOMES.INVALID_TOKEN
+        };
     }
 
     const digest = hashToken(token);
@@ -246,6 +283,7 @@ const confirm = async (token) => {
         `UPDATE newsletter_subscribers
             SET status = 'confirmed',
                 confirmed_at = NOW(),
+                spent_confirm_token = confirm_token,
                 confirm_token = NULL,
                 confirm_token_expires_at = NULL
           WHERE confirm_token = ?
@@ -254,24 +292,56 @@ const confirm = async (token) => {
         [digest]
     );
 
-    if (result.affectedRows === 0) {
-        // Already-confirmed is not a failure from the subscriber's point of
-        // view -- clicking the link twice should not look broken. Distinguished
-        // here so the controller can say something sensible.
-        const [rows] = await db.query(
-            `SELECT status FROM newsletter_subscribers
-              WHERE confirm_token = ? LIMIT 1`,
-            [digest]
-        );
-
-        if (!rows.length) {
-            return { confirmed: false, reason: 'invalid_token' };
-        }
-
-        return { confirmed: false, reason: 'expired' };
+    if (result.affectedRows > 0) {
+        return { confirmed: true, outcome: CONFIRM_OUTCOMES.CONFIRMED };
     }
 
-    return { confirmed: true };
+    // Nothing was confirmed. Which of the four reasons applies is worth
+    // knowing, and the caller is holding a token that was mailed to the
+    // address, so they have already demonstrated they are entitled to know.
+    //
+    // Both columns, because a row reaches `spent_confirm_token` by being
+    // confirmed *or* by being unsubscribed while still pending.
+    const [rows] = await db.query(
+        `SELECT status, confirm_token_expires_at
+           FROM newsletter_subscribers
+          WHERE confirm_token = ? OR spent_confirm_token = ?
+          LIMIT 1`,
+        [digest, digest]
+    );
+
+    const row = rows[0];
+
+    if (!row) {
+        return {
+            confirmed: false,
+            outcome: CONFIRM_OUTCOMES.INVALID_TOKEN,
+            reason: CONFIRM_OUTCOMES.INVALID_TOKEN
+        };
+    }
+
+    if (row.status === 'confirmed') {
+        // `confirmed: true` deliberately. The subscriber asked to be on the
+        // list and is on the list; that the work was done by an earlier click
+        // is not their problem, and reporting it as a failure is what sends
+        // them back to the sign-up form.
+        return { confirmed: true, outcome: CONFIRM_OUTCOMES.ALREADY_CONFIRMED };
+    }
+
+    if (row.status === 'unsubscribed') {
+        return {
+            confirmed: false,
+            outcome: CONFIRM_OUTCOMES.ALREADY_UNSUBSCRIBED,
+            reason: CONFIRM_OUTCOMES.ALREADY_UNSUBSCRIBED
+        };
+    }
+
+    // Still pending, so the only way the UPDATE missed it is the expiry.
+    return {
+        confirmed: false,
+        outcome: CONFIRM_OUTCOMES.EXPIRED,
+        reason: CONFIRM_OUTCOMES.EXPIRED
+    };
 };
 
 /**
@@ -295,10 +365,18 @@ const unsubscribe = async (token) => {
 
     const digest = hashToken(token);
 
+    // `spent_confirm_token = COALESCE(confirm_token, spent_confirm_token)`
+    // rather than a bare assignment: a row that was already confirmed has NULL
+    // in `confirm_token` and its real spent digest in the other column, and
+    // overwriting that with NULL would lose the audit key this change exists to
+    // keep (#1612). A row unsubscribed while still pending records its live
+    // token as spent, which is what lets a confirmation link followed after an
+    // unsubscribe be answered truthfully instead of as an invalid link.
     const [result] = await db.query(
         `UPDATE newsletter_subscribers
             SET status = 'unsubscribed',
                 unsubscribed_at = COALESCE(unsubscribed_at, NOW()),
+                spent_confirm_token = COALESCE(confirm_token, spent_confirm_token),
                 confirm_token = NULL,
                 confirm_token_expires_at = NULL
           WHERE unsubscribe_token = ?`,
@@ -345,6 +423,7 @@ const listConfirmed = async () => {
 module.exports = {
     subscribe,
     confirm,
+    CONFIRM_OUTCOMES,
     unsubscribe,
     listConfirmed,
     normalizeEmail,

--- a/backend/tests/newsletter.test.js
+++ b/backend/tests/newsletter.test.js
@@ -222,6 +222,16 @@ describe('confirming', () => {
             .toMatch(/confirm_token\s*=\s*NULL/);
     });
 
+    test('keeps the spent digest as an audit key rather than dropping it', async () => {
+        // The whole of #1612: setting confirm_token to NULL and nothing else
+        // made the already-confirmed branch below unreachable, because it looks
+        // the row up by the value that had just been erased.
+        await newsletterService.confirm('abc123');
+
+        expect(String(statementMatching('UPDATE newsletter_subscribers')[0]))
+            .toMatch(/spent_confirm_token\s*=\s*confirm_token/);
+    });
+
     test('an unknown token is reported as invalid', async () => {
         db.query
             .mockResolvedValueOnce([{ affectedRows: 0 }])
@@ -229,7 +239,7 @@ describe('confirming', () => {
 
         const result = await newsletterService.confirm('nope');
 
-        expect(result).toEqual({ confirmed: false, reason: 'invalid_token' });
+        expect(result).toMatchObject({ confirmed: false, reason: 'invalid_token' });
     });
 
     test('a known but spent or expired token is told apart from an unknown one', async () => {
@@ -414,6 +424,151 @@ describe('confirm and unsubscribe do report what happened', () => {
     });
 });
 
+describe('a confirmation link followed twice (#1612)', () => {
+    const { CONFIRM_OUTCOMES } = newsletterService;
+
+    /** The UPDATE matched nothing, and the fallback lookup found this row. */
+    const spentTokenBelongingTo = (row) => {
+        db.query
+            .mockResolvedValueOnce([{ affectedRows: 0 }])
+            .mockResolvedValueOnce([[row]]);
+    };
+
+    test('the fallback lookup searches the spent column too', async () => {
+        // Without this the query looks for a digest the successful UPDATE has
+        // just removed, finds nothing, and reports a live subscription as an
+        // invalid link.
+        spentTokenBelongingTo({ status: 'confirmed' });
+
+        await newsletterService.confirm('abc123');
+
+        const lookup = statementMatching('SELECT status');
+        expect(String(lookup[0])).toMatch(/confirm_token = \? OR spent_confirm_token = \?/);
+
+        const digest = crypto.createHash('sha256').update('abc123').digest('hex');
+        expect(lookup[1]).toEqual([digest, digest]);
+    });
+
+    test('a second click on a working link reports the subscription as live', async () => {
+        spentTokenBelongingTo({ status: 'confirmed' });
+
+        const result = await newsletterService.confirm('abc123');
+
+        // `confirmed: true`, not a failure. The subscriber asked to be on the
+        // list and is on the list; that an earlier click did the work is not
+        // their problem.
+        expect(result).toEqual({
+            confirmed: true,
+            outcome: CONFIRM_OUTCOMES.ALREADY_CONFIRMED
+        });
+    });
+
+    test('a link followed after unsubscribing says so', async () => {
+        spentTokenBelongingTo({ status: 'unsubscribed' });
+
+        const result = await newsletterService.confirm('abc123');
+
+        expect(result).toMatchObject({
+            confirmed: false,
+            outcome: CONFIRM_OUTCOMES.ALREADY_UNSUBSCRIBED
+        });
+    });
+
+    test('a pending row past its expiry is expired, not invalid', async () => {
+        spentTokenBelongingTo({ status: 'pending', confirm_token_expires_at: '2020-01-01' });
+
+        const result = await newsletterService.confirm('abc123');
+
+        expect(result.outcome).toBe(CONFIRM_OUTCOMES.EXPIRED);
+    });
+
+    test('a digest no row has ever carried is still invalid', async () => {
+        db.query
+            .mockResolvedValueOnce([{ affectedRows: 0 }])
+            .mockResolvedValueOnce([[]]);
+
+        const result = await newsletterService.confirm('never-issued');
+
+        expect(result.outcome).toBe(CONFIRM_OUTCOMES.INVALID_TOKEN);
+    });
+
+    test('the first click still confirms and says nothing about a second', async () => {
+        db.query.mockResolvedValueOnce([{ affectedRows: 1 }]);
+
+        const result = await newsletterService.confirm('abc123');
+
+        expect(result).toEqual({ confirmed: true, outcome: CONFIRM_OUTCOMES.CONFIRMED });
+        // No fallback lookup: the UPDATE answered the question.
+        expect(statementMatching('SELECT status')).toBeUndefined();
+    });
+
+    test('unsubscribing preserves an already-recorded spent digest', async () => {
+        // A confirmed row has NULL in confirm_token and its real spent digest
+        // in the other column. A bare assignment would overwrite that with
+        // NULL and lose the audit key this change exists to keep.
+        await newsletterService.unsubscribe('bye');
+
+        expect(String(statementMatching('UPDATE newsletter_subscribers')[0]))
+            .toMatch(/spent_confirm_token = COALESCE\(confirm_token, spent_confirm_token\)/);
+    });
+});
+
+describe('what the confirm endpoint says (#1612)', () => {
+    const confirmWith = async (outcome, extra = {}) => {
+        jest.spyOn(newsletterService, 'confirm').mockResolvedValueOnce({
+            outcome,
+            confirmed: Boolean(extra.confirmed),
+            ...extra
+        });
+        return post(newsletterController.confirm, { token: 't' });
+    };
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('an already-confirmed link is a 200, not an error', async () => {
+        const { statusCode, body } = await confirmWith('already_confirmed', { confirmed: true });
+
+        expect(statusCode).toBe(200);
+        expect(body.success).toBe(true);
+        expect(body.message).toMatch(/already subscribed/i);
+        expect(body.message).not.toMatch(/not valid|expired/i);
+    });
+
+    test('a first confirmation is still its own message', async () => {
+        const { statusCode, body } = await confirmWith('confirmed', { confirmed: true });
+
+        expect(statusCode).toBe(200);
+        expect(body.message).toMatch(/Thanks for signing up/i);
+    });
+
+    test('an unsubscribed address is a 409 pointing back at the form', async () => {
+        const { statusCode, body } = await confirmWith('already_unsubscribed');
+
+        expect(statusCode).toBe(409);
+        expect(body.success).toBe(false);
+        expect(body.message).toMatch(/sign up again/i);
+    });
+
+    test('an expired link is a 410 and no longer claims it may have been used', async () => {
+        const { statusCode, body } = await confirmWith('expired');
+
+        expect(statusCode).toBe(410);
+        // The old copy hedged -- "expired or has already been used" -- because
+        // the two were indistinguishable. They are not any more.
+        expect(body.message).toMatch(/expired/i);
+        expect(body.message).not.toMatch(/already been used/i);
+    });
+
+    test('an unknown token is still a 400', async () => {
+        const { statusCode, body } = await confirmWith('invalid_token');
+
+        expect(statusCode).toBe(400);
+        expect(body.message).toMatch(/not valid/i);
+    });
+});
+
 describe('mail delivery', () => {
     test('a send failure does not fail the sign-up', async () => {
         // The row is already recorded and the caller gets the same answer
@@ -465,5 +620,54 @@ describe('the migration', () => {
         // A subscription is to an address, not to an account. Closing an
         // account must not silently drop the address off the list.
         expect(sql).not.toMatch(/REFERENCES\s+users/i);
+    });
+});
+
+describe('the spent-token migration (#1612)', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const { columnsOf, hasColumn } = require('./helpers/migrationSchema');
+
+    const sql = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'migrations', '0048_newsletter_spent_confirm_token.sql'),
+        'utf8'
+    );
+
+    test('the column the service reads and writes actually exists', () => {
+        // The class of bug the migration reader was built for (#1581): a query
+        // names a column that is not there, every gate passes, and the endpoint
+        // 500s for everyone until somebody calls it.
+        expect(hasColumn('newsletter_subscribers', 'spent_confirm_token')).toBe(true);
+    });
+
+    test('the columns confirm() touches are all real', () => {
+        const columns = columnsOf('newsletter_subscribers');
+
+        [
+            'status',
+            'confirmed_at',
+            'confirm_token',
+            'confirm_token_expires_at',
+            'spent_confirm_token',
+            'unsubscribe_token',
+            'unsubscribed_at'
+        ].forEach((column) => expect(columns.has(column)).toBe(true));
+    });
+
+    test('amends the table rather than re-creating it', () => {
+        // A table has exactly one owning migration (migrations/README.md); a
+        // second CREATE TABLE IF NOT EXISTS is skipped silently and makes the
+        // schema depend on apply order.
+        expect(sql).toMatch(/ALTER TABLE newsletter_subscribers/);
+        expect(sql).not.toMatch(/CREATE TABLE/i);
+    });
+
+    test('indexes the new lookup, which is unauthenticated like the others', () => {
+        expect(sql).toMatch(/idx_newsletter_spent_confirm_token/);
+    });
+
+    test('is nullable, because existing rows have nothing to backfill from', () => {
+        expect(sql).toMatch(/spent_confirm_token CHAR\(64\) NULL/);
+        expect(sql).not.toMatch(/spent_confirm_token CHAR\(64\) NOT NULL/);
     });
 });

--- a/backend/tests/newsletterStatusPage.test.js
+++ b/backend/tests/newsletterStatusPage.test.js
@@ -1,0 +1,310 @@
+// backend/tests/newsletterStatusPage.test.js
+//
+// The page at the end of a newsletter link (#1612), driven for real in jsdom.
+//
+// `newsletterService.confirm()` and the controller decide what happened;
+// `frontend/scripts/newsletter-status.js` is where a subscriber actually finds
+// out. The symptom of #1612 was not a wrong return value, it was this page
+// telling somebody with a live subscription that their link was invalid -- so
+// the outcomes are asserted here too, at the layer where a person reads them.
+//
+// The page is loaded whole and given a stand-in `AppUtils.apiRequest` that
+// answers exactly what the controller answers for each outcome. Nothing is
+// mocked below that; the real script parses the query string, chooses the
+// action, makes the call and writes the DOM.
+//
+// One property worth stating plainly: `success` decides the tone, not the fact
+// that the await returned. `apiRequest` resolves with `{ success: false }` on a
+// non-2xx rather than rejecting, and a page that keyed off the promise settling
+// would report every one of these as a success.
+
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const STATUS_JS = path.join(REPO_ROOT, 'frontend', 'scripts', 'newsletter-status.js');
+const NEWSLETTER_HTML = path.join(REPO_ROOT, 'frontend', 'newsletter.html');
+
+const source = fs.readFileSync(STATUS_JS, 'utf8');
+
+// The two elements the script writes into, lifted from the real page so a
+// rename there fails this suite rather than silently skipping it.
+const pageMarkup = fs.readFileSync(NEWSLETTER_HTML, 'utf8');
+
+/**
+ * Exactly what `newsletterController.confirm` returns for each outcome.
+ *
+ * Copied as literals rather than imported, deliberately: this suite is about
+ * the contract between the two layers, and a shared constant would let both
+ * sides drift together without a test noticing.
+ */
+const CONTROLLER_RESPONSES = Object.freeze({
+    confirmed: {
+        status: 200,
+        body: { success: true, message: "You're subscribed. Thanks for signing up." }
+    },
+    already_confirmed: {
+        status: 200,
+        body: { success: true, message: "You're already subscribed — nothing more to do." }
+    },
+    already_unsubscribed: {
+        status: 409,
+        body: {
+            success: false,
+            message:
+                'This address has unsubscribed. Sign up again if you would '
+                + 'like to start receiving the newsletter.'
+        }
+    },
+    expired: {
+        status: 410,
+        body: {
+            success: false,
+            message: 'That confirmation link has expired. Sign up again to get a new one.'
+        }
+    },
+    invalid_token: {
+        status: 400,
+        body: { success: false, message: 'That confirmation link is not valid.' }
+    }
+});
+
+const settle = async () => {
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+};
+
+/**
+ * Load the status page with a given query string and a canned API answer.
+ *
+ * @param {object} options
+ * @param {string} options.search e.g. '?action=confirm&token=abc'
+ * @param {object|null} options.response what apiRequest resolves with
+ * @param {Error} [options.rejectWith] make apiRequest reject instead
+ */
+const mountStatusPage = async ({ search, response = null, rejectWith = null } = {}) => {
+    const dom = new JSDOM(
+        `<!doctype html><html><body>
+            <h1 id="newsletter-status-heading">Newsletter</h1>
+            <p id="newsletter-status-message"></p>
+        </body></html>`,
+        { url: `https://shop.example/newsletter.html${search}`, runScripts: 'outside-only' }
+    );
+
+    const { window } = dom;
+    const requests = [];
+
+    window.AppUtils = {
+        apiRequest: async (url, options) => {
+            requests.push({ url, options });
+            if (rejectWith) throw rejectWith;
+            return response;
+        }
+    };
+
+    window.eval(source);
+    await settle();
+
+    const message = window.document.getElementById('newsletter-status-message');
+    const heading = window.document.getElementById('newsletter-status-heading');
+
+    return {
+        window,
+        requests,
+        text: () => message.textContent,
+        tone: () => message.className,
+        heading: () => heading.textContent,
+        title: () => window.document.title
+    };
+};
+
+describe('the page the real markup provides', () => {
+    it('has the two elements the script writes into', () => {
+        expect(pageMarkup).toMatch(/id="newsletter-status-heading"/);
+        expect(pageMarkup).toMatch(/id="newsletter-status-message"/);
+    });
+
+    it('loads the script with defer, which the script is written for', () => {
+        // The script initialises against document.readyState rather than
+        // registering a bare DOMContentLoaded listener, which is what makes
+        // defer safe here.
+        expect(pageMarkup).toMatch(/<script defer src="scripts\/newsletter-status\.js">/);
+        expect(source).toMatch(/document\.readyState === "loading"/);
+    });
+});
+
+describe('confirming', () => {
+    it('reports a first confirmation as a success', async () => {
+        const page = await mountStatusPage({
+            search: '?action=confirm&token=abc',
+            response: CONTROLLER_RESPONSES.confirmed.body
+        });
+
+        expect(page.text()).toBe("You're subscribed. Thanks for signing up.");
+        expect(page.tone()).toBe('newsletter-status-success');
+    });
+
+    it('reports an already-confirmed link as a success, not an error', async () => {
+        // This is #1612 at the layer a person sees. Before the fix the service
+        // answered invalid_token here and this line read "That confirmation
+        // link is not valid" for a live subscription.
+        const page = await mountStatusPage({
+            search: '?action=confirm&token=abc',
+            response: CONTROLLER_RESPONSES.already_confirmed.body
+        });
+
+        expect(page.text()).toMatch(/already subscribed/i);
+        expect(page.tone()).toBe('newsletter-status-success');
+        expect(page.text()).not.toMatch(/not valid|expired|went wrong/i);
+    });
+
+    it('reports an unsubscribed address as an error pointing back at the form', async () => {
+        const page = await mountStatusPage({
+            search: '?action=confirm&token=abc',
+            response: CONTROLLER_RESPONSES.already_unsubscribed.body
+        });
+
+        expect(page.text()).toMatch(/sign up again/i);
+        expect(page.tone()).toBe('newsletter-status-error');
+    });
+
+    it('reports an expired link without claiming it may have been used', async () => {
+        const page = await mountStatusPage({
+            search: '?action=confirm&token=abc',
+            response: CONTROLLER_RESPONSES.expired.body
+        });
+
+        expect(page.text()).toMatch(/expired/i);
+        expect(page.text()).not.toMatch(/already been used/i);
+        expect(page.tone()).toBe('newsletter-status-error');
+    });
+
+    it('reports an unknown token as an error', async () => {
+        const page = await mountStatusPage({
+            search: '?action=confirm&token=abc',
+            response: CONTROLLER_RESPONSES.invalid_token.body
+        });
+
+        expect(page.text()).toBe('That confirmation link is not valid.');
+        expect(page.tone()).toBe('newsletter-status-error');
+    });
+});
+
+describe('the request it makes', () => {
+    it('POSTs the token rather than following the link as a GET', async () => {
+        // A GET is followed by mail clients and security scanners that prefetch
+        // links, which would confirm subscriptions nobody clicked -- the whole
+        // point of the confirmation step.
+        const page = await mountStatusPage({
+            search: '?action=confirm&token=abc',
+            response: CONTROLLER_RESPONSES.confirmed.body
+        });
+
+        expect(page.requests).toHaveLength(1);
+        expect(page.requests[0].url).toBe('/newsletter/confirm');
+        expect(page.requests[0].options.method).toBe('POST');
+        expect(JSON.parse(page.requests[0].options.body)).toEqual({ token: 'abc' });
+    });
+
+    it('routes an unsubscribe link to the unsubscribe endpoint', async () => {
+        const page = await mountStatusPage({
+            search: '?action=unsubscribe&token=xyz',
+            response: { success: true, message: 'You have been unsubscribed.' }
+        });
+
+        expect(page.requests[0].url).toBe('/newsletter/unsubscribe');
+        expect(page.heading()).toBe('Unsubscribe');
+        expect(page.tone()).toBe('newsletter-status-success');
+    });
+
+    it('treats any other action as a confirm', async () => {
+        const page = await mountStatusPage({
+            search: '?action=something-else&token=abc',
+            response: CONTROLLER_RESPONSES.confirmed.body
+        });
+
+        expect(page.requests[0].url).toBe('/newsletter/confirm');
+        expect(page.heading()).toBe('Confirm your subscription');
+    });
+
+    it('does not call the API at all without a token', async () => {
+        const page = await mountStatusPage({ search: '?action=confirm', response: null });
+
+        expect(page.requests).toHaveLength(0);
+        expect(page.text()).toMatch(/incomplete/i);
+        expect(page.tone()).toBe('newsletter-status-error');
+    });
+
+    it('trims a token that arrived with whitespace around it', async () => {
+        const page = await mountStatusPage({
+            search: '?action=confirm&token=%20abc%20',
+            response: CONTROLLER_RESPONSES.confirmed.body
+        });
+
+        expect(JSON.parse(page.requests[0].options.body)).toEqual({ token: 'abc' });
+    });
+});
+
+describe('when the call itself fails', () => {
+    it('says so rather than leaving the page blank', async () => {
+        const page = await mountStatusPage({
+            search: '?action=confirm&token=abc',
+            rejectWith: new Error('network down')
+        });
+
+        expect(page.text()).toMatch(/went wrong/i);
+        expect(page.tone()).toBe('newsletter-status-error');
+    });
+
+    it('falls back to its own copy when the server sends none', async () => {
+        const page = await mountStatusPage({
+            search: '?action=confirm&token=abc',
+            response: { success: false }
+        });
+
+        expect(page.text()).toMatch(/not one we recognise/i);
+        expect(page.tone()).toBe('newsletter-status-error');
+    });
+
+    it('keys the tone off success, not off the promise settling', async () => {
+        // apiRequest resolves with { success: false } on a non-2xx rather than
+        // rejecting, so a page that keyed off the await returning would report
+        // every failure above as a success.
+        const page = await mountStatusPage({
+            search: '?action=confirm&token=abc',
+            response: { success: false, message: 'nope' }
+        });
+
+        expect(page.tone()).toBe('newsletter-status-error');
+    });
+});
+
+describe('the page identifies itself', () => {
+    it('titles itself for the action it is performing', async () => {
+        const confirmPage = await mountStatusPage({
+            search: '?action=confirm&token=abc',
+            response: CONTROLLER_RESPONSES.confirmed.body
+        });
+        expect(confirmPage.title()).toMatch(/^Confirm your subscription \|/);
+
+        const unsubscribePage = await mountStatusPage({
+            search: '?action=unsubscribe&token=abc',
+            response: { success: true, message: 'Done.' }
+        });
+        expect(unsubscribePage.title()).toMatch(/^Unsubscribe \|/);
+    });
+
+    it('writes the message as text, never as markup', async () => {
+        // The message comes from the API, and a status line is not somewhere
+        // anyone should have to reason about markup.
+        const page = await mountStatusPage({
+            search: '?action=confirm&token=abc',
+            response: { success: true, message: '<img src=x onerror=alert(1)>' }
+        });
+
+        const node = page.window.document.getElementById('newsletter-status-message');
+        expect(node.querySelector('img')).toBeNull();
+        expect(node.textContent).toBe('<img src=x onerror=alert(1)>');
+    });
+});

--- a/migrations/0048_newsletter_spent_confirm_token.sql
+++ b/migrations/0048_newsletter_spent_confirm_token.sql
@@ -1,0 +1,60 @@
+-- ============================================
+-- A SPENT CONFIRMATION TOKEN IS STILL A KEY
+-- ============================================
+--
+-- `newsletterService.confirm()` is written to tell a subscriber who follows the
+-- link twice that they are already confirmed, rather than that their link is
+-- broken. Its own comment says so:
+--
+--     Already-confirmed is not a failure from the subscriber's point of view --
+--     clicking the link twice should not look broken.
+--
+-- The successful branch then destroys the value the second branch looks up
+-- (#1612):
+--
+--     SET status = 'confirmed', confirm_token = NULL, ...
+--      WHERE confirm_token = ? AND status = 'pending' ...
+--
+--     -- and, when that matched nothing:
+--     SELECT status FROM newsletter_subscribers WHERE confirm_token = ?
+--
+-- After a successful confirmation no row carries that digest any more, so the
+-- second click falls through to `invalid_token`. The already-confirmed arm is
+-- unreachable: dead code guarding the exact case it was written for.
+--
+-- This is not a wording nit. Double-clicking a link in a mail client is
+-- ordinary, and several mail security scanners follow links in a message before
+-- the recipient ever sees it -- so the scanner spends the token and the human
+-- is told their confirmation link is invalid for a subscription that is, in
+-- fact, live. The natural response is to submit the form again, which (
+-- correctly, by design) mails nothing to an already-confirmed address, so the
+-- page stays broken from their point of view forever.
+--
+-- WHY NOT SIMPLY KEEP `confirm_token`
+--
+-- Because a consumed confirm token is a bearer credential for putting an
+-- address on a mailing list. Leaving it live in the column that the confirm
+-- UPDATE matches on means the only thing standing between a leaked link and a
+-- re-confirmation is the `status = 'pending'` guard -- one clause, in one query,
+-- forever. Moving the digest to a column that no write path ever matches on
+-- makes it an audit key and nothing else: findable, not usable.
+--
+-- The same move happens on unsubscribe, which also clears `confirm_token`. A
+-- confirmation link followed after unsubscribing can then be answered
+-- truthfully instead of as an invalid link.
+--
+-- Nullable with no default: existing rows have no recorded spent token and
+-- there is nothing to reconstruct one from. They keep answering `invalid_token`
+-- for a second click, which is what they do today; every row confirmed from
+-- here on answers correctly.
+
+ALTER TABLE newsletter_subscribers
+    ADD COLUMN spent_confirm_token CHAR(64) NULL
+        COMMENT 'SHA-256 of a confirm token that has been consumed. Audit key only; no write path matches on it.'
+        AFTER confirm_token_expires_at;
+
+-- Both token lookups on this table are single-row fetches by an exact hash and
+-- both are reachable unauthenticated, so neither may become a scan. Same
+-- reasoning as idx_newsletter_confirm_token in 0044.
+CREATE INDEX idx_newsletter_spent_confirm_token
+    ON newsletter_subscribers (spent_confirm_token);


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

Clicking the newsletter confirmation link a second time reported the link as invalid, for a subscription that was confirmed and live.

`confirm()` is written to distinguish exactly this case, and says so in its own comment:

> Already-confirmed is not a failure from the subscriber's point of view — clicking the link twice should not look broken. Distinguished here so the controller can say something sensible.

The successful branch then destroys the value the second branch looks up:

```js
SET status = 'confirmed', confirm_token = NULL, ...      -- the digest is erased
 WHERE confirm_token = ? AND status = 'pending' ...

-- and, when that matched nothing:
SELECT status FROM newsletter_subscribers WHERE confirm_token = ?   -- never matches
```

After a successful confirmation no row carries that digest, so the second click falls through to `invalid_token`. The already-confirmed arm was **unreachable — dead code guarding the exact case it was written for.**

**Why this is not a wording nit.** Double-clicking a link in a mail client is ordinary, and several mail security scanners follow links in a message before the recipient ever sees it. In both cases the token is spent by something other than the human, who then gets *"That confirmation link is not valid"* for a subscription that is live. The natural response is to submit the form again — which, correctly and by design, mails nothing to an already-confirmed address. So the page stays broken from their point of view forever.

**The fix.** Migration `0048` adds `spent_confirm_token`, and the successful UPDATE *moves* the digest there rather than dropping it. Deliberately a different column rather than simply keeping `confirm_token`: a consumed confirm token is a bearer credential for putting an address on a mailing list, and **no write path matches on the new column**, so the digest becomes an audit key and stops being usable. The fallback lookup searches both.

`confirm()` now returns a named outcome and the controller answers each one:

| outcome | status | why |
|---|---|---|
| `already_confirmed` | **200**, `confirmed: true` | the subscriber asked to be on the list and is on the list |
| `already_unsubscribed` | **409** pointing back at the form | silently re-adding an address on the strength of an old link in an inbox would undo an explicit request not to be mailed |
| `expired` | **410** | and the copy no longer has to hedge with *"or has already been used"*, now the two are distinguishable |
| `invalid_token` | **400** | unchanged |

`unsubscribe()` records a live confirm token as spent on its way out — `COALESCE(confirm_token, spent_confirm_token)`, so a row that was already confirmed does not have its recorded digest overwritten with `NULL`.

---

## 🔗 Related Issue

Closes #1612

---

## 🛠️ Type of Change

- [x] Bug fix
- [ ] New feature
- [x] UI/UX improvement
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Security fix
- [x] Testing improvement
- [ ] Other (please specify)

---

## 📷 Screenshots / Demo

Following the same link twice:

```
                     before                       after
first click   200 "You're subscribed."      200 "You're subscribed."
second click  400 "That confirmation        200 "You're already subscribed
                  link is not valid."           — nothing more to do."
```

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Migration.** `0048_newsletter_spent_confirm_token.sql` — `ALTER TABLE` plus an index, no `CREATE TABLE` (a table has exactly one owning migration). Please check `0048` is still the next free number before merging, per `migrations/README.md`.

**Existing rows.** The column is nullable with no default and there is nothing to backfill it from, so rows confirmed before this migration keep answering `invalid_token` on a second click — exactly what they do today. Every row confirmed from here on answers correctly. No data migration, no backfill job.

**On the tests.** 35 cases added in total.

18 across the service, the controller and the migration, including one that asserts the fallback lookup searches *both* columns — the specific line whose absence made the branch unreachable. The migration cases use the existing `tests/helpers/migrationSchema.js` reader to confirm every column `confirm()` touches actually exists in the sequence, which is the guard built for the `#1538`/`#1539`/`#1581` family of column-name bugs.

17 more in `tests/newsletterStatusPage.test.js`, which is new. The symptom of this issue was never a wrong return value — it was `newsletter.html` telling somebody with a live subscription that their link was invalid — so the outcomes are asserted at the layer where a person reads them too. That page had no coverage at all. It also pins one property that is easy to lose: `apiRequest` resolves with `{ success: false }` on a non-2xx rather than rejecting, so the tone has to key off the flag and not off the await returning.

**No frontend change was needed.** `newsletter-status.js` already renders whatever the controller returns, so the 200 for `already_confirmed` shows in the success tone and the 409 in the error tone without touching it. The tests confirm that rather than assuming it.

Full suite: 110 suites, 2392 tests, green.