### PR TITLE
fix(reviews): stop storing truncated photos, and size the caps to the body limit (#1654)

### DIFF
--- a/backend/controllers/reviewController.js
+++ b/backend/controllers/reviewController.js
@@ -8,6 +8,20 @@ const reviewModerationService = require("../services/reviewModerationService");
 
 /** Cap on photos per review. */
 const MAX_REVIEW_IMAGES = 5;
+
+// Cap on one inlined photo, in characters of data URI.
+//
+// Photos arrive as base64 in the JSON body rather than as an upload, so the
+// per-image cap and MAX_REVIEW_IMAGES together have to fit inside
+// appConfig.bodyLimit, which is 10mb. Five images at the old 5,000,000 was a
+// 25MB ceiling against a 10MB door: three ordinary photos already 413ed, and
+// the failure surfaced as a generic "Failed to submit review" (#1654).
+//
+// 1,500,000 characters is about 1.1MB of image. Five of them is 7.5MB, which
+// leaves the rest of the review room inside the limit. The frontend downscales
+// to fit this before it uploads, so the cap is a backstop rather than
+// something a shopper is expected to meet by choosing smaller photos.
+const MAX_REVIEW_IMAGE_CHARS = 1500000;
 const { ReviewError, REPORT_REASONS } = require("../services/reviewModerationService");
 const {
     safeArray,
@@ -381,16 +395,29 @@ const deleteProductReview = async (req, res) => {
 function normalizeReviewImages(value) {
     if (!Array.isArray(value)) return [];
 
+    const isDataImage = (url) =>
+        /^data:image\/(png|jpe?g|webp|gif);base64,/i.test(url);
+
     return value
         .slice(0, MAX_REVIEW_IMAGES)
         .map((url) => {
             const str = sanitizeString(url || "");
-            if (/^data:image\/(png|jpe?g|webp|gif);base64,/i.test(str)) {
-                return str.slice(0, 5000000);
+
+            // An oversized data URI is dropped, not trimmed.
+            //
+            // `slice()` cut the payload mid-stream and the result still began
+            // `data:image/jpeg;base64,`, so it passed the filter below and was
+            // written to reviews.images -- a truncated, undecodable URI that
+            // renders as a broken image for as long as the review exists.
+            // Truncating turns a rejectable request into permanent bad data;
+            // rejecting is recoverable (#1654).
+            if (isDataImage(str)) {
+                return str.length > MAX_REVIEW_IMAGE_CHARS ? "" : str;
             }
+
             return str.slice(0, 500);
         })
-        .filter((url) => /^https?:\/\//i.test(url) || /^data:image\/(png|jpe?g|webp|gif);base64,/i.test(url));
+        .filter((url) => /^https?:\/\//i.test(url) || isDataImage(url));
 }
 
 /**
@@ -576,6 +603,13 @@ const moderateReview = async (req, res) => {
 };
 
 module.exports = {
+    // Exported for the size and truncation rules to be tested directly. What
+    // goes wrong here is arithmetic against a request body limit, and reaching
+    // it through a full createProductReview round trip would test the mocking
+    // rather than the rule (#1654).
+    normalizeReviewImages,
+    MAX_REVIEW_IMAGES,
+    MAX_REVIEW_IMAGE_CHARS,
     getProductReviews,
     createProductReview,
     deleteProductReview,

--- a/backend/controllers/reviewController.js
+++ b/backend/controllers/reviewController.js
@@ -603,13 +603,6 @@ const moderateReview = async (req, res) => {
 };
 
 module.exports = {
-    // Exported for the size and truncation rules to be tested directly. What
-    // goes wrong here is arithmetic against a request body limit, and reaching
-    // it through a full createProductReview round trip would test the mocking
-    // rather than the rule (#1654).
-    normalizeReviewImages,
-    MAX_REVIEW_IMAGES,
-    MAX_REVIEW_IMAGE_CHARS,
     getProductReviews,
     createProductReview,
     deleteProductReview,
@@ -619,5 +612,13 @@ module.exports = {
     getReportReasons,
     getModerationQueue,
     getReviewReports,
-    moderateReview
+    moderateReview,
+
+    // Exported for the size and truncation rules to be tested directly. What
+    // goes wrong here is arithmetic against a request body limit, and reaching
+    // it through a full createProductReview round trip would test the mocking
+    // rather than the rule (#1654).
+    normalizeReviewImages,
+    MAX_REVIEW_IMAGES,
+    MAX_REVIEW_IMAGE_CHARS
 };

--- a/backend/tests/reviewImageLimits.test.js
+++ b/backend/tests/reviewImageLimits.test.js
@@ -1,0 +1,189 @@
+// backend/tests/reviewImageLimits.test.js
+//
+// Review photos are inlined as base64 in the JSON body, so their size is not a
+// storage question -- it is arithmetic against `appConfig.bodyLimit`, and it
+// was wrong in both directions (#1654):
+//
+//   - a data URI over the cap was `slice()`d, and the truncated string still
+//     began `data:image/jpeg;base64,`, so it passed the filter and was stored:
+//     an undecodable URI that renders as a broken image forever
+//   - five images at 5,000,000 characters is a 25MB ceiling against a 10MB
+//     door, so three ordinary phone photos 413ed before reaching any of this
+
+jest.mock("../config/db", () => ({
+    query: jest.fn(),
+    getConnection: jest.fn()
+}));
+
+const {
+    normalizeReviewImages,
+    MAX_REVIEW_IMAGES,
+    MAX_REVIEW_IMAGE_CHARS
+} = require("../controllers/reviewController");
+
+const appConfig = require("../config/appConfig");
+
+const dataUri = (chars, mime = "image/jpeg") =>
+    `data:${mime};base64,${"A".repeat(chars)}`;
+
+const bodyLimitBytes = () => {
+    const match = String(appConfig.bodyLimit).match(/^(\d+)\s*mb$/i);
+    return Number(match[1]) * 1024 * 1024;
+};
+
+describe("the caps fit through the door", () => {
+    test("bodyLimit is expressed in whole megabytes", () => {
+        expect(String(appConfig.bodyLimit)).toMatch(/^\d+mb$/i);
+    });
+
+    test("a full set of images fits inside the request body limit", () => {
+        // The regression, stated as the arithmetic that failed:
+        // 5 x 5,000,000 = 25,000,000 against a 10,485,760 byte limit.
+        const worstCase = MAX_REVIEW_IMAGES * MAX_REVIEW_IMAGE_CHARS;
+
+        expect(worstCase).toBeLessThan(bodyLimitBytes());
+    });
+
+    test("leaves room for the rest of the review", () => {
+        // Not just under the limit -- under it with the comment, title, rating
+        // and JSON envelope still to fit.
+        const worstCase = MAX_REVIEW_IMAGES * MAX_REVIEW_IMAGE_CHARS;
+
+        expect(worstCase).toBeLessThan(bodyLimitBytes() * 0.8);
+    });
+});
+
+describe("normalizeReviewImages", () => {
+    test("keeps a data URI inside the cap intact", () => {
+        const image = dataUri(1000);
+
+        expect(normalizeReviewImages([image])).toEqual([image]);
+    });
+
+    test("keeps one exactly at the cap", () => {
+        const prefix = "data:image/jpeg;base64,";
+        const image = prefix + "A".repeat(MAX_REVIEW_IMAGE_CHARS - prefix.length);
+
+        expect(image.length).toBe(MAX_REVIEW_IMAGE_CHARS);
+        expect(normalizeReviewImages([image])).toEqual([image]);
+    });
+
+    test("drops an oversized data URI rather than truncating it", () => {
+        const image = dataUri(MAX_REVIEW_IMAGE_CHARS + 1);
+
+        expect(normalizeReviewImages([image])).toEqual([]);
+    });
+
+    test("never returns a data URI it has cut short", () => {
+        // The precise failure: the old code returned `str.slice(0, 5000000)`,
+        // which is still prefixed `data:image/...;base64,` and so survived the
+        // filter below it. Nothing that comes back may be shorter than it went
+        // in.
+        const images = [
+            dataUri(200),
+            dataUri(MAX_REVIEW_IMAGE_CHARS * 2),
+            dataUri(5000)
+        ];
+
+        const result = normalizeReviewImages(images);
+
+        for (const url of result) {
+            expect(images).toContain(url);
+        }
+
+        expect(result).toEqual([dataUri(200), dataUri(5000)]);
+    });
+
+    test("an oversized image does not take the others with it", () => {
+        const good = dataUri(100);
+
+        expect(normalizeReviewImages([good, dataUri(MAX_REVIEW_IMAGE_CHARS + 50)]))
+            .toEqual([good]);
+    });
+
+    test("accepts the mime types the column is meant to hold", () => {
+        for (const mime of ["image/png", "image/jpeg", "image/jpg", "image/webp", "image/gif"]) {
+            expect(normalizeReviewImages([dataUri(50, mime)])).toHaveLength(1);
+        }
+    });
+
+    test("still takes http(s) URLs, trimmed at 500", () => {
+        const long = `https://cdn.example.com/${"a".repeat(900)}.jpg`;
+
+        const [result] = normalizeReviewImages([long]);
+
+        expect(result).toHaveLength(500);
+        expect(result.startsWith("https://cdn.example.com/")).toBe(true);
+    });
+
+    test("refuses anything that is not an image URL", () => {
+        // A javascript: URL in an image list is stored XSS (#1276).
+        expect(
+            normalizeReviewImages([
+                "javascript:alert(1)",
+                "data:text/html;base64,PHNjcmlwdD4=",
+                "data:application/pdf;base64,JVBERi0=",
+                "ftp://example.com/x.png",
+                "",
+                null,
+                undefined,
+                42
+            ])
+        ).toEqual([]);
+    });
+
+    test("caps the number of photos", () => {
+        const many = Array.from({ length: MAX_REVIEW_IMAGES + 4 }, () => dataUri(10));
+
+        expect(normalizeReviewImages(many)).toHaveLength(MAX_REVIEW_IMAGES);
+    });
+
+    test("the count cap is applied before the size rule, so it cannot be widened", () => {
+        // Oversized entries are dropped after the slice, so a caller cannot
+        // push a sixth valid photo through by padding the list with rejects.
+        const images = [
+            ...Array.from({ length: MAX_REVIEW_IMAGES }, () =>
+                dataUri(MAX_REVIEW_IMAGE_CHARS + 1)
+            ),
+            dataUri(10)
+        ];
+
+        expect(normalizeReviewImages(images)).toEqual([]);
+    });
+
+    test("a non-array is no images", () => {
+        expect(normalizeReviewImages(undefined)).toEqual([]);
+        expect(normalizeReviewImages(null)).toEqual([]);
+        expect(normalizeReviewImages("data:image/png;base64,AAA")).toEqual([]);
+        expect(normalizeReviewImages({ 0: "x", length: 1 })).toEqual([]);
+    });
+});
+
+describe("the frontend downscales to the same cap", () => {
+    const fs = require("fs");
+    const path = require("path");
+
+    const source = fs.readFileSync(
+        path.join(__dirname, "..", "..", "frontend", "scripts", "product-reviews.js"),
+        "utf8"
+    );
+
+    test("states the same per-image cap the server enforces", () => {
+        const match = source.match(/MAX_REVIEW_IMAGE_CHARS\s*=\s*(\d+)/);
+
+        expect(match).not.toBeNull();
+        expect(Number(match[1])).toBe(MAX_REVIEW_IMAGE_CHARS);
+    });
+
+    test("resizes rather than uploading whatever the camera produced", () => {
+        expect(source).toMatch(/downscaleToLimit/);
+        expect(source).toMatch(/canvas/i);
+        expect(source).toMatch(/toDataURL\(\s*["']image\/jpeg["']/);
+    });
+
+    test("refuses a photo it cannot get under the cap", () => {
+        // Before this, a file that could not fit was uploaded anyway and the
+        // server stored a truncated copy of it.
+        expect(source).toMatch(/too large to attach/i);
+    });
+});

--- a/frontend/scripts/product-reviews.js
+++ b/frontend/scripts/product-reviews.js
@@ -587,8 +587,90 @@
     });
   }
 
+  // Photos are inlined as base64 in the JSON body, so what the camera produced
+  // is not what can be sent. A phone photo is 4-12MB; five of those is far past
+  // the 10mb request body limit, and the server used to `slice()` anything over
+  // its own cap, storing a truncated data URI that renders as a broken image
+  // for as long as the review exists (#1654).
+  //
+  // So the resizing happens here, before anything is queued. A review photo is
+  // displayed a few hundred pixels wide; 1600px on the long edge is already
+  // more than the page can show.
+  const MAX_REVIEW_IMAGE_CHARS = 1500000; // mirrors the server's cap
+  const MAX_IMAGE_DIMENSION = 1600;
+  const JPEG_QUALITY_STEPS = [0.82, 0.7, 0.6, 0.5, 0.4];
+
+  const readFileAsDataURL = (file) =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = (loadEvent) => resolve(loadEvent.target?.result || "");
+      reader.onerror = () => reject(new Error(`Failed to read ${file.name}`));
+      reader.readAsDataURL(file);
+    });
+
+  const loadImage = (src) =>
+    new Promise((resolve, reject) => {
+      const image = new Image();
+      image.onload = () => resolve(image);
+      image.onerror = () => reject(new Error("Unreadable image"));
+      image.src = src;
+    });
+
+  /**
+   * Scale a photo down until its data URI fits the cap.
+   *
+   * Quality is stepped down first because it costs the least visibly; only if
+   * the smallest quality is still too big does the pixel size halve. Returns
+   * null when even that cannot get it under, which is a real answer -- better
+   * than uploading something the server will refuse or, worse, store truncated.
+   */
+  const downscaleToLimit = async (file) => {
+    const original = await readFileAsDataURL(file);
+
+    if (original.length <= MAX_REVIEW_IMAGE_CHARS) {
+      return original;
+    }
+
+    const image = await loadImage(original);
+
+    let width = image.naturalWidth || image.width;
+    let height = image.naturalHeight || image.height;
+
+    const longestEdge = Math.max(width, height);
+
+    if (longestEdge > MAX_IMAGE_DIMENSION) {
+      const scale = MAX_IMAGE_DIMENSION / longestEdge;
+      width = Math.round(width * scale);
+      height = Math.round(height * scale);
+    }
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const canvas = document.createElement("canvas");
+      canvas.width = Math.max(1, width);
+      canvas.height = Math.max(1, height);
+
+      const context = canvas.getContext("2d");
+      if (!context) return null;
+
+      context.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+      for (const quality of JPEG_QUALITY_STEPS) {
+        const candidate = canvas.toDataURL("image/jpeg", quality);
+
+        if (candidate.length <= MAX_REVIEW_IMAGE_CHARS) {
+          return candidate;
+        }
+      }
+
+      width = Math.round(width / 2);
+      height = Math.round(height / 2);
+    }
+
+    return null;
+  };
+
   if (reviewImagesInput) {
-    reviewImagesInput.addEventListener("change", (e) => {
+    reviewImagesInput.addEventListener("change", async (e) => {
       const files = Array.from(e.target.files || []);
       if (!files.length) return;
 
@@ -599,26 +681,35 @@
       const remainingSlots = 5 - selectedReviewImages.length;
       const filesToRead = files.slice(0, remainingSlots);
 
-      filesToRead.forEach((file) => {
+      // Cleared up front: the resizing below is async, and leaving the input
+      // populated lets the same file be picked again while it is still being
+      // processed.
+      reviewImagesInput.value = "";
+
+      for (const file of filesToRead) {
         if (!file.type.startsWith("image/")) {
           AppUtils.notify(`File ${file.name} is not a valid image`, "error");
-          return;
+          continue;
         }
 
-        const reader = new FileReader();
-        reader.onload = (loadEvent) => {
-          if (loadEvent.target?.result) {
-            selectedReviewImages.push(loadEvent.target.result);
-            renderImagePreviews();
-          }
-        };
-        reader.onerror = () => {
-          AppUtils.notify(`Failed to read file ${file.name}`, "error");
-        };
-        reader.readAsDataURL(file);
-      });
+        try {
+          const prepared = await downscaleToLimit(file);
 
-      reviewImagesInput.value = "";
+          if (!prepared) {
+            AppUtils.notify(
+              `${file.name} is too large to attach, even resized`,
+              "error"
+            );
+            continue;
+          }
+
+          selectedReviewImages.push(prepared);
+          renderImagePreviews();
+        } catch (error) {
+          console.error("REVIEW IMAGE ERROR:", error);
+          AppUtils.notify(`Failed to read file ${file.name}`, "error");
+        }
+      }
     });
   }
 


### PR DESCRIPTION
Closes #1654

## What was wrong

Review photos are inlined as base64 in the JSON body, so their size is arithmetic against `appConfig.bodyLimit` — not a storage question. It was wrong in both directions.

**Truncation stored corrupt data.** `normalizeReviewImages` trimmed an oversized data URI with `str.slice(0, 5000000)`, and the result still began `data:image/jpeg;base64,` — so it passed the filter immediately below it and was written to `reviews.images`:

```
input len : 6000023
stored len: 5000000
truncated : true
still passes filter (stored corrupt): true
```

A base64 URI is ~1.37× the file, so the cap bit at roughly **3.6 MB of original image**. Anything larger became an undecodable URI that renders as a broken image for as long as the review exists.

**The caps did not fit through the door.** `MAX_REVIEW_IMAGES = 5` at 5,000,000 characters is a **25 MB** ceiling against `bodyLimit: "10mb"`. Three ordinary phone photos 413ed before any of that logic ran, surfacing as a generic "Failed to submit review".

**The client measured nothing.** `product-reviews.js` counted files and checked `file.type`, then read whatever was picked straight to a data URL and queued it — so a 4–12 MB phone photo went up exactly as it came off the camera.

## What this does

**Server: drop, don't trim.** An oversized data URI is refused rather than sliced. Truncating turns a rejectable request into permanent bad data; rejecting is recoverable.

**Server: caps that add up.** Per-image cap is now 1,500,000 characters — about 1.1 MB of image, 7.5 MB for a full set of five, leaving the rest of the review room inside the 10 MB limit.

**Client: downscale before queueing.** 1600 px on the long edge, then stepping JPEG quality down (`0.82 → 0.4`), then halving the pixel size if that is still not enough. A review photo is displayed a few hundred pixels wide, so this costs nothing visible and turns a 4 MB camera file into something well under the cap. A file that genuinely cannot be brought under it is refused with a message that says so, instead of being uploaded for the server to truncate.

The file input is also cleared up front now — the resizing is async, and leaving it populated let the same file be re-picked mid-process.

## Verification

```
Tests: 17 passed, 17 total
```

The tests pin the **arithmetic**, not just the branch:

- `MAX_REVIEW_IMAGES × MAX_REVIEW_IMAGE_CHARS` must fit inside `bodyLimit` — with 20% headroom for the comment, title, rating and JSON envelope. On `main` that is `5 × 5,000,000 = 25,000,000` against `10,485,760`, so this fails there.
- Nothing `normalizeReviewImages` returns may be shorter than it went in — the exact shape of the truncation bug.
- The count cap is applied before the size rule, so padding the list with rejects cannot smuggle a sixth photo through.
- The frontend's stated cap must equal the server's, so the two cannot drift.

Existing review suites unaffected:

```
tests/reviewRoutes, reviewResubmission, reviewModeration, reviewRepository
Tests: 76 passed, 76 total
```

```
✅ syntax check passed — 633 JavaScript file(s) parsed cleanly
✅ asset check passed — 585 local reference(s) across 30 page(s) resolve
✅ landmark check passed — 30 page(s) have a skip link, a main landmark and one h1
```

## Note on CI

The **Backend tests** check on this PR fails only on the 5 failures already present on `main` — `subscriptionRoutes`, `subscriptionRenewal` and the three `mergeScarRegression` shop.js cases. None of them touch this change, and this PR's own tests all pass inside that run.

#1660 clears them (`118 suites, 2527 tests, all passing`). **Merging that one first turns this check green**; nothing here needs to change for it.

The red **Vercel** check is the usual "Authorization required to deploy" against the `bhuvanshs-projects` team, and is unrelated.
