### PR TITLE
fix(navbar): give signed-in shoppers a way to log out (#1672)

### DIFF
--- a/backend/tests/navbarAuthContract.test.js
+++ b/backend/tests/navbarAuthContract.test.js
@@ -1,0 +1,200 @@
+// The ids the navbar's account menu is built out of.
+//
+// auth.js and components.js look up #auth-link, #profile-dropdown and
+// #logout-btn, and components.css and base.css style the last two in about
+// fifty lines. None of them existed in any markup: navbar.html shipped only the
+// "Sign In" anchor, so a signed-in shopper had no way to log out on any page,
+// and the profile icon toggled a class on null (#1672).
+//
+// Nothing could catch that. check:assets resolves src/href references, not
+// element ids; check:a11y looks at landmarks. The JS is written defensively
+// (`dropdown?.classList`), so it never threw -- it just quietly did nothing.
+//
+// This pins the contract from both ends: the ids the scripts reach for exist in
+// the component that is supposed to provide them, and the attribute the CSS
+// keys the menu on is present to be flipped.
+
+const fs = require("fs");
+const path = require("path");
+
+const frontend = (...parts) =>
+    path.join(__dirname, "..", "..", "frontend", ...parts);
+
+const navbar = fs.readFileSync(frontend("components", "navbar.html"), "utf8");
+const authJs = fs.readFileSync(frontend("scripts", "auth.js"), "utf8");
+const componentsJs = fs.readFileSync(frontend("scripts", "components.js"), "utf8");
+const componentsCss = fs.readFileSync(frontend("styles", "components.css"), "utf8");
+
+/** Does the markup declare an element with this id? */
+const declaresId = (markup, id) =>
+    new RegExp(`id=["']${id}["']`).test(markup);
+
+describe("the account menu markup exists", () => {
+    test.each(["auth-link", "profile-dropdown", "logout-btn"])(
+        "navbar.html declares #%s",
+        (id) => {
+            expect(declaresId(navbar, id)).toBe(true);
+        }
+    );
+
+    test("the menu sits inside .profile-wrapper", () => {
+        // components.css positions #profile-dropdown absolutely against
+        // .profile-wrapper and opens it on hover of that wrapper. Outside it,
+        // the menu would be positioned against the page instead.
+        const wrapper = navbar.match(
+            /<li class="profile-wrapper">([\s\S]*?)<\/li>/
+        );
+
+        expect(wrapper).not.toBeNull();
+        expect(wrapper[1]).toMatch(/id="profile-dropdown"/);
+        expect(wrapper[1]).toMatch(/id="auth-link"/);
+    });
+
+    test("the logout control is inside the menu", () => {
+        const menu = navbar.match(
+            /<div id="profile-dropdown"[\s\S]*?<\/div>/
+        );
+
+        expect(menu).not.toBeNull();
+        expect(menu[0]).toMatch(/id="logout-btn"/);
+    });
+
+    test("the logout control is a button, not a link", () => {
+        // It ends a session rather than navigating, and components.css styles
+        // `#profile-dropdown button` for exactly this element.
+        expect(navbar).toMatch(/<button[^>]*id="logout-btn"/);
+    });
+});
+
+describe("every id the scripts look up is provided", () => {
+    // Collect the ids auth.js and components.js resolve, then check the ones
+    // that belong to the navbar are actually in it. Scoped to this menu on
+    // purpose: auth.js also looks up the signin and signup form fields, which
+    // live on their own pages and are legitimately absent elsewhere.
+    const NAVBAR_IDS = ["auth-link", "profile-dropdown", "logout-btn"];
+
+    const lookupsIn = (source) =>
+        new Set(
+            [...source.matchAll(/getElementById\(\s*["']([\w-]+)["']\s*\)/g)].map(
+                (match) => match[1]
+            )
+        );
+
+    test("auth.js looks up the menu ids, and navbar.html has them", () => {
+        const looked = lookupsIn(authJs);
+        const wanted = NAVBAR_IDS.filter((id) => looked.has(id));
+
+        expect(wanted).toEqual(NAVBAR_IDS);
+
+        for (const id of wanted) {
+            expect(declaresId(navbar, id)).toBe(true);
+        }
+    });
+
+    test("components.js no longer resolves the menu at module load", () => {
+        // loadComponent() injects navbar.html asynchronously, so a top-level
+        // lookup runs before the element exists. The write has to wait for
+        // componentsLoaded.
+        const topLevel = componentsJs.slice(
+            0,
+            componentsJs.indexOf('document.addEventListener("componentsLoaded"')
+        );
+
+        expect(topLevel).not.toMatch(/getElementById\(\s*["']profile-dropdown["']/);
+        expect(componentsJs).toMatch(/componentsLoaded/);
+    });
+
+    test("components.js reads the stored user through AppUtils", () => {
+        // A bare JSON.parse(localStorage.getItem("user")) at the top level of
+        // this file throws on a corrupt value and takes the rest of the module
+        // -- including the navbar search combobox -- with it.
+        expect(componentsJs).not.toMatch(
+            /JSON\.parse\(\s*localStorage\.getItem\(\s*["']user["']/
+        );
+        expect(componentsJs).toMatch(/AppUtils\.getUser\(\)/);
+    });
+});
+
+describe("the data-loggedin contract the CSS depends on", () => {
+    test("components.css opens the menu on that attribute", () => {
+        expect(componentsCss).toMatch(
+            /#profile-dropdown\[data-loggedin="true"\]/
+        );
+    });
+
+    test("navbar.html ships the attribute so it can be flipped", () => {
+        expect(navbar).toMatch(/id="profile-dropdown"[^>]*data-loggedin=/);
+    });
+
+    test("something actually sets it", () => {
+        // It was written in exactly one place before, on an element that did
+        // not exist. If both writers disappear again the menu can never open
+        // on hover, which is the desktop path.
+        const written =
+            /setAttribute\(\s*["']data-loggedin["']/.test(componentsJs) ||
+            /setAttribute\(\s*["']data-loggedin["']/.test(authJs);
+
+        expect(written).toBe(true);
+    });
+});
+
+describe("the menu is announced properly", () => {
+    test("the trigger declares its relationship to the menu", () => {
+        const trigger = navbar.match(/<a[^>]*id="auth-link"[^>]*>/);
+
+        expect(trigger).not.toBeNull();
+        expect(trigger[0]).toMatch(/aria-haspopup="true"/);
+        expect(trigger[0]).toMatch(/aria-expanded="false"/);
+        expect(trigger[0]).toMatch(/aria-controls="profile-dropdown"/);
+    });
+
+    test("the menu carries a menu role and a label", () => {
+        const menu = navbar.match(/<div id="profile-dropdown"[^>]*>/);
+
+        expect(menu[0]).toMatch(/role="menu"/);
+        expect(menu[0]).toMatch(/aria-labelledby="auth-link"/);
+    });
+
+    test("every item in the menu is a menuitem", () => {
+        const menu = navbar.match(/<div id="profile-dropdown"[\s\S]*?<\/div>/)[0];
+        const items = [...menu.matchAll(/<(?:a|button)\b[^>]*>/g)].map((m) => m[0]);
+
+        expect(items.length).toBeGreaterThan(1);
+
+        for (const item of items) {
+            expect(item).toMatch(/role="menuitem"/);
+        }
+    });
+
+    test("decorative icons are hidden from assistive technology", () => {
+        const menu = navbar.match(/<div id="profile-dropdown"[\s\S]*?<\/div>/)[0];
+        const icons = [...menu.matchAll(/<i\b[^>]*>/g)].map((m) => m[0]);
+
+        expect(icons.length).toBeGreaterThan(0);
+
+        for (const icon of icons) {
+            expect(icon).toMatch(/aria-hidden="true"/);
+        }
+    });
+
+    test("aria-expanded is kept in step when the menu toggles", () => {
+        // The old handler only toggled a class, so the trigger always claimed
+        // to be collapsed.
+        expect(authJs).toMatch(/aria-expanded/);
+    });
+});
+
+describe("the menu closes the ways a menu should", () => {
+    test.each([
+        ["on Escape", /Escape/],
+        ["on a click outside", /document\.addEventListener\(\s*["']click["']/],
+        ["after an item is chosen", /closest\(\s*["']a, button["']\s*\)/]
+    ])("auth.js closes it %s", (_label, pattern) => {
+        expect(authJs).toMatch(pattern);
+    });
+
+    test("logout is bound to a real handler", () => {
+        expect(authJs).toMatch(/logoutBtn\?\.addEventListener/);
+        expect(authJs).toMatch(/clearAuthSession\(\)/);
+    });
+});

--- a/frontend/components/navbar.html
+++ b/frontend/components/navbar.html
@@ -549,7 +549,32 @@
       </li>
 
       <li class="profile-wrapper">
-        <a href="signin.html" id="auth-link">Sign In</a>
+        <!--
+          When signed out this is a plain link to signin.html and the menu below
+          stays hidden. When signed in, auth.js swaps the label for the profile
+          icon and turns this into the menu's trigger, which is why the ARIA
+          attributes are declared here rather than added from script: the
+          relationship is part of the markup, and only its state changes.
+        -->
+        <a href="signin.html" id="auth-link" aria-haspopup="true" aria-expanded="false"
+          aria-controls="profile-dropdown">Sign In</a>
+
+        <!--
+          The account menu. #profile-dropdown and #logout-btn were referenced by
+          auth.js and styled by components.css and base.css, but had never been
+          added to any page, so a signed-in shopper had no way to log out (#1672).
+
+          data-loggedin is the attribute components.css keys the desktop
+          hover-to-open rule on; components.js sets it once the navbar exists.
+          Kept out of the tab order until it opens.
+        -->
+        <div id="profile-dropdown" role="menu" aria-labelledby="auth-link" data-loggedin="false">
+          <a href="dashboard.html" role="menuitem"><i class="fas fa-chart-bar" aria-hidden="true"></i> Dashboard</a>
+          <a href="profile.html" role="menuitem"><i class="fas fa-user" aria-hidden="true"></i> My Profile</a>
+          <a href="dashboard.html#orders" role="menuitem"><i class="fas fa-box" aria-hidden="true"></i> My Orders</a>
+          <a href="wishlist.html" role="menuitem"><i class="far fa-heart" aria-hidden="true"></i> Wishlist</a>
+          <button type="button" id="logout-btn" role="menuitem"><i class="fas fa-sign-out-alt" aria-hidden="true"></i> Log out</button>
+        </div>
       </li>
       <li class="currency-selector-item">
         <select id="currency-selector" class="currency-selector-select" aria-label="Select currency">

--- a/frontend/scripts/auth.js
+++ b/frontend/scripts/auth.js
@@ -839,6 +839,74 @@ function syncNavbarAuth() {
     });
 }
 
+// The account menu lives in navbar.html, which loadComponent() injects, so
+// nothing here can be resolved at module load -- initializeAuthUI runs on the
+// componentsLoaded event instead. auth.js caches these ids into `elements` at
+// the top of the file for the signin/signup forms; those lookups are null on
+// every other page and are not used for the menu.
+
+/** Open or close the account menu, keeping the trigger's ARIA state in step. */
+function setProfileMenuOpen(dropdown, trigger, open) {
+    if (!dropdown) return;
+
+    dropdown.classList.toggle("active", open);
+    trigger?.setAttribute("aria-expanded", String(open));
+}
+
+/**
+ * Wire the account menu.
+ *
+ * The markup, the ids and the CSS already agreed with each other; what was
+ * missing was the markup itself (#1672), so the click handler toggled a class
+ * on null and the logout button was never bound. With the menu present this
+ * adds the behaviour a menu is expected to have: it closes on Escape, on a
+ * click outside it, and after any item inside it is chosen.
+ */
+function bindProfileMenu(authLink, dropdown) {
+    if (!authLink || !dropdown) return;
+
+    authLink.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const willOpen = !dropdown.classList.contains("active");
+        setProfileMenuOpen(dropdown, authLink, willOpen);
+
+        if (willOpen) {
+            // Move focus into the menu so it is usable without a pointer. The
+            // desktop CSS opens this on hover too; that path needs no focus
+            // management because the pointer is already there.
+            dropdown.querySelector("a, button")?.focus();
+        }
+    });
+
+    // A click anywhere else closes it. Bound on the document, so it also
+    // catches clicks on other navbar controls.
+    document.addEventListener("click", (event) => {
+        if (!dropdown.classList.contains("active")) return;
+        if (dropdown.contains(event.target) || authLink.contains(event.target)) return;
+
+        setProfileMenuOpen(dropdown, authLink, false);
+    });
+
+    document.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape") return;
+        if (!dropdown.classList.contains("active")) return;
+
+        setProfileMenuOpen(dropdown, authLink, false);
+        authLink.focus();
+    });
+
+    // Choosing an item closes the menu. The links navigate anyway; the button
+    // does not, and leaving it open behind the logout toast looks like the
+    // click did nothing.
+    dropdown.addEventListener("click", (event) => {
+        if (event.target.closest("a, button")) {
+            setProfileMenuOpen(dropdown, authLink, false);
+        }
+    });
+}
+
 function initializeAuthUI() {
     syncNavbarAuth();
 
@@ -850,19 +918,24 @@ function initializeAuthUI() {
 
     const user = AppUtils.getUser();
 
+    // The desktop hover rule in components.css is keyed on this attribute, so
+    // it is what decides whether the menu can open at all.
+    dropdown?.setAttribute("data-loggedin", user ? "true" : "false");
+
     if (user) {
         authLink.innerHTML = `<i class="fas fa-user"></i>`;
         authLink.href = "#";
         authLink.classList.add("profile-active");
+        authLink.setAttribute(
+            "aria-label",
+            `Account menu for ${user.name || user.email || "your account"}`
+        );
 
-        authLink.addEventListener("click", (event) => {
-            event.preventDefault();
-            dropdown?.classList.toggle("active");
-        });
+        bindProfileMenu(authLink, dropdown);
 
         logoutBtn?.addEventListener("click", async () => {
             await clearAuthSession();
-            dropdown?.classList.remove("active");
+            setProfileMenuOpen(dropdown, authLink, false);
             AppUtils.notify("Logged out successfully!", "success");
             setTimeout(() => {
                 window.location.href = document.referrer?.includes(window.location.hostname)
@@ -874,7 +947,8 @@ function initializeAuthUI() {
         authLink.innerHTML = "Sign In";
         authLink.href = "signin.html";
         authLink.classList.remove("profile-active");
-        dropdown?.classList.remove("active");
+        authLink.removeAttribute("aria-label");
+        setProfileMenuOpen(dropdown, authLink, false);
     }
 }
 

--- a/frontend/scripts/components.js
+++ b/frontend/scripts/components.js
@@ -1281,13 +1281,31 @@ async function initializeComponents() {
     document.dispatchEvent(new CustomEvent("componentsLoaded"));
 }
 
-const user = JSON.parse(localStorage.getItem("user"));
+// The account menu's open-on-hover rule (components.css) is keyed on
+// data-loggedin, so something has to set it.
+//
+// This used to run here, at the top level of the module, and could not work for
+// three separate reasons (#1672):
+//
+//   1. #profile-dropdown existed in no markup at all, so the lookup was null;
+//   2. even once it exists, this code runs before loadComponent() has injected
+//      navbar.html, so the lookup would still be null;
+//   3. JSON.parse was unguarded. A non-JSON value under the "user" key -- a
+//      partial write, or anything left by an older build -- threw a SyntaxError
+//      at the top level, which aborted the rest of this file, taking the navbar
+//      search combobox defined below down with it on all 28 pages that load it.
+//
+// So it waits for the navbar, and reads the user through AppUtils.getUser(),
+// which already parses defensively and answers null on junk.
+document.addEventListener("componentsLoaded", () => {
+    const profileDropdown = document.getElementById("profile-dropdown");
 
-const profileDropdown = document.getElementById("profile-dropdown");
+    if (!profileDropdown) return;
 
-if (user && profileDropdown) {
-    profileDropdown.setAttribute("data-loggedin", "true");
-}
+    const user = window.AppUtils?.getUser ? AppUtils.getUser() : null;
+
+    profileDropdown.setAttribute("data-loggedin", user ? "true" : "false");
+});
 
 
 // ===== NAVBAR SEARCH =====


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

A signed-in shopper had no way to sign out.

`auth.js` and `components.js` both look up `#profile-dropdown` and `#logout-btn`, and `components.css` (lines 910–960) plus `base.css` (lines 451–470) style them across roughly fifty lines. Neither id existed in any markup. `navbar.html` shipped one element for the account slot:

```html
<li class="profile-wrapper">
  <a href="signin.html" id="auth-link">Sign In</a>
</li>
```

Because the JS is written defensively (`dropdown?.classList.toggle("active")`), nothing ever threw. It just silently did nothing:

- **No logout control anywhere in the storefront.** `clearAuthSession()` is the only function that ends a session, and `#logout-btn` was its only trigger on any of the 30 pages. A session could only be ended by clearing site data by hand. (`profile.html` has a "Sign Out Other Devices" button — that revokes *other* sessions and deliberately leaves the current one alone, so it is not a way out either.)
- **A dead profile icon.** Once signed in, `auth-link` became `href="#"` with a user icon, and its click handler called `preventDefault()` then toggled a class on `null`. The control looked interactive and did nothing.
- **Fifty lines of CSS styling nothing**, including the desktop hover-to-open rule keyed on `[data-loggedin="true"]`.

### What this changes

**`frontend/components/navbar.html`** — adds the menu inside `.profile-wrapper`, using the ids, the nesting and the `data-loggedin` attribute the CSS and JS already expected. Nothing in the stylesheets had to change; the markup simply now matches what they were written against. Icons follow the names already in use in the repo (`fas fa-sign-out-alt` is what `profile.html` uses).

**`frontend/scripts/auth.js`** — the click handler existed but had nothing to act on. Now that the menu is real it needs the behaviour a menu is expected to have, so `initializeAuthUI` is split up and the open/close path gained: `Escape` closes and returns focus to the trigger, a click anywhere outside closes, choosing any item closes, `aria-expanded` tracks the state, and opening from the keyboard moves focus to the first item. The signed-out branch clears the state rather than leaving a stale one behind.

**`frontend/scripts/components.js`** — two problems in five lines, both fixed by moving the work onto `componentsLoaded`:

```js
const user = JSON.parse(localStorage.getItem("user"));
const profileDropdown = document.getElementById("profile-dropdown");
if (user && profileDropdown) {
    profileDropdown.setAttribute("data-loggedin", "true");
}
```

`data-loggedin` is the attribute `components.css:927` keys the hover rule on and it is written nowhere else — but this is top-level module code that runs *before* `loadComponent()` has injected `navbar.html`, so the lookup would return `null` even once the markup existed.

The `JSON.parse` is also unguarded. A non-JSON value under the `user` key throws a `SyntaxError` at the top level of the module, which aborts the rest of the file — including the navbar search combobox defined below it — on all 28 pages that load it. `JSON.parse(null)` is fine, so this only bites on corrupt data, but the blast radius when it does is the whole navbar. It now reads through `AppUtils.getUser()`, which already parses defensively and answers `null` on junk.

---

## 🔗 Related Issue

Closes #1672

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] UI/UX improvement
- [x] Testing improvement

---

## 📷 Screenshots / Demo

Before — the entire account slot, on every page:

```html
<li class="profile-wrapper">
  <a href="signin.html" id="auth-link">Sign In</a>
</li>
```

```
$ grep -rl "profile-dropdown\|logout-btn" frontend/*.html frontend/components/*.html
(no matches)
```

After — signed in, clicking the profile icon opens a menu with Dashboard, My Profile, My Orders, Wishlist and **Log out**. Signed out, it is the plain "Sign In" link it always was and the menu cannot open.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Tests.** `backend/tests/navbarAuthContract.test.js` is new — 21 cases pinning the contract from both ends: the ids the scripts reach for exist in the component that provides them, the menu is nested where the CSS positions it, the `data-loggedin` attribute is present and something writes it, the ARIA relationships are declared, and the close paths are wired.

It is a real guard, not a restatement — against `navbar.html` as it stood, **11 of the 21 cases fail**:

```
$ git stash && npx jest tests/navbarAuthContract.test.js
Tests:       11 failed, 10 passed, 21 total

$ git stash pop && npx jest tests/navbarAuthContract.test.js
Tests:       21 passed, 21 total
```

It follows `tests/appUtilsExports.test.js`, which already reads `frontend/` from the backend suite for the same reason: this is a defect no existing gate can see. `check:assets` resolves `src`/`href` references, not element ids, and `check:a11y` looks at landmarks.

The id lookups it cross-checks are scoped to the three navbar ids on purpose — `auth.js` also resolves the signin and signup form fields, which live on their own pages and are legitimately `null` everywhere else.

**Verification.**

```
$ npm run check:syntax     ✅ 636 file(s) parsed cleanly
$ npm run check:assets     ✅ 585 reference(s) across 30 page(s) resolve
$ npm run check:a11y       ✅ 30 page(s) pass
$ npm run check:sitemap    ✅ covers all 20 public page(s)
$ npx jest                 ✅ 121 suites, 2571 tests passed
```

The Vercel check fails on every PR in this repo with "Authorization required to deploy" and is unrelated to this change.
