### PR TITLE
fix: Order Success page text becomes invisible

### DIFF
--- a/frontend/styles/success.css
+++ b/frontend/styles/success.css
@@ -94,3 +94,39 @@
     }
 
 }
+
+/* ===== DARK THEME OVERRIDES ===== */
+body.dark-theme #success-page {
+    background: #121212;
+}
+
+body.dark-theme .success-box {
+    background: #1e1e1e;
+    color: #ffffff;
+    box-shadow: 0 5px 25px rgba(0, 0, 0, 0.4);
+}
+
+body.dark-theme .success-box h2 {
+    color: #ffffff;
+}
+
+body.dark-theme .success-box p {
+    color: #cccccc;
+}
+
+body.dark-theme .order-info {
+    background: #2a2a2a;
+    color: #ffffff;
+}
+
+body.dark-theme .order-info p {
+    color: #e0e0e0;
+}
+
+body.dark-theme .order-info p strong {
+    color: #ffffff;
+}
+
+body.dark-theme #order-items-container {
+    color: #e0e0e0;
+}


### PR DESCRIPTION
The Order Success page dark mode styling bug has been fixed.

Changes Made


success.css
: Added body.dark-theme CSS overrides so that when dark mode is enabled:
#success-page background switches to #121212.
.success-box background switches to #1e1e1e with text color #ffffff (and headings/labels styled in high-contrast white #ffffff / #cccccc).
.order-info box background switches to #2a2a2a with text #e0e0e0 / #ffffff.
#order-items-container text matches dark theme contrast.


closes #1515