### PR TITLE
fix(subscription): clamp advancePeriod calculation to target month length

### DIFF
--- a/backend/services/subscriptionService.js
+++ b/backend/services/subscriptionService.js
@@ -98,12 +98,24 @@ function advancePeriod(from, interval, count = 1) {
         case 'weekly':
             end.setDate(end.getDate() + 7 * steps);
             break;
-        case 'monthly':
-            end.setMonth(end.getMonth() + steps);
+        case 'monthly': {
+            const desiredDay = start.getDate();
+            end.setDate(1);
+            end.setMonth(start.getMonth() + steps);
+            const maxDays = new Date(end.getFullYear(), end.getMonth() + 1, 0).getDate();
+            end.setDate(Math.min(desiredDay, maxDays));
             break;
-        case 'yearly':
-            end.setFullYear(end.getFullYear() + steps);
+        }
+        case 'yearly': {
+            const desiredDay = start.getDate();
+            const desiredMonth = start.getMonth();
+            end.setDate(1);
+            end.setFullYear(start.getFullYear() + steps);
+            end.setMonth(desiredMonth);
+            const maxDays = new Date(end.getFullYear(), desiredMonth + 1, 0).getDate();
+            end.setDate(Math.min(desiredDay, maxDays));
             break;
+        }
         default:
             throw new SubscriptionError(
                 `Unsupported billing interval: ${interval}`,

--- a/backend/tests/subscriptionPeriodClamp.test.js
+++ b/backend/tests/subscriptionPeriodClamp.test.js
@@ -1,0 +1,35 @@
+const { advancePeriod } = require('../services/subscriptionService');
+
+describe('SubscriptionService - advancePeriod End-of-Month Clamping', () => {
+    test('should clamp January 31 + 1 month to February 28 in non-leap year', () => {
+        const from = new Date(2025, 0, 31); // 2025-01-31
+        const next = advancePeriod(from, 'monthly', 1);
+        expect(next.getFullYear()).toBe(2025);
+        expect(next.getMonth()).toBe(1); // February
+        expect(next.getDate()).toBe(28);
+    });
+
+    test('should clamp January 31 + 1 month to February 29 in leap year', () => {
+        const from = new Date(2024, 0, 31); // 2024-01-31
+        const next = advancePeriod(from, 'monthly', 1);
+        expect(next.getFullYear()).toBe(2024);
+        expect(next.getMonth()).toBe(1); // February
+        expect(next.getDate()).toBe(29);
+    });
+
+    test('should clamp August 31 + 1 month to September 30', () => {
+        const from = new Date(2025, 7, 31); // 2025-08-31
+        const next = advancePeriod(from, 'monthly', 1);
+        expect(next.getFullYear()).toBe(2025);
+        expect(next.getMonth()).toBe(8); // September
+        expect(next.getDate()).toBe(30);
+    });
+
+    test('should clamp Feb 29 leap year + 1 year to Feb 28', () => {
+        const from = new Date(2024, 1, 29); // 2024-02-29
+        const next = advancePeriod(from, 'yearly', 1);
+        expect(next.getFullYear()).toBe(2025);
+        expect(next.getMonth()).toBe(1); // February
+        expect(next.getDate()).toBe(28);
+    });
+});


### PR DESCRIPTION
## Description
Fixes Date overflow and monthly renewal calendar drift in \ackend/services/subscriptionService.js\. Previously, calling \setMonth(start.getMonth() + steps)\ on a date near the end of a month (e.g. Jan 31) caused native JavaScript Date overflow into March (skipping February billing entirely) and permanently shifted all subsequent monthly renewal dates to the 2nd/3rd.

## Related Issue
Closes #1646

## Clean Architecture & Changes
- In \dvancePeriod()\, clamped \monthly\ and \yearly\ interval day calculation to \Math.min(desiredDay, maxDaysInTargetMonth)\.
- Added unit tests in \ackend/tests/subscriptionPeriodClamp.test.js\ covering standard year, leap year, and end-of-month (Jan 31, Aug 31, Feb 29) rollover transitions.

## Verification
- Run \
px jest tests/subscriptionPeriodClamp.test.js\ (All unit tests passing cleanly).