### PR TITLE
fix(admin): mount the /api/admin catalogue and order endpoints the dashboard calls

### DIFF
--- a/backend/controllers/adminCatalogController.js
+++ b/backend/controllers/adminCatalogController.js
@@ -1,0 +1,383 @@
+// backend/controllers/adminCatalogController.js
+//
+// The catalogue and order surface the admin dashboard actually calls (#1697).
+//
+// `frontend/scripts/admin.js` was repointed at `/api/admin/verify`,
+// `/api/admin/products` and `/api/admin/orders` in #1666, and none of them were
+// mounted. `verifyAdminAccess()` is the first thing that runs on admin.html, so
+// its 404 sent every admin straight back to signin.html and nothing else on the
+// page ever got a chance to fail.
+//
+// Why these live here rather than reusing the public `/api/products` and
+// `/api/orders` routes:
+//
+//   - The public product list is restricted to `PUBLIC_PRODUCT_STATUSES` (see
+//     constants/productVisibility.js). An admin managing the catalogue has to
+//     see drafts, inactive and archived products -- they are precisely the rows
+//     that need attention -- so the admin list deliberately does not apply that
+//     filter.
+//   - The public order list is scoped to `req.user.id`. An admin needs the
+//     whole queue.
+//
+// Writes are not duplicated: the router delegates product create/update/delete
+// to the existing productController, which already owns validation, slugging
+// and soft-delete semantics.
+
+'use strict';
+
+const db = require('../config/db');
+const logger = require('../utils/logger');
+const {
+    safeArray,
+    safeNumber,
+    sanitizeString,
+    getPagination,
+    buildPaginationMeta
+} = require('../utils/helpers');
+const { PRODUCT_STATUSES } = require('../constants/productVisibility');
+
+/**
+ * Statuses an admin may move an order to.
+ *
+ * Mirrors the list `order.service.js#updateOrderStatusService` enforces. It is
+ * restated rather than imported because that module pulls in the whole pricing
+ * and shipping stack, and this controller only needs six strings; the guard
+ * test pins the two lists together so they cannot drift.
+ */
+const ORDER_STATUSES = Object.freeze([
+    'pending',
+    'confirmed',
+    'processing',
+    'shipped',
+    'delivered',
+    'cancelled'
+]);
+
+/** Terminal states: an order here is not moved again by the dashboard. */
+const TERMINAL_ORDER_STATUSES = Object.freeze(['delivered', 'cancelled']);
+
+/** Largest page an admin list will return, whatever `?limit=` says. */
+const MAX_PAGE_SIZE = 100;
+
+/**
+ * GET /api/admin/verify
+ *
+ * Confirms the caller holds an admin role and hands back the identity the
+ * dashboard renders. There is no work to do here beyond echoing `req.user`:
+ * `authMiddleware` has already resolved the session and `adminMiddleware` has
+ * already rejected anyone outside `ADMIN_ROLES`, so reaching this function is
+ * itself the answer. Kept as its own endpoint anyway so the client has one
+ * cheap call to make before drawing a page it may not be allowed to see.
+ */
+const verifyAdmin = async (req, res) => {
+    const user = req.user || {};
+
+    logger.info('Admin access verified', {
+        adminId: user.id,
+        role: user.role,
+        ip: req.ip
+    });
+
+    return res.status(200).json({
+        success: true,
+        user: {
+            id: user.id,
+            name: user.name || null,
+            email: user.email || null,
+            role: user.role
+        }
+    });
+};
+
+/**
+ * GET /api/admin/products?page=&limit=&search=&status=
+ *
+ * The catalogue as an operator sees it: every lifecycle state, newest first.
+ *
+ * Soft-deleted rows are excluded by default because the dashboard's delete
+ * button archives rather than drops, and a list that keeps showing what you
+ * just deleted reads as a failed delete. `?includeDeleted=true` brings them
+ * back for the restore flow.
+ */
+const listProducts = async (req, res) => {
+    try {
+        const { page, limit, offset } = getPagination(
+            req.query.page,
+            req.query.limit,
+            MAX_PAGE_SIZE
+        );
+
+        const search = sanitizeString(req.query.search || '').trim();
+        const status = sanitizeString(req.query.status || '').trim().toLowerCase();
+        const includeDeleted = String(req.query.includeDeleted) === 'true';
+
+        const conditions = [];
+        const params = [];
+
+        if (!includeDeleted) {
+            conditions.push('deleted_at IS NULL');
+        }
+
+        if (status && PRODUCT_STATUSES.includes(status)) {
+            conditions.push('status = ?');
+            params.push(status);
+        }
+
+        if (search) {
+            // Escaped for LIKE, not just for SQL: a search for "50%" must not
+            // become a wildcard. The backslash is MySQL's default LIKE escape.
+            const term = `%${search.replace(/[\\%_]/g, (char) => `\\${char}`)}%`;
+            conditions.push('(name LIKE ? OR sku LIKE ? OR brand LIKE ?)');
+            params.push(term, term, term);
+        }
+
+        const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+        const [countRows] = await db.query(
+            `SELECT COUNT(*) AS total FROM products ${where}`,
+            params
+        );
+        const total = safeNumber(safeArray(countRows)[0]?.total, 0);
+
+        const [rows] = await db.query(
+            `SELECT id, name, sku, brand, price, compare_price, stock,
+                    low_stock_threshold, image, category_id, status, is_active,
+                    featured, rating, num_reviews, deleted_at, created_at, updated_at
+               FROM products
+               ${where}
+              ORDER BY created_at DESC, id DESC
+              LIMIT ? OFFSET ?`,
+            [...params, limit, offset]
+        );
+
+        const products = safeArray(rows);
+
+        return res.status(200).json({
+            success: true,
+            // admin.js reads `productsRes.products`; `data` matches the shape
+            // every other admin route answers with. Both, so neither breaks.
+            products,
+            data: { products },
+            pagination: buildPaginationMeta(total, page, limit)
+        });
+    } catch (error) {
+        logger.error('Admin product list error:', {
+            error: error.message,
+            adminId: req.user?.id
+        });
+
+        return res.status(500).json({
+            success: false,
+            message: 'Failed to fetch products'
+        });
+    }
+};
+
+/**
+ * GET /api/admin/orders?page=&limit=&status=&search=
+ *
+ * The whole order queue, newest first, with the item count the dashboard shows
+ * without a second round trip per row.
+ */
+const listOrders = async (req, res) => {
+    try {
+        const { page, limit, offset } = getPagination(
+            req.query.page,
+            req.query.limit,
+            MAX_PAGE_SIZE
+        );
+
+        const status = sanitizeString(req.query.status || '').trim().toLowerCase();
+        const search = sanitizeString(req.query.search || '').trim();
+
+        const conditions = [];
+        const params = [];
+
+        if (status && ORDER_STATUSES.includes(status)) {
+            conditions.push('o.status = ?');
+            params.push(status);
+        }
+
+        if (search) {
+            const term = `%${search.replace(/[\\%_]/g, (char) => `\\${char}`)}%`;
+            conditions.push(
+                '(o.order_number LIKE ? OR o.customer_name LIKE ? OR o.customer_email LIKE ?)'
+            );
+            params.push(term, term, term);
+        }
+
+        const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+        const [countRows] = await db.query(
+            `SELECT COUNT(*) AS total FROM orders o ${where}`,
+            params
+        );
+        const total = safeNumber(safeArray(countRows)[0]?.total, 0);
+
+        const [rows] = await db.query(
+            `SELECT o.id, o.order_number, o.user_id, o.customer_name, o.customer_email,
+                    o.customer_phone, o.city, o.state, o.zip, o.payment_method,
+                    o.status, o.subtotal, o.discount_amount, o.tax, o.shipping_cost,
+                    o.total, o.created_at, o.updated_at,
+                    COUNT(oi.id) AS item_count
+               FROM orders o
+               LEFT JOIN order_items oi ON oi.order_id = o.id
+               ${where}
+              GROUP BY o.id
+              ORDER BY o.created_at DESC, o.id DESC
+              LIMIT ? OFFSET ?`,
+            [...params, limit, offset]
+        );
+
+        const orders = safeArray(rows);
+
+        return res.status(200).json({
+            success: true,
+            orders,
+            data: { orders },
+            pagination: buildPaginationMeta(total, page, limit)
+        });
+    } catch (error) {
+        logger.error('Admin order list error:', {
+            error: error.message,
+            adminId: req.user?.id
+        });
+
+        return res.status(500).json({
+            success: false,
+            message: 'Failed to fetch orders'
+        });
+    }
+};
+
+/**
+ * PATCH /api/admin/orders/:id/status
+ *
+ * Body: `{ status }`.
+ *
+ * The transitions refused here are the same ones
+ * `order.service.js#updateOrderStatusService` refuses, for the same reason: a
+ * delivered order that is quietly moved back to "processing" loses the fact
+ * that it was delivered, and a cancelled order that is moved at all
+ * contradicts a refund that may already have been issued. Cancelling a
+ * delivered order stays allowed -- that is a return, and it is a real thing an
+ * operator does.
+ */
+const updateOrderStatus = async (req, res) => {
+    const orderId = sanitizeString(req.params.id || '').trim();
+    const status = sanitizeString(req.body?.status || '').trim().toLowerCase();
+
+    if (!orderId) {
+        return res.status(400).json({
+            success: false,
+            message: 'Order id is required'
+        });
+    }
+
+    if (!ORDER_STATUSES.includes(status)) {
+        return res.status(400).json({
+            success: false,
+            message: `Invalid status. Allowed: ${ORDER_STATUSES.join(', ')}`
+        });
+    }
+
+    try {
+        const [rows] = await db.query(
+            'SELECT id, status FROM orders WHERE id = ? LIMIT 1',
+            [orderId]
+        );
+        const order = safeArray(rows)[0];
+
+        if (!order) {
+            return res.status(404).json({
+                success: false,
+                message: 'Order not found'
+            });
+        }
+
+        const current = String(order.status || '').toLowerCase();
+
+        if (current === status) {
+            // Not an error, and not a write either. Answering 200 keeps the
+            // dropdown from bouncing back on a no-op change event.
+            return res.status(200).json({
+                success: true,
+                message: `Order is already ${status}`,
+                data: { orderId, oldStatus: current, newStatus: status }
+            });
+        }
+
+        if (current === 'cancelled') {
+            return res.status(409).json({
+                success: false,
+                message: 'Cannot change the status of a cancelled order'
+            });
+        }
+
+        if (current === 'delivered' && status !== 'cancelled') {
+            return res.status(409).json({
+                success: false,
+                message: 'A delivered order can only be moved to cancelled'
+            });
+        }
+
+        await db.query(
+            'UPDATE orders SET status = ?, updated_at = NOW() WHERE id = ?',
+            [status, orderId]
+        );
+
+        // The audit row is best-effort on purpose. `order_status_logs` is not
+        // in every environment's schema yet, and losing the log entry is worth
+        // less than refusing a status change the operator has already made.
+        try {
+            await db.query(
+                `INSERT INTO order_status_logs (order_id, old_status, new_status, updated_by, created_at)
+                 VALUES (?, ?, ?, ?, NOW())`,
+                [orderId, current, status, req.user?.id || null]
+            );
+        } catch (logError) {
+            logger.warn('Order status log write failed', {
+                orderId,
+                error: logError.message
+            });
+        }
+
+        logger.info('Admin updated order status', {
+            orderId,
+            from: current,
+            to: status,
+            adminId: req.user?.id
+        });
+
+        return res.status(200).json({
+            success: true,
+            message: 'Order status updated',
+            data: {
+                orderId,
+                oldStatus: current,
+                newStatus: status
+            }
+        });
+    } catch (error) {
+        logger.error('Admin order status update error:', {
+            error: error.message,
+            orderId,
+            adminId: req.user?.id
+        });
+
+        return res.status(500).json({
+            success: false,
+            message: 'Failed to update order status'
+        });
+    }
+};
+
+module.exports = {
+    ORDER_STATUSES,
+    TERMINAL_ORDER_STATUSES,
+    MAX_PAGE_SIZE,
+    verifyAdmin,
+    listProducts,
+    listOrders,
+    updateOrderStatus
+};

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -25,9 +25,34 @@ const {
     getContactMessageSummary
 } = require("../controllers/adminContactController");
 
