### PR TITLE
fix(recently-viewed): apply canonical publicProductCondition to filter inactive and draft products

### DIFF
--- a/backend/services/recentlyViewedService.js
+++ b/backend/services/recentlyViewedService.js
@@ -40,6 +40,7 @@
 // database read, and only a complete entry may be served without one.
 
 const db = require('../config/db').promise;
+const { publicProductCondition } = require('../constants/productVisibility');
 
 const PLACEHOLDER_IMAGE = '/assets/images/placeholder.png';
 
@@ -189,13 +190,14 @@ class RecentlyViewedService {
         }
 
         try {
+            const visible = publicProductCondition('products');
             const [product] = await db.query(
-                'SELECT id, name, price, image, stock FROM products WHERE id = ? AND deleted_at IS NULL',
-                [productId]
+                `SELECT id, name, price, image, stock FROM products WHERE id = ? AND ${visible.sql}`,
+                [productId, ...visible.params]
             );
 
-            if (product.length === 0) {
-                console.warn(`Product ${productId} not found`);
+            if (!product || product.length === 0) {
+                console.warn(`Product ${productId} not found or not visible`);
                 return [];
             }
 
@@ -306,6 +308,7 @@ class RecentlyViewedService {
      * @returns {Promise<Array>}
      */
     async fetchFromDatabase(userId, limit) {
+        const visible = publicProductCondition('p');
         const [rows] = await db.query(
             `SELECT
                 p.id,
@@ -315,10 +318,10 @@ class RecentlyViewedService {
                 rv.viewed_at AS viewedAt
              FROM recently_viewed rv
              INNER JOIN products p ON p.id = rv.product_id
-             WHERE rv.user_id = ? AND p.stock > 0 AND p.deleted_at IS NULL
+             WHERE rv.user_id = ? AND p.stock > 0 AND ${visible.sql}
              ORDER BY rv.viewed_at DESC
              LIMIT ?`,
-            [PLACEHOLDER_IMAGE, userId, limit]
+            [PLACEHOLDER_IMAGE, userId, ...visible.params, limit]
         );
 
         return Array.isArray(rows) ? rows : [];

--- a/backend/tests/recentlyViewedVisibility.test.js
+++ b/backend/tests/recentlyViewedVisibility.test.js
@@ -1,0 +1,42 @@
+const recentlyViewedService = require('../services/recentlyViewedService');
+const db = require('../config/db').promise;
+
+jest.mock('../config/db', () => ({
+    promise: {
+        query: jest.fn()
+    }
+}));
+
+describe('RecentlyViewedService - Canonical Product Visibility', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        recentlyViewedService.cache.clear();
+    });
+
+    test('fetchFromDatabase should include publicProductCondition status check in SQL query', async () => {
+        db.query.mockResolvedValueOnce([
+            [{ id: 'prod-1', name: 'Shoes', price: 99.99, imageUrl: 'img.jpg', viewedAt: new Date() }]
+        ]);
+
+        const result = await recentlyViewedService.fetchFromDatabase('user-1', 10);
+        expect(result.length).toBe(1);
+        expect(db.query).toHaveBeenCalledTimes(1);
+
+        const sql = db.query.mock.calls[0][0];
+        const params = db.query.mock.calls[0][1];
+
+        expect(sql).toContain('p.status IN (?)');
+        expect(sql).toContain('p.deleted_at IS NULL');
+        expect(params).toContain('active');
+    });
+
+    test('addViewed should reject product if it is not visible / not found in query', async () => {
+        db.query.mockResolvedValueOnce([[]]); // empty product result for non-public product
+
+        const result = await recentlyViewedService.addViewed('user-1', 'prod-draft-1');
+        expect(result).toEqual([]);
+        // Should not insert into recently_viewed table
+        expect(db.query).toHaveBeenCalledTimes(1);
+        expect(db.query.mock.calls[0][0]).toContain('SELECT id, name, price, image, stock FROM products');
+    });
+});


### PR DESCRIPTION
## Description
Fixes display of draft, archived, and inactive products in \ackend/services/recentlyViewedService.js\. Previously, \etchFromDatabase\ only filtered by \p.deleted_at IS NULL\ without verifying product lifecycle \status = 'active'\, leading to 404 links on customer dashboards for withdrawn products.

## Related Issue
Closes #1647

## Clean Architecture & Changes
- Imported and applied canonical \publicProductCondition('p')\ in \etchFromDatabase()\ and \ddViewed()\.
- Added unit tests in \ackend/tests/recentlyViewedVisibility.test.js\ validating exclusion of non-public status records.

## Verification
- Run \
px jest tests/recentlyViewedVisibility.test.js\ (All unit tests passing cleanly).