### PR TITLE
fix(utils): write the reorderOrder the exports promised (#1651)

### DIFF
--- a/backend/tests/appUtilsExports.test.js
+++ b/backend/tests/appUtilsExports.test.js
@@ -1,0 +1,190 @@
+// Every name `utils.js` exports must be a name `utils.js` declares.
+//
+// `window.AppUtils = { ... }` is one top-level object literal. An undeclared
+// identifier inside it throws `ReferenceError` while the literal is being
+// evaluated, which means the assignment never happens: `window.AppUtils` stays
+// undefined, and every statement after it — the whole backward-compatibility
+// block that publishes `notify`, `apiRequest`, `formatPrice`, `requireAuth`
+// and the rest onto `window` — never runs either.
+//
+// That is what #1641 shipped. `reorderOrder` was added to the export list and
+// to `window`, and the function itself never landed, so one missing function
+// took out the shared helper surface on every page of the storefront (#1651).
+//
+// `npm run check:syntax` cannot see this. The file parses perfectly well; the
+// identifier is only unresolved at evaluation time. So it is checked here.
+
+const fs = require("fs");
+const path = require("path");
+
+const UTILS_PATH = path.join(
+    __dirname,
+    "..",
+    "..",
+    "frontend",
+    "scripts",
+    "utils.js"
+);
+
+const source = fs.readFileSync(UTILS_PATH, "utf8");
+
+/**
+ * Every identifier the given source declares at any depth.
+ *
+ * Deliberately generous: this test is here to catch a name that exists
+ * nowhere, not to police scope. A shorthand property naming something that is
+ * declared inside a function would be a different bug, and a stricter reading
+ * here would only produce false alarms on a file this size.
+ */
+const declarationsIn = (text) => {
+    const names = new Set();
+
+    const add = (pattern) => {
+        for (const match of text.matchAll(pattern)) {
+            if (match[1]) {
+                names.add(match[1]);
+            }
+        }
+    };
+
+    add(/\b(?:function|class)\s+([A-Za-z_$][\w$]*)/g);
+    add(/\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)/g);
+
+    // Destructured declarations: `const { a, b: c } = ...`
+    for (const match of text.matchAll(/\b(?:const|let|var)\s*\{([^}]*)\}\s*=/g)) {
+        match[1]
+            .split(",")
+            .map((part) => part.split(":").pop().split("=")[0].trim())
+            .filter(Boolean)
+            .forEach((name) => names.add(name));
+    }
+
+    return names;
+};
+
+/**
+ * What an identifier in `utils.js` can legitimately resolve to.
+ *
+ * A bare identifier reaches the global scope, so a name `utils.js` never
+ * declares still resolves if a script loaded before it published one onto
+ * `window` -- `CONFIG` comes from `config.js` that way. Those count as
+ * available; a name nothing anywhere declares or publishes does not.
+ */
+const resolvableNames = () => {
+    const names = declarationsIn(source);
+
+    const dir = path.dirname(UTILS_PATH);
+
+    for (const file of fs.readdirSync(dir)) {
+        if (!file.endsWith(".js") || file === "utils.js") {
+            continue;
+        }
+
+        const sibling = fs.readFileSync(path.join(dir, file), "utf8");
+
+        for (const match of sibling.matchAll(
+            /window\.([A-Za-z_$][\w$]*)\s*=/g
+        )) {
+            names.add(match[1]);
+        }
+
+        // `config.js` declares CONFIG at the top level and freezes it onto
+        // window at the end; the declaration is the thing utils.js sees.
+        if (file === "config.js") {
+            declarationsIn(sibling).forEach((name) => names.add(name));
+        }
+    }
+
+    return names;
+};
+
+/**
+ * The shorthand properties of the `window.AppUtils = { ... }` literal.
+ *
+ * Only shorthand entries are collected. `key: value` pairs carry their own
+ * expression and are not the failure mode this guards.
+ */
+const appUtilsExports = () => {
+    const start = source.indexOf("window.AppUtils = {");
+
+    if (start === -1) {
+        return null;
+    }
+
+    const open = source.indexOf("{", start);
+
+    let depth = 0;
+    let end = -1;
+
+    for (let i = open; i < source.length; i += 1) {
+        if (source[i] === "{") depth += 1;
+        else if (source[i] === "}") {
+            depth -= 1;
+            if (depth === 0) {
+                end = i;
+                break;
+            }
+        }
+    }
+
+    const body = source.slice(open + 1, end);
+
+    return body
+        .split("\n")
+        .map((line) => line.replace(/\/\/.*$/, "").trim())
+        .filter((line) => /^[A-Za-z_$][\w$]*,?$/.test(line))
+        .map((line) => line.replace(/,$/, ""));
+};
+
+describe("frontend/scripts/utils.js exports", () => {
+    const declared = resolvableNames();
+
+    test("assigns window.AppUtils from one object literal", () => {
+        expect(source).toContain("window.AppUtils = {");
+    });
+
+    test("declares every name it puts on AppUtils", () => {
+        const exported = appUtilsExports();
+
+        expect(exported).not.toBeNull();
+        expect(exported.length).toBeGreaterThan(20);
+
+        const missing = exported.filter((name) => !declared.has(name));
+
+        expect(missing).toEqual([]);
+    });
+
+    test("declares every name it publishes on window", () => {
+        const missing = [];
+
+        for (const match of source.matchAll(
+            /window\.([A-Za-z_$][\w$]*)\s*=\s*([A-Za-z_$][\w$]*)\s*;/g
+        )) {
+            const value = match[2];
+
+            if (["window", "document", "globalThis", "undefined"].includes(value)) {
+                continue;
+            }
+
+            if (!declared.has(value)) {
+                missing.push(`window.${match[1]} = ${value}`);
+            }
+        }
+
+        expect(missing).toEqual([]);
+    });
+
+    test("declares reorderOrder, which #1641 exported without writing", () => {
+        expect(declared.has("reorderOrder")).toBe(true);
+        expect(source).toMatch(/\breorderOrder\s*=\s*async\s*\(/);
+    });
+
+    test("exports reorderOrder on both AppUtils and window", () => {
+        // Both call sites are defensive -- `dashboard-orders.js` and
+        // `ordersHistory.js` each try `AppUtils.reorderOrder` and then fall
+        // back to the bare global -- so both surfaces have to carry it or the
+        // "Buy Again" button silently does nothing.
+        expect(appUtilsExports()).toContain("reorderOrder");
+        expect(source).toContain("window.reorderOrder = reorderOrder;");
+    });
+});

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -2210,6 +2210,99 @@ const addToCompare = (productId) => {
     return true;
 };
 
+// Put every line of a past order back in the cart.
+//
+// The order is re-read from the server rather than trusted from whatever the
+// history page happens to be holding: `GET /orders/:id` is behind `ownsOrder`,
+// so this cannot be pointed at somebody else's order, and the lines it returns
+// are the ones that were actually billed.
+//
+// Quantities are merged into the existing cart rather than replacing it. A
+// shopper who clicks "Buy Again" while already holding something has asked for
+// both, and `mergeCartLines` is the same summing rule the sign-in merge uses,
+// so one product bought twice stays one line.
+//
+// `order_items.product_id` is nullable — a line whose product was hard-deleted
+// keeps its name and price for the receipt but can no longer be added to a
+// cart. Those lines are skipped and counted, because a basket that comes back
+// shorter than the order it came from has to say why.
+const reorderOrder = async (orderId) => {
+    const id = String(orderId ?? "").trim();
+
+    if (!id) {
+        return false;
+    }
+
+    if (!requireAuth()) {
+        return false;
+    }
+
+    try {
+        const response = await apiRequest(`/orders/${id}`);
+
+        const order = response?.order || response?.data || null;
+        const orderItems = safeArray(order?.items);
+
+        if (!orderItems.length) {
+            notify("That order has no items to reorder", "info");
+            return false;
+        }
+
+        const lines = orderItems
+            .map((item) =>
+                normalizeCartItem({
+                    id: item?.product_id ?? item?.productId ?? null,
+                    name: item?.name,
+                    price: item?.price,
+                    img: item?.img || item?.image || "",
+                    image: item?.image || item?.img || "",
+                    color: item?.color,
+                    size: item?.size,
+                    variantId: item?.variant_id ?? item?.variantId,
+                    qty: item?.qty ?? item?.quantity
+                })
+            )
+            .filter(Boolean);
+
+        const skipped = orderItems.length - lines.length;
+
+        if (!lines.length) {
+            notify(
+                "None of the items from that order are available any more",
+                "warning"
+            );
+            return false;
+        }
+
+        saveCart(mergeCartLines(getCart(), lines));
+
+        if (skipped > 0) {
+            notify(
+                skipped === 1
+                    ? "1 item from that order is no longer available and was not added."
+                    : `${skipped} items from that order are no longer available and were not added.`,
+                "warning"
+            );
+        } else {
+            notify(
+                lines.length === 1
+                    ? "Item added to your cart"
+                    : `${lines.length} items added to your cart`,
+                "success"
+            );
+        }
+
+        return true;
+    } catch (error) {
+        console.error("REORDER ERROR:", error);
+        notify(
+            error?.message || "Could not reorder that order right now",
+            "error"
+        );
+        return false;
+    }
+};
+
 // app utils assignment
 window.AppUtils = {
     CONFIG,


### PR DESCRIPTION
Closes #1651

## What was wrong

`window.AppUtils = { ... }` listed `reorderOrder`, and nothing in the repository declared it:

```
$ grep -rn "reorderOrder" frontend/
frontend/scripts/ordersHistory.js:349:    if (typeof AppUtils !== "undefined" && typeof AppUtils.reorderOrder === "function") {
frontend/scripts/ordersHistory.js:350:        await AppUtils.reorderOrder(orderId);
frontend/scripts/dashboard-orders.js:193:    if (typeof AppUtils !== "undefined" && typeof AppUtils.reorderOrder === "function") {
frontend/scripts/dashboard-orders.js:194:        await AppUtils.reorderOrder(orderId);
frontend/scripts/utils.js:2268:    reorderOrder,
frontend/scripts/utils.js:2293:window.reorderOrder = reorderOrder;
```

An undeclared identifier inside a top-level object literal throws `ReferenceError` while the literal is being evaluated — *before* the assignment. So `window.AppUtils` was never assigned, and every statement after line 2268 never ran either: the whole backward-compatibility block publishing `notify`, `apiRequest`, `formatPrice`, `requireAuth`, `handleImageError`, `safeForEach` onto `window`.

`utils.js` loads on every page. One missing function took out the shared helper surface across the storefront.

#1641 added the export and the two "Buy Again" buttons that call it. The function body never landed.

## What this does

**Writes `reorderOrder`.** It re-reads the order from `GET /orders/:id` rather than trusting whatever the history page is holding — that route sits behind `ownsOrder`, so it cannot be pointed at someone else's order, and the lines it returns are the ones that were actually billed.

Quantities merge into the existing cart through `mergeCartLines`, the same summing rule the sign-in merge uses. A shopper who clicks "Buy Again" while already holding something has asked for both, and one product bought twice stays one line.

`order_items.product_id` is nullable — a line whose product was hard-deleted keeps its name and price for the receipt but can no longer go in a cart. Those lines are skipped and counted, so a basket that comes back shorter than the order it came from says why rather than looking like it lost items.

**Adds the guard.** `npm run check:syntax` cannot catch this: the file parses fine, the identifier is only unresolved at evaluation time. `backend/tests/appUtilsExports.test.js` now asserts that every name `utils.js` exports — on `AppUtils` and on `window` — is a name something actually declares, reading through to the globals `config.js` publishes so legitimate cross-file names like `CONFIG` still resolve.

## Verification

Against `utils.js` **as it is on main**, the new test fails three ways:

```
✓ assigns window.AppUtils from one object literal
✕ declares every name it puts on AppUtils
✕ declares every name it publishes on window
✕ declares reorderOrder, which #1641 exported without writing
✓ exports reorderOrder on both AppUtils and window
Tests: 3 failed, 2 passed, 5 total
```

With the fix:

```
Tests: 5 passed, 5 total
```

`npm run check:syntax` passes — 633 files parse cleanly.

## Note on CI

The **Backend tests** check on this PR fails only on the 5 failures already present on `main` — `subscriptionRoutes`, `subscriptionRenewal` and the three `mergeScarRegression` shop.js cases. None of them touch this change, and this PR's own tests all pass inside that run.

#1660 clears them (`118 suites, 2527 tests, all passing`). **Merging that one first turns this check green**; nothing here needs to change for it.

The red **Vercel** check is the usual "Authorization required to deploy" against the `bhuvanshs-projects` team, and is unrelated.