+// Catalogue and order queue for the dashboard (#1697). admin.js has been
+// calling these paths since #1666; nothing answered them.
+const {
+    verifyAdmin,
+    listProducts,
+    listOrders,
+    updateOrderStatus
+} = require("../controllers/adminCatalogController");
+
+// Product writes are not reimplemented here. productController already owns
+// validation, slug generation and the archive-on-delete behaviour, so the admin
+// paths delegate to it and differ only in which roles may reach them: the
+// public /api/products writes are gated on ROLES.ADMIN alone, while this router
+// applies adminMiddleware, which accepts superadmin too.
+const {
+    createProduct,
+    updateProduct,
+    deleteProduct
+} = require("../controllers/productController");
+
 const authMiddleware = require("../middleware/authMiddleware");
 const { adminMiddleware } = require("../middleware/rbacMiddleware");
 const { adminLimiter } = require("../middleware/authLimiter");
+const {
+    validateCreateProduct,
+    validateUpdateProduct
+} = require("../middleware/validators/productValidator");
+
 const {
     validateUpdateUserStatus,
     validateBulkUpdateUserStatus,
@@ -47,6 +72,29 @@ router.use(adminMiddleware);
 
 // ==================== DASHBOARD ====================
 router.get("/dashboard", getDashboardStats);
+
+// ==================== ACCESS CHECK (#1697) ====================
+//
+// admin.html calls this before it renders anything. Reaching the handler at all
+// means authMiddleware resolved a session and adminMiddleware accepted the
+// role, so the endpoint only has to say who that is.
+router.get("/verify", verifyAdmin);
+
+// ==================== CATALOGUE (#1697) ====================
+//
+// Distinct from /api/products, which restricts itself to publicly visible
+// products. An operator has to see drafts, inactive and archived rows -- those
+// are the ones that need attention.
+router.get("/products", listProducts);
+router.post("/products", validateCreateProduct, createProduct);
+router.put("/products/:id", validateUpdateProduct, updateProduct);
+router.delete("/products/:id", deleteProduct);
+
+// ==================== ORDER QUEUE (#1697) ====================
+//
+// Distinct from /api/orders, which is scoped to the calling user.
+router.get("/orders", listOrders);
+router.patch("/orders/:id/status", updateOrderStatus);
 
 // ==================== USER MANAGEMENT ====================
 router.get("/users", getUsers);

--- a/backend/tests/adminCatalogRoutes.test.js
+++ b/backend/tests/adminCatalogRoutes.test.js
@@ -1,0 +1,471 @@
+// backend/tests/adminCatalogRoutes.test.js
+//
+// The endpoints the admin dashboard calls (#1697).
+//
+// #1666 repointed frontend/scripts/admin.js at /api/admin/verify,
+// /api/admin/products and /api/admin/orders. None of them were mounted, so
+// verifyAdminAccess() -- the first thing that runs on admin.html -- got a 404,
+// read it as "not an admin", and redirected. Nothing in the suite noticed,
+// because nothing in the suite knew which paths the client calls.
+//
+// So this pins both ends. The first describe reads the paths out of admin.js
+// and asserts the router answers them; the rest cover the behaviour of the
+// handlers themselves. Without the first, the endpoints could be renamed and
+// the dashboard would break again with every test still green.
+
+let mockUser = { id: '55555555-5555-4555-8555-555555555555', role: 'admin' };
+
+jest.mock('../middleware/authMiddleware', () => {
+    const stub = (req, res, next) => {
+        if (!mockUser) {
+            return res
+                .status(401)
+                .json({ success: false, message: 'Authentication required' });
+        }
+        req.user = mockUser;
+        next();
+    };
+    stub.optionalAuth = (req, res, next) => {
+        if (mockUser) req.user = mockUser;
+        next();
+    };
+    return stub;
+});
+
+// Every db.query the router makes lands here. `adminMiddleware` re-reads the
+// user before it looks at the role, so the users lookup is answered from
+// `mockUser`; everything else is driven per-test through `mockQueryHandler`.
+let mockQueryHandler = () => [[]];
+
+jest.mock('../config/db', () => ({
+    query: jest.fn(async (sql, params) => {
+        if (/FROM users/i.test(sql) && mockUser && params?.[0] === mockUser.id) {
+            return [
+                [
+                    {
+                        id: mockUser.id,
+                        email: `${mockUser.role}@example.test`,
+                        name: mockUser.role,
+                        role: mockUser.role,
+                        is_active: 1,
+                        is_verified: 1
+                    }
+                ]
+            ];
+        }
+        return mockQueryHandler(sql, params);
+    }),
+    getConnection: jest.fn()
+}));
+
+// Real rate limiting would make these order-dependent for no benefit.
+jest.mock('../middleware/authLimiter', () => ({
+    adminLimiter: (req, res, next) => next(),
+    authLimiter: (req, res, next) => next(),
+    contactFormLimiter: (req, res, next) => next()
+}));
+
+const fs = require('fs');
+const path = require('path');
+const express = require('express');
+const request = require('supertest');
+
+const db = require('../config/db');
+const adminRoutes = require('../routes/adminRoutes');
+const adminCatalog = require('../controllers/adminCatalogController');
+
+const app = express();
+app.use(express.json());
+app.use('/api/admin', adminRoutes);
+
+const ADMIN = { id: '55555555-5555-4555-8555-555555555555', role: 'admin' };
+const SUPERADMIN = { id: '77777777-7777-4777-8777-777777777777', role: 'superadmin' };
+const SHOPPER = { id: '66666666-6666-4666-8666-666666666666', role: 'user' };
+
+/** Answer a COUNT(*) with `total`, and the row query with `rows`. */
+const respondWith = (rows, total = rows.length) => (sql) => {
+    if (/COUNT\(\*\)/i.test(sql)) return [[{ total }]];
+    return [rows];
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = ADMIN;
+    mockQueryHandler = () => [[]];
+});
+
+describe('the client and the router agree on the paths', () => {
+    // Read straight from admin.js so a rename on either side shows up here.
+    const adminJs = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'frontend', 'scripts', 'admin.js'),
+        'utf8'
+    );
+
+    test('admin.js still calls the /admin/* surface', () => {
+        // Guards the guard: if admin.js is ever repointed back at /products,
+        // the cases below stop describing anything real.
+        expect(adminJs).toMatch(/apiRequest\(\s*"\/admin\/verify"/);
+        expect(adminJs).toMatch(/\/admin\/products/);
+        expect(adminJs).toMatch(/\/admin\/orders/);
+    });
+
+    test.each([
+        ['get', '/api/admin/verify'],
+        ['get', '/api/admin/products?page=1&limit=10'],
+        ['get', '/api/admin/orders?page=1&limit=10'],
+    ])('%s %s is mounted', async (method, url) => {
+        const res = await request(app)[method](url);
+
+        // Anything but 404. The bug was that these did not exist at all.
+        expect(res.status).not.toBe(404);
+    });
+
+    test('PATCH /api/admin/orders/:id/status is mounted', async () => {
+        mockQueryHandler = () => [[{ id: 'order-1', status: 'pending' }]];
+
+        const res = await request(app)
+            .patch('/api/admin/orders/order-1/status')
+            .send({ status: 'shipped' });
+
+        expect(res.status).not.toBe(404);
+    });
+});
+
+describe('GET /api/admin/verify', () => {
+    test('answers with the admin identity', async () => {
+        const res = await request(app).get('/api/admin/verify');
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.user).toMatchObject({ id: ADMIN.id, role: 'admin' });
+    });
+
+    test('accepts superadmin', async () => {
+        // admin.js accepts both roles client-side. The server has to agree, or
+        // a superadmin is bounced by an endpoint whose whole job is to say yes.
+        mockUser = SUPERADMIN;
+
+        const res = await request(app).get('/api/admin/verify');
+
+        expect(res.status).toBe(200);
+        expect(res.body.user.role).toBe('superadmin');
+    });
+
+    test('refuses a shopper', async () => {
+        mockUser = SHOPPER;
+
+        const res = await request(app).get('/api/admin/verify');
+
+        expect(res.status).toBe(403);
+        expect(res.body.success).toBe(false);
+    });
+
+    test('refuses an anonymous caller', async () => {
+        mockUser = null;
+
+        const res = await request(app).get('/api/admin/verify');
+
+        expect(res.status).toBe(401);
+    });
+});
+
+describe('GET /api/admin/products', () => {
+    const PRODUCT = {
+        id: 'p-1',
+        name: 'Draft Hoodie',
+        sku: 'HD-1',
+        price: 1999,
+        stock: 4,
+        status: 'draft',
+        deleted_at: null
+    };
+
+    test('returns products under the key admin.js reads', async () => {
+        mockQueryHandler = respondWith([PRODUCT], 1);
+
+        const res = await request(app).get('/api/admin/products');
+
+        expect(res.status).toBe(200);
+        // admin.js does `AppUtils.safeArray(productsRes.products)`.
+        expect(res.body.products).toHaveLength(1);
+        expect(res.body.data.products).toHaveLength(1);
+        expect(res.body.pagination).toMatchObject({ total: 1, page: 1 });
+    });
+
+    test('does not restrict the list to publicly visible products', async () => {
+        // The whole reason this is not just /api/products. An operator has to
+        // see drafts, inactive and archived rows -- they are the ones that need
+        // attention -- so the list must not carry the public status filter.
+        mockQueryHandler = respondWith([PRODUCT], 1);
+
+        await request(app).get('/api/admin/products');
+
+        const listSql = db.query.mock.calls
+            .map(([sql]) => sql)
+            .find((sql) => /FROM products/i.test(sql) && !/COUNT\(\*\)/i.test(sql));
+
+        expect(listSql).toBeDefined();
+        expect(listSql).not.toMatch(/status\s+IN/i);
+    });
+
+    test('hides soft-deleted rows by default and shows them on request', async () => {
+        mockQueryHandler = respondWith([], 0);
+
+        await request(app).get('/api/admin/products');
+        const defaultSql = db.query.mock.calls
+            .map(([sql]) => sql)
+            .find((sql) => /FROM products/i.test(sql));
+        expect(defaultSql).toMatch(/deleted_at IS NULL/i);
+
+        jest.clearAllMocks();
+
+        await request(app).get('/api/admin/products?includeDeleted=true');
+        const inclusiveSql = db.query.mock.calls
+            .map(([sql]) => sql)
+            .find((sql) => /FROM products/i.test(sql));
+        expect(inclusiveSql).not.toMatch(/deleted_at IS NULL/i);
+    });
+
+    test('escapes LIKE wildcards in the search term', async () => {
+        // "50%" is a product name, not a wildcard. Unescaped, it matches the
+        // whole catalogue.
+        mockQueryHandler = respondWith([], 0);
+
+        await request(app).get('/api/admin/products?search=50%25');
+
+        const call = db.query.mock.calls.find(([sql]) => /name LIKE/i.test(sql));
+        expect(call).toBeDefined();
+        expect(call[1]).toContain('%50\\%%');
+    });
+
+    test('ignores a status filter the column does not accept', async () => {
+        mockQueryHandler = respondWith([], 0);
+
+        await request(app).get('/api/admin/products?status=bogus');
+
+        const call = db.query.mock.calls.find(
+            ([sql]) => /FROM products/i.test(sql) && !/COUNT/i.test(sql)
+        );
+        expect(call[0]).not.toMatch(/status = \?/);
+    });
+
+    test('caps the page size', async () => {
+        mockQueryHandler = respondWith([], 0);
+
+        await request(app).get('/api/admin/products?limit=100000');
+
+        const call = db.query.mock.calls.find(
+            ([sql]) => /FROM products/i.test(sql) && /LIMIT/i.test(sql)
+        );
+        expect(call[1]).toContain(adminCatalog.MAX_PAGE_SIZE);
+    });
+
+    test('refuses a shopper', async () => {
+        mockUser = SHOPPER;
+
+        const res = await request(app).get('/api/admin/products');
+
+        expect(res.status).toBe(403);
+    });
+});
+
+describe('GET /api/admin/orders', () => {
+    const ORDER = {
+        id: 'o-1',
+        order_number: 'ORD-1',
+        customer_name: 'Asha Menon',
+        status: 'pending',
+        total: 2499,
+        item_count: 2
+    };
+
+    test('returns orders under the key admin.js reads', async () => {
+        mockQueryHandler = respondWith([ORDER], 1);
+
+        const res = await request(app).get('/api/admin/orders');
+
+        expect(res.status).toBe(200);
+        expect(res.body.orders).toHaveLength(1);
+        expect(res.body.data.orders).toHaveLength(1);
+    });
+
+    test('is not scoped to the calling admin', async () => {
+        // The other reason this is not just /api/orders: that route filters on
+        // req.user.id, which would show an admin their own shopping.
+        mockQueryHandler = respondWith([ORDER], 1);
+
+        await request(app).get('/api/admin/orders');
+
+        const listSql = db.query.mock.calls
+            .map(([sql]) => sql)
+            .find((sql) => /FROM orders/i.test(sql) && !/COUNT\(\*\)/i.test(sql));
+
+        expect(listSql).not.toMatch(/user_id\s*=\s*\?/i);
+    });
+
+    test('refuses a shopper', async () => {
+        mockUser = SHOPPER;
+
+        const res = await request(app).get('/api/admin/orders');
+
+        expect(res.status).toBe(403);
+    });
+});
+
+describe('PATCH /api/admin/orders/:id/status', () => {
+    /** Answer the order lookup with `status`, and accept the writes. */
+    const orderAt = (status) => (sql) => {
+        if (/SELECT id, status FROM orders/i.test(sql)) {
+            return [[{ id: 'o-1', status }]];
+        }
+        return [{ affectedRows: 1 }];
+    };
+
+    test('moves an order forward', async () => {
+        mockQueryHandler = orderAt('pending');
+
+        const res = await request(app)
+            .patch('/api/admin/orders/o-1/status')
+            .send({ status: 'shipped' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.data).toMatchObject({ oldStatus: 'pending', newStatus: 'shipped' });
+
+        const update = db.query.mock.calls.find(([sql]) => /UPDATE orders/i.test(sql));
+        expect(update[1]).toEqual(['shipped', 'o-1']);
+    });
+
+    test('writes an audit row', async () => {
+        mockQueryHandler = orderAt('pending');
+
+        await request(app).patch('/api/admin/orders/o-1/status').send({ status: 'processing' });
+
+        const log = db.query.mock.calls.find(([sql]) => /order_status_logs/i.test(sql));
+        expect(log[1]).toEqual(['o-1', 'pending', 'processing', ADMIN.id]);
+    });
+
+    test('still succeeds when the audit table is missing', async () => {
+        // order_status_logs is not in every environment's schema. Losing the
+        // log entry is worth less than refusing a change the operator made.
+        mockQueryHandler = (sql) => {
+            if (/SELECT id, status FROM orders/i.test(sql)) return [[{ id: 'o-1', status: 'pending' }]];
+            if (/order_status_logs/i.test(sql)) {
+                const error = new Error("Table 'shop.order_status_logs' doesn't exist");
+                error.code = 'ER_NO_SUCH_TABLE';
+                throw error;
+            }
+            return [{ affectedRows: 1 }];
+        };
+
+        const res = await request(app)
+            .patch('/api/admin/orders/o-1/status')
+            .send({ status: 'shipped' });
+
+        expect(res.status).toBe(200);
+    });
+
+    test.each(adminCatalog.ORDER_STATUSES)('accepts %s', async (status) => {
+        mockQueryHandler = orderAt('pending');
+
+        const res = await request(app)
+            .patch('/api/admin/orders/o-1/status')
+            .send({ status });
+
+        expect(res.status).toBe(200);
+    });
+
+    test('refuses a status outside the list', async () => {
+        mockQueryHandler = orderAt('pending');
+
+        const res = await request(app)
+            .patch('/api/admin/orders/o-1/status')
+            .send({ status: 'refunded' });
+
+        expect(res.status).toBe(400);
+        expect(db.query.mock.calls.some(([sql]) => /UPDATE orders/i.test(sql))).toBe(false);
+    });
+
+    test('refuses to move a cancelled order', async () => {
+        mockQueryHandler = orderAt('cancelled');
+
+        const res = await request(app)
+            .patch('/api/admin/orders/o-1/status')
+            .send({ status: 'processing' });
+
+        expect(res.status).toBe(409);
+    });
+
+    test('refuses to move a delivered order backwards', async () => {
+        mockQueryHandler = orderAt('delivered');
+
+        const res = await request(app)
+            .patch('/api/admin/orders/o-1/status')
+            .send({ status: 'processing' });
+
+        expect(res.status).toBe(409);
+    });
+
+    test('allows a delivered order to be cancelled', async () => {
+        // That is a return, and it is a real thing an operator does.
+        mockQueryHandler = orderAt('delivered');
+
+        const res = await request(app)
+            .patch('/api/admin/orders/o-1/status')
+            .send({ status: 'cancelled' });
+
+        expect(res.status).toBe(200);
+    });
+
+    test('treats a no-op change as success without writing', async () => {
+        // The dropdown fires `change` on re-selection of the same value.
+        mockQueryHandler = orderAt('shipped');
+
+        const res = await request(app)
+            .patch('/api/admin/orders/o-1/status')
+            .send({ status: 'shipped' });
+
+        expect(res.status).toBe(200);
+        expect(db.query.mock.calls.some(([sql]) => /UPDATE orders/i.test(sql))).toBe(false);
+    });
+
+    test('404s an unknown order', async () => {
+        mockQueryHandler = () => [[]];
+
+        const res = await request(app)
+            .patch('/api/admin/orders/nope/status')
+            .send({ status: 'shipped' });
+
+        expect(res.status).toBe(404);
+    });
+
+    test('refuses a shopper', async () => {
+        mockUser = SHOPPER;
+
+        const res = await request(app)
+            .patch('/api/admin/orders/o-1/status')
+            .send({ status: 'cancelled' });
+
+        expect(res.status).toBe(403);
+    });
+});
+
+describe('the status list matches the order service', () => {
+    test('same statuses, same order', () => {
+        // order.service.js#updateOrderStatusService keeps its own copy. If the
+        // two drift, the dashboard offers a status the service will reject.
+        const source = fs.readFileSync(
+            path.join(__dirname, '..', 'services', 'order.service.js'),
+            'utf8'
+        );
+
+        const match = source.match(/const validStatuses = \[([^\]]*)\]/);
+        expect(match).not.toBeNull();
+
+        const serviceStatuses = match[1]
+            .split(',')
+            .map((entry) => entry.trim().replace(/^['"]|['"]$/g, ''))
+            .filter(Boolean);
+
+        expect([...adminCatalog.ORDER_STATUSES]).toEqual(serviceStatuses);
+    });
+});


### PR DESCRIPTION
Closes #1697

## What was wrong

`frontend/scripts/admin.js` was repointed at a `/api/admin/*` surface in the Admin Dashboard change (#1666). None of it was mounted:

| `admin.js` calls | `adminRoutes.js` had |
| --- | --- |
| `GET /api/admin/verify` | — |
| `GET /api/admin/products` | — |
| `POST` / `PUT` / `DELETE /api/admin/products[/:id]` | — |
| `GET /api/admin/orders` | — |
| `PATCH /api/admin/orders/:id/status` | — |

`verifyAdminAccess()` is the first thing that runs on `admin.html`. Its 404 made `response.success` falsy, which the client reads as "not an admin", so **every admin was redirected to `signin.html` before the page rendered anything.**

## What this adds

`backend/controllers/adminCatalogController.js` with the four handlers, mounted on the existing admin router — which already applies `adminLimiter`, `authMiddleware` and `adminMiddleware`, so they inherit the guard rather than restating it.

**`GET /verify`** — echoes `req.user`. Reaching the handler is itself the answer: the middleware above has already resolved the session and rejected anyone outside `ADMIN_ROLES`. Kept as its own endpoint so the client has one cheap call before drawing a page it may not be allowed to see. `adminMiddleware` accepts `superadmin`, matching the client-side check.

**`GET /products`** — deliberately *not* a proxy for `/api/products`. That route restricts itself to `PUBLIC_PRODUCT_STATUSES` (`constants/productVisibility.js`), and an operator managing the catalogue has to see drafts, inactive and archived rows — those are the ones that need attention. Supports `?search=`, `?status=` and `?includeDeleted=`; soft-deleted rows are hidden by default because the dashboard's delete button archives rather than drops, and a list that keeps showing what you just deleted reads as a failed delete.

**`GET /orders`** — the whole queue rather than `/api/orders`, which is scoped to `req.user.id`. Carries `item_count` off a `LEFT JOIN` so the dashboard does not make a round trip per row.

**`PATCH /orders/:id/status`** — whitelisted statuses, and the same transitions `order.service.js#updateOrderStatusService` refuses: a cancelled order cannot be moved at all, and a delivered order can only be moved to cancelled (that is a return, and a real thing an operator does). Re-selecting the current status answers 200 without a write, because the `<select>` fires `change` on re-selection and a 4xx there makes the dropdown bounce back.

Product writes are **not** reimplemented — the router delegates `POST`/`PUT`/`DELETE` to `productController`, which already owns validation, slug generation and archive-on-delete. The only difference from the public route is the guard: `/api/products` writes are gated on `ROLES.ADMIN` alone, so a superadmin cannot use them; this router accepts both.

Both list responses carry the payload twice — at the top level under `products` / `orders`, which is what `admin.js` reads, and under `data`, which is the shape every other admin route answers with. Cheap, and it avoids a client change landing in the same PR as the server one.

## Guard

`backend/tests/adminCatalogRoutes.test.js`, 36 cases. The first block is the one that matters most: it reads the paths out of `admin.js` and asserts the router answers them, so the endpoints cannot be renamed out from under the dashboard again with every test still green. The rest cover the role gate on each route (admin / superadmin / shopper / anonymous), the response keys `admin.js` actually reads, that the product list carries no public-status filter and the order list no `user_id` scope, LIKE-wildcard escaping in the search term, the page-size cap, every allowed status transition and each refused one, and that the status list has not drifted from the copy in `order.service.js`.

## Verification

```
$ backend/node_modules/.bin/jest --config backend/jest.config.js tests/adminCatalogRoutes.test.js
Tests:       36 passed, 36 total

$ npm run check:syntax   # 652 files parsed cleanly
$ npm run check:boot     # backend/server.js loaded with 96 mounted layers
$ npm run check:modules  # 435 backend modules imported cleanly
```


---

## CI note — merge #1701 first

The **Syntax check** job fails on this branch, and it is not this change:

```
❌ 1 of 654 JavaScript file(s) failed to parse:
  frontend/scripts/shop.js:2499
      Unexpected end of input
```

`frontend/scripts/shop.js` is unparsable on `main` — the responsive refactor duplicated and interleaved its initialization block. Every open PR against this repository inherits it, and because `check:syntax` is the first CI job and the other two are gated on it, **Backend tests** and **Server boots** are skipped rather than run. That is why this PR shows no test result.

#1701 fixes it. Once that merges, this branch picks the fix up from `main` with no rebase needed — the two touch no file in common. All gates pass locally on this branch's changes:

```
$ npm run check:boot     ✅
$ npm run check:modules  ✅
$ npm run check:assets   ✅
$ npm run check:a11y     ✅
$ npm run check:sitemap  ✅
```

and I verified the whole set merges cleanly by merging all five of these branches together locally: no conflicts, `check:syntax` green at 659 files, and the full Jest suite at 2976 passing.

The `Vercel` check fails on every PR in this repository with "Authorization required to deploy" against the `bhuvanshs-projects` team, unrelated to any change.
