### PR TITLE
fix(migrations): 0014 could not apply, blocking 0015-0048 (#1673)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -300,11 +300,20 @@ const verifySignup = async (req, res) => {
             }
         }
 
-        // Save to MySQL with email_verified flag
+        // Save to MySQL with email_verified flag.
+        //
+        // signup_ip is recorded here because this is where the row is created,
+        // and it is what velocity_monitoring groups by -- without it the view
+        // has nothing to report and the whole velocity signal is dead (#1673).
+        // req.ip honours the configured `trust proxy` setting, so it is the
+        // caller's address rather than the load balancer's; truncated to the
+        // column width so an unusually long forwarded value cannot fail the
+        // insert and lose a signup over a monitoring field.
         const userId = crypto.randomUUID();
+        const signupIp = sanitizeString(req.ip).slice(0, 45) || null;
         await db.query(
-            `INSERT INTO users (id, name, email, password, role, is_verified) VALUES (?, ?, ?, ?, ?, ?)`,
-            [userId, pendingUser.name, cleanEmail, pendingUser.hashedPassword, "user", 1]
+            `INSERT INTO users (id, name, email, password, role, is_verified, signup_ip) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+            [userId, pendingUser.name, cleanEmail, pendingUser.hashedPassword, "user", 1, signupIp]
         );
 
         // Cleanup Appwrite session

--- a/backend/tests/migrationViewColumns.test.js
+++ b/backend/tests/migrationViewColumns.test.js
@@ -1,0 +1,278 @@
+// Every column a view selects must exist on the table it selects from.
+//
+// MySQL resolves a view's SELECT at CREATE VIEW time, so a view over a column
+// that does not exist is not a lazy failure on first read -- it is
+// ER_BAD_FIELD_ERROR while the migration is being applied. And because
+// applyMigration() runs a file's statements in one loop and rethrows on the
+// first failure, a single bad view stops the whole sequence: nothing after it
+// applies, ever, on any fresh database.
+//
+// That is what 0014 did. `velocity_monitoring` grouped `users` by `ip_address`,
+// a column no migration has ever declared, so migrations 0015 through 0048
+// could not be applied at all (#1673).
+//
+// Nothing in the repo could see it. The suite has no database, `check:syntax`
+// only parses JavaScript, and the runner is the only thing that reads these
+// files -- at which point it is too late. So the schema is resolved here,
+// statically, from the migrations themselves.
+
+const fs = require("fs");
+const path = require("path");
+
+const MIGRATIONS_DIR = path.join(__dirname, "..", "..", "migrations");
+
+const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((name) => name.endsWith(".sql"))
+    .sort();
+
+// ---------------------------------------------------------------------------
+// A very small SQL reader
+//
+// Deliberately narrow. It is not a parser -- it understands enough of the
+// dialect this repo writes to resolve single-table views, and it skips anything
+// it cannot be confident about rather than guessing and reporting noise.
+// ---------------------------------------------------------------------------
+
+const COLUMN_TYPES =
+    "CHAR|VARCHAR|INT|BIGINT|TINYINT|SMALLINT|MEDIUMINT|TEXT|LONGTEXT|" +
+    "MEDIUMTEXT|DATETIME|TIMESTAMP|DATE|TIME|DECIMAL|FLOAT|DOUBLE|JSON|" +
+    "ENUM|BOOLEAN|BLOB|BINARY";
+
+const NOT_A_COLUMN = /^(PRIMARY|UNIQUE|INDEX|KEY|CONSTRAINT|FOREIGN|FULLTEXT|SPATIAL)$/i;
+
+/** Strip comments and string literals so neither can look like a column. */
+const stripNoise = (sql) =>
+    sql
+        .replace(/--[^\n]*/g, " ")
+        .replace(/\/\*[\s\S]*?\*\//g, " ")
+        .replace(/'(?:[^'\\]|\\.)*'/g, " '' ")
+        .replace(/"(?:[^"\\]|\\.)*"/g, ' "" ');
+
+/** Words that are SQL, not column names. */
+const SQL_WORDS = new Set(
+    `select from where group by having order asc desc as and or not null is in
+     between like case when then else end distinct all union join left right
+     inner outer on limit offset with interval hour day week month year minute
+     second count sum avg min max round abs coalesce ifnull nullif if concat
+     cast convert date now curdate curtime date_sub date_add datediff
+     timestampdiff timestampadd date_format json_object json_arrayagg
+     json_object_agg group_concat unix_timestamp sec_to_time lower upper trim
+     substring length replace greatest least std stddev variance over partition
+     row_number rank dense_rank exists any some char_length signed unsigned
+     integer decimal true false`
+        .split(/\s+/)
+        .filter(Boolean)
+);
+
+/**
+ * Accumulate the schema across the whole sequence, in order, the way the runner
+ * would apply it.
+ */
+const buildSchema = () => {
+    const tables = new Map(); // name -> Set(columns)
+    const views = new Set();
+    const viewDefinitions = [];
+
+    for (const filename of files) {
+        const sql = stripNoise(fs.readFileSync(path.join(MIGRATIONS_DIR, filename), "utf8"));
+
+        for (const match of sql.matchAll(
+            /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?`?(\w+)`?\s*\(([\s\S]*?)\n\)\s*ENGINE/gi
+        )) {
+            const name = match[1].toLowerCase();
+            if (!tables.has(name)) tables.set(name, new Set());
+
+            for (const line of match[2].split("\n")) {
+                const column = line.match(
+                    new RegExp(`^\\s*\`?(\\w+)\`?\\s+(?:${COLUMN_TYPES})\\b`, "i")
+                );
+                if (column && !NOT_A_COLUMN.test(column[1])) {
+                    tables.get(name).add(column[1].toLowerCase());
+                }
+            }
+        }
+
+        for (const match of sql.matchAll(/ALTER\s+TABLE\s+`?(\w+)`?([\s\S]*?);/gi)) {
+            const name = match[1].toLowerCase();
+            if (!tables.has(name)) tables.set(name, new Set());
+
+            for (const added of match[2].matchAll(
+                new RegExp(`ADD\\s+(?:COLUMN\\s+)?\`?(\\w+)\`?\\s+(?:${COLUMN_TYPES})\\b`, "gi")
+            )) {
+                if (!NOT_A_COLUMN.test(added[1])) {
+                    tables.get(name).add(added[1].toLowerCase());
+                }
+            }
+
+            for (const renamed of match[2].matchAll(
+                /(?:CHANGE|RENAME)\s+COLUMN\s+`?\w+`?\s+(?:TO\s+)?`?(\w+)`?/gi
+            )) {
+                tables.get(name).add(renamed[1].toLowerCase());
+            }
+
+            for (const dropped of match[2].matchAll(/DROP\s+COLUMN\s+`?(\w+)`?/gi)) {
+                tables.get(name).delete(dropped[1].toLowerCase());
+            }
+        }
+
+        for (const renamed of sql.matchAll(
+            /RENAME\s+TABLE\s+`?(\w+)`?\s+TO\s+`?(\w+)`?/gi
+        )) {
+            const from = renamed[1].toLowerCase();
+            const to = renamed[2].toLowerCase();
+            tables.set(to, tables.get(from) || new Set());
+            tables.delete(from);
+        }
+
+        for (const view of sql.matchAll(
+            /CREATE\s+(?:OR\s+REPLACE\s+)?VIEW\s+`?(\w+)`?\s+AS\s*([\s\S]*?);/gi
+        )) {
+            views.add(view[1].toLowerCase());
+            viewDefinitions.push({
+                filename,
+                name: view[1].toLowerCase(),
+                body: view[2],
+                // Snapshot the schema as it stands at this point in the
+                // sequence -- a view cannot read a column added after it.
+                tables: new Map([...tables].map(([t, c]) => [t, new Set(c)])),
+                views: new Set(views)
+            });
+        }
+    }
+
+    return { tables, views, viewDefinitions };
+};
+
+const { tables, viewDefinitions } = buildSchema();
+
+/**
+ * The single table a view reads, or null if it reads anything more complicated
+ * than that -- a join, a subquery or another view. Those are out of scope: this
+ * test exists to catch a column that exists nowhere, not to typecheck SQL.
+ */
+const soleSourceOf = (definition) => {
+    const sources = [...definition.body.matchAll(/\b(?:FROM|JOIN)\s+`?(\w+)`?/gi)].map(
+        (match) => match[1].toLowerCase()
+    );
+
+    if (sources.length !== 1) return null;
+    if (/\bSELECT\b[\s\S]*\bSELECT\b/i.test(definition.body)) return null;
+    if (definition.views.has(sources[0])) return null;
+    if (!definition.tables.has(sources[0])) return null;
+
+    return sources[0];
+};
+
+/** Identifiers in a view body that are meant to be columns of its source. */
+const columnsReferencedBy = (definition, source) => {
+    const aliases = new Set(
+        [...definition.body.matchAll(/\bAS\s+`?(\w+)`?/gi)].map((m) => m[1].toLowerCase())
+    );
+
+    const referenced = new Set();
+
+    for (const token of definition.body.matchAll(/`?\b([a-z_][a-z0-9_]*)\b`?/gi)) {
+        const name = token[1].toLowerCase();
+
+        if (SQL_WORDS.has(name)) continue;
+        if (aliases.has(name)) continue;
+        if (name === source || name === definition.name) continue;
+        if (/^\d/.test(name)) continue;
+
+        referenced.add(name);
+    }
+
+    return referenced;
+};
+
+// ---------------------------------------------------------------------------
+
+describe("the migration sequence parses into a schema", () => {
+    test("there are migrations to check", () => {
+        expect(files.length).toBeGreaterThan(40);
+    });
+
+    test("the baseline declares the users table", () => {
+        expect(tables.has("users")).toBe(true);
+        expect(tables.get("users").size).toBeGreaterThan(20);
+    });
+
+    test("at least one view is checkable", () => {
+        const checkable = viewDefinitions.filter((view) => soleSourceOf(view));
+
+        expect(checkable.length).toBeGreaterThan(0);
+    });
+});
+
+describe("every single-table view reads columns that exist", () => {
+    const checkable = viewDefinitions.filter((view) => soleSourceOf(view));
+
+    test.each(checkable.map((view) => [view.filename, view.name, view]))(
+        "%s: %s",
+        (_filename, _name, view) => {
+            const source = soleSourceOf(view);
+            const available = view.tables.get(source);
+
+            const missing = [...columnsReferencedBy(view, source)].filter(
+                (column) => !available.has(column)
+            );
+
+            expect(missing).toEqual([]);
+        }
+    );
+});
+
+describe("the column 0014 was missing", () => {
+    test("users has signup_ip", () => {
+        // The column velocity_monitoring groups by. Without it, CREATE VIEW
+        // fails and migrations 0015-0048 never apply.
+        expect(tables.get("users").has("signup_ip")).toBe(true);
+    });
+
+    test("users still has no ip_address, and the view no longer asks for one", () => {
+        expect(tables.get("users").has("ip_address")).toBe(false);
+
+        const view = viewDefinitions.find((v) => v.name === "velocity_monitoring");
+
+        expect(view).toBeDefined();
+        expect(view.body).toMatch(/signup_ip/);
+        expect(view.body).not.toMatch(/FROM\s+users[\s\S]*GROUP BY\s+ip_address/i);
+    });
+
+    test("the column is declared before the view that reads it", () => {
+        const sql = fs.readFileSync(
+            path.join(MIGRATIONS_DIR, "0014_synthetic_identity_fraud.sql"),
+            "utf8"
+        );
+
+        expect(sql.indexOf("ADD COLUMN signup_ip")).toBeGreaterThan(-1);
+        expect(sql.indexOf("ADD COLUMN signup_ip")).toBeLessThan(
+            sql.indexOf("CREATE VIEW velocity_monitoring")
+        );
+    });
+
+    test("accounts with no recorded address are excluded from the view", () => {
+        // Every row predating the column is NULL, and MySQL groups NULLs
+        // together -- counting them would collapse the existing user table into
+        // one bucket and report it as the highest-velocity address on the
+        // system.
+        const view = viewDefinitions.find((v) => v.name === "velocity_monitoring");
+
+        expect(view.body).toMatch(/signup_ip\s+IS\s+NOT\s+NULL/i);
+    });
+});
+
+describe("the sequence is still well formed", () => {
+    test("no two migrations claim the same version", () => {
+        const versions = files.map((name) => name.slice(0, 4));
+
+        expect(new Set(versions).size).toBe(versions.length);
+    });
+
+    test("every file matches NNNN_name.sql", () => {
+        for (const name of files) {
+            expect(name).toMatch(/^\d{4}_[a-z0-9_]+\.sql$/);
+        }
+    });
+});

