### PR TITLE
fix(gift-cards): mount the router that has been required and unreachable (#1652)

### DIFF
--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -60,4 +60,8 @@ module.exports = {
     "/api/interactions": require("./interactionRoutes"),
     "/api/newsletter": require("./newsletterRoutes"),
     "/api/reviews": require("./reviewRoutes"),
+    // Required in server.js since #1231 and never mounted, so every gift
+    // card path 404ed while the service and both migrations were live
+    // (#1652).
+    "/api/gift-cards": require("./giftCardRoutes"),
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -183,7 +183,6 @@ const { detectBot, addBotDetectionHeaders } = require('./middleware/botProtectio
 const { verifyAICrawler } = require('./middleware/aiCrawlerMiddleware');
 const fraudRoutes = require('./routes/fraudRoutes');
 const aiRoutes = require('./routes/aiRoutes');
-const giftCardRoutes = require('./routes/giftCardRoutes');
 
 // Back-in-stock & price-drop alerts (#1233)
 const stockAlertRoutes = require('./routes/stockAlertRoutes');

--- a/backend/tests/giftCardRoutes.test.js
+++ b/backend/tests/giftCardRoutes.test.js
@@ -1,0 +1,349 @@
+// backend/tests/giftCardRoutes.test.js
+//
+// The gift card router was written, hardened (#1478) and never mounted, so
+// every path it serves answered 404 while giftCardService and both migrations
+// were live in the tree (#1652). Two things are checked here: that the router
+// behaves over HTTP, and -- the part that actually failed -- that it is
+// reachable at all.
+
+const request = require("supertest");
+const express = require("express");
+
+jest.mock("../middleware/authMiddleware", () =>
+    jest.fn((req, res, next) => {
+        req.user = { id: "user-123", role: req.headers["x-test-role"] || "user" };
+        next();
+    })
+);
+
+jest.mock("../middleware/rbacMiddleware", () => ({
+    authorizeRoles: (...roles) =>
+        function authorizeRolesMiddleware(req, res, next) {
+            if (!roles.includes(req.user?.role)) {
+                return res.status(403).json({
+                    success: false,
+                    message: "Forbidden"
+                });
+            }
+            next();
+        }
+}));
+
+class FakeGiftCardError extends Error {
+    constructor(message, code) {
+        super(message);
+        this.name = "GiftCardError";
+        this.code = code;
+    }
+}
+
+jest.mock("../services/giftCardService", () => {
+    const service = {
+        issue: jest.fn(),
+        getBalance: jest.fn(),
+        applyToOrder: jest.fn()
+    };
+    return service;
+});
+
+const giftCardService = require("../services/giftCardService");
+giftCardService.GiftCardError = FakeGiftCardError;
+
+const giftCardRoutes = require("../routes/giftCardRoutes");
+
+const app = express();
+app.use(express.json());
+app.use("/api/gift-cards", giftCardRoutes);
+
+const asAdmin = (req) => req.set("x-test-role", "admin");
+
+describe("gift card routes are mounted", () => {
+    // The regression itself. `routes/index.js` is the map server.js mounts at
+    // boot (`server.js:313`); if the entry is not in it, nothing else in this
+    // file matters.
+    //
+    // Read as source rather than required: `require("../routes")` pulls in
+    // every router in the application, which is a hundred modules and their
+    // service graphs, to answer a question about one line of a lookup table.
+    const fs = require("fs");
+    const path = require("path");
+
+    const read = (relative) =>
+        fs.readFileSync(path.join(__dirname, "..", relative), "utf8");
+
+    const routeMapSource = read("routes/index.js");
+    const serverSource = read("server.js");
+
+    test("routes/index.js carries a gift card entry", () => {
+        expect(routeMapSource).toMatch(
+            /["']\/api\/gift-cards["']\s*:\s*require\(["']\.\/giftCardRoutes["']\)/
+        );
+    });
+
+    test("server.js no longer requires a router it does not mount", () => {
+        expect(serverSource).not.toMatch(
+            /require\(["']\.\/routes\/giftCardRoutes["']\)/
+        );
+    });
+
+    // The general form of the same defect: server.js pulling in a router that
+    // then reaches no URL. There are two legitimate ways to mount one -- an
+    // `app.use` in server.js, or an entry in the routes/index.js map -- and
+    // gift cards had neither, which is how the feature went dark with its
+    // service and both its migrations live in the tree.
+    test("every router server.js requires reaches a URL", () => {
+        // `complexityRoutes` is dangling the same way gift cards were: required
+        // at server.js:130, mounted nowhere. It is left that way deliberately.
+        // Its seven endpoints report architecture-complexity analysis of this
+        // codebase, and quietly publishing them as a side effect of a gift card
+        // fix is a disclosure decision that is not this PR's to make. Named
+        // here so the guard stays green and the debt stays visible rather than
+        // invisible, which is the state that produced #1652.
+        const KNOWN_UNMOUNTED = ["complexityRoutes"];
+
+        const dangling = [];
+
+        for (const match of serverSource.matchAll(
+            /const\s+([A-Za-z_$][\w$]*)\s*=\s*require\(["']\.\/routes\/([\w.]+)["']\)/g
+        )) {
+            const [, binding, moduleName] = match;
+
+            const mountedDirectly = new RegExp(
+                `app\\.use\\(\\s*(?:[^,]+,\\s*)?${binding}\\b`
+            ).test(serverSource);
+
+            const mountedViaMap = new RegExp(
+                `require\\(["']\\./${moduleName}["']\\)`
+            ).test(routeMapSource);
+
+            if (
+                !mountedDirectly &&
+                !mountedViaMap &&
+                !KNOWN_UNMOUNTED.includes(binding)
+            ) {
+                dangling.push(binding);
+            }
+        }
+
+        expect(dangling).toEqual([]);
+    });
+});
+
+describe("POST /api/gift-cards/issue", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    test("issues a card for an admin and returns the code once", async () => {
+        giftCardService.issue.mockResolvedValueOnce({
+            id: 7,
+            code: "GC-PLAINTEXT-ONCE",
+            amount: 500,
+            currency: "INR"
+        });
+
+        const res = await asAdmin(
+            request(app).post("/api/gift-cards/issue")
+        ).send({ amount: 500, currency: "INR" });
+
+        expect(res.statusCode).toBe(201);
+        expect(res.body.success).toBe(true);
+        expect(res.body.data.code).toBe("GC-PLAINTEXT-ONCE");
+        expect(giftCardService.issue).toHaveBeenCalledWith({
+            amount: 500,
+            currency: "INR",
+            expiresAt: undefined
+        });
+    });
+
+    test("refuses a non-admin", async () => {
+        const res = await request(app)
+            .post("/api/gift-cards/issue")
+            .send({ amount: 500 });
+
+        expect(res.statusCode).toBe(403);
+        expect(giftCardService.issue).not.toHaveBeenCalled();
+    });
+
+    test("maps INVALID_AMOUNT onto 400", async () => {
+        giftCardService.issue.mockRejectedValueOnce(
+            new FakeGiftCardError("Amount must be positive", "INVALID_AMOUNT")
+        );
+
+        const res = await asAdmin(
+            request(app).post("/api/gift-cards/issue")
+        ).send({ amount: -1 });
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toBe("Amount must be positive");
+    });
+});
+
+describe("POST /api/gift-cards/balance", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    test("returns the balance for a code in the body", async () => {
+        giftCardService.getBalance.mockResolvedValueOnce({
+            balance: 250,
+            currency: "INR"
+        });
+
+        const res = await request(app)
+            .post("/api/gift-cards/balance")
+            .send({ code: "GC-ABC" });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.data.balance).toBe(250);
+        expect(giftCardService.getBalance).toHaveBeenCalledWith("GC-ABC");
+    });
+
+    test("requires a code", async () => {
+        const res = await request(app)
+            .post("/api/gift-cards/balance")
+            .send({});
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toMatch(/code is required/i);
+        expect(giftCardService.getBalance).not.toHaveBeenCalled();
+    });
+
+    test("answers NOT_FOUND with a 404", async () => {
+        giftCardService.getBalance.mockRejectedValueOnce(
+            new FakeGiftCardError("Gift card not found", "NOT_FOUND")
+        );
+
+        const res = await request(app)
+            .post("/api/gift-cards/balance")
+            .send({ code: "GC-NOPE" });
+
+        expect(res.statusCode).toBe(404);
+    });
+
+    test("an expired card is a 410", async () => {
+        giftCardService.getBalance.mockRejectedValueOnce(
+            new FakeGiftCardError("Gift card expired", "EXPIRED")
+        );
+
+        const res = await request(app)
+            .post("/api/gift-cards/balance")
+            .send({ code: "GC-OLD" });
+
+        expect(res.statusCode).toBe(410);
+    });
+});
+
+describe("POST /api/gift-cards/redeem", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    test("redeems against an order and reports a full settlement", async () => {
+        giftCardService.applyToOrder.mockResolvedValueOnce({
+            applied: 300,
+            remainingBalance: 0,
+            orderSettled: true
+        });
+
+        const res = await request(app)
+            .post("/api/gift-cards/redeem")
+            .send({ code: "GC-ABC", orderId: "order-1", amount: 300 });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.message).toMatch(/paid in full/i);
+
+        // The owner comes from the token, never from the body -- authMiddleware
+        // establishes who is calling, not that the order is theirs.
+        expect(giftCardService.applyToOrder).toHaveBeenCalledWith(
+            "GC-ABC",
+            "order-1",
+            300,
+            null,
+            { userId: "user-123" }
+        );
+    });
+
+    test("a partial redemption does not claim the order is paid", async () => {
+        giftCardService.applyToOrder.mockResolvedValueOnce({
+            applied: 100,
+            remainingBalance: 0,
+            orderSettled: false
+        });
+
+        const res = await request(app)
+            .post("/api/gift-cards/redeem")
+            .send({ code: "GC-ABC", orderId: "order-1" });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.message).toBe("Gift card redeemed");
+    });
+
+    test("requires an order id (#1478)", async () => {
+        const res = await request(app)
+            .post("/api/gift-cards/redeem")
+            .send({ code: "GC-ABC" });
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toMatch(/order ID is required/i);
+        expect(giftCardService.applyToOrder).not.toHaveBeenCalled();
+    });
+
+    test("requires a code", async () => {
+        const res = await request(app)
+            .post("/api/gift-cards/redeem")
+            .send({ orderId: "order-1" });
+
+        expect(res.statusCode).toBe(400);
+        expect(giftCardService.applyToOrder).not.toHaveBeenCalled();
+    });
+
+    test("answers ORDER_NOT_FOUND with 404 rather than 403", async () => {
+        // "not yours" and "no such order" have to be indistinguishable, or the
+        // endpoint enumerates order ids.
+        giftCardService.applyToOrder.mockRejectedValueOnce(
+            new FakeGiftCardError("Order not found", "ORDER_NOT_FOUND")
+        );
+
+        const res = await request(app)
+            .post("/api/gift-cards/redeem")
+            .send({ code: "GC-ABC", orderId: "someone-elses-order" });
+
+        expect(res.statusCode).toBe(404);
+    });
+
+    test("an insufficient balance is a 402", async () => {
+        giftCardService.applyToOrder.mockRejectedValueOnce(
+            new FakeGiftCardError("Insufficient balance", "INSUFFICIENT_BALANCE")
+        );
+
+        const res = await request(app)
+            .post("/api/gift-cards/redeem")
+            .send({ code: "GC-ABC", orderId: "order-1", amount: 10000 });
+
+        expect(res.statusCode).toBe(402);
+    });
+
+    test("an already-settled order is a 409", async () => {
+        giftCardService.applyToOrder.mockRejectedValueOnce(
+            new FakeGiftCardError("This order has nothing left to pay", "ORDER_SETTLED")
+        );
+
+        const res = await request(app)
+            .post("/api/gift-cards/redeem")
+            .send({ code: "GC-ABC", orderId: "order-1" });
+
+        expect(res.statusCode).toBe(409);
+    });
+
+    test("an unrecognised failure is a 500, not a leaked message", async () => {
+        const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+        giftCardService.applyToOrder.mockRejectedValueOnce(
+            new Error("ER_LOCK_DEADLOCK: retry the transaction")
+        );
+
+        const res = await request(app)
+            .post("/api/gift-cards/redeem")
+            .send({ code: "GC-ABC", orderId: "order-1" });
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body.message).toBe("Internal server error");
+
+        spy.mockRestore();
+    });
+});


### PR DESCRIPTION
Closes #1652

## What was wrong

`server.js` required the gift card router and never mounted it:

```
$ grep -n "giftCardRoutes" backend/server.js
186:const giftCardRoutes = require('./routes/giftCardRoutes');
```

That was the only occurrence — no `app.use`, and no entry in `routes/index.js`, the map every other router is mounted through at `server.js:313`. All three endpoints answered 404:

| Endpoint | Purpose |
|---|---|
| `POST /issue` | admin issues a card, returns the plaintext code once |
| `POST /balance` | shopper checks a card's remaining balance |
| `POST /redeem` | shopper pays part or all of an order with a card |

None of this was unfinished work. The router maps `GiftCardError` codes onto HTTP statuses, keeps the code out of the URL, takes the order owner from the token rather than the body, and carries the #1478 hardening that made `orderId` mandatory. `giftCardService.js` is 487 lines behind it, and the schema has shipped since `0003_gift_cards.sql` with settlement added in `0047_gift_card_order_settlement.sql`. Only the mount was missing.

## What this does

- Adds `"/api/gift-cards": require("./giftCardRoutes")` to `routes/index.js`.
- Drops the now-redundant `require` in `server.js`, since the map owns the mounting.
- Adds `backend/tests/giftCardRoutes.test.js` — 18 tests covering the three endpoints over HTTP (admin gating, the `#1478` mandatory `orderId`, owner-from-token, full vs partial settlement, and the `GiftCardError` → status mapping including `ORDER_NOT_FOUND` answering 404 rather than 403 so order ids cannot be enumerated), plus the mount assertions.

The mount tests read `routes/index.js` and `server.js` as source rather than `require`-ing the map — pulling in a hundred routers and their service graphs to answer a question about one line of a lookup table is not a trade worth making.

## One thing worth a maintainer's decision

The guard generalises the defect: a router `server.js` requires has to reach a URL somehow, either through an `app.use` there or an entry in the map. Running it across the tree turns up **one more dangling router** — `complexityRoutes`, required at `server.js:130` and mounted nowhere, exactly as gift cards were.

I have **not** mounted it. Its seven endpoints report architecture-complexity analysis of this codebase, and publishing them as a side effect of a gift card fix is a disclosure decision that is not mine to make. It is named explicitly in the test's `KNOWN_UNMOUNTED` list with a comment, so the guard stays green and the debt stays *visible* — invisibility is the state that produced this issue in the first place.

Happy to mount it in a follow-up if that is wanted.

## Verification

```
Test Suites: 1 passed, 1 total
Tests:       18 passed, 18 total
```

```
✅ syntax check passed — 634 JavaScript file(s) parsed cleanly
✅ boot check passed — backend/server.js loaded with 95 mounted layers
```

Layer count is up by one, which is the mount.

## Note on CI

The **Backend tests** check on this PR fails only on the 5 failures already present on `main` — `subscriptionRoutes`, `subscriptionRenewal` and the three `mergeScarRegression` shop.js cases. None of them touch this change, and this PR's own tests all pass inside that run.

#1660 clears them (`118 suites, 2527 tests, all passing`). **Merging that one first turns this check green**; nothing here needs to change for it.

The red **Vercel** check is the usual "Authorization required to deploy" against the `bhuvanshs-projects` team, and is unrelated.
