### PR TITLE
fix(wishlist): update LIVE_PRODUCT filter to check status = active

### DIFF
--- a/backend/controllers/wishlistController.js
+++ b/backend/controllers/wishlistController.js
@@ -27,7 +27,7 @@ const MAX_CACHE_ENTRIES = 1000;
  * Written once and applied by every read below, because the reason it was
  * missing from six of them is that each one had to remember it separately.
  */
-const LIVE_PRODUCT = "p.is_active = 1 AND p.deleted_at IS NULL";
+const LIVE_PRODUCT = "p.status = 'active' AND p.deleted_at IS NULL";
 
 // ==================== CACHE ====================
 const cache = new Map();

--- a/backend/tests/wishlistVisibility.test.js
+++ b/backend/tests/wishlistVisibility.test.js
@@ -1,0 +1,43 @@
+const wishlistController = require('../controllers/wishlistController');
+const promisePool = require('../config/db');
+
+jest.mock('../config/db', () => ({
+    query: jest.fn()
+}));
+
+describe('WishlistController - Canonical Product Visibility', () => {
+    let req;
+    let res;
+
+    beforeEach(() => {
+        req = {
+            user: { id: 'user-1' },
+            query: { page: '1', limit: '10' },
+            params: {}
+        };
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn()
+        };
+        jest.clearAllMocks();
+    });
+
+    test('getUserWishlist queries should filter by status = active and deleted_at IS NULL', async () => {
+        promisePool.query
+            .mockResolvedValueOnce([[{ total: 1 }]]) // count query
+            .mockResolvedValueOnce([[              // items query
+                { id: 'p1', name: 'Product 1', price: 50, status: 'active' }
+            ]]);
+
+        await wishlistController.getUserWishlist(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(promisePool.query).toHaveBeenCalledTimes(2);
+
+        const countQuery = promisePool.query.mock.calls[0][0];
+        const itemsQuery = promisePool.query.mock.calls[1][0];
+
+        expect(countQuery).toContain("p.status = 'active' AND p.deleted_at IS NULL");
+        expect(itemsQuery).toContain("p.status = 'active' AND p.deleted_at IS NULL");
+    });
+});


### PR DESCRIPTION
## Description
Fixes product visibility inconsistencies in \ackend/controllers/wishlistController.js\. Previously, wishlist queries used a legacy \p.is_active = 1\ predicate which ignored product lifecycle status updates (e.g. moving a product to \inactive\, \draft\, or \rchived\).

## Related Issue
Closes #1648

## Clean Architecture & Changes
- Aligned \LIVE_PRODUCT\ predicate in \wishlistController.js\ with canonical visibility rules (\p.status = 'active' AND p.deleted_at IS NULL\).
- Added unit tests in \ackend/tests/wishlistVisibility.test.js\ validating SQL predicate construction.

## Verification
- Run \
px jest tests/wishlistVisibility.test.js\ (All unit tests passing cleanly).