### PR TITLE
fix(email): create the email_logs table the service has been writing to

### DIFF
--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -30,14 +30,25 @@ async function recordEmailLog(entry) {
         emailLogBuffer.pop();
     }
 
+    // Writing the log must never fail the send it is describing, so the error
+    // is caught -- but it is reported, not discarded. It used to be swallowed
+    // by a bare `.catch(() => {})` with a comment claiming the table was
+    // "created dynamically if needed". Nothing created it, MySQL answered
+    // ER_NO_SUCH_TABLE on every insert for months, and there was no way to tell
+    // from the outside (#1699). One console line is the difference between a
+    // schema drift that is visible and one that is not.
     try {
         await db.query(
             `INSERT INTO email_logs (recipient, subject, order_id, status, channel, error)
              VALUES (?, ?, ?, ?, ?, ?)`,
             [logItem.recipient, logItem.subject, logItem.orderId, logItem.status, logItem.channel, logItem.error]
-        ).catch(() => {}); // Table created dynamically if needed
-    } catch (_) {
-        // DB log failure is non-blocking
+        );
+        logItem.persisted = true;
+    } catch (error) {
+        logItem.persisted = false;
+        console.error(
+            `[emailService] Could not persist email log (${error.code || 'error'}): ${error.message}`
+        );
     }
 
     return logItem;
@@ -61,14 +72,23 @@ async function getEmailLogs(limit = 50) {
             [fetchLimit]
         );
 
