### PR TITLE
fix: Compare feature only works from the homepage

### DIFF
--- a/backend/tests/shopPageInit.test.js
+++ b/backend/tests/shopPageInit.test.js
@@ -370,7 +370,7 @@ describe('shop.js has one of each', () => {
             'clearTimeout', 'console', 'document', 'window', 'globalThis', 'fetch',
             'localStorage', 'Event', 'CustomEvent',
             // utils.js, loaded before this script on every page that uses it
-            'escapeHTML',
+            'escapeHTML', 'addToCompare',
             // Guarded with `typeof x === "function"` at each call site
             'addToCartFromProduct', 'updateCartCount', 'renderCartDrawer',
         ]);

--- a/frontend/product.html
+++ b/frontend/product.html
@@ -528,6 +528,19 @@
                     Wishlist
 
                 </button>
+
+                <button
+                    id="compare-btn"
+                    type="button"
+                    aria-label="Add this product to comparison"
+                    title="Compare product"
+                >
+
+                    <i class="fas fa-balance-scale"></i>
+
+                    Compare
+
+                </button>
                                 <!-- Share Buttons (WhatsApp + Copy Link) -->
 
                 <button

--- a/frontend/scripts/mens.js
+++ b/frontend/scripts/mens.js
@@ -157,9 +157,14 @@
                 </div>
                 <h4>₹${Number(product.price).toFixed(2)}</h4>
             </div>
-            <button class="add-to-cart-btn" data-id="${product.id}">
-                <i class="fal fa-shopping-cart cart"></i>
-            </button>
+            <div class="card-action-btns" style="display: flex; gap: 6px; position: absolute; bottom: 20px; right: 10px; z-index: 2;">
+                <button class="compare-btn-card" data-id="${product.id}" title="Compare Product" style="background: #e8f6ea; color: #088178; border: none; width: 40px; height: 40px; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer;">
+                    <i class="fas fa-balance-scale"></i>
+                </button>
+                <button class="add-to-cart-btn" data-id="${product.id}">
+                    <i class="fal fa-shopping-cart cart"></i>
+                </button>
+            </div>
         `;
         
         // Cart click setup helper
@@ -172,6 +177,19 @@
                 } else {
                     console.log(`Added product ${product.id} to cart (Simulated)`);
                     if (typeof showToast === 'function') showToast("Added to cart!");
+                }
+            });
+        }
+
+        // Compare click setup helper
+        const compareBtn = div.querySelector('.compare-btn-card');
+        if (compareBtn) {
+            compareBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                if (typeof AppUtils !== "undefined" && typeof AppUtils.addToCompare === "function") {
+                    AppUtils.addToCompare(product.id);
+                } else if (typeof addToCompare === "function") {
+                    addToCompare(product.id);
                 }
             });
         }

--- a/frontend/scripts/product-actions-home.js
+++ b/frontend/scripts/product-actions-home.js
@@ -320,42 +320,15 @@ document.addEventListener(
     event.target.closest(".compare-btn");
 
 if (compareBtn) {
-
     event.preventDefault();
-
     const id = compareBtn.dataset.id;
-
-    let compareProducts =
-    AppUtils.getJSON(
-        "compareProducts",
-        []
-    );
-    if (compareProducts.includes(id)) {
-    AppUtils.notify(
-        "Product already selected",
-        "info"
-    );
-    return;
-}
-    if (compareProducts.length >= 3) {
-    AppUtils.notify(
-        "You can compare up to 3 products only",
-        "warning"
-    );
-    return;
-}
-
-    compareProducts.push(id);
-
-    AppUtils.setJSON(
-    "compareProducts",
-    compareProducts
-);
-
-   AppUtils.notify(
-    "Added for comparison",
-    "success"
-);
+    if (id) {
+        if (typeof AppUtils !== "undefined" && typeof AppUtils.addToCompare === "function") {
+            AppUtils.addToCompare(id);
+        } else if (typeof addToCompare === "function") {
+            addToCompare(id);
+        }
+    }
 }
     }
 );

--- a/frontend/scripts/product-actions.js
+++ b/frontend/scripts/product-actions.js
@@ -470,6 +470,11 @@ document.addEventListener(
                 "wishlist-btn"
             );
 
+        const compareBtn =
+            document.getElementById(
+                "compare-btn"
+            );
+
         const whatsappShareBtn =
             document.getElementById(
                 "whatsapp-share-btn"
@@ -524,9 +529,7 @@ document.addEventListener(
             );
         }
 
-        if (
-            wishlistBtn
-        ) {
+        if (wishlistBtn) {
 
             wishlistBtn.addEventListener(
                 "click",
@@ -537,6 +540,24 @@ document.addEventListener(
                     event.preventDefault();
 
                     toggleProductWishlist();
+                }
+            );
+        }
+
+        if (compareBtn) {
+            compareBtn.addEventListener(
+                "click",
+                (event) => {
+                    event.preventDefault();
+                    if (currentProduct && currentProduct.id) {
+                        AppUtils.addToCompare(currentProduct.id);
+                    } else {
+                        const params = new URLSearchParams(window.location.search);
+                        const id = params.get("id");
+                        if (id) {
+                            AppUtils.addToCompare(id);
+                        }
+                    }
                 }
             );
         }

--- a/frontend/scripts/product-render.js
+++ b/frontend/scripts/product-render.js
@@ -194,6 +194,20 @@ function createProductCardHTML(
             >
                 Add Cart
             </button>
+
+            <button
+                type="button"
+
+                class="compare-btn"
+
+                data-id="${
+                    encodeURIComponent(
+                        product.id
+                    )
+                }"
+            >
+                Compare
+            </button>
         </div>
     `;
 }
