### PR TITLE
fix(agent-liability): ensure idempotent prom-client metric registration

### DIFF
--- a/backend/services/agentLiabilityService.js
+++ b/backend/services/agentLiabilityService.js
@@ -58,33 +58,34 @@ const CACHE_TTL = {
 
 const register = new prometheus.Registry();
 
-const agentCounter = new prometheus.Counter({
+const getOrCreateMetric = (MetricClass, config) => {
+    const existing = register.getSingleMetric(config.name);
+    if (existing) return existing;
+    return new MetricClass({ ...config, registers: [register] });
+};
+
+const agentCounter = getOrCreateMetric(prometheus.Counter, {
     name: 'agent_liability_registrations_total',
     help: 'Total number of agent registrations',
 });
 
-const liabilityGauge = new prometheus.Gauge({
+const liabilityGauge = getOrCreateMetric(prometheus.Gauge, {
     name: 'agent_liability_amount',
     help: 'Current liability amount by tier',
     labelNames: ['tier']
 });
 
-const claimCounter = new prometheus.Counter({
+const claimCounter = getOrCreateMetric(prometheus.Counter, {
     name: 'liability_claims_total',
     help: 'Total number of liability claims',
     labelNames: ['status']
 });
 
-const latencyHistogram = new prometheus.Histogram({
+const latencyHistogram = getOrCreateMetric(prometheus.Histogram, {
     name: 'liability_operation_duration_seconds',
     help: 'Duration of liability operations',
     labelNames: ['operation']
 });
-
-register.registerMetric(agentCounter);
-register.registerMetric(liabilityGauge);
-register.registerMetric(claimCounter);
-register.registerMetric(latencyHistogram);
 
 // ============================================
 // VALIDATION SCHEMAS

--- a/backend/tests/agentLiabilityMetrics.test.js
+++ b/backend/tests/agentLiabilityMetrics.test.js
@@ -1,0 +1,15 @@
+const prometheus = require('prom-client');
+
+describe('AgentLiabilityService - Prometheus Metrics Registration Idempotency', () => {
+    test('should allow safe metric instantiation without duplicate registration errors', () => {
+        expect(() => {
+            // Require service multiple times to simulate test environment reload
+            jest.isolateModules(() => {
+                require('../services/agentLiabilityService');
+            });
+            jest.isolateModules(() => {
+                require('../services/agentLiabilityService');
+            });
+        }).not.toThrow();
+    });
+});


### PR DESCRIPTION
## Description
Fixes metric registration errors during module reload or test worker re-initialization in \ackend/services/agentLiabilityService.js\. Previously, metrics were unconditionally registered with \egister.registerMetric(...)\, throwing \Error: A metric with the name ... has already been registered\ on subsequent imports.

## Related Issue
Closes #1650

## Clean Architecture & Changes
- Implemented \getOrCreateMetric()\ helper to look up existing metrics from the Prometheus Registry before instantiating new instances.
- Added unit tests in \ackend/tests/agentLiabilityMetrics.test.js\ validating safe repeated module imports and metric registration idempotency.

## Verification
- Run \
px jest tests/agentLiabilityMetrics.test.js\ (All unit tests passing cleanly).