### PR TITLE
feat(orders): send the confirmation email the order flow never dispatched

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -1,6 +1,8 @@
 const db =
     require("../config/db");
 
+const orderNotificationService = require("../services/orderNotificationService");
+
 const {
     createOrderService,
     TOTAL_MISMATCH_CODE
@@ -331,6 +333,22 @@ const createOrder =
             if (addressId) {
                 await addressService.markAddressUsed(checkout.userId, addressId);
             }
+
+            // The confirmation email (#1698). After the commit, for the same
+            // reason markAddressUsed is: an email cannot be un-sent, so telling
+            // a customer about an order that then rolls back is strictly worse
+            // than a missing email.
+            //
+            // Not awaited into the order's fate either. dispatchOrderConfirmation
+            // never rejects, but it can wait on an SMTP handshake, and the
+            // shopper should not sit on a spinner for it. A failure is logged
+            // and shows in the admin email log, where it can be resent.
+            orderNotificationService.dispatchOrderConfirmation({
+                result,
+                customer,
+                address,
+                paymentMethod: canonicalPaymentMethod
+            });
 
             return res.status(201)
                 .json({
@@ -1063,6 +1081,17 @@ const createPaymentIntent = async (req, res) => {
         await connection.query("UPDATE orders SET payment_intent_id = ? WHERE id = ?", [paymentIntentResult.paymentIntentId, result.orderId]);
 
         await connection.commit();
+
+        // Same dispatch as the main checkout path (#1698). The order exists and
+        // is committed at this point; the payment intent is confirmed
+        // client-side afterwards, and the confirmation describes the order that
+        // was placed rather than the settlement.
+        orderNotificationService.dispatchOrderConfirmation({
+            result,
+            customer,
+            address,
+            paymentMethod: "credit_card"
+        });
 
         return res.status(201).json({
             success: true,

--- a/backend/services/orderNotificationService.js
+++ b/backend/services/orderNotificationService.js
@@ -1,0 +1,143 @@
+// backend/services/orderNotificationService.js
+//
+// The caller emailService has been waiting for (#1698).
+//
+// #1668 shipped `sendOrderEmail`, an HTML template, an admin log viewer, a
+// robots.txt entry and a vercel.json header rule -- and nothing that called any
+// of it. `grep -rn sendOrderEmail backend` returned the definition, the export
+// and one unit test. No shopper has ever received a confirmation.
+//
+// This module is the seam between the order flow and the mail transport. It
+// exists rather than the controller calling `sendOrderEmail` directly for two
+// reasons:
+//
+//   1. `createOrderService` returns a result shaped for the HTTP response --
+//      `orderId`, `breakdown`, `items` -- and `sendOrderEmail` reads a shape
+//      built for the template -- `orderNumber`, `subtotal`, `shippingAddress`.
+//      Somewhere has to translate, and doing it inline in two call sites is how
+//      the two drift.
+//   2. Dispatch has to be non-blocking and non-throwing, and that is a property
+//      worth stating once, in a place a test can point at.
+//
+// ORDERING: the caller invokes this AFTER `connection.commit()`. An email is
+// not transactional -- there is no un-sending it -- so sending inside the
+// transaction risks telling a customer about an order that then rolls back,
+// which is strictly worse than a missing email. Committing first means the
+// worst case is an order that exists with no confirmation, which the admin
+// email log makes visible and an operator can resend.
+
+'use strict';
+
+const emailService = require('./emailService');
+const logger = require('../utils/logger');
+const { safeArray, safeNumber, sanitizeString } = require('../utils/helpers');
+
+/**
+ * Turn a `createOrderService` result into the shape `sendOrderEmail` reads.
+ *
+ * Every field is resolved from the breakdown first and the top-level result
+ * second. The breakdown is what the pricing engine actually charged; the
+ * top-level fields are conveniences copied out of it, and a template that
+ * quotes a different number from the one on the invoice is a support ticket.
+ *
+ * @param {Object} params
+ * @param {Object} params.result - Return value of `createOrderService`.
+ * @param {Object} [params.customer] - `{ name, email, phone }` as submitted.
+ * @param {Object} [params.address] - `{ fullAddress, city, state, zip }`.
+ * @param {string} [params.paymentMethod] - Canonical payment method.
+ * @returns {Object} Payload for `emailService.sendOrderEmail`.
+ */
+function buildOrderEmailPayload({ result, customer = {}, address = {}, paymentMethod = null }) {
+    const breakdown = result?.breakdown || {};
+
+    return {
+        id: result?.orderId || null,
+        orderId: result?.orderId || null,
+        orderNumber: result?.orderNumber || null,
+        createdAt: new Date().toISOString(),
+
+        customerName: sanitizeString(customer.name || ''),
+        email: sanitizeString(customer.email || ''),
+
+        paymentMethod: paymentMethod ? sanitizeString(paymentMethod) : null,
+
+        subtotal: safeNumber(breakdown.subtotal ?? result?.subtotal, 0),
+        discount: safeNumber(breakdown.discount ?? result?.discountAmount, 0),
+        tax: safeNumber(breakdown.tax, 0),
+        shipping: safeNumber(breakdown.shipping, 0),
+        total: safeNumber(breakdown.total ?? result?.total, 0),
+
+        // The order lines as priced, not as submitted. `validatedItems` carries
+        // the price the order was actually written with; the cart's copy may be
+        // stale, and a confirmation quoting the stale one is the wrong number
+        // in writing.
+        items: safeArray(result?.items).map((item) => ({
+            name: item.name,
+            qty: safeNumber(item.qty, 1),
+            price: safeNumber(item.price, 0),
+            color: item.color || null,
+            size: item.size || null
+        })),
+
+        shippingAddress: {
+            fullName: sanitizeString(customer.name || ''),
+            street: sanitizeString(address.fullAddress || ''),
+            city: sanitizeString(address.city || ''),
+            state: sanitizeString(address.state || ''),
+            zip: sanitizeString(address.zip || '')
+        }
+    };
+}
+
+/**
+ * Send the order confirmation, without ever failing the order.
+ *
+ * Returns a promise that always resolves. A checkout that has committed is
+ * done: the customer has been charged, stock has moved and the cart is closed.
+ * Throwing out of here -- an SMTP timeout, a DNS failure, a template that will
+ * not read -- would turn a completed order into a 500 and invite the shopper to
+ * pay twice. The failure is logged instead, and `recordEmailLog` leaves the
+ * trail an operator needs to resend.
+ *
+ * @param {Object} params - See `buildOrderEmailPayload`.
+ * @returns {Promise<{success: boolean, reason?: string, channel?: string}>}
+ */
+async function dispatchOrderConfirmation(params) {
+    const recipient = sanitizeString(params?.customer?.email || '').trim();
+
+    if (!recipient) {
+        // A guest checkout without an email is refused upstream, so this is a
+        // shape problem rather than a shopper problem -- worth a line in the
+        // log, not worth an exception.
+        logger.warn('Order confirmation skipped: no recipient', {
+            orderId: params?.result?.orderId || null
+        });
+        return { success: false, reason: 'missing_recipient' };
+    }
+
+    try {
+        const payload = buildOrderEmailPayload(params);
+        const outcome = await emailService.sendOrderEmail(recipient, payload);
+
+        logger.info('Order confirmation dispatched', {
+            orderId: payload.orderId,
+            orderNumber: payload.orderNumber,
+            channel: outcome?.channel || 'unknown',
+            delivered: Boolean(outcome?.delivered)
+        });
+
+        return outcome;
+    } catch (error) {
+        logger.error('Order confirmation failed', {
+            orderId: params?.result?.orderId || null,
+            error: error.message
+        });
+
+        return { success: false, reason: 'send_failed' };
+    }
+}
+
+module.exports = {
+    buildOrderEmailPayload,
+    dispatchOrderConfirmation
+};

--- a/backend/tests/orderConfirmationEmail.test.js
+++ b/backend/tests/orderConfirmationEmail.test.js
@@ -1,0 +1,328 @@
+// backend/tests/orderConfirmationEmail.test.js
+//
+// The order flow actually sends the confirmation (#1698).
+//
+// #1668 shipped emailService, the HTML template, the admin log viewer, the
+// robots.txt entry and the vercel.json header rule -- and no caller. The only
+// references to `sendOrderEmail` in the repo were its definition, its export
+// and one unit test that called it directly, so the feature was complete
+// everywhere except where it mattered.
+//
+// The suite that shipped with it could not have caught that: it tested the
+// service in isolation, which is exactly the shape of test that passes while
+// nothing calls the thing under test. These cover the wiring instead.
+
+jest.mock('../services/emailService', () => ({
+    sendOrderEmail: jest.fn(async () => ({ success: true, delivered: true, channel: 'smtp' })),
+    recordEmailLog: jest.fn(async () => ({})),
+    getEmailLogs: jest.fn(async () => [])
+}));
+
+const fs = require('fs');
+const path = require('path');
+
+const emailService = require('../services/emailService');
+const {
+    buildOrderEmailPayload,
+    dispatchOrderConfirmation
+} = require('../services/orderNotificationService');
+
+/** A `createOrderService` return value, in the shape the real one produces. */
+const ORDER_RESULT = {
+    success: true,
+    orderId: 'a1b2c3d4-0000-4000-8000-000000000001',
+    orderNumber: 'ORD-2026-000123',
+    subtotal: 2400,
+    total: 2652,
+    finalAmount: 2652,
+    discountAmount: 200,
+    promoCode: 'WELCOME200',
+    breakdown: {
+        subtotal: 2400,
+        discount: 200,
+        tax: 396,
+        shipping: 56,
+        total: 2652,
+        promoCode: 'WELCOME200'
+    },
+    items: [
+        { id: 'p1', name: 'Linen Shirt', price: 1200, qty: 2, color: 'Ecru', size: 'M' },
+        { id: 'p2', name: 'Canvas Tote', price: 0, qty: 1, color: null, size: null }
+    ]
+};
+
+const CUSTOMER = {
+    name: 'Asha Menon',
+    email: 'asha@example.com',
+    phone: '9876543210'
+};
+
+const ADDRESS = {
+    fullAddress: '12 Residency Road',
+    city: 'Bengaluru',
+    state: 'Karnataka',
+    zip: '560025'
+};
+
+const dispatchArgs = (overrides = {}) => ({
+    result: ORDER_RESULT,
+    customer: CUSTOMER,
+    address: ADDRESS,
+    paymentMethod: 'cod',
+    ...overrides
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('the order flow calls the mailer', () => {
+    // Read straight from the controller. A unit test of the service can pass
+    // with no caller at all -- that is the failure this file exists for -- so
+    // the wiring is asserted at the source.
+    const controller = fs.readFileSync(
+        path.join(__dirname, '..', 'controllers', 'orderController.js'),
+        'utf8'
+    );
+
+    test('orderController requires the notification service', () => {
+        expect(controller).toMatch(
+            /require\(\s*["']\.\.\/services\/orderNotificationService["']\s*\)/
+        );
+    });
+
+    test('every createOrderService call site dispatches a confirmation', () => {
+        const creates = (controller.match(/createOrderService\(/g) || []).length;
+        const dispatches = (controller.match(/dispatchOrderConfirmation\(/g) || []).length;
+
+        // Both call sites -- the main checkout and the card path -- and one
+        // dispatch each. A third call site added later without a dispatch
+        // fails here rather than shipping silently.
+        expect(creates).toBe(2);
+        expect(dispatches).toBe(creates);
+    });
+
+    test('the dispatch happens after the commit, never before', () => {
+        // An email cannot be un-sent. Sending inside the transaction risks
+        // telling a customer about an order that then rolls back, which is
+        // strictly worse than a missing email.
+        const segments = controller.split('dispatchOrderConfirmation(');
+
+        segments.slice(0, -1).forEach((before) => {
+            const lastCommit = before.lastIndexOf('connection.commit()');
+            const lastCreate = before.lastIndexOf('createOrderService(');
+
+            expect(lastCommit).toBeGreaterThan(-1);
+            expect(lastCommit).toBeGreaterThan(lastCreate);
+        });
+    });
+
+    test('the dispatch is not awaited into the order response', () => {
+        // dispatchOrderConfirmation never rejects, but it can wait on an SMTP
+        // handshake. The shopper should not sit on a spinner for it.
+        expect(controller).not.toMatch(/await\s+orderNotificationService\.dispatchOrderConfirmation/);
+    });
+});
+
+describe('buildOrderEmailPayload', () => {
+    test('carries the identifiers the template renders', () => {
+        const payload = buildOrderEmailPayload(dispatchArgs());
+
+        expect(payload.orderNumber).toBe('ORD-2026-000123');
+        expect(payload.orderId).toBe(ORDER_RESULT.orderId);
+        expect(payload.customerName).toBe('Asha Menon');
+        expect(payload.email).toBe('asha@example.com');
+        expect(payload.paymentMethod).toBe('cod');
+    });
+
+    test('takes the money from the breakdown, not the convenience fields', () => {
+        // The breakdown is what the pricing engine charged. The top-level
+        // fields are copies of it, and a confirmation quoting a different
+        // number from the invoice is a support ticket.
+        const payload = buildOrderEmailPayload(dispatchArgs());
+
+        expect(payload.subtotal).toBe(2400);
+        expect(payload.discount).toBe(200);
+        expect(payload.tax).toBe(396);
+        expect(payload.shipping).toBe(56);
+        expect(payload.total).toBe(2652);
+    });
+
+    test('prefers the breakdown when the two disagree', () => {
+        const payload = buildOrderEmailPayload(
+            dispatchArgs({
+                result: {
+                    ...ORDER_RESULT,
+                    total: 9999,
+                    subtotal: 8888
+                }
+            })
+        );
+
+        expect(payload.total).toBe(2652);
+        expect(payload.subtotal).toBe(2400);
+    });
+
+    test('carries the lines as priced', () => {
+        const payload = buildOrderEmailPayload(dispatchArgs());
+
+        expect(payload.items).toHaveLength(2);
+        expect(payload.items[0]).toEqual({
+            name: 'Linen Shirt',
+            qty: 2,
+            price: 1200,
+            color: 'Ecru',
+            size: 'M'
+        });
+    });
+
+    test('keeps a zero-priced line rather than dropping it', () => {
+        // A free gift is still a line on the confirmation.
+        const payload = buildOrderEmailPayload(dispatchArgs());
+
+        expect(payload.items[1].name).toBe('Canvas Tote');
+        expect(payload.items[1].price).toBe(0);
+    });
+
+    test('assembles the shipping address the template joins', () => {
+        const payload = buildOrderEmailPayload(dispatchArgs());
+
+        expect(payload.shippingAddress).toMatchObject({
+            street: '12 Residency Road',
+            city: 'Bengaluru',
+            state: 'Karnataka',
+            zip: '560025'
+        });
+    });
+
+    test('survives a result with no items and no breakdown', () => {
+        const payload = buildOrderEmailPayload({
+            result: { orderId: 'x', orderNumber: 'ORD-1' },
+            customer: CUSTOMER,
+            address: {}
+        });
+
+        expect(payload.items).toEqual([]);
+        expect(payload.total).toBe(0);
+        expect(payload.subtotal).toBe(0);
+    });
+});
+
+describe('dispatchOrderConfirmation', () => {
+    test('sends to the customer email', async () => {
+        await dispatchOrderConfirmation(dispatchArgs());
+
+        expect(emailService.sendOrderEmail).toHaveBeenCalledTimes(1);
+
+        const [recipient, payload] = emailService.sendOrderEmail.mock.calls[0];
+        expect(recipient).toBe('asha@example.com');
+        expect(payload.orderNumber).toBe('ORD-2026-000123');
+    });
+
+    test('skips, without throwing, when there is no recipient', async () => {
+        const outcome = await dispatchOrderConfirmation(
+            dispatchArgs({ customer: { name: 'Asha' } })
+        );
+
+        expect(outcome).toEqual({ success: false, reason: 'missing_recipient' });
+        expect(emailService.sendOrderEmail).not.toHaveBeenCalled();
+    });
+
+    test('never rejects when the transport throws', async () => {
+        // The checkout has committed: the customer has been charged, stock has
+        // moved and the cart is closed. Throwing here would turn a completed
+        // order into a 500 and invite the shopper to pay twice.
+        emailService.sendOrderEmail.mockRejectedValueOnce(
+            Object.assign(new Error('connect ETIMEDOUT smtp.example.com:587'), {
+                code: 'ETIMEDOUT'
+            })
+        );
+
+        await expect(dispatchOrderConfirmation(dispatchArgs())).resolves.toEqual({
+            success: false,
+            reason: 'send_failed'
+        });
+    });
+
+    test('never rejects when the payload cannot be built', async () => {
+        await expect(
+            dispatchOrderConfirmation({ result: null, customer: CUSTOMER })
+        ).resolves.toBeDefined();
+    });
+
+    test('passes the transport outcome back to the caller', async () => {
+        emailService.sendOrderEmail.mockResolvedValueOnce({
+            success: true,
+            delivered: false,
+            channel: 'log'
+        });
+
+        const outcome = await dispatchOrderConfirmation(dispatchArgs());
+
+        expect(outcome).toMatchObject({ channel: 'log', delivered: false });
+    });
+});
+
+describe('the payload satisfies the template', () => {
+    // The template is substituted by literal {{name}} replacement, so a
+    // placeholder the payload cannot fill renders as the raw {{token}} in the
+    // customer's inbox.
+    const template = fs.readFileSync(
+        path.join(__dirname, '..', 'templates', 'order-confirmation.html'),
+        'utf8'
+    );
+
+    const placeholders = [
+        ...new Set((template.match(/{{\s*([A-Za-z0-9_]+)\s*}}/g) || [])
+            .map((token) => token.replace(/[{}\s]/g, '')))
+    ];
+
+    test('the template still has placeholders to fill', () => {
+        expect(placeholders.length).toBeGreaterThan(0);
+    });
+
+    test('every placeholder is one sendOrderEmail substitutes', () => {
+        const service = fs.readFileSync(
+            path.join(__dirname, '..', 'services', 'emailService.js'),
+            'utf8'
+        );
+
+        const unsubstituted = placeholders.filter(
+            (name) => !new RegExp(`{{${name}}}`).test(service)
+        );
+
+        expect(unsubstituted).toEqual([]);
+    });
+});
+
+describe('the admin email log is reachable', () => {
+    const frontend = (...parts) =>
+        path.join(__dirname, '..', '..', 'frontend', ...parts);
+
+    test('admin.html links to admin-email-logs.html', () => {
+        // The page existed, was excluded from the sitemap and disallowed in
+        // robots.txt -- and nothing linked to it, so an operator had to know
+        // the filename (#1698).
+        const adminHtml = fs.readFileSync(frontend('admin.html'), 'utf8');
+
+        expect(adminHtml).toMatch(/href="admin-email-logs\.html"/);
+    });
+
+    test('the link is not a tab, so the switcher leaves it alone', () => {
+        // admin.js switches panels on `.admin-tab`. A link carrying that class
+        // would have its navigation swallowed.
+        const adminHtml = fs.readFileSync(frontend('admin.html'), 'utf8');
+        const item = adminHtml.match(
+            /<li class="admin-nav-link">[\s\S]*?<\/li>/
+        );
+
+        expect(item).not.toBeNull();
+        expect(item[0]).not.toMatch(/admin-tab/);
+    });
+
+    test('the email log page links back to the dashboard', () => {
+        const logsHtml = fs.readFileSync(frontend('admin-email-logs.html'), 'utf8');
+
+        expect(logsHtml).toMatch(/href="admin\.html"/);
+    });
+});

--- a/frontend/admin-email-logs.html
+++ b/frontend/admin-email-logs.html
@@ -65,6 +65,12 @@
     <div id="navbar"></div>
 
     <main id="main-content" tabindex="-1" class="section-p1" style="max-width: 1200px; margin: 40px auto; padding: 0 20px;">
+        <p style="margin-bottom: 16px;">
+            <a href="admin.html" class="admin-back-link">
+                <i class="fas fa-arrow-left" aria-hidden="true"></i> Back to the admin dashboard
+            </a>
+        </p>
+
         <div class="email-logs-header">
             <div>
                 <h1>Recent Email Confirmation Logs</h1>

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -175,6 +175,25 @@
 
                 </li>
 
+                <!--
+                    Not a tab. admin-email-logs.html is a separate page, and it
+                    had no route into it from anywhere in the app (#1698) -- an
+                    operator had to know the filename. The .admin-tab class is
+                    deliberately absent so admin.js's tab switcher leaves it
+                    alone and the anchor navigates.
+                -->
+                <li class="admin-nav-link">
+
+                    <a href="admin-email-logs.html">
+
+                        <i class="fas fa-envelope-open-text" aria-hidden="true"></i>
+
+                        Email Logs
+
+                    </a>
+
+                </li>
+
             </ul>
 
         </div>

--- a/frontend/styles/admin.css
+++ b/frontend/styles/admin.css
@@ -37,6 +37,45 @@
     margin-right: 10px;
 }
 
+/*
+ * The sidebar's other entries are tabs -- <li>s the script switches panels on.
+ * Email Logs is a separate page (#1698), so it carries an anchor. The <li>
+ * already supplies the padding and hover, so the link stretches to fill it and
+ * inherits the colour rather than arriving as a default blue underlined link
+ * on a dark panel.
+ */
+.admin-sidebar ul li.admin-nav-link{
+    padding: 0;
+}
+
+.admin-sidebar ul li.admin-nav-link a{
+    display: block;
+    padding: 15px 18px;
+    color: inherit;
+    text-decoration: none;
+}
+
+.admin-sidebar ul li.admin-nav-link a:focus-visible{
+    outline: 2px solid currentColor;
+    outline-offset: -2px;
+}
+
+/* The way back, on the page the link above leads to. */
+.admin-back-link{
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: #475569;
+    font-size: 14px;
+    text-decoration: none;
+}
+
+.admin-back-link:hover,
+.admin-back-link:focus-visible{
+    color: #0f172a;
+    text-decoration: underline;
+}
+
 .admin-content{
     flex: 1;
     padding: 40px;


### PR DESCRIPTION
Closes #1698

## What was wrong

The order-confirmation feature shipped a service, an HTML template, an admin log viewer, a `robots.txt` entry and a `vercel.json` header rule. It did not ship a caller.

```bash
$ grep -rn "sendOrderEmail" backend --include='*.js' | grep -v node_modules
backend/services/emailService.js:117:async function sendOrderEmail(toEmail, order) {
backend/services/emailService.js:249:    sendOrderEmail,
backend/tests/emailService.test.js:36:  const result = await emailService.sendOrderEmail(...)
```

A definition, an export, and one unit test calling it directly. `createOrderService` builds the order, records promo usage, converts the cart and returns a summary, and never touches the mailer. **No shopper has received a confirmation since it landed.**

Separately, `frontend/admin-email-logs.html` was linked from nowhere — reaching it meant knowing the filename.

## What this does

**`backend/services/orderNotificationService.js`** — the seam between the order flow and the transport. It exists rather than the controller calling `sendOrderEmail` directly for two reasons:

1. `createOrderService` returns a result shaped for the HTTP response (`orderId`, `breakdown`, `items`); `sendOrderEmail` reads a shape built for the template (`orderNumber`, `subtotal`, `shippingAddress`). Something has to translate, and doing it inline at two call sites is how the two drift.
2. Dispatch has to be non-blocking and non-throwing, and that is a property worth stating once somewhere a test can point at.

The money comes from `result.breakdown` — what the pricing engine actually charged — rather than the convenience copies at the top level, so the confirmation cannot quote a different total from the invoice. Lines come from `validatedItems`, priced as the order was written, not as the cart submitted.

**Both call sites in `orderController.js`** — `createOrder` and `createOrderWithPayment` — dispatch after `connection.commit()`, alongside `markAddressUsed`, and neither awaits it:

- **After the commit**, because an email cannot be un-sent. Telling a customer about an order that then rolls back is strictly worse than a missing email. The worst case here is an order with no confirmation, which the admin email log makes visible and an operator can resend.
- **Not awaited**, because the shopper should not sit on a spinner through an SMTP handshake, and a checkout that has already charged them and moved stock must not become a 500 because `smtp.example.com` timed out.

**`frontend/admin.html`** gets an Email Logs entry in the sidebar, and the log page gets a link back. The entry deliberately does not carry `.admin-tab` — that is the class `admin.js` switches panels on, and it would swallow the navigation.

## Guard

`backend/tests/orderConfirmationEmail.test.js`, 21 cases.

The first block is the one that would have caught the original bug. A unit test of a service passes perfectly well with no caller at all — that is exactly the shape of test that shipped with #1668 — so the wiring is asserted against the controller source: the require is present, every `createOrderService` call site has a matching dispatch, each dispatch sits after its `connection.commit()` and after its `createOrderService`, and none is awaited.

The rest cover payload assembly (breakdown wins over the convenience fields when they disagree; a zero-priced line is kept; an empty result does not throw), the dispatch contract (skips without a recipient, resolves rather than rejects when the transport throws or the payload cannot be built, passes the outcome back), that every `{{placeholder}}` in the template is one `sendOrderEmail` substitutes — an unfilled one renders as the raw `{{token}}` in the customer's inbox — and that the admin log page is now reachable in both directions.

## Verification

```
$ backend/node_modules/.bin/jest --config backend/jest.config.js tests/orderConfirmationEmail.test.js
Tests:       21 passed, 21 total

$ npm run check:boot     # backend/server.js loaded with 96 mounted layers
$ npm run check:assets   # 594 local references across 31 pages resolve
$ npm run check:a11y     # 31 pages have a skip link, a main landmark and one h1
$ npm run check:sitemap  # covers all 20 public pages
```

---

## CI note — merge #1701 first

The **Syntax check** job fails on this branch, and it is not this change:

```
❌ 1 of 654 JavaScript file(s) failed to parse:
  frontend/scripts/shop.js:2499
      Unexpected end of input
```

`frontend/scripts/shop.js` is unparsable on `main` — the responsive refactor duplicated and interleaved its initialization block. Every open PR against this repository inherits it, and because `check:syntax` is the first CI job and the other two are gated on it, **Backend tests** and **Server boots** are skipped rather than run. That is why this PR shows no test result.

#1701 fixes it. Once that merges, this branch picks the fix up from `main` with no rebase needed — the two touch no file in common. All gates pass locally on this branch's changes:

```
$ npm run check:boot     ✅
$ npm run check:modules  ✅
$ npm run check:assets   ✅
$ npm run check:a11y     ✅
$ npm run check:sitemap  ✅
```

and I verified the whole set merges cleanly by merging all five of these branches together locally: no conflicts, `check:syntax` green at 659 files, and the full Jest suite at 2976 passing.

The `Vercel` check fails on every PR in this repository with "Authorization required to deploy" against the `bhuvanshs-projects` team, unrelated to any change.