@@ -229,6 +243,18 @@ function renderProductCard(
         createProductCardHTML(
             product
         );
+
+    const compareBtn = card.querySelector(".compare-btn");
+    if (compareBtn) {
+        compareBtn.addEventListener("click", (e) => {
+            e.stopPropagation();
+            if (typeof AppUtils !== "undefined" && typeof AppUtils.addToCompare === "function") {
+                AppUtils.addToCompare(product.id);
+            } else if (typeof addToCompare === "function") {
+                addToCompare(product.id);
+            }
+        });
+    }
 
     container.appendChild(
         card

--- a/frontend/scripts/shop.js
+++ b/frontend/scripts/shop.js
@@ -431,6 +431,9 @@ function createProductCard(
     // Action Buttons (disabled if out of stock)
     const actionButtons = isOutOfStock ? '' : `
         <div style="position: absolute; bottom: 20px; right: 12px; display: flex; gap: 8px; z-index: 2;">
+            <button class="compare-btn-shop cart" data-id="${product.id}" aria-label="Add to Compare" title="Compare product" style="position: relative; bottom: 0; right: 0;">
+                <i class="fas fa-balance-scale"></i>
+            </button>
             <button class="wishlist-btn-shop cart" data-id="${product.id}" aria-label="Add to Wishlist" style="position: relative; bottom: 0; right: 0;">
                 <i class="${ AppUtils.getWishlist().some(item => String(item.id) === String(product.id)) ? 'fas' : 'far' } fa-heart"></i>
             </button>
@@ -668,6 +671,20 @@ function setupProductCard(
                 await globalThis.toggleWishlist(product);
             } else {
                 await syncWishlistFallback(product);
+            }
+        });
+    }
+
+    // add to compare
+    const compareBtn = card.querySelector(".compare-btn-shop, .compare-btn");
+    if (compareBtn) {
+        compareBtn.addEventListener("click", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            if (typeof AppUtils !== "undefined" && typeof AppUtils.addToCompare === "function") {
+                AppUtils.addToCompare(product.id);
+            } else if (typeof addToCompare === "function") {
+                addToCompare(product.id);
             }
         });
     }

--- a/frontend/scripts/tshirt.js
+++ b/frontend/scripts/tshirt.js
@@ -167,9 +167,14 @@
                 </div>
                 <h4>₹${Number(product.price).toFixed(2)}</h4>
             </div>
-            <button class="add-to-cart-btn" data-id="${product.id}">
-                <i class="fal fa-shopping-cart cart"></i>
-            </button>
+            <div class="card-action-btns" style="display: flex; gap: 6px; position: absolute; bottom: 20px; right: 10px; z-index: 2;">
+                <button class="compare-btn-card" data-id="${product.id}" title="Compare Product" style="background: #e8f6ea; color: #088178; border: none; width: 40px; height: 40px; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer;">
+                    <i class="fas fa-balance-scale"></i>
+                </button>
+                <button class="add-to-cart-btn" data-id="${product.id}">
+                    <i class="fal fa-shopping-cart cart"></i>
+                </button>
+            </div>
         `;
         
         // Cart click setup helper
@@ -182,6 +187,19 @@
                 } else {
                     console.log(`Added product ${product.id} to cart (Simulated)`);
                     if (typeof showToast === 'function') showToast("Added to cart!");
+                }
+            });
+        }
+
+        // Compare click setup helper
+        const compareBtn = div.querySelector('.compare-btn-card');
+        if (compareBtn) {
+            compareBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                if (typeof AppUtils !== "undefined" && typeof AppUtils.addToCompare === "function") {
+                    AppUtils.addToCompare(product.id);
+                } else if (typeof addToCompare === "function") {
+                    addToCompare(product.id);
                 }
             });
         }

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -2180,6 +2180,36 @@ const renderSkeletonState = (container, count = 4) => {
     container.innerHTML = getSkeletonCardHTML(count);
 };
 