--- a/migrations/0014_synthetic_identity_fraud.sql
+++ b/migrations/0014_synthetic_identity_fraud.sql
@@ -45,10 +45,36 @@ ALTER TABLE device_fingerprints
     ADD COLUMN language VARCHAR(50) NULL,
     ADD INDEX idx_device_fingerprints_last_seen (last_seen);
 
+-- Signup Source Address
+--
+-- `velocity_monitoring` below groups accounts by the address they were created
+-- from, and `users` had nowhere to record one: the baseline declares no
+-- `ip_address`, and no later migration adds one. The view was written against a
+-- column that has never existed, so `CREATE VIEW` failed with ER_BAD_FIELD_ERROR
+-- and took the rest of the sequence down with it -- 0015 through 0048 could not
+-- apply on a fresh database (#1673).
+--
+-- The column belongs here rather than in a later file, because this is the
+-- migration that introduces the velocity feature and the view two statements
+-- down cannot be created without it.
+--
+-- Named `signup_ip` and not `ip_address`: it records where the account was
+-- created, once, and is not a "current address" that anything should update.
+ALTER TABLE users
+    ADD COLUMN signup_ip VARCHAR(45) NULL,
+    ADD INDEX idx_users_signup_ip (signup_ip);
+
 -- Velocity Monitoring View
+--
+-- How many accounts one address created in the last 24 hours.
+--
+-- Rows with no recorded address are excluded rather than grouped. Every account
+-- that predates the column has `signup_ip IS NULL`, and MySQL groups NULLs
+-- together, so counting them would collapse the entire existing user table into
+-- a single bucket and report it as the highest-velocity address on the system.
 CREATE VIEW velocity_monitoring AS
 SELECT 
-    ip_address,
+    signup_ip AS ip_address,
     COUNT(*) as account_count,
     MAX(created_at) as last_account,
     TIMESTAMPDIFF(HOUR, MIN(created_at), MAX(created_at)) as hours_span,
@@ -59,7 +85,8 @@ SELECT
     END as velocity_risk
 FROM users
 WHERE created_at > DATE_SUB(NOW(), INTERVAL 24 HOUR)
-GROUP BY ip_address
+  AND signup_ip IS NOT NULL
+GROUP BY signup_ip
 HAVING account_count > 2
 ORDER BY account_count DESC;
 

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -200,6 +200,36 @@ that never existed.
 `security_logs` had its time column renamed to `timestamp`, which is what the
 admin endpoint orders by.
 
+## Corrected migration: 0014
+
+`0014_synthetic_identity_fraud.sql` was edited in place rather than amended by a
+later file, which is an exception to the immutability rule above and needs the
+reason recorded.
+
+Its `velocity_monitoring` view grouped `users` by `ip_address`, a column no
+migration has ever declared. MySQL resolves a view's `SELECT` at `CREATE VIEW`
+time, so this was not a lazy failure on first read — it raised
+`ER_BAD_FIELD_ERROR` while the migration was being applied, and `applyMigration`
+rethrows on the first failing statement. The file therefore could not complete
+on any database, and nothing after it applied: `0015` through `0048` were
+permanently pending on every fresh install.
+
+That is why a follow-up migration would not have worked. The runner never
+reaches one. The broken statement has to stop being broken where it is.
+
+Editing it is safe for the same reason it had to be edited: because the
+transaction is rolled back and no `schema_migrations` row is ever written, `0014`
+has no recorded checksum on any database, so `assertNoDrift` has nothing to
+compare against and cannot report drift. The immutability rule protects
+migrations that *did* apply; this one provably never has.
+
+The fix adds `users.signup_ip` — declared in `0014`, before the view that reads
+it, because this is the migration that introduces the velocity feature — and
+points the view at it. `backend/tests/migrationViewColumns.test.js` resolves
+every single-table view in the sequence against the accumulated schema, so a
+view over a column that does not exist now fails the suite instead of the
+deployment.
+
 ## Known remaining gap: the analytics modules
 
 The metrics, CQRS read-model and parts of the recommendation services query a


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`migrations/0014_synthetic_identity_fraud.sql` could not be applied to any database, and because the runner stops on the first failing statement, it took the rest of the sequence down with it.

The offending statement:

```sql
CREATE VIEW velocity_monitoring AS
SELECT 
    ip_address,
    COUNT(*) as account_count,
    ...
FROM users
WHERE created_at > DATE_SUB(NOW(), INTERVAL 24 HOUR)
GROUP BY ip_address
```

`users` has no `ip_address`. The baseline declares 25 columns and the only later change to the table is `0021`, which adds `delete_reason`. No migration anywhere adds `ip_address`.

MySQL resolves a view's `SELECT` at `CREATE VIEW` time, so this is not a lazy failure on first read — it raises `ERROR 1054 (42S22): Unknown column 'ip_address' in 'field list'` while the migration is being applied. `applyMigration` (`backend/scripts/migrate.js:175`) runs a file's statements in one loop and rethrows, and the driver loop above it has no per-file recovery.

**So on a fresh database `npm run migrate` applied `0001`–`0013` and stopped.** Migrations `0015`–`0048` were permanently pending — 34 files, covering order status tracking, product Q&A, cart lifecycle and recovery, shipping methods and rate rules, delivery estimates, guest carts, order numbers, cart merge, newsletter subscribers, loyalty award idempotency, refund quantity accounting and gift card settlement. The application queries all of those tables.

### Why this edits 0014 instead of adding 0049

A follow-up migration cannot fix it, because **the runner never reaches one**. `0014` fails, the loop rethrows, and everything after it — including any new file — stays pending. The broken statement has to stop being broken where it is.

Editing it is safe for the same reason it had to be edited. The failure happens inside a transaction that is rolled back before the `schema_migrations` row is written, so `0014` has **no recorded checksum on any database** — it has never completed anywhere. `assertNoDrift` has nothing to compare against and cannot report drift. The "never edit an applied migration" rule in `migrations/README.md` protects files that *did* apply; this one provably never has.

I have recorded this in `migrations/README.md` under a new **Corrected migration: 0014** section, alongside the existing notes on renumbered and de-duplicated files, so the exception is documented where the rule is.

### The fix

`users.signup_ip` is declared **in `0014`, before the view that reads it** — this is the migration that introduces the velocity feature, and the view two statements down cannot be created without it. Named `signup_ip` rather than `ip_address` because it records where the account was created, once; it is not a "current address" anything should update.

The view excludes rows with no recorded address:

```sql
WHERE created_at > DATE_SUB(NOW(), INTERVAL 24 HOUR)
  AND signup_ip IS NOT NULL
GROUP BY signup_ip
```

Every account predating the column is `NULL`, and MySQL groups `NULL`s together — counting them would collapse the entire existing user table into a single bucket and report it as the highest-velocity address on the system, which is worse than reporting nothing.

`verifySignup` now records the address on the row it creates, so the view has something to report rather than being permanently empty. It uses `req.ip`, which honours the `trust proxy` setting configured at `server.js:212`, and truncates to the column width so an unusually long forwarded value cannot fail the insert and lose a signup over a monitoring field.

---

## 🔗 Related Issue

Closes #1673

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] Testing improvement
- [x] Documentation update

---

## 📷 Screenshots / Demo

Before, on an empty database:

```
Applying 0013_bot_protection.sql...
Applied 0013_bot_protection.sql in 41ms.
Applying 0014_synthetic_identity_fraud.sql...
MigrationError: 0014_synthetic_identity_fraud.sql failed after 18ms:
  Unknown column 'ip_address' in 'field list'
```

`npm run migrate:status` then listed `0015`–`0048` as pending, and no further run could change that.

After: the sequence applies to completion.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Tests.** `backend/tests/migrationViewColumns.test.js` is new — 24 cases. It accumulates the schema across the whole sequence in order (`CREATE TABLE`, `ALTER TABLE ADD`/`DROP`/`CHANGE COLUMN`, `RENAME TABLE`) and then resolves every **single-table** view body against the schema *as it stood at that point in the sequence*, since a view cannot read a column added after it.

It is deliberately narrow, not a SQL parser. Views over joins, subqueries or other views are skipped rather than guessed at, and string literals and comments are stripped first so `CASE WHEN status = 'delivered'` and `JSON_OBJECT('status', new_status)` are not mistaken for column references. The point is to catch a column that exists *nowhere*, with no false alarms.

It is a real guard:

```
$ git stash && npx jest tests/migrationViewColumns.test.js
✕ 0014_synthetic_identity_fraud.sql: velocity_monitoring
✕ users has signup_ip
✕ users still has no ip_address, and the view no longer asks for one
✕ the column is declared before the view that reads it
✕ accounts with no recorded address are excluded from the view
Tests:       5 failed, 19 passed, 24 total

$ git stash pop && npx jest tests/migrationViewColumns.test.js
Tests:       24 passed, 24 total
```

It flags `velocity_monitoring` and **no other view in the sequence** — I checked the rest by hand and the remaining apparent hits were all string literals or function names, which is what the stripping pass is for.

**Scope.** `velocity_monitoring` has no reader in the application yet — its only occurrence in the repo was its own `CREATE VIEW` — so nothing depended on the shape it had. The related `fraud_monitoring_queue` gap (a table written to with no migration at all) is a separate defect, filed as #1674 and fixed separately, to keep the migration repair reviewable on its own.

**Verification.**

```
$ npm run check:syntax     ✅ 636 file(s) parsed cleanly
$ npx jest                 ✅ 121 suites, 2574 tests passed
```

The Vercel check fails on every PR in this repo with "Authorization required to deploy" and is unrelated to this change.
