### PR TITLE
fix(shop): repair duplicated initialization block that left shop.js unparsable

### DIFF
--- a/backend/tests/frontendScriptParse.test.js
+++ b/backend/tests/frontendScriptParse.test.js
@@ -1,0 +1,153 @@
+// Every frontend script has to parse, and shop.js has to keep exactly one
+// initialization block.
+//
+// `frontend/scripts/shop.js` reached `main` unparsable (#1696). The responsive
+// refactor duplicated the tail of the file and interleaved the two copies,
+// leaving an unclosed arrow body, a second half-finished `DOMContentLoaded`
+// registration, orphaned statements referring to a `filterUrlParams` that was
+// no longer declared, and an IntersectionObserver options object passed as the
+// third argument to `addEventListener`. The browser answered with
+// `Uncaught SyntaxError: Unexpected end of input` and ran nothing at all on
+// shop.html: no product fetch, no filters, no sort, no infinite scroll.
+//
+// `scripts/check-syntax.js` does catch the parse failure, but it is a separate
+// npm script and CI runs it as its own step, so a red parse is easy to read as
+// "the syntax job is flaky" rather than "the shop page is dead". Pinning it in
+// the jest suite puts the failure next to the behaviour it breaks.
+//
+// The parse goal here matches check-syntax.js: `frontend/scripts/**` are
+// classic <script> files, not modules, so they are compiled with `vm.Script`,
+// which uses V8's script goal -- the same goal a <script> tag and CommonJS use.
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+// Messages V8 emits when module-only syntax meets the script goal.
+const ESM_MARKER =
+    /^(Cannot use import statement|Unexpected token 'export'|await is only valid)/;
+
+const SCRIPTS_DIR = path.join(__dirname, "..", "..", "frontend", "scripts");
+
+/** Every `.js` file the shop pages can load, relative to frontend/scripts. */
+const scriptFiles = fs
+    .readdirSync(SCRIPTS_DIR)
+    .filter((name) => name.endsWith(".js"))
+    .sort();
+
+const readScript = (name) =>
+    fs.readFileSync(path.join(SCRIPTS_DIR, name), "utf8");
+
+/**
+ * Compile `source` the way a browser compiles a classic script.
+ *
+ * @param {string} source - File contents.
+ * @param {string} filename - Reported in the thrown error.
+ * @returns {Error|null} The SyntaxError, or null when it parses.
+ */
+function parseFailure(source, filename) {
+    try {
+        // `new vm.Script` compiles but never runs the code.
+        new vm.Script(source, { filename });
+        return null;
+    } catch (error) {
+        // `instanceof` is unreliable here: jest runs each suite in its own vm
+        // context, so a SyntaxError raised by `new vm.Script` is not an
+        // instance of *this* realm's SyntaxError. Match on the name instead.
+        if (error.name !== "SyntaxError") throw error;
+
+        // A handful of files under frontend/scripts are genuine ES modules.
+        // The script goal rejects `import`/`export` outright, so retry them the
+        // way scripts/check-syntax.js does before calling the file broken.
+        if (typeof vm.SourceTextModule === "function") {
+            try {
+                new vm.SourceTextModule(source, { identifier: filename });
+                return null;
+            } catch (moduleError) {
+                if (moduleError.name !== "SyntaxError") throw moduleError;
+                return moduleError;
+            }
+        }
+
+        // vm.SourceTextModule needs --experimental-vm-modules, which the jest
+        // config does not pass. Without it, unambiguous ESM markers are
+        // accepted rather than failing a file this test cannot judge.
+        if (ESM_MARKER.test(error.message)) {
+            return null;
+        }
+
+        return error;
+    }
+}
+
+describe("frontend scripts parse", () => {
+    test("there is at least one script to check", () => {
+        // A glob that silently matches nothing is a test that silently passes.
+        expect(scriptFiles.length).toBeGreaterThan(0);
+    });
+
+    test.each(scriptFiles)("%s parses as a classic script", (name) => {
+        const failure = parseFailure(readScript(name), name);
+
+        expect(failure && `${name}: ${failure.message}`).toBeNull();
+    });
+});
+
+describe("shop.js has one initialization block", () => {
+    const shopJs = readScript("shop.js");
+
+    test("exactly one DOMContentLoaded listener is registered", () => {
+        // Two registrations is the shape the duplication took, and the second
+        // copy is where the unbalanced braces came from. One handler also
+        // means the element lookups happen once, in a known order, before
+        // fetchProducts() runs.
+        const registrations = shopJs.match(/"DOMContentLoaded"/g) || [];
+
+        expect(registrations).toHaveLength(1);
+    });
+
+    test("no statement references an undeclared filterUrlParams", () => {
+        // `filterUrlParams` is declared inside the clear-filters listener. The
+        // broken file had `filterUrlParams.delete(...)` stranded in the second
+        // handler, several scopes away from any declaration -- a ReferenceError
+        // waiting for the first click.
+        const declarations = (shopJs.match(/const\s+filterUrlParams\s*=/g) || []).length;
+        const uses = (shopJs.match(/\bfilterUrlParams\b/g) || []).length;
+
+        expect(declarations).toBe(1);
+        // One declaration plus its uses inside the one listener that declares it.
+        expect(uses).toBeGreaterThan(1);
+    });
+
+    test("addEventListener is never handed IntersectionObserver options", () => {
+        // `{ rootMargin: ... }` is an observer option. Passing it as the third
+        // argument to addEventListener is silently accepted by the browser --
+        // it is read as an options bag with no recognised keys -- so this only
+        // ever showed up as a listener that looked wired and was not.
+        const misuse = /addEventListener\([\s\S]{0,600}?rootMargin/;
+
+        expect(misuse.test(shopJs)).toBe(false);
+    });
+});
+
+describe("clearing filters clears the URL too", () => {
+    const shopJs = readScript("shop.js");
+
+    // A shopper arriving from the mega menu carries ?category=&subcategory= and
+    // has filters.megaCategory/megaSubcategory seeded from them. Resetting only
+    // the checkboxes leaves both in place, so the next applyFilters() re-applies
+    // the filter the button just cleared and a reload brings it back. These
+    // four steps were all inside the fragment the merge stranded.
+    const listener = shopJs.slice(shopJs.indexOf("active-clear-filters"));
+
+    test.each([
+        ['strips "category" from the query string', /filterUrlParams\.delete\(\s*"category"\s*\)/],
+        ['strips "subcategory" from the query string', /filterUrlParams\.delete\(\s*"subcategory"\s*\)/],
+        ["rewrites the address bar", /window\.history\.replaceState\(/],
+        ["clears filters.megaCategory", /filters\.megaCategory\s*=\s*""/],
+        ["clears filters.megaSubcategory", /filters\.megaSubcategory\s*=\s*""/],
+        ["re-runs the query", /applyFilters\(\s*\{\s*resetPage:\s*true\s*\}\s*\)/],
+    ])("the clear-filters handler %s", (_label, pattern) => {
+        expect(pattern.test(listener)).toBe(true);
+    });
+});

--- a/frontend/scripts/shop.js
+++ b/frontend/scripts/shop.js
@@ -2261,6 +2261,11 @@ function setupProductObserver() {
 // ---------------------------------------------------------
 // INITIALIZATION
 // ---------------------------------------------------------
+//
+// One handler, not two. The responsive refactor duplicated this block and then
+// interleaved the two copies, which left the file unparsable and the whole
+// shop page without JavaScript (#1696). What follows is the single registration
+// the page has always needed: resolve the elements, wire the controls, fetch.
 
 document.addEventListener(
     "DOMContentLoaded",
@@ -2288,211 +2293,108 @@ document.addEventListener(
         setupFilterDrawer();
         fetchProducts();
 
+        // ---------------------------------------------------------
         // ACTIVE CLEAR FILTERS BUTTON
-        const activeClearFiltersBtn =
-            document.getElementById(
-                "active-clear-filters"
-            );
+        // ---------------------------------------------------------
+        //
+        // Clearing has to reach the URL as well as the form. A shopper who arrived
+        // from the mega menu carries `category`/`subcategory` in the query string,
+        // and `filters.megaCategory`/`filters.megaSubcategory` are seeded from
+        // them. Resetting only the checkboxes leaves both in place, so the next
+        // `applyFilters()` re-applies the very filter the button just cleared, and
+        // a reload brings it back. Strip the params, clear the mega filters, then
+        // re-run the query.
+        //
+        // Note the third argument to `addEventListener` here used to be an
+        // IntersectionObserver options object (`{ rootMargin: "200px 0px" }`) that
+        // belongs to `observeSentinel()`. It is not a valid listener option and is
+        // gone.
+        const activeClearFiltersBtn = document.getElementById("active-clear-filters");
 
         if (activeClearFiltersBtn) {
-            activeClearFiltersBtn.addEventListener(
-                "click",
-                () => {
-                    resetCategoryCheckboxes();
+            activeClearFiltersBtn.addEventListener("click", () => {
+                resetCategoryCheckboxes();
 
-                    if (
-                        elements.searchInput
-                    ) {
-                        elements.searchInput.value =
-                            "";
-                    }
-                },
-                {
-                    rootMargin:
-                        "200px 0px"
+                if (elements.searchInput) {
+                    elements.searchInput.value = "";
                 }
-            );
-    }
 
-    // ---------------------------------------------------------
-    // INITIALIZATION
-    // ---------------------------------------------------------
+                const filterUrlParams = new URLSearchParams(window.location.search);
 
-    document.addEventListener(
-    "DOMContentLoaded",
-        () => {
-            elements.searchForm =
-                document.getElementById(
-                    "shop-search-form"
-                );
+                filterUrlParams.delete("category");
+                filterUrlParams.delete("subcategory");
 
-            elements.searchInput =
-                document.getElementById(
-                    "search-input"
-                );
+                const query = filterUrlParams.toString();
+                const newUrl = window.location.pathname + (query ? `?${query}` : "");
 
-            elements.suggestions =
-                document.getElementById(
-                    "search-suggestions"
-                );
+                window.history.replaceState({}, "", newUrl);
 
-            elements.categoryList =
-                document.getElementById(
-                    "category-filter-list"
-                );
+                filters.megaCategory = "";
+                filters.megaSubcategory = "";
 
-            elements.minPriceRange =
-                document.getElementById(
-                    "min-price-range"
-                );
-
-            elements.maxPriceRange =
-                document.getElementById(
-                    "max-price-range"
-                );
-
-            elements.minPriceNumber =
-                document.getElementById(
-                    "min-price-number"
-                );
-
-            elements.maxPriceNumber =
-                document.getElementById(
-                    "max-price-number"
-                );
-
-            elements.priceOutput =
-                document.getElementById(
-                    "price-range-output"
-                );
-
-            elements.sortSelect = document.getElementById("product-sort");
-
-                    filterUrlParams.delete(
-                        "category"
-                    );
-
-                    filterUrlParams.delete(
-                        "subcategory"
-                    );
-
-                    const newUrl =
-                        window.location
-                            .pathname +
-                        (
-                            filterUrlParams.toString()
-                                ? "?" +
-                                  filterUrlParams.toString()
-                                : ""
-                        );
-
-                    window.history.replaceState(
-                        {},
-                        "",
-                        newUrl
-                    );
-
-                    filters.megaCategory =
-                        "";
-
-                    filters.megaSubcategory =
-                        "";
-
-            elements.clearFilters = document.getElementById("clear-filters");
-
-        // CATEGORY CARD CLICK FILTER
-        document
-            .querySelectorAll(
-                ".fashion-card"
-            )
-            .forEach((card) => {
-                const handleCategorySelect =
-                    () => {
-                        const category =
-                            card.dataset
-                                .category;
-
-                        let checkbox =
-                            document.querySelector(
-                                `input[name="category-filter"][value="${category}"]`
-                            );
-
-                        resetCategoryCheckboxes();
-
-                        if (
-                            !checkbox &&
-                            elements.categoryList
-                        ) {
-                            const label =
-                                document.createElement(
-                                    "label"
-                                );
-
-                            label.innerHTML = `
-                                <input
-                                    type="checkbox"
-                                    name="category-filter"
-                                    value="${AppUtils.escapeHTML(
-                                        category
-                                    )}"
-                                >
-
-                                ${AppUtils.escapeHTML(
-                                    category
-                                )}
-                            `;
-
-                            elements.categoryList.appendChild(
-                                label
-                            );
-
-                            checkbox =
-                                label.querySelector(
-                                    "input"
-                                );
-                        }
-
-                        if (checkbox) {
-                            checkbox.checked =
-                                true;
-
-                            applyFilters({
-                                resetPage: true
-                            });
-
-                            document
-                                .getElementById(
-                                    "product-container"
-                                )
-                                ?.scrollIntoView(
-                                    {
-                                        behavior:
-                                            "smooth"
-                                    }
-                                );
-                        }
-                    };
-
-                card.addEventListener(
-                    "click",
-                    handleCategorySelect
-                );
-
-                card.addEventListener(
-                    "keydown",
-                    (event) => {
-                        if (
-                            event.key ===
-                                "Enter" ||
-                            event.key ===
-                                " "
-                        ) {
-                            event.preventDefault();
-
-                            handleCategorySelect();
-                        }
-                    }
-                );
+                applyFilters({ resetPage: true });
             });
+        }
+
+        // ---------------------------------------------------------
+        // CATEGORY CARD CLICK FILTER
+        // ---------------------------------------------------------
+        //
+        // The category cards on the shop landing strip filter the grid without a
+        // round trip. A card may name a category the sidebar has no checkbox for --
+        // the list is built from what the current result set contains -- so one is
+        // created on demand rather than dropping the click.
+        document.querySelectorAll(".fashion-card").forEach((card) => {
+            const handleCategorySelect = () => {
+                const category = card.dataset.category;
+
+                if (!category) {
+                    return;
+                }
+
+                let checkbox = document.querySelector(
+                    `input[name="category-filter"][value="${category}"]`
+                );
+
+                resetCategoryCheckboxes();
+
+                if (!checkbox && elements.categoryList) {
+                    const label = document.createElement("label");
+
+                    label.innerHTML = `
+                        <input
+                            type="checkbox"
+                            name="category-filter"
+                            value="${AppUtils.escapeHTML(category)}"
+                        >
+                        ${AppUtils.escapeHTML(category)}
+                    `;
+
+                    elements.categoryList.appendChild(label);
+
+                    checkbox = label.querySelector("input");
+                }
+
+                if (checkbox) {
+                    checkbox.checked = true;
+
+                    applyFilters({ resetPage: true });
+
+                    document
+                        .getElementById("product-container")
+                        ?.scrollIntoView({ behavior: "smooth" });
+                }
+            };
+
+            card.addEventListener("click", handleCategorySelect);
+
+            card.addEventListener("keydown", (event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+
+                    handleCategorySelect();
+                }
+            });
+        });
     }
 );


### PR DESCRIPTION
Closes #1696

## What was wrong

`frontend/scripts/shop.js` did not parse. `npm run check:syntax` was red on `main`:

```
❌ 1 of 652 JavaScript file(s) failed to parse:
  frontend/scripts/shop.js:2499
      Unexpected end of input
```

The responsive-design refactor duplicated the initialization block at the bottom of the file and then interleaved the two copies. The tail ended up with two `DOMContentLoaded` registrations: the first with an arrow body that is never closed and a clear-filters listener that lost its body and picked up `{ rootMargin: "200px 0px" }` — an `IntersectionObserver` options object belonging to `observeSentinel()` — as its third argument; the second re-doing the same element lookups, stopping halfway through them, and running into orphaned fragments of the first handler's body that referenced a `filterUrlParams` no longer in scope.

A `SyntaxError` aborts the whole script, so `shop.html` had **no** JavaScript: no product fetch, no filters, no sort, no infinite scroll, no search suggestions.

## What this does

Collapses the two blocks back into the single handler the page has always needed, reconstructed from `b8b934a^`, and restores the clear-filters behaviour the merge stranded. That behaviour matters beyond tidiness: a shopper arriving from the mega menu carries `category`/`subcategory` in the query string, and `filters.megaCategory` / `filters.megaSubcategory` are seeded from them. Resetting only the checkboxes leaves both in place, so the next `applyFilters()` re-applies the filter the button just cleared and a reload brings it back. The handler now strips the params, rewrites the address bar, clears the mega filters, and re-runs the query.

Two small things kept from the reconstruction rather than the original:

- `handleCategorySelect` returns early when a card has no `data-category`, instead of building a checkbox with `value="undefined"`.
- The stray `addEventListener` options object is gone. The browser silently accepts it — it reads as an options bag with no recognised keys — which is why this only ever looked like a listener that was wired and was not.

## The call shape

The listener is written as the multi-line form:

```js
document.addEventListener(
    "DOMContentLoaded",
    () => {
        ...
    }
);
```

not the compact `document.addEventListener("DOMContentLoaded", () => { ... });`. That is not a style preference — `tests/mergeScarRegression.test.js` already pins it:

```js
it('closes that listener rather than running on into what follows', () => {
    // The #1444 scar itself: `}\n);` closes the arrow function and the call
    // it is an argument to. Dropping the `);` merged the listener into the
    // next declaration.
    expect(source.slice(listener)).toMatch(/\n\s*\}\n\s*\);/);
});
```

That suite has been red on `main` since the refactor. This makes its `parses`, `has exactly one DOMContentLoaded initialiser` and `closes that listener` cases green again.

## Guard

`backend/tests/frontendScriptParse.test.js` compiles every file under `frontend/scripts` with `vm.Script`, the same parse goal a classic `<script>` tag and CommonJS use, retrying genuine ES modules the way `scripts/check-syntax.js` does. It then pins the shape of shop.js's init block: one `DOMContentLoaded` registration, one declaration of `filterUrlParams` with no stranded uses, no observer options handed to `addEventListener`, and all six steps of the clear-filters handler present.

`check:syntax` already catches the parse failure, but it is a separate CI step; having it in the jest suite puts the failure next to the behaviour it breaks.

## Verification

```
$ npm run check:syntax
✅ syntax check passed — 652 JavaScript file(s) parsed cleanly

$ backend/node_modules/.bin/jest --rootDir backend tests/frontendScriptParse.test.js
Tests:       81 passed, 81 total
```

Confirmed the guard is real by stashing the shop.js fix and re-running the new test against the broken file:

```
✕ shop.js parses as a classic script
✕ exactly one DOMContentLoaded listener is registered
✕ no statement references an undeclared filterUrlParams
✕ addEventListener is never handed IntersectionObserver options
Tests:       4 failed, 77 passed, 81 total
```

The pre-existing `tests/mergeScarRegression.test.js` goes from three failures on `main` to one:

```
frontend/scripts/shop.js
  ✓ parses
  ✓ has exactly one DOMContentLoaded initialiser
  ✓ closes that listener rather than running on into what follows
  ✓ declares no function twice
  ✓ declares the functions its own code calls
  ✓ resolves the clear-filters button and sort select by the ids the page uses
  ✓ has one owner for the clear-filters click
```

The one it still reports — `frontend/scripts/product-cards-home.js › declares the stock bindings its card template reads` — is a different file and a separate defect from the same refactor, and is out of scope here.

Also ran `check:assets`, `check:a11y`, `check:sitemap`, `check:boot` and `check:modules` — all pass.


---

## CI note

**Syntax check ✅** and **Server boots ✅** — the two jobs that were red on `main` because of this file.

**Backend tests** is still red, on suites this PR does not touch. All five already fail on `main`:

| suite | failing case | fixed by |
| --- | --- | --- |
| `mergeScarRegression` | `product-cards-home.js › declares the stock bindings its card template reads` | not yet — separate defect from the same refactor |
| `cartBulkSelection` | `does not put handlers on the global object` | not yet |
| `wishlistReads` | 7 cases, all `p.is_active = 1` missing from the queries | not yet |
| `migrationViewColumns` | `no two migrations claim the same version` | #1705 |
| `fraudMonitoringQueue` | `takes the next free migration number` | #1705 |

This PR takes `mergeScarRegression`'s `frontend/scripts/shop.js` block from three failures to zero:

```
frontend/scripts/shop.js
  ✓ parses
  ✓ has exactly one DOMContentLoaded initialiser
  ✓ closes that listener rather than running on into what follows
  ✓ declares no function twice
  ✓ declares the functions its own code calls
  ✓ resolves the clear-filters button and sort select by the ids the page uses
  ✓ has one owner for the clear-filters click
```

The `Vercel` check fails on every PR in this repository with "Authorization required to deploy" against the `bhuvanshs-projects` team, unrelated to any change.