+const addToCompare = (productId) => {
+    const id = String(productId ?? "").trim();
+    if (!id) return false;
+
+    const STORAGE_KEYS = ["compareProducts", "comparisonList"];
+    let currentCompare = getJSON("compareProducts", []);
+    if (!Array.isArray(currentCompare) || !currentCompare.length) {
+        currentCompare = getJSON("comparisonList", []);
+    }
+    if (!Array.isArray(currentCompare)) currentCompare = [];
+
+    const stringIds = currentCompare.map((item) => String(item ?? "").trim()).filter(Boolean);
+
+    if (stringIds.includes(id)) {
+        notify("Product already selected", "info");
+        return false;
+    }
+
+    if (stringIds.length >= 3) {
+        notify("You can compare up to 3 products only", "warning");
+        return false;
+    }
+
+    stringIds.push(id);
+    STORAGE_KEYS.forEach((key) => setJSON(key, stringIds));
+
+    notify("Added for comparison", "success");
+    return true;
+};
+
 // app utils assignment
 window.AppUtils = {
     CONFIG,
@@ -2234,6 +2264,7 @@ window.AppUtils = {
     formatFreeShippingProgress,
     getWishlist,
     saveWishlist,
+    addToCompare,
     getSkeletonCardHTML,
     renderSkeletonState,
     FALLBACK_PRODUCT_IMAGE,
@@ -2257,6 +2288,7 @@ window.FALLBACK_PRODUCT_IMAGE = FALLBACK_PRODUCT_IMAGE;
 window.handleImageError = handleImageError;
 window.safeForEach = safeForEach;
 window.safeMap = safeMap;
+window.addToCompare = addToCompare;
 
 // Side-by-side tabs converge instead of competing: whichever envelope carries
 // the later timestamp is the one that stands, and everything listening on

--- a/frontend/scripts/womens.js
+++ b/frontend/scripts/womens.js
@@ -157,9 +157,14 @@
                 </div>
                 <h4>₹${Number(product.price).toFixed(2)}</h4>
             </div>
-            <button class="add-to-cart-btn" data-id="${product.id}">
-                <i class="fal fa-shopping-cart cart"></i>
-            </button>
+            <div class="card-action-btns" style="display: flex; gap: 6px; position: absolute; bottom: 20px; right: 10px; z-index: 2;">
+                <button class="compare-btn-card" data-id="${product.id}" title="Compare Product" style="background: #e8f6ea; color: #088178; border: none; width: 40px; height: 40px; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer;">
+                    <i class="fas fa-balance-scale"></i>
+                </button>
+                <button class="add-to-cart-btn" data-id="${product.id}">
+                    <i class="fal fa-shopping-cart cart"></i>
+                </button>
+            </div>
         `;
         
         // Cart click setup helper
@@ -172,6 +177,19 @@
                 } else {
                     console.log(`Added product ${product.id} to cart (Simulated)`);
                     if (typeof showToast === 'function') showToast("Added to cart!");
+                }
+            });
+        }
+
+        // Compare click setup helper
+        const compareBtn = div.querySelector('.compare-btn-card');
+        if (compareBtn) {
+            compareBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                if (typeof AppUtils !== "undefined" && typeof AppUtils.addToCompare === "function") {
+                    AppUtils.addToCompare(product.id);
+                } else if (typeof addToCompare === "function") {
+                    addToCompare(product.id);
                 }
             });
         }

--- a/frontend/styles/product.css
+++ b/frontend/styles/product.css
@@ -146,7 +146,8 @@
 
 #add-to-cart-btn,
 #buy-now-btn,
-#wishlist-btn {
+#wishlist-btn,
+#compare-btn {
   background: #088178;
   color: #fff;
   border: none;
@@ -159,7 +160,8 @@
 
 #add-to-cart-btn:hover,
 #buy-now-btn:hover,
-#wishlist-btn:hover {
+#wishlist-btn:hover,
+#compare-btn:hover {
   transform: translateY(-2px);
   opacity: 0.9;
 }
@@ -170,6 +172,10 @@
 
 #buy-now-btn {
   background: #ff6b00;
+}
+
+#compare-btn {
+  background: #2563eb;
 }
 
 .single-product-details span {


### PR DESCRIPTION
I have completed the task to enable the Add to Compare feature across all pages in the application.

Summary of Accomplishments
Extracted Shared Comparison Utility:

Added AppUtils.addToCompare(productId) in utils.js
.
Handles storage syncing across compareProducts and comparisonList localStorage keys.
Enforces duplicate detection and a maximum limit of 3 products for comparison with toast notifications.
Refactored Homepage:

Updated product-actions-home.js to delegate compare card clicks to AppUtils.addToCompare.
Wired Product Detail Page:

Added Compare button (#compare-btn) to product.html
.
Added event listener in product-actions.js to compare the active product.
Added matching action button styling in product.css
.
Wired Shop & Category Pages:

Added Compare action buttons and click handlers across shop.js,mens.js,womens.js,tshirt.js, and product-render.js
.


closes #1484