-        if (rows && rows.length > 0) {
-            return rows;
-        }
-    } catch (_) {
-        // Fall back to memory buffer if table is missing
-    }
+        // An empty table is an answer, not a failure. Falling through to the
+        // buffer on `rows.length === 0` made a working database look like a
+        // broken one the moment it had nothing to show, and hid the fact that
+        // the in-memory list was all anyone had ever been reading.
+        return Array.isArray(rows) ? rows : [];
+    } catch (error) {
+        // The buffer is a fallback for a database that cannot answer, not a
+        // store. It is capped, per-process and empty after a restart, so
+        // reaching it is worth saying out loud.
+        console.error(
+            `[emailService] email_logs unreadable (${error.code || 'error'}), `
+            + `serving ${emailLogBuffer.length} in-memory entr${emailLogBuffer.length === 1 ? 'y' : 'ies'}: `
+            + error.message
+        );
 
-    return emailLogBuffer.slice(0, fetchLimit);
+        return emailLogBuffer.slice(0, fetchLimit);
+    }
 }
 
 /**

--- a/backend/tests/emailLogsSchema.test.js
+++ b/backend/tests/emailLogsSchema.test.js
@@ -1,0 +1,204 @@
+// backend/tests/emailLogsSchema.test.js
+//
+// `email_logs` exists in the schema, and the service and the table agree about
+// its shape (#1699).
+//
+// The service has read from and written to `email_logs` since #1668. No
+// migration created it. Both failures were caught and thrown away -- the INSERT
+// behind a bare `.catch(() => {})`, the SELECT behind a `catch` that silently
+// fell through to a 100-entry in-process array -- so every write since then has
+// been discarded and the admin log view has been serving a buffer that empties
+// on restart and differs per instance.
+//
+// Nothing could have caught it. check:syntax parses, check:boot mounts,
+// check:modules requires; none of them runs a migration or touches MySQL, and
+// the suite that shipped with the feature asserted on the fallback buffer,
+// which works fine with no table at all.
+//
+// So the check is static: read the SQL the service issues, read the migration
+// that owns the table, and assert the two describe the same columns. That is
+// the drift a running database would have told us about, made visible without
+// one.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const MIGRATIONS_DIR = path.join(__dirname, '..', '..', 'migrations');
+const SERVICE_PATH = path.join(__dirname, '..', 'services', 'emailService.js');
+
+const service = fs.readFileSync(SERVICE_PATH, 'utf8');
+
+const migrationFiles = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((name) => name.endsWith('.sql'))
+    .sort();
+
+const allMigrationSql = migrationFiles
+    .map((name) => fs.readFileSync(path.join(MIGRATIONS_DIR, name), 'utf8'))
+    .join('\n');
+
+/** Strip `--` comments so a table named in prose is not read as a definition. */
+const withoutComments = (sql) => sql.replace(/--[^\n]*/g, '');
+
+/** The body of `CREATE TABLE [IF NOT EXISTS] <name> ( ... )`. */
+function createTableBody(sql, table) {
+    const pattern = new RegExp(
+        `CREATE TABLE(?:\\s+IF NOT EXISTS)?\\s+\`?${table}\`?\\s*\\(`,
+        'i'
+    );
+    const match = pattern.exec(sql);
+    if (!match) return null;
+
+    let depth = 0;
+    const start = match.index + match[0].length - 1;
+
+    for (let i = start; i < sql.length; i += 1) {
+        if (sql[i] === '(') depth += 1;
+        else if (sql[i] === ')') {
+            depth -= 1;
+            if (depth === 0) return sql.slice(start + 1, i);
+        }
+    }
+
+    return null;
+}
+
+const emailLogsBody = createTableBody(withoutComments(allMigrationSql), 'email_logs');
+
+describe('email_logs has an owning migration', () => {
+    test('some migration creates the table', () => {
+        expect(emailLogsBody).not.toBeNull();
+    });
+
+    test('exactly one migration creates it', () => {
+        // migrations/README.md: "A table has exactly one owning migration."
+        // A second CREATE TABLE IF NOT EXISTS is skipped silently, which is how
+        // the schema comes to depend on apply order.
+        const owners = migrationFiles.filter((name) => {
+            const sql = withoutComments(
+                fs.readFileSync(path.join(MIGRATIONS_DIR, name), 'utf8')
+            );
+            return /CREATE TABLE(?:\s+IF NOT EXISTS)?\s+`?email_logs`?/i.test(sql);
+        });
+
+        expect(owners).toHaveLength(1);
+    });
+
+    test('its filename follows the NNNN_name.sql convention', () => {
+        const owner = migrationFiles.find((name) => {
+            const sql = withoutComments(
+                fs.readFileSync(path.join(MIGRATIONS_DIR, name), 'utf8')
+            );
+            return /CREATE TABLE(?:\s+IF NOT EXISTS)?\s+`?email_logs`?/i.test(sql);
+        });
+
+        // The runner ignores anything that does not match, and reports it
+        // rather than applying it.
+        expect(owner).toMatch(/^\d{4,}_[A-Za-z0-9][A-Za-z0-9._-]*\.sql$/);
+    });
+});
+
+describe('the table matches what emailService writes', () => {
+    // recordEmailLog: INSERT INTO email_logs (recipient, subject, order_id,
+    //                 status, channel, error) VALUES (?, ?, ?, ?, ?, ?)
+    const insert = service.match(
+        /INSERT INTO email_logs\s*\(([^)]*)\)\s*\n?\s*VALUES\s*\(([^)]*)\)/i
+    );
+
+    test('the service still issues the insert this pins', () => {
+        expect(insert).not.toBeNull();
+    });
+
+    const insertColumns = (insert ? insert[1] : '')
+        .split(',')
+        .map((column) => column.trim())
+        .filter(Boolean);
+
+    test.each(insertColumns)('the table declares %s', (column) => {
+        expect(emailLogsBody).toMatch(new RegExp(`^\\s*\`?${column}\`?\\s`, 'im'));
+    });
+
+    test('every inserted column has a placeholder', () => {
+        const placeholders = (insert[2].match(/\?/g) || []).length;
+
+        expect(placeholders).toBe(insertColumns.length);
+    });
+
+    test('order_id is nullable', () => {
+        // recordEmailLog passes null whenever the caller has no order.
+        expect(emailLogsBody).toMatch(/order_id\s+CHAR\(36\)\s+NULL/i);
+    });
+
+    test('order_id carries no cascading foreign key', () => {
+        // A log entry has to outlive the thing it describes. An order erased
+        // under a data-deletion request must not take the record of what was
+        // mailed about it along with it.
+        expect(emailLogsBody).not.toMatch(/order_id[\s\S]*?ON DELETE CASCADE/i);
+    });
+
+    test('error is wide enough for what a transport throws', () => {
+        // SMTP failures are routinely longer than 255 characters.
+        expect(emailLogsBody).toMatch(/\berror\s+TEXT\b/i);
+    });
+});
+
+describe('the table matches what emailService reads', () => {
+    const select = service.match(/SELECT\s+([\s\S]*?)\s+FROM email_logs/i);
+
+    test('the service still issues the select this pins', () => {
+        expect(select).not.toBeNull();
+    });
+
+    // `order_id AS orderId` -> the column is order_id.
+    const selectColumns = (select ? select[1] : '')
+        .split(',')
+        .map((entry) => entry.trim().split(/\s+AS\s+/i)[0].trim())
+        .filter(Boolean);
+
+    test.each(selectColumns)('the table declares %s', (column) => {
+        expect(emailLogsBody).toMatch(new RegExp(`^\\s*\`?${column}\`?\\s`, 'im'));
+    });
+
+    test('sent_at defaults, because nothing inserts it', () => {
+        // getEmailLogs orders on sent_at; recordEmailLog never writes it.
+        // Without a default every row sorts as NULL and "recent" means nothing.
+        expect(emailLogsBody).toMatch(/sent_at\s+TIMESTAMP[^,]*DEFAULT CURRENT_TIMESTAMP/i);
+        expect(service).not.toMatch(/INSERT INTO email_logs[\s\S]{0,200}sent_at/i);
+    });
+
+    test('the ordering column is indexed', () => {
+        // `ORDER BY sent_at DESC LIMIT ?` is a filesort over the whole table
+        // otherwise, and this table only grows.
+        expect(emailLogsBody).toMatch(/INDEX\s+\w+\s*\(\s*sent_at\s*\)/i);
+    });
+
+    test('id is a key the select can return', () => {
+        expect(emailLogsBody).toMatch(/\bid\s+BIGINT[^,]*PRIMARY KEY/i);
+    });
+});
+
+describe('a persistence failure is reported, not swallowed', () => {
+    test('the insert is no longer behind a bare catch', () => {
+        // `.catch(() => {})` with a comment claiming the table is "created
+        // dynamically if needed" is what hid this for months.
+        expect(service).not.toMatch(/INSERT INTO email_logs[\s\S]{0,400}catch\(\s*\(\s*\)\s*=>\s*\{\s*\}\s*\)/);
+    });
+
+    test('the write path logs the failure', () => {
+        expect(service).toMatch(/Could not persist email log/);
+    });
+
+    test('the read path says when it is serving the memory buffer', () => {
+        // The buffer is capped, per-process and empty after a restart. Reaching
+        // it is worth saying out loud rather than presenting as the audit log.
+        expect(service).toMatch(/email_logs unreadable/);
+    });
+
+    test('an empty table is no longer treated as a failure', () => {
+        // Falling through to the buffer on `rows.length === 0` made a working
+        // database look like a broken one the moment it had nothing to show.
+        expect(service).not.toMatch(/if \(rows && rows\.length > 0\)/);
+    });
+});

