### PR TITLE
fix(reviews): put every /api/reviews write behind the guards the product page uses (#1653)

### DIFF
--- a/backend/controllers/reviewController.js
+++ b/backend/controllers/reviewController.js
@@ -576,6 +576,10 @@ const moderateReview = async (req, res) => {
 };
 
 module.exports = {
+    // Exported so the /api/reviews router can keep the product's rating
+    // aggregate in step after an edit, instead of leaving `products.rating`
+    // reporting a number no review supports any more (#1653).
+    refreshProductReviewStats,
     getProductReviews,
     createProductReview,
     deleteProductReview,

--- a/backend/repositories/reviewRepository.js
+++ b/backend/repositories/reviewRepository.js
@@ -45,6 +45,15 @@ class ReviewRepository extends BaseRepository {
 
     /**
      * Find reviews by product ID
+     *
+     * Visibility is decided by `moderation_status`, not by `is_approved`.
+     * `0026_review_moderation.sql` made the status the authority and kept the
+     * boolean only so a legacy reader still saw something sensible; every
+     * other reader in the codebase filters on the status -- reviewController
+     * and reviewModerationService alike. Two readers of one table disagreeing
+     * about which column decides what the public sees is the defect, whichever
+     * way they happen to agree today (#1653).
+     *
      * @param {string} productId
      * @param {Object} options
      * @returns {Promise<Object[]>}
@@ -55,7 +64,7 @@ class ReviewRepository extends BaseRepository {
             `SELECT r.*, u.name as user_name
              FROM ${this.tableName} r
              LEFT JOIN users u ON r.user_id = u.id
-             WHERE r.product_id = ? AND r.${LIVE} AND r.is_approved = 1
+             WHERE r.product_id = ? AND r.${LIVE} AND r.moderation_status = 'approved'
              ORDER BY r.created_at DESC
              LIMIT ? OFFSET ?`,
             [productId, Number(limit), Number(offset)]

--- a/backend/routes/reviewRoutes.js
+++ b/backend/routes/reviewRoutes.js
@@ -1,50 +1,63 @@
 // backend/routes/reviewRoutes.js
+//
+// The account-facing view of reviews: "what have I written", and the writes a
+// shopper makes against their own review.
+//
+// Every write here goes through reviewController rather than straight to the
+// repository. That router shipped in #1643 calling `reviewRepo.create()`
+// directly, which meant `POST /api/reviews` was a second door into the
+// `reviews` table with none of the locks on the first one: no purchase check,
+// no duplicate check, no `is_verified`, no rating refresh, no transaction. Any
+// signed-in account could review any product, repeatedly, and the stars on the
+// shop grid never moved because nothing recomputed them (#1653).
+//
+// The guards are not reimplemented here. They live in reviewController, which
+// the product page already posts through, and this router adapts the request
+// shape and hands over. One set of rules, two URLs -- rather than two sets of
+// rules that drift.
+
 const express = require('express');
 const router = express.Router();
 const authMiddleware = require('../middleware/authMiddleware');
 const reviewRepo = require('../repositories/reviewRepository');
+const reviewController = require('../controllers/reviewController');
+
+/**
+ * Hand a request to a controller that reads the product id from the path.
+ *
+ * `createProductReview` and `deleteProductReview` are mounted under
+ * `/products/:id/...`, so they take the product from `req.params.id`. Here it
+ * arrives in the body, or has to be looked up from the review. Rewriting
+ * `req.params` is the whole adaptation.
+ */
+const withParams = (req, params) => {
+    req.params = { ...req.params, ...params };
+    return req;
+};
 
 /**
  * @route   POST /api/reviews
  * @desc    Create a review for a product
- * @access  Private
+ * @access  Private -- and only for a product the caller has actually received
  */
 router.post('/', authMiddleware, async (req, res) => {
-    try {
-        const { productId, rating, comment, title, images } = req.body;
-        const userId = req.user.id;
+    const productId = req.body?.productId;
 
-        if (!productId) {
-            return res.status(400).json({ success: false, message: 'Product ID is required' });
-        }
-
-        const numRating = Number(rating);
-        if (isNaN(numRating) || numRating < 1 || numRating > 5) {
-            return res.status(400).json({ success: false, message: 'Rating must be an integer between 1 and 5' });
-        }
-
-        if (!comment || typeof comment !== 'string' || comment.trim().length < 3) {
-            return res.status(400).json({ success: false, message: 'Comment must be at least 3 characters long' });
-        }
-
-        const review = await reviewRepo.create({
-            productId,
-            userId,
-            rating: numRating,
-            comment: comment.trim(),
-            title: title ? String(title).trim() : null,
-            images
+    if (!productId) {
+        return res.status(400).json({
+            success: false,
+            message: 'Product ID is required'
         });
-
-        return res.status(201).json({
-            success: true,
-            message: 'Review created successfully',
-            review
-        });
-    } catch (error) {
-        console.error('Error creating review:', error);
-        return res.status(500).json({ success: false, message: error.message || 'Server error creating review' });
     }
+
+    // Everything after this -- the UUID check, the 1-5 rating, the comment
+    // length, the product-exists check, the FOR UPDATE duplicate check, the
+    // delivered-order purchase check, is_verified, moderation_status and the
+    // rating refresh -- is the controller's, inside its transaction.
+    return reviewController.createProductReview(
+        withParams(req, { id: productId }),
+        res
+    );
 });
 
 /**
@@ -110,7 +123,32 @@ router.put('/:id', authMiddleware, async (req, res) => {
             return res.status(403).json({ success: false, message: 'Unauthorized to update this review' });
         }
 
+        // A rating outside 1-5 is refused rather than clamped.
+        //
+        // `reviewRepository.update` computes `Math.max(1, Math.min(5, Number(x) || 5))`,
+        // so a 0 became a 5 and a 99 became a 5 -- a shopper's one-star edit
+        // silently stored as five stars. Clamping is the wrong answer to a
+        // value nobody meant.
+        if (req.body?.rating !== undefined) {
+            const numRating = Number(req.body.rating);
+
+            if (!Number.isInteger(numRating) || numRating < 1 || numRating > 5) {
+                return res.status(400).json({
+                    success: false,
+                    message: 'Rating must be an integer between 1 and 5'
+                });
+            }
+        }
+
         const updated = await reviewRepo.update(req.params.id, req.body);
+
+        // An edited rating changes the product's average. Nothing recomputed
+        // it, so `products.rating` kept reporting the figure from before the
+        // edit indefinitely.
+        if (req.body?.rating !== undefined && existing.product_id) {
+            await reviewController.refreshProductReviewStats(existing.product_id);
+        }
+
         return res.status(200).json({ success: true, message: 'Review updated successfully', review: updated });
     } catch (error) {
         console.error('Error updating review:', error);
@@ -134,8 +172,18 @@ router.delete('/:id', authMiddleware, async (req, res) => {
             return res.status(403).json({ success: false, message: 'Unauthorized to delete this review' });
         }
 
-        const deleted = await reviewRepo.delete(req.params.id);
-        return res.status(200).json({ success: true, message: 'Review deleted successfully', deleted });
+        // Delegated for the same reason the create is: the controller's delete
+        // is a soft delete that records `deleted_by` and a reason, sets
+        // `moderation_status`, and refreshes the product's rating -- all in one
+        // transaction. `reviewRepo.delete()` only stamped `deleted_at`, so a
+        // removed review went on counting towards the product's stars.
+        return reviewController.deleteProductReview(
+            withParams(req, {
+                id: existing.product_id,
+                reviewId: req.params.id
+            }),
+            res
+        );
     } catch (error) {
         console.error('Error deleting review:', error);
         return res.status(500).json({ success: false, message: error.message || 'Server error deleting review' });

--- a/backend/tests/reviewRoutes.test.js
+++ b/backend/tests/reviewRoutes.test.js
@@ -1,8 +1,14 @@
 // backend/tests/reviewRoutes.test.js
+//
+// `/api/reviews` used to write to the `reviews` table itself, which made it a
+// second door with none of the locks on the first one (#1653). These tests
+// pin the thing that matters: every write goes through reviewController, so
+// the purchase check, the duplicate check, `is_verified` and the rating
+// refresh apply here exactly as they do on the product page.
+
 const request = require('supertest');
 const express = require('express');
 
-// Mock authMiddleware
 jest.mock('../middleware/authMiddleware', () => {
     return jest.fn((req, res, next) => {
         req.user = { id: 'user-123', role: 'user' };
@@ -10,7 +16,6 @@ jest.mock('../middleware/authMiddleware', () => {
     });
 });
 
-// Mock reviewRepository
 jest.mock('../repositories/reviewRepository', () => ({
     create: jest.fn(),
     findById: jest.fn(),
@@ -20,27 +25,42 @@ jest.mock('../repositories/reviewRepository', () => ({
     delete: jest.fn()
 }));
 
+jest.mock('../controllers/reviewController', () => ({
+    createProductReview: jest.fn((req, res) =>
+        res.status(201).json({
+            success: true,
+            message: 'Review submitted successfully',
+            reviewId: 1,
+            averageRating: 4.5,
+            reviewCount: 2
+        })
+    ),
+    deleteProductReview: jest.fn((req, res) =>
+        res.status(200).json({
+            success: true,
+            message: 'Review deleted',
+            averageRating: 4.0,
+            reviewCount: 1
+        })
+    ),
+    refreshProductReviewStats: jest.fn().mockResolvedValue({
+        averageRating: 4.5,
+        reviewCount: 2
+    })
+}));
+
 const reviewRepo = require('../repositories/reviewRepository');
+const reviewController = require('../controllers/reviewController');
 const reviewRoutes = require('../routes/reviewRoutes');
 
 const app = express();
 app.use(express.json());
 app.use('/api/reviews', reviewRoutes);
 
-describe('Review Routes (/api/reviews)', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-    });
+describe('POST /api/reviews goes through the guarded path', () => {
+    beforeEach(() => jest.clearAllMocks());
 
-    test('POST /api/reviews creates review successfully', async () => {
-        reviewRepo.create.mockResolvedValueOnce({
-            id: 1,
-            product_id: 'prod-100',
-            user_id: 'user-123',
-            rating: 5,
-            comment: 'Excellent quality!'
-        });
-
+    test('hands the write to reviewController, not to the repository', async () => {
         const res = await request(app)
             .post('/api/reviews')
             .send({
@@ -50,24 +70,76 @@ describe('Review Routes (/api/reviews)', () => {
             });
 
         expect(res.statusCode).toBe(201);
-        expect(res.body.success).toBe(true);
-        expect(res.body.review.id).toBe(1);
+        expect(reviewController.createProductReview).toHaveBeenCalledTimes(1);
+
+        // The regression: this used to be the only thing the route called, and
+        // it skipped every guard the controller applies.
+        expect(reviewRepo.create).not.toHaveBeenCalled();
     });
 
-    test('POST /api/reviews rejects invalid rating', async () => {
+    test('moves productId from the body onto req.params.id', async () => {
+        // The controller reads the product from the path because it is mounted
+        // under /products/:id. Adapting the shape is the whole delegation.
+        await request(app)
+            .post('/api/reviews')
+            .send({ productId: 'prod-100', rating: 5, comment: 'Great' });
+
+        const [req] = reviewController.createProductReview.mock.calls[0];
+
+        expect(req.params.id).toBe('prod-100');
+    });
+
+    test('still requires a product id up front', async () => {
         const res = await request(app)
             .post('/api/reviews')
-            .send({
-                productId: 'prod-100',
-                rating: 6,
-                comment: 'Bad rating'
-            });
+            .send({ rating: 5, comment: 'Great' });
 
         expect(res.statusCode).toBe(400);
-        expect(res.body.success).toBe(false);
+        expect(res.body.message).toMatch(/Product ID is required/i);
+        expect(reviewController.createProductReview).not.toHaveBeenCalled();
     });
 
-    test('GET /api/reviews lists reviews by productId', async () => {
+    test('a refusal from the controller is the response', async () => {
+        // The purchase check is the controller's. What matters here is that the
+        // route does not paper over it, which is what writing to the repository
+        // directly amounted to.
+        reviewController.createProductReview.mockImplementationOnce((req, res) =>
+            res.status(403).json({
+                success: false,
+                message: 'You can only review products you have purchased'
+            })
+        );
+
+        const res = await request(app)
+            .post('/api/reviews')
+            .send({ productId: 'prod-100', rating: 5, comment: 'Never bought it' });
+
+        expect(res.statusCode).toBe(403);
+        expect(res.body.message).toMatch(/only review products you have purchased/i);
+        expect(reviewRepo.create).not.toHaveBeenCalled();
+    });
+
+    test('a duplicate is refused by the controller and not written twice', async () => {
+        reviewController.createProductReview.mockImplementationOnce((req, res) =>
+            res.status(400).json({
+                success: false,
+                message: 'You have already reviewed this product'
+            })
+        );
+
+        const res = await request(app)
+            .post('/api/reviews')
+            .send({ productId: 'prod-100', rating: 5, comment: 'Again' });
+
+        expect(res.statusCode).toBe(400);
+        expect(reviewRepo.create).not.toHaveBeenCalled();
+    });
+});
+
+describe('GET /api/reviews', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    test('lists reviews by productId', async () => {
         reviewRepo.findByProduct.mockResolvedValueOnce([
             { id: 1, rating: 5, comment: 'Awesome' }
         ]);
@@ -79,17 +151,135 @@ describe('Review Routes (/api/reviews)', () => {
         expect(res.body.reviews).toHaveLength(1);
     });
 
-    test('DELETE /api/reviews/:id deletes review owned by user', async () => {
+    test('falls back to the caller\'s own reviews', async () => {
+        reviewRepo.findByUser.mockResolvedValueOnce([]);
+
+        await request(app).get('/api/reviews');
+
+        expect(reviewRepo.findByUser).toHaveBeenCalledWith(
+            'user-123',
+            expect.any(Object)
+        );
+    });
+
+    test('GET /api/reviews/:id returns 404 for a review that is not there', async () => {
+        reviewRepo.findById.mockResolvedValueOnce(null);
+
+        const res = await request(app).get('/api/reviews/999');
+
+        expect(res.statusCode).toBe(404);
+    });
+});
+
+describe('PUT /api/reviews/:id', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    const ownReview = { id: 1, user_id: 'user-123', product_id: 'prod-100' };
+
+    test('refuses a rating outside 1-5 instead of clamping it', async () => {
+        // reviewRepository.update computes Math.max(1, Math.min(5, Number(x) || 5)),
+        // so 0 stored as 5 and 99 stored as 5 -- a one-star edit silently
+        // becoming five stars.
+        reviewRepo.findById.mockResolvedValue(ownReview);
+
+        for (const rating of [0, 6, 99, -1]) {
+            const res = await request(app)
+                .put('/api/reviews/1')
+                .send({ rating });
+
+            expect(res.statusCode).toBe(400);
+            expect(res.body.message).toMatch(/integer between 1 and 5/i);
+        }
+
+        expect(reviewRepo.update).not.toHaveBeenCalled();
+    });
+
+    test('refuses a non-integer rating', async () => {
+        reviewRepo.findById.mockResolvedValueOnce(ownReview);
+
+        const res = await request(app).put('/api/reviews/1').send({ rating: 3.7 });
+
+        expect(res.statusCode).toBe(400);
+        expect(reviewRepo.update).not.toHaveBeenCalled();
+    });
+
+    test('refreshes the product rating after a rating change', async () => {
+        reviewRepo.findById.mockResolvedValue(ownReview);
+        reviewRepo.update.mockResolvedValueOnce({ ...ownReview, rating: 2 });
+
+        const res = await request(app).put('/api/reviews/1').send({ rating: 2 });
+
+        expect(res.statusCode).toBe(200);
+        expect(reviewController.refreshProductReviewStats).toHaveBeenCalledWith('prod-100');
+    });
+
+    test('does not recompute the average when the rating did not change', async () => {
+        reviewRepo.findById.mockResolvedValue(ownReview);
+        reviewRepo.update.mockResolvedValueOnce({ ...ownReview, comment: 'edited' });
+
+        await request(app).put('/api/reviews/1').send({ comment: 'edited' });
+
+        expect(reviewController.refreshProductReviewStats).not.toHaveBeenCalled();
+    });
+
+    test('refuses an edit to somebody else\'s review', async () => {
         reviewRepo.findById.mockResolvedValueOnce({
             id: 1,
-            user_id: 'user-123'
+            user_id: 'someone-else',
+            product_id: 'prod-100'
         });
-        reviewRepo.delete.mockResolvedValueOnce(true);
+
+        const res = await request(app).put('/api/reviews/1').send({ rating: 1 });
+
+        expect(res.statusCode).toBe(403);
+        expect(reviewRepo.update).not.toHaveBeenCalled();
+    });
+});
+
+describe('DELETE /api/reviews/:id', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    test('delegates to the controller so the delete is soft and the stars move', async () => {
+        reviewRepo.findById.mockResolvedValueOnce({
+            id: 1,
+            user_id: 'user-123',
+            product_id: 'prod-100'
+        });
 
         const res = await request(app).delete('/api/reviews/1');
 
         expect(res.statusCode).toBe(200);
-        expect(res.body.success).toBe(true);
-        expect(res.body.deleted).toBe(true);
+        expect(reviewController.deleteProductReview).toHaveBeenCalledTimes(1);
+
+        // reviewRepo.delete only stamped deleted_at: no deleted_by, no
+        // moderation_status, and no rating refresh, so a removed review went on
+        // counting towards the product's average.
+        expect(reviewRepo.delete).not.toHaveBeenCalled();
+
+        const [req] = reviewController.deleteProductReview.mock.calls[0];
+        expect(req.params.id).toBe('prod-100');
+        expect(req.params.reviewId).toBe('1');
+    });
+
+    test('refuses a delete of somebody else\'s review before delegating', async () => {
+        reviewRepo.findById.mockResolvedValueOnce({
+            id: 1,
+            user_id: 'someone-else',
+            product_id: 'prod-100'
+        });
+
+        const res = await request(app).delete('/api/reviews/1');
+
+        expect(res.statusCode).toBe(403);
+        expect(reviewController.deleteProductReview).not.toHaveBeenCalled();
+    });
+
+    test('404s for a review that is not there', async () => {
+        reviewRepo.findById.mockResolvedValueOnce(null);
+
+        const res = await request(app).delete('/api/reviews/1');
+
+        expect(res.statusCode).toBe(404);
+        expect(reviewController.deleteProductReview).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Closes #1653

## What was wrong

`POST /api/reviews` (added in #1643) called `reviewRepo.create()` directly. `reviewController.createProductReview` — the path the product page posts through — does four things first:

- a `FOR UPDATE` duplicate check, so one shopper gets one review per product
- a purchase check against a `delivered` order containing the product
- `is_verified = 1` and an explicit `moderation_status`
- `refreshProductReviewStats()`, inside the transaction

The router did none of them. Consequences, all reachable with a plain `POST`:

- **Anyone could review anything.** No purchase required — rating manipulation and review-bombing were one request away for any authenticated account.
- **Unlimited reviews per user per product.** No application check, and no `UNIQUE (product_id, user_id)` on the table to catch it.
- **Product ratings never moved.** Nothing recomputed `products.rating` / `products.num_reviews`, so the stars on the shop grid and product page stayed on whatever figure predated the review.
- **`is_verified` stayed 0**, so a genuine buyer coming through this route lost the verified-purchase badge.

## What this does

**The guards are not reimplemented.** The route adapts the request shape — `productId` arrives in the body, the controller reads it from the path because it is mounted under `/products/:id` — and hands over. One set of rules serving two URLs, rather than two sets that drift apart.

`DELETE` delegates for the same reason: `reviewRepo.delete()` only stamped `deleted_at` — no `deleted_by`, no `moderation_status`, no rating refresh — so a review a shopper withdrew went on counting towards the product's average.

`PUT` keeps its own handler but **stops clamping**. `reviewRepository.update` computes `Math.max(1, Math.min(5, Number(x) || 5))`, which turned a `0` into a `5` and a `99` into a `5` — a shopper's one-star edit silently stored as five stars. Out-of-range and non-integer ratings are now refused, and an edit that changes the rating refreshes the product's average, which nothing did before.

**`findByProduct` settles on `moderation_status`.** `0026_review_moderation.sql` made the status the authority and kept `is_approved` only so a legacy reader still saw something sensible. `reviewController.js:61` and `reviewModerationService.js` (lines 152, 162, 194, 226) all filter on the status; this repository was the last reader still deciding public visibility by the boolean. Same defect class as #1648.

`refreshProductReviewStats` is exported from the controller so the edit path can reuse it rather than growing a second copy of the aggregate query.

## Verification

`backend/tests/reviewRoutes.test.js` is rewritten — the previous version asserted the unguarded behaviour (`201` straight from `reviewRepo.create`), which is the bug.

```
Tests: 16 passed, 16 total
```

The new tests pin the thing that actually matters: `reviewRepo.create` and `reviewRepo.delete` are **not** called, a controller refusal (403 "only review products you have purchased", 400 duplicate) is passed through rather than papered over, `productId` lands on `req.params.id`, ratings of `0`/`6`/`99`/`-1`/`3.7` are refused rather than clamped, and the average is refreshed on a rating edit but not on a comment-only edit.

Existing suites unaffected:

```
tests/reviewRepository.test.js, tests/reviewResubmission.test.js, tests/reviewModeration.test.js
Tests: 72 passed, 72 total
```

```
✅ syntax check passed — 633 JavaScript file(s) parsed cleanly
✅ boot check passed — backend/server.js loaded with 94 mounted layers
```

## Note on CI

The **Backend tests** check on this PR fails only on the 5 failures already present on `main` — `subscriptionRoutes`, `subscriptionRenewal` and the three `mergeScarRegression` shop.js cases. None of them touch this change, and this PR's own tests all pass inside that run.

#1660 clears them (`118 suites, 2527 tests, all passing`). **Merging that one first turns this check green**; nothing here needs to change for it.

The red **Vercel** check is the usual "Authorization required to deploy" against the `bhuvanshs-projects` team, and is unrelated.
