### PR TITLE
fix: get the backend suite green on main (#1655)

### DIFF
--- a/backend/controllers/subscriptionController.js
+++ b/backend/controllers/subscriptionController.js
@@ -126,9 +126,14 @@ const subscriptionController = {
 
             return res.status(200).json({
                 success: true,
+                // The pair distinguishes two outcomes: a resume that also
+                // withdrew a pending cancellation, and a plain resume. The
+                // second said "resumed successfully", which adds nothing to
+                // `success: true` and reads as the more significant of the two
+                // rather than the lesser.
                 message: subscription.withdrewCancellation
                     ? 'Subscription resumed and the pending cancellation withdrawn'
-                    : 'Subscription resumed successfully',
+                    : 'Subscription resumed',
                 data: { subscription }
             });
         } catch (error) {

--- a/backend/services/subscriptionService.js
+++ b/backend/services/subscriptionService.js
@@ -141,11 +141,26 @@ async function getForUser(userId) {
 // Write Operations & Transactions
 // ---------------------------------------------------------------------------
 
-async function fetchAndValidatePlan(connection, planId) {
+/**
+ * The plan id as a positive integer, or a refusal.
+ *
+ * Split out of fetchAndValidatePlan so callers can run it before they open a
+ * transaction. "abc" is not a plan id under any state of the database, and
+ * settling that after `withTransaction` has taken a connection means an
+ * unusable argument costs a connection from the pool and a rollback to answer.
+ */
+function normalisePlanId(planId) {
     const plan = Math.trunc(safeNumber(planId));
+
     if (plan < 1) {
         throw new SubscriptionError('Invalid plan ID', 400, 'INVALID_PLAN');
     }
+
+    return plan;
+}
+
+async function fetchAndValidatePlan(connection, planId) {
+    const plan = normalisePlanId(planId);
 
     const [plans] = await connection.query(
         `SELECT id, name, price, currency, \`interval\`, interval_count, trial_days
@@ -173,8 +188,14 @@ async function subscribe(userId, planId) {
         throw new SubscriptionError('Authentication required', 401, 'UNAUTHENTICATED');
     }
 
+    // Both argument checks happen before the transaction, for the same reason.
+    // Neither depends on anything in the database, and an unusable argument
+    // that opens and rolls back a transaction to answer is paying for a
+    // connection to say no.
+    const plan = normalisePlanId(planId);
+
     return withTransaction(async (connection) => {
-        const billingPlan = await fetchAndValidatePlan(connection, planId);
+        const billingPlan = await fetchAndValidatePlan(connection, plan);
 
         const [existing] = await connection.query(
             `SELECT id, status, cancel_at_period_end

--- a/backend/tests/mergeScarRegression.test.js
+++ b/backend/tests/mergeScarRegression.test.js
@@ -314,24 +314,38 @@ describe('frontend/scripts/shop.js', () => {
     });
 
     it('closes that listener rather than running on into what follows', () => {
-        // The #1444 scar itself: `}\n);` closes the arrow function and the call
-        // it is an argument to. Dropping the `);` merged the listener into the
-        // next declaration.
-        const listener = source.indexOf('document.addEventListener(\n    "DOMContentLoaded"');
+        // The #1444 scar itself: `}` then `);` closes the arrow function and the
+        // call it is an argument to. Dropping the `);` merged the listener into
+        // the next declaration.
+        //
+        // Matched by shape rather than by a literal with the indentation baked
+        // in. #1644 wrapped this file in an IIFE, which moved every line one
+        // level right and broke an assertion that was pinning the whitespace
+        // instead of the structure (#1655).
+        const listener = source.search(
+            /document\.addEventListener\(\s*["']DOMContentLoaded["']/
+        );
         expect(listener).toBeGreaterThan(-1);
 
-        expect(source.slice(listener)).toMatch(/\n\s*\}\n\);/);
+        expect(source.slice(listener)).toMatch(/\n\s*\}\n\s*\);/);
     });
 
     it('declares no function twice', () => {
         // `setupSearch` was declared twice, ~250 lines apart. Declarations
         // hoist, so the second silently replaced the first and the first became
         // unreachable -- no error, no warning.
+        //
+        // The leading `\s*` is load-bearing. Anchored at `^function` this
+        // matched nothing once #1644 indented the file inside an IIFE, so the
+        // check passed by finding no declarations at all rather than by finding
+        // no duplicates (#1655).
         const counts = new Map();
 
-        for (const match of source.matchAll(/^function\s+([A-Za-z_$][\w$]*)/gm)) {
+        for (const match of source.matchAll(/^\s*function\s+([A-Za-z_$][\w$]*)/gm)) {
             counts.set(match[1], (counts.get(match[1]) || 0) + 1);
         }
+
+        expect(counts.size).toBeGreaterThan(10);
 
         expect([...counts.entries()].filter(([, n]) => n > 1).map(([name]) => name)).toEqual([]);
     });
@@ -354,7 +368,9 @@ describe('frontend/scripts/shop.js', () => {
             'getReviewCount',
             'getRatingLabel'
         ]) {
-            expect(source).toMatch(new RegExp(`^function ${name}\\(`, 'm'));
+            // `\\s*` rather than an anchor: what matters is that the
+            // declaration is in the file, not what column it starts in.
+            expect(source).toMatch(new RegExp(`^\\s*function ${name}\\(`, 'm'));
         }
     });
 
@@ -364,10 +380,16 @@ describe('frontend/scripts/shop.js', () => {
         expect(html).toMatch(/id="clear-filters"/);
         expect(html).toMatch(/id="product-sort"/);
 
-        expect(source).not.toMatch(/getElementById\(['"]clear-filters-btn['"]\)/);
-        expect(source).not.toMatch(/getElementById\(['"]sort-select['"]\)/);
-        expect(source).toMatch(/getElementById\(["']clear-filters["']\)/);
-        expect(source).toMatch(/getElementById\(["']product-sort["']\)/);
+        // Whitespace-tolerant on both sides of the argument: this file now
+        // wraps the call across three lines, which a single-line pattern misses
+        // even though the id it asks for is exactly right (#1655).
+        const resolvesById = (id) =>
+            new RegExp(`getElementById\\(\\s*["']${id}["']\\s*\\)`);
+
+        expect(source).not.toMatch(resolvesById('clear-filters-btn'));
+        expect(source).not.toMatch(resolvesById('sort-select'));
+        expect(source).toMatch(resolvesById('clear-filters'));
+        expect(source).toMatch(resolvesById('product-sort'));
     });
 
     it('has one owner for the clear-filters click', () => {


### PR DESCRIPTION
Closes #1655

`main` (`ebe0b77`) had 5 failures across 3 suites, from two unrelated causes. Every PR opened against it inherited them, so a genuinely broken change and a clean one produced the same red CI.

## Subscriptions — the code was wrong

Both regressions arrive with #1645, which removed 265 lines from `subscriptionService.js` and `subscriptionController.js`.

**Plan validation ran inside the transaction.** `subscribe()` settled an unusable plan id from within `withTransaction`, because the shape check lived in `fetchAndValidatePlan` — which only runs once a connection has been taken:

```
● subscribe › rejects an unusable plan id before touching the database
  expect(jest.fn()).not.toHaveBeenCalled()
  Expected number of calls: 0
  Received number of calls: 1
```

`"abc"` is not a plan id under any state of the database. Answering it cost a connection from the pool and a rollback. The check is now `normalisePlanId`, called alongside the `userId` check *before* the transaction opens. `fetchAndValidatePlan` still calls it, so the path that looks the plan up keeps its own guarantee.

**The resume message drifted.**

```
● POST /api/subscriptions/resume › and says the other one when that is what happened
  Expected: "Subscription resumed"
  Received: "Subscription resumed successfully"
```

The two messages there exist to distinguish a resume that also withdrew a pending cancellation from a plain one. "successfully" adds nothing to `success: true`, and reads as the larger of the two outcomes rather than the smaller.

## shop.js — the assertions were wrong

The other three are not product defects. #1644 restructured `shop.js` into an IIFE, moving every line one level right, and three checks were pinning whitespace rather than structure:

| Assertion | Why it broke |
|---|---|
| `declares the functions its own code calls` | `^function name(` no longer matches an indented declaration — though **all fourteen are declared** |
| `closes that listener rather than running on into what follows` | a literal `document.addEventListener(\n    "DOMContentLoaded"` with the indentation baked in |
| `resolves the clear-filters button and sort select by the ids the page uses` | `getElementById("clear-filters")` is now wrapped across three lines |

Verified before changing anything: the ids in `shop.js` (`"clear-filters"` line 2351, `"product-sort"` line 2316) still agree with `shop.html`, the listener is still closed, and no function is declared twice. Each assertion now matches by shape.

### One of these was worse than a false alarm

`declares no function twice` anchored on `^function\s+`. After the reformat that matched **nothing at all** — so it passed by finding no declarations, not by finding no duplicates, and would have gone on silently passing through any duplicate anyone added. It is the exact regression the case was written to catch, and it had stopped being able to catch it.

It now asserts it found declarations (`counts.size > 10`) before concluding anything about them.

## Verification

```
Test Suites: 118 passed, 118 total
Tests:       2527 passed, 2527 total
```

```
✅ syntax check passed — 633 JavaScript file(s) parsed cleanly
```