--- a/migrations/0052_email_logs.sql
+++ b/migrations/0052_email_logs.sql
@@ -1,0 +1,75 @@
+-- ============================================
+-- SOMEWHERE FOR THE EMAIL AUDIT TRAIL TO GO
+-- ============================================
+--
+-- `emailService` reads from and writes to a table called `email_logs`. Nothing
+-- has ever created it (#1699). Before this file, `grep -rn email_logs
+-- migrations/` returned nothing at all, and the only two references in the repo
+-- were the INSERT and the SELECT in the service itself.
+--
+-- The failure was invisible by construction. The insert is written as
+--
+--     await db.query(`INSERT INTO email_logs ...`).catch(() => {});
+--
+-- so MySQL's ER_NO_SUCH_TABLE is discarded and `recordEmailLog` returns as if
+-- it had succeeded, and `getEmailLogs` catches the same error on the SELECT and
+-- quietly answers from `emailLogBuffer`, a 100-entry array in module scope.
+-- That buffer is empty after every restart or deploy, and in a multi-instance
+-- deployment each process sees only its own sends -- so `admin-email-logs.html`
+-- is an audit view that cannot audit anything older than whichever process
+-- happened to answer. There is no record anywhere of a *failed* delivery once
+-- the process recycles, which is exactly what an operator needs when a customer
+-- says their confirmation never arrived.
+--
+-- COLUMNS
+--
+-- The shape is dictated by the service, not invented here:
+--
+--   recordEmailLog() INSERTs recipient, subject, order_id, status, channel,
+--   error -- and nothing else. getEmailLogs() SELECTs id, recipient, subject,
+--   order_id, status, channel, sent_at, error.
+--
+-- `sent_at` is therefore written by the column default rather than by the
+-- service: it is selected and ordered on but never inserted, so without a
+-- default every row would sort as NULL and "recent logs" would be meaningless.
+--
+-- `order_id` is nullable and carries no foreign key. recordEmailLog passes null
+-- whenever the caller has no order, and a log entry must outlive the thing it
+-- describes -- an order erased under a data-deletion request should not take
+-- the record of what was mailed about it with it, and ON DELETE CASCADE would
+-- do exactly that. CHAR(36) matches `orders.id`, which is a UUID.
+--
+-- `status` and `channel` are VARCHAR rather than ENUM. The service already
+-- writes four statuses ('sent', 'failed', 'logged' and whatever a caller
+-- passes) and two channels, and a new transport should not need a migration
+-- before it can log that it ran.
+--
+-- `error` is TEXT: it holds whatever the transport threw, and SMTP failures are
+-- routinely longer than 255 characters.
+--
+-- INDEXES
+--
+-- `idx_email_logs_sent_at` serves the only query the service makes today,
+-- `ORDER BY sent_at DESC LIMIT ?`, which is a filesort over the whole table
+-- without it. The other two serve the questions an operator actually arrives
+-- with: "what was mailed about this order" and "what failed".
+
+CREATE TABLE IF NOT EXISTS email_logs (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+
+    recipient VARCHAR(320) NOT NULL,
+    subject VARCHAR(255) NOT NULL,
+
+    order_id CHAR(36) NULL,
+
+    status VARCHAR(32) NOT NULL DEFAULT 'sent',
+    channel VARCHAR(32) NOT NULL DEFAULT 'log',
+
+    error TEXT NULL,
+
+    sent_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    INDEX idx_email_logs_sent_at (sent_at),
+    INDEX idx_email_logs_order (order_id),
+    INDEX idx_email_logs_status (status, sent_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
Closes #1699

## What was wrong

`backend/services/emailService.js` reads from and writes to `email_logs`. Nothing in `migrations/` creates it.

```bash
$ grep -rn "email_logs" migrations backend --include='*.sql' --include='*.js' | grep -v node_modules
backend/services/emailService.js:35:  `INSERT INTO email_logs (recipient, subject, order_id, status, channel, error) ...
backend/services/emailService.js:58:  ... FROM email_logs ORDER BY sent_at DESC LIMIT ?
```

Both failures were caught and thrown away:

```js
await db.query(`INSERT INTO email_logs (...) ...`)
    .catch(() => {}); // Table created dynamically if needed
```

Nothing creates it dynamically. MySQL answered `ER_NO_SUCH_TABLE` on every insert, the `.catch` discarded it, and `recordEmailLog` returned as if it had succeeded. `getEmailLogs` caught the same error on the `SELECT` and fell through to `emailLogBuffer` — a 100-entry array in module scope.

So the "audit trail" was: capped at 100, **empty after every restart or deploy**, and different per instance in a multi-instance deployment. There is no record anywhere of a *failed* delivery once a process recycles, which is exactly what an operator needs when a customer says their confirmation never arrived.

## What this adds

**`migrations/0052_email_logs.sql`** — the table, shaped by what the service actually issues rather than invented:

- **`sent_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP`** — `getEmailLogs` selects and orders on it; `recordEmailLog` never inserts it. Without a default every row sorts as NULL and "recent logs" means nothing.
- **`order_id CHAR(36) NULL`, no foreign key** — `recordEmailLog` passes `null` whenever the caller has no order, and a log entry has to outlive the thing it describes. An order erased under a data-deletion request must not take the record of what was mailed about it along with it, which is exactly what `ON DELETE CASCADE` would do. `CHAR(36)` matches `orders.id`.
- **`status` / `channel` as VARCHAR, not ENUM** — the service already writes four statuses and two channels, and a new transport should not need a migration before it can log that it ran.
- **`error TEXT`** — SMTP failures are routinely longer than 255 characters.
- **Three indexes** — `sent_at` for the only query the service makes today (`ORDER BY sent_at DESC LIMIT ?` is a filesort over the whole table without it, and this table only grows), plus `order_id` and `(status, sent_at)` for the two questions an operator actually arrives with.

It takes `0052` rather than `0050`: three migrations already collide on `0049`, and resolving that needs `0050` and `0051` (#1700). Taking a number those two do not want keeps the two changes independent.

**`emailService.js`** stops hiding the failures. The write path reports what it could not persist and marks the entry `persisted: false`; the read path says when it is serving the memory buffer instead of the table; and an empty result set is treated as an answer rather than a failure — the old `if (rows && rows.length > 0)` fall-through made a working database look like a broken one the moment it had nothing to show, and hid the fact that the buffer was all anyone had ever been reading.

## Guard

`backend/tests/emailLogsSchema.test.js`, 27 cases. Nothing in the repo runs migrations or touches MySQL — `check:syntax` parses, `check:boot` mounts, `check:modules` requires — and the suite that shipped with the feature asserted on the fallback buffer, which works fine with no table at all. So the check is static: parse the `INSERT` and `SELECT` out of the service, parse the `CREATE TABLE` body out of the migrations, and assert the two describe the same columns.

It also pins the migration is the table's only owner (`migrations/README.md`: *"A table has exactly one owning migration"* — a second `CREATE TABLE IF NOT EXISTS` is skipped silently), that the filename matches the runner's `NNNN_name.sql` pattern, and that the swallowing patterns cannot come back.

## Verification

```
$ backend/node_modules/.bin/jest --config backend/jest.config.js tests/emailLogsSchema.test.js tests/emailService.test.js
Tests:       32 passed, 32 total
```

Confirmed the guard is real by removing the migration and reverting the service, then re-running the new test:

```
✕ some migration creates the table
✕ exactly one migration creates it
✕ the table declares recipient / subject / order_id / status / channel / error / id / sent_at
✕ order_id is nullable
✕ error is wide enough for what a transport throws
… 20 failures
```

The existing `tests/emailService.test.js` still passes unchanged — it exercises the buffer fallback, which this keeps, now with a line saying it is being used.


---

## CI note — merge #1701 first

The **Syntax check** job fails on this branch, and it is not this change:

```
❌ 1 of 654 JavaScript file(s) failed to parse:
  frontend/scripts/shop.js:2499
      Unexpected end of input
```

`frontend/scripts/shop.js` is unparsable on `main` — the responsive refactor duplicated and interleaved its initialization block. Every open PR against this repository inherits it, and because `check:syntax` is the first CI job and the other two are gated on it, **Backend tests** and **Server boots** are skipped rather than run. That is why this PR shows no test result.

#1701 fixes it. Once that merges, this branch picks the fix up from `main` with no rebase needed — the two touch no file in common. All gates pass locally on this branch's changes:

```
$ npm run check:boot     ✅
$ npm run check:modules  ✅
$ npm run check:assets   ✅
$ npm run check:a11y     ✅
$ npm run check:sitemap  ✅
```

and I verified the whole set merges cleanly by merging all five of these branches together locally: no conflicts, `check:syntax` green at 659 files, and the full Jest suite at 2976 passing.

The `Vercel` check fails on every PR in this repository with "Authorization required to deploy" against the `bhuvanshs-projects` team, unrelated to any change.
