### PR TITLE
fix: Coupon End Date Can Be Earlier Than Start Date

### DIFF
--- a/backend/tests/couponValidator.test.js
+++ b/backend/tests/couponValidator.test.js
@@ -1,0 +1,97 @@
+const { couponValidator, BaseValidator } = require('../validators');
+
+describe('CouponValidator Date Range Validation', () => {
+    const futureDate1 = new Date(Date.now() + 86400000).toISOString(); // 1 day in future
+    const futureDate2 = new Date(Date.now() + 172800000).toISOString(); // 2 days in future
+    const pastDate1 = new Date(Date.now() - 86400000).toISOString(); // 1 day in past
+
+    describe('validateCreate', () => {
+        test('passes validation when endDate is after startDate', () => {
+            const validData = {
+                code: 'SUMMER2026',
+                discountType: 'percentage',
+                discountValue: 20,
+                startDate: futureDate1,
+                endDate: futureDate2
+            };
+
+            const result = couponValidator.validateCreate(validData);
+            expect(result.isValid()).toBe(true);
+            expect(result.getErrors()).toHaveLength(0);
+        });
+
+        test('fails validation when endDate is before startDate', () => {
+            const invalidData = {
+                code: 'SUMMER2026',
+                discountType: 'percentage',
+                discountValue: 20,
+                startDate: futureDate2,
+                endDate: futureDate1
+            };
+
+            const result = couponValidator.validateCreate(invalidData);
+            expect(result.isValid()).toBe(false);
+            const errors = result.getErrors();
+            expect(errors.some(e => e.field === 'endDate' && e.message.includes('must be after startDate'))).toBe(true);
+        });
+
+        test('fails validation when endDate equals startDate', () => {
+            const invalidData = {
+                code: 'SUMMER2026',
+                discountType: 'percentage',
+                discountValue: 20,
+                startDate: futureDate1,
+                endDate: futureDate1
+            };
+
+            const result = couponValidator.validateCreate(invalidData);
+            expect(result.isValid()).toBe(false);
+            const errors = result.getErrors();
+            expect(errors.some(e => e.field === 'endDate' && e.message.includes('must be after startDate'))).toBe(true);
+        });
+    });
+
+    describe('validateUpdate', () => {
+        test('passes validation when updated endDate is after startDate', () => {
+            const validData = {
+                startDate: futureDate1,
+                endDate: futureDate2
+            };
+
+            const result = couponValidator.validateUpdate(validData);
+            expect(result.isValid()).toBe(true);
+        });
+
+        test('fails validation when updated endDate is before startDate', () => {
+            const invalidData = {
+                startDate: futureDate2,
+                endDate: futureDate1
+            };
+
+            const result = couponValidator.validateUpdate(invalidData);
+            expect(result.isValid()).toBe(false);
+            const errors = result.getErrors();
+            expect(errors.some(e => e.field === 'endDate' && e.message.includes('must be after startDate'))).toBe(true);
+        });
+    });
+
+    describe('BaseValidator dateAfter method', () => {
+        test('returns true when value date is after target value date', () => {
+            const validator = new BaseValidator();
+            const valid = validator.dateAfter(futureDate2, 'endDate', futureDate1, 'startDate');
+            expect(valid).toBe(true);
+            expect(validator.isValid()).toBe(true);
+        });
+
+        test('returns false and adds error when value date is before target value date', () => {
+            const validator = new BaseValidator();
+            const valid = validator.dateAfter(futureDate1, 'endDate', futureDate2, 'startDate');
+            expect(valid).toBe(false);
+            expect(validator.isValid()).toBe(false);
+            expect(validator.getErrors()[0]).toEqual(expect.objectContaining({
+                field: 'endDate',
+                message: 'endDate must be after startDate'
+            }));
+        });
+    });
+});

--- a/backend/validators/baseValidator.js
+++ b/backend/validators/baseValidator.js
@@ -212,6 +212,19 @@ class BaseValidator {
     }
 
     /**
+     * Validate that date value is after target date value
+     */
+    dateAfter(value, field, targetValue, targetField = 'target date', message = null) {
+        if (value && targetValue && !isNaN(Date.parse(value)) && !isNaN(Date.parse(targetValue))) {
+            if (new Date(value) <= new Date(targetValue)) {
+                this.addError(field, message || `${field} must be after ${targetField}`);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Validate positive number
      */
     positive(value, field, message = null) {

--- a/backend/validators/couponValidator.js
+++ b/backend/validators/couponValidator.js
@@ -40,6 +40,10 @@ class CouponValidator extends BaseValidator {
             this.futureDate(data.endDate, 'endDate');
         }
 
+        if (data.startDate && data.endDate) {
+            this.dateAfter(data.endDate, 'endDate', data.startDate, 'startDate');
+        }
+
         if (data.usageLimit) {
             this.positive(data.usageLimit, 'usageLimit');
             this.integer(data.usageLimit, 'usageLimit');
@@ -84,6 +88,19 @@ class CouponValidator extends BaseValidator {
 
         if (data.discountValue !== undefined) {
             this.positive(data.discountValue, 'discountValue');
+        }
+
+        if (data.startDate !== undefined) {
+            this.date(data.startDate, 'startDate');
+        }
+
+        if (data.endDate !== undefined) {
+            this.date(data.endDate, 'endDate');
+            this.futureDate(data.endDate, 'endDate');
+        }
+
+        if (data.startDate && data.endDate) {
+            this.dateAfter(data.endDate, 'endDate', data.startDate, 'startDate');
         }
 
         return this;


### PR DESCRIPTION
I have resolved the issue where a coupon could be created or updated with an endDate earlier than or equal to its startDate.

Summary of Changes


baseValidator.js:

Added dateAfter(value, field, targetValue, targetField, message) method to BaseValidator to ensure date comparison checks pass (i.e. value must be strictly after targetValue).


couponValidator.js:

Added this.dateAfter(data.endDate, 'endDate', data.startDate, 'startDate') validation in both validateCreate and validateUpdate.


couponValidator.test.js:

Created unit tests verifying date range validity for coupon creation/update and checking BaseValidator date utility logic.
Verification
Ran Jest test suite:

npx jest tests/couponValidator.test.js passed with 7/7 tests passing.


closes #1223