### PR TITLE
fix: Unsupported Billing Interval Can Create a Subscription With an incorrect end date

### DIFF
--- a/backend/services/subscriptionService.js
+++ b/backend/services/subscriptionService.js
@@ -107,7 +107,7 @@ function advancePeriod(from, interval, count = 1) {
         default:
             throw new SubscriptionError(
                 `Unsupported billing interval: ${interval}`,
-                500,
+                400,
                 'UNSUPPORTED_INTERVAL'
             );
     }
@@ -247,6 +247,15 @@ async function subscribe(userId, planId) {
         }
 
         const billingPlan = plans[0];
+
+        const ALLOWED_INTERVALS = ['daily', 'weekly', 'monthly', 'yearly'];
+        if (!ALLOWED_INTERVALS.includes(billingPlan.interval)) {
+            throw new SubscriptionError(
+                `Unsupported billing interval: ${billingPlan.interval}`,
+                400,
+                'UNSUPPORTED_INTERVAL'
+            );
+        }
 
         // FOR UPDATE so a second concurrent subscribe waits here rather than
         // reading the same empty result and inserting alongside this one.

--- a/backend/tests/subscriptionRenewal.test.js
+++ b/backend/tests/subscriptionRenewal.test.js
@@ -264,6 +264,15 @@ describe('subscribe', () => {
         expect(days).toBe(14);
     });
 
+    test('refuses a plan with an unsupported billing interval', async () => {
+        mockConnectionQuery.mockResolvedValueOnce([[{ ...PLAN, interval: 'fortnightly' }]]);
+
+        await expect(subscriptionService.subscribe(USER, 2)).rejects.toMatchObject({
+            status: 400,
+            code: 'UNSUPPORTED_INTERVAL'
+        });
+    });
+
     test('rejects an unusable plan id before touching the database', async () => {
         await expect(subscriptionService.subscribe(USER, 'abc')).rejects.toMatchObject({
             code: 'INVALID_PLAN'


### PR DESCRIPTION
I have resolved the issue where a billing plan with an unsupported interval could be used to create a subscription with an invalid period end date.

Summary of Changes


subscriptionService.js:

Added validation in subscribe() to check whether billingPlan.interval is one of the supported intervals ('daily', 'weekly', 'monthly', 'yearly').
Throws a SubscriptionError with HTTP status 400 and code 'UNSUPPORTED_INTERVAL' if an unsupported billing interval is encountered.
Updated advancePeriod() to return status 400 for unsupported billing interval errors.


subscriptionRenewal.test.js:

Added unit test asserting that subscribing to a plan with an unsupported interval (e.g. 'fortnightly') is rejected with a 400 status code and 'UNSUPPORTED_INTERVAL' error code.
Verification
Ran Jest test suite:

npx jest tests/subscriptionRenewal.test.js tests/subscriptionRoutes.test.js passed with 33/33 tests passing.


closes #1226