### PR TITLE
fix(fraud): create the queue medium-risk signups were being written to (#1674)

### DIFF
--- a/backend/middleware/fraudDetectionMiddleware.js
+++ b/backend/middleware/fraudDetectionMiddleware.js
@@ -3,6 +3,7 @@ const detector = require('../services/syntheticIdentityDetector');
 const db = require('../config/db').promise;
 const redis = require('../config/redis');
 const crypto = require('crypto');
+const logger = require('../utils/logger');
 /**
  * Middleware to detect synthetic identity fraud during signup
  */
@@ -194,8 +195,20 @@ async function flagForMonitoring(req, detection) {
                 req.ip || 'unknown'
             ]
         );
+
+        return true;
     } catch (error) {
-        console.error('Error flagging for monitoring:', error);
+        // Non-fatal on purpose: a monitoring write must not fail a signup. But
+        // the queue is the only record a medium-risk decision leaves, so a
+        // dropped row has to say which signup it was -- the old message named
+        // no email, no score and no level, which made it impossible to tie the
+        // failure back to anything (#1674).
+        logger.error(
+            `Fraud monitoring queue write failed for ${req.body?.email || 'unknown address'} ` +
+            `(${detection?.riskLevel} / ${detection?.riskScore}): ${error.message}`
+        );
+
+        return false;
     }
 }
 
@@ -241,5 +254,9 @@ async function getFraudStats(req, res) {
 module.exports = {
     detectSyntheticIdentity,
     detectCheckoutFraud,
-    getFraudStats
+    getFraudStats,
+    // Exported so the queue write can be driven directly in tests. It is the
+    // only record a medium-risk signup leaves, and it failed silently for as
+    // long as the table was missing (#1674).
+    flagForMonitoring
 };

--- a/backend/tests/fraudMonitoringQueue.test.js
+++ b/backend/tests/fraudMonitoringQueue.test.js
@@ -1,0 +1,243 @@
+// The medium-risk signup queue.
+//
+// detectSyntheticIdentity blocks a critical signup, challenges a high one, and
+// lets a medium one through -- queued for review. The queue is the whole of the
+// record for that middle band: nothing else on the signup path writes a row for
+// it, so if the write is lost, the decision is lost.
+//
+// It was lost. flagForMonitoring inserted into `fraud_monitoring_queue`, which
+// no migration created, so every call failed with ER_NO_SUCH_TABLE and the
+// catch swallowed it into a console.error (#1674). The signup succeeded, the
+// queue stayed empty, and nothing anywhere said so.
+//
+// Two things are checked here: that the table the code writes to is actually
+// declared in the migration sequence, and that the write behaves -- shape,
+// non-fatality, and a diagnosable message when it does fail.
+
+const fs = require("fs");
+const path = require("path");
+
+jest.mock("../config/db", () => {
+    const query = jest.fn();
+    const pool = { query, getConnection: jest.fn() };
+    // fraudDetectionMiddleware reaches the pool through `.promise`.
+    pool.promise = pool;
+    return pool;
+});
+
+jest.mock("../utils/logger", () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+jest.mock("../config/redis", () => ({ eval: jest.fn() }));
+
+const db = require("../config/db");
+const logger = require("../utils/logger");
+const { flagForMonitoring } = require("../middleware/fraudDetectionMiddleware");
+
+const MIGRATIONS_DIR = path.join(__dirname, "..", "..", "migrations");
+
+const allMigrations = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((name) => name.endsWith(".sql"))
+    .map((name) => fs.readFileSync(path.join(MIGRATIONS_DIR, name), "utf8"))
+    .join("\n");
+
+const detection = {
+    riskScore: 55,
+    riskLevel: "medium",
+    flags: ["disposable_email_domain", "no_device_id"]
+};
+
+const makeReq = (overrides = {}) => ({
+    body: { email: "shopper@example.com" },
+    ip: "203.0.113.9",
+    ...overrides
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    db.query.mockResolvedValue([{ insertId: 1 }]);
+});
+
+// ---------------------------------------------------------------------------
+// The gap itself
+// ---------------------------------------------------------------------------
+
+describe("the table the middleware writes to", () => {
+    test("is declared by a migration", () => {
+        // The regression. Before 0049 this matched nothing, and every insert
+        // failed with ER_NO_SUCH_TABLE.
+        expect(allMigrations).toMatch(
+            /CREATE TABLE IF NOT EXISTS fraud_monitoring_queue/
+        );
+    });
+
+    test("declares every column the INSERT names", () => {
+        const table = allMigrations.match(
+            /CREATE TABLE IF NOT EXISTS fraud_monitoring_queue([\s\S]*?)ENGINE=/
+        );
+
+        expect(table).not.toBeNull();
+
+        for (const column of [
+            "email",
+            "risk_score",
+            "risk_level",
+            "flags",
+            "ip_address",
+            "created_at"
+        ]) {
+            expect(table[1]).toMatch(new RegExp(`\\b${column}\\b`));
+        }
+    });
+
+    test("can record that an entry was reviewed", () => {
+        // Without these a queue is only a log -- there is no way to take an
+        // entry off it, so the next read returns everything ever queued.
+        const table = allMigrations.match(
+            /CREATE TABLE IF NOT EXISTS fraud_monitoring_queue([\s\S]*?)ENGINE=/
+        )[1];
+
+        expect(table).toMatch(/reviewed_at/);
+        expect(table).toMatch(/reviewed_by/);
+    });
+
+    test("indexes the pending read", () => {
+        const table = allMigrations.match(
+            /CREATE TABLE IF NOT EXISTS fraud_monitoring_queue([\s\S]*?)ENGINE=/
+        )[1];
+
+        expect(table).toMatch(/INDEX\s+idx_fraud_queue_pending/);
+    });
+
+    test("describes a risk band the same way 0014 does", () => {
+        // synthetic_identity_detections already declares this ENUM. Two tables
+        // in the same feature disagreeing about the vocabulary is how a band
+        // becomes unqueryable across both.
+        const table = allMigrations.match(
+            /CREATE TABLE IF NOT EXISTS fraud_monitoring_queue([\s\S]*?)ENGINE=/
+        )[1];
+
+        expect(table).toMatch(/ENUM\('low', 'medium', 'high', 'critical'\)/);
+    });
+
+    test("takes the next free migration number", () => {
+        const numbers = fs
+            .readdirSync(MIGRATIONS_DIR)
+            .filter((name) => name.endsWith(".sql"))
+            .map((name) => name.slice(0, 4));
+
+        expect(new Set(numbers).size).toBe(numbers.length);
+        expect(numbers).toContain("0049");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The write
+// ---------------------------------------------------------------------------
+
+describe("flagForMonitoring", () => {
+    test("inserts into fraud_monitoring_queue", async () => {
+        await flagForMonitoring(makeReq(), detection);
+
+        expect(db.query).toHaveBeenCalledTimes(1);
+
+        const [sql] = db.query.mock.calls[0];
+        expect(sql).toMatch(/INSERT INTO fraud_monitoring_queue/);
+    });
+
+    test("binds one value per placeholder", async () => {
+        await flagForMonitoring(makeReq(), detection);
+
+        const [sql, params] = db.query.mock.calls[0];
+        const placeholders = (sql.match(/\?/g) || []).length;
+
+        expect(params).toHaveLength(placeholders);
+    });
+
+    test("records the address, the score, the level and the flags", async () => {
+        await flagForMonitoring(makeReq(), detection);
+
+        const [, params] = db.query.mock.calls[0];
+
+        expect(params[0]).toBe("shopper@example.com");
+        expect(params[1]).toBe(55);
+        expect(params[2]).toBe("medium");
+        expect(JSON.parse(params[3])).toEqual(detection.flags);
+        expect(params[4]).toBe("203.0.113.9");
+    });
+
+    test("serialises the flags, since the column is JSON", async () => {
+        await flagForMonitoring(makeReq(), detection);
+
+        const [, params] = db.query.mock.calls[0];
+
+        expect(typeof params[3]).toBe("string");
+    });
+
+    test("falls back to 'unknown' when there is no address to record", async () => {
+        await flagForMonitoring(makeReq({ ip: undefined }), detection);
+
+        const [, params] = db.query.mock.calls[0];
+
+        expect(params[4]).toBe("unknown");
+    });
+
+    test("reports success", async () => {
+        await expect(flagForMonitoring(makeReq(), detection)).resolves.toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Failing the way it should
+// ---------------------------------------------------------------------------
+
+describe("when the queue write fails", () => {
+    const failing = () => {
+        db.query.mockRejectedValue(
+            new Error("ER_NO_SUCH_TABLE: Table 'ecommerce.fraud_monitoring_queue' doesn't exist")
+        );
+    };
+
+    test("does not throw -- a monitoring write must not fail a signup", async () => {
+        failing();
+
+        await expect(flagForMonitoring(makeReq(), detection)).resolves.toBe(false);
+    });
+
+    test("says which signup was dropped", async () => {
+        // The old message was 'Error flagging for monitoring:' and the error.
+        // No email, no score, no level -- nothing to tie the failure back to.
+        failing();
+
+        await flagForMonitoring(makeReq(), detection);
+
+        expect(logger.error).toHaveBeenCalledTimes(1);
+
+        const [message] = logger.error.mock.calls[0];
+        expect(message).toContain("shopper@example.com");
+        expect(message).toContain("medium");
+        expect(message).toContain("55");
+    });
+
+    test("goes through the project logger, not console", async () => {
+        failing();
+
+        await flagForMonitoring(makeReq(), detection);
+
+        expect(logger.error).toHaveBeenCalled();
+    });
+
+    test("still names the failure when the address is missing", async () => {
+        failing();
+
+        await flagForMonitoring({ body: {}, ip: "203.0.113.9" }, detection);
+
+        const [message] = logger.error.mock.calls[0];
+        expect(message).toContain("unknown address");
+    });
+});

--- a/migrations/0049_fraud_monitoring_queue.sql
+++ b/migrations/0049_fraud_monitoring_queue.sql
@@ -1,0 +1,63 @@
+-- ============================================
+-- THE MEDIUM-RISK SIGNUP QUEUE
+-- ============================================
+--
+-- `detectSyntheticIdentity` scores every signup and does one of four things:
+--
+--   critical -> 403, blocked, and the caller is told
+--   high     -> 202, verification required, and the caller is told
+--   medium   -> allowed through, and queued for a human to look at later
+--   low      -> allowed through
+--
+-- The medium band is the only one whose decision leaves no trace anywhere else,
+-- which makes the queue the whole of its record. `flagForMonitoring` has been
+-- writing that record to `fraud_monitoring_queue` since the middleware landed,
+-- and no migration has ever created the table (#1674).
+--
+-- Every insert therefore failed with ER_NO_SUCH_TABLE. The catch around it
+-- swallows the error into a console.error -- correctly, because a monitoring
+-- write must never fail a signup -- so the account was created, nothing was
+-- queued, and the only evidence was a line on stdout.
+--
+-- Note this is not the same defect as #1673. That one is a view in 0014 that
+-- stops the sequence from applying at all; this is a table the sequence never
+-- declared in the first place. Both had to be fixed for the fraud path to work
+-- end to end.
+
+CREATE TABLE IF NOT EXISTS fraud_monitoring_queue (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+
+    -- The columns flagForMonitoring names, in the order it names them.
+    --
+    -- `email` and not `user_id`: the middleware runs before the account row
+    -- exists, so there is no id to reference yet and no foreign key to declare.
+    -- It is nullable for the same reason the detector is defensive about its
+    -- input -- a request that reached the detector without a parseable address
+    -- is itself worth queueing, and losing the row to a NOT NULL would discard
+    -- the more interesting case.
+    email VARCHAR(255) NULL,
+    risk_score INT NOT NULL DEFAULT 0,
+
+    -- Same ENUM as synthetic_identity_detections in 0014, so the two tables
+    -- describe a band the same way. Only 'medium' is written today; the full
+    -- set is declared because the band that gets queued is a policy decision
+    -- the application should be able to change without a migration.
+    risk_level ENUM('low', 'medium', 'high', 'critical') NOT NULL DEFAULT 'medium',
+
+    flags JSON NULL,
+    ip_address VARCHAR(45) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    -- A queue nobody can close is a log. These let an entry be marked done and
+    -- kept out of the next read, which is what makes it a queue.
+    reviewed_at DATETIME NULL,
+    reviewed_by CHAR(36) NULL,
+    review_notes VARCHAR(500) NULL,
+
+    -- The queue read: oldest unreviewed first.
+    INDEX idx_fraud_queue_pending (reviewed_at, created_at),
+    INDEX idx_fraud_queue_created (created_at),
+    INDEX idx_fraud_queue_level (risk_level),
+    INDEX idx_fraud_queue_email (email),
+    INDEX idx_fraud_queue_ip (ip_address)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Description

`detectSyntheticIdentity` scores every signup and does one of four things:

| band | outcome | trace |
| --- | --- | --- |
| `critical` | `403`, blocked | the caller is told |
| `high` | `202`, verification required | the caller is told |
| `medium` | **allowed through, queued for review** | the queue row — and nothing else |
| `low` | allowed through | — |

The medium band is the only one whose decision leaves no other record, so the queue **is** the record. It was never written.

`flagForMonitoring` (`middleware/fraudDetectionMiddleware.js:183`) inserts into `fraud_monitoring_queue`, and no migration has ever created that table:

```
$ grep -ril "fraud_monitoring_queue" migrations/ backend/sql/
(no matches)
```

Every call failed with `ER_NO_SUCH_TABLE`. The `catch` swallowed it into a `console.error` — correctly, since a monitoring write must never fail a signup — so the account was created, nothing was queued, and the detector's work was discarded. The only evidence was a line on stdout:

```
⚠️ Medium risk signup: someone@example.com (score: 55)
Error flagging for monitoring: Error: ER_NO_SUCH_TABLE: Table 'ecommerce.fraud_monitoring_queue' doesn't exist
```

That message named no email, no score and no level, so even the log could not be tied back to the signup it belonged to.

The middleware is live — `routes/authRoutes.js:44` imports `detectSyntheticIdentity` and it runs on the signup path.

### What this changes

**`migrations/0049_fraud_monitoring_queue.sql`** creates the table with the columns the `INSERT` names, in the order it names them, plus:

- `reviewed_at` / `reviewed_by` / `review_notes` — a queue nobody can close is a log. Without these there is no way to take an entry off it, so every read returns everything ever queued.
- `INDEX idx_fraud_queue_pending (reviewed_at, created_at)` — the queue read: oldest unreviewed first.
- `risk_level` reuses the exact `ENUM('low','medium','high','critical')` that `0014` declared on `synthetic_identity_detections`, so the two tables in the same feature describe a band the same way. Only `medium` is written today; the full set is declared because which band gets queued is a policy decision the application should be able to change without a migration.
- `email` is nullable and carries no foreign key: the middleware runs *before* the account row exists, so there is no id to reference. It is nullable rather than `NOT NULL` because a request that reached the detector without a parseable address is itself worth queueing, and a `NOT NULL` would discard the more interesting case.

**`middleware/fraudDetectionMiddleware.js`** keeps the `catch` non-fatal, but the failure is now diagnosable: it logs through the project `logger` (the rest of the middleware layer's `console.error` calls do not reach the configured log streams) with the email, level and score, and returns whether the row actually landed.

---

## 🔗 Related Issue

Closes #1674

---

## 🛠️ Type of Change

- [x] Bug fix
- [x] Security fix
- [x] Testing improvement

---

## 📷 Screenshots / Demo

Before — the table the code writes to, searched for across the whole schema:

```
$ grep -ril "fraud_monitoring_queue" migrations/ backend/sql/
(no matches)
```

After — `0049` declares it, and the write is exercised directly:

```
$ npx jest tests/fraudMonitoringQueue.test.js
Tests:       16 passed, 16 total
```

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes properly
- [x] I have checked for console errors
- [x] I have updated documentation if required
- [x] This PR does not break existing functionality
- [x] I have linked the related issue correctly

---

## 🌐 Additional Notes

**Tests.** `backend/tests/fraudMonitoringQueue.test.js` is new — 16 cases in two halves.

The first half checks the schema side: that the table is declared, that it declares every column the `INSERT` names, that an entry can be marked reviewed, that the pending read is indexed, that the ENUM matches `0014`'s, and that `0049` is a free number.

The second half drives `flagForMonitoring` against a mocked pool, following the `jest.mock('../config/db', ...)` pattern already used by `tests/cartRecovery.test.js` and `tests/cartLifecycle.test.js`. It pins the parameter binding (one value per placeholder — the defect class of #1583), the JSON serialisation of `flags`, the `'unknown'` address fallback, and the failure path: that it resolves rather than throwing, and that the log line names the signup.

`flagForMonitoring` is now exported so the queue write can be driven directly. It was previously module-private, which is part of why nothing covered it.

**Scope.** This is deliberately separate from #1673 / #1678. That one is a *view* in `0014` that stops the migration sequence from applying at all; this is a *table* the sequence never declared. They are in the same feature area but they are different defects with different fixes, and both are needed for the fraud path to work end to end. Keeping them apart keeps each reviewable on its own — and the migration numbers do not collide (`0049` is the next free one; #1678 edits `0014` in place and adds no new file).

I did not add a read endpoint for the queue. Building the review UI is a feature, not part of repairing the write, and `GET /api/fraud/stats` already reports on `synthetic_identity_detections` separately.

**Verification.**

```
$ npm run check:syntax     ✅ 636 file(s) parsed cleanly
$ npx jest                 ✅ 121 suites, 2566 tests passed
```

The Vercel check fails on every PR in this repo with "Authorization required to deploy" and is unrelated to this change.
