### PR TITLE
fix(migrations): unblock the runner and make 0049 apply on MySQL

### DIFF
--- a/backend/tests/migrationSequence.test.js
+++ b/backend/tests/migrationSequence.test.js
@@ -1,0 +1,219 @@
+// backend/tests/migrationSequence.test.js
+//
+// The migrations directory is loadable, and every statement in it is MySQL
+// (#1700).
+//
+// Three migrations landed on `main` all claiming version 0049. The runner
+// throws while building the file list -- before it compares anything against
+// `schema_migrations` -- so the failure is total: `npm run migrate` and even
+// `npm run migrate:status` refuse the whole directory, not just the three
+// files. `coupons`, `fraud_monitoring_queue` and the products full-text index
+// were unreachable, and so was anything added after them.
+//
+// Nothing in CI runs the migration runner, so `main` stayed green while the
+// schema pipeline was fully blocked. migrations/README.md names this exact
+// hazard -- "a collision takes the whole sequence down and not just the two
+// files involved" -- and the three still merged, because each looked fine in
+// isolation and in review. A rule a human has to remember at merge time is a
+// rule that gets forgotten; this is the same rule, checked.
+//
+// The dialect half is the second thing that file taught us. MySQL and MariaDB
+// diverge on `ALTER TABLE ... IF NOT EXISTS`, and the version that only MariaDB
+// accepts fails at deploy time on a fresh database rather than in review.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const MIGRATIONS_DIR = path.join(__dirname, '..', '..', 'migrations');
+
+// The pattern backend/scripts/migrate.js matches filenames against. Anything
+// that does not match is ignored and reported rather than applied.
+const MIGRATION_FILENAME = /^(\d{4,})_([A-Za-z0-9][A-Za-z0-9._-]*)\.sql$/;
+
+const sqlFiles = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((name) => name.toLowerCase().endsWith('.sql'))
+    .sort();
+
+const read = (name) => fs.readFileSync(path.join(MIGRATIONS_DIR, name), 'utf8');
+
+/** Strip `--` and `/* *​/` comments, so prose is not read as SQL. */
+const stripComments = (sql) =>
+    sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ');
+
+describe('the runner can load the directory', () => {
+    test('there are migrations to check', () => {
+        expect(sqlFiles.length).toBeGreaterThan(0);
+    });
+
+    test('every .sql file matches the runner filename pattern', () => {
+        const unmatched = sqlFiles.filter((name) => !MIGRATION_FILENAME.test(name));
+
+        expect(unmatched).toEqual([]);
+    });
+
+    test('no two migrations claim the same version', () => {
+        // This is the assertion the three 0049s would have failed. The runner
+        // throws a MigrationError here and applies nothing at all.
+        const byVersion = new Map();
+        const collisions = [];
+
+        for (const name of sqlFiles) {
+            const [, version] = MIGRATION_FILENAME.exec(name) || [];
+            if (!version) continue;
+
+            if (byVersion.has(version)) {
+                collisions.push(`${version}: ${byVersion.get(version)} and ${name}`);
+            }
+            byVersion.set(version, name);
+        }
+
+        expect(collisions).toEqual([]);
+    });
+
+    test('the baseline is still the lowest version', () => {
+        // 0001_baseline_schema.sql declares stored procedures and is not safe
+        // to re-run; the runner has a --baseline path for adopting it. A file
+        // numbered below it would be applied before it, against no schema.
+        const [, first] = MIGRATION_FILENAME.exec(sqlFiles[0]) || [];
+
+        expect(first).toBe('0001');
+        expect(sqlFiles[0]).toMatch(/baseline/i);
+    });
+});
+
+describe('every statement is MySQL', () => {
+    // MariaDB accepts `ALTER TABLE ... ADD/DROP COLUMN IF [NOT] EXISTS`. MySQL
+    // 8.0 does not, and answers ERROR 1064. This project runs MySQL: mysql2,
+    // utf8mb4_unicode_ci, ENGINE=InnoDB throughout.
+    //
+    // The failure mode is worse than a plain syntax error. The statement sits
+    // at the end of a migration that has already created a table, so the
+    // migration aborts partway through with the table present and the version
+    // unrecorded -- and the next run then hits the "never edit an applied
+    // migration" checksum rule on the way past.
+    const MARIADB_ONLY = [
+        [/ALTER\s+TABLE[\s\S]{0,200}?ADD\s+COLUMN\s+IF\s+NOT\s+EXISTS/i, 'ADD COLUMN IF NOT EXISTS'],
+        [/ALTER\s+TABLE[\s\S]{0,200}?DROP\s+COLUMN\s+IF\s+EXISTS/i, 'DROP COLUMN IF EXISTS'],
+        [/ALTER\s+TABLE[\s\S]{0,200}?ADD\s+INDEX\s+IF\s+NOT\s+EXISTS/i, 'ADD INDEX IF NOT EXISTS'],
+        [/CREATE\s+OR\s+REPLACE\s+TABLE/i, 'CREATE OR REPLACE TABLE'],
+    ];
+
+    test.each(sqlFiles)('%s uses no MariaDB-only syntax', (name) => {
+        const sql = stripComments(read(name));
+
+        const found = MARIADB_ONLY
+            .filter(([pattern]) => pattern.test(sql))
+            .map(([, label]) => label);
+
+        expect(found).toEqual([]);
+    });
+
+    test('the coupons migration amends the baseline rather than re-creating it', () => {
+        // `coupons` is owned by 0001_baseline_schema.sql. A second CREATE TABLE
+        // IF NOT EXISTS here is skipped silently, so the migration records
+        // itself as applied having changed nothing -- which is how the coupon
+        // columns came to be missing from every database.
+        const sql = stripComments(read('0049_coupons_schema.sql'));
+
+        expect(sql).not.toMatch(/CREATE TABLE(?:\s+IF NOT EXISTS)?\s+`?coupons`?/i);
+        expect(sql).toMatch(/ALTER TABLE\s+`?coupons`?/i);
+    });
+
+    test('it adds the columns couponService reads', () => {
+        const sql = stripComments(read('0049_coupons_schema.sql'));
+
+        // validateCoupon reads expires_at first, falling back to end_date. The
+        // baseline's end_date is NOT NULL, so without this a coupon with no
+        // expiry cannot be expressed.
+        expect(sql).toMatch(/ADD COLUMN\s+expires_at\s+DATETIME\s+NULL/i);
+
+        // 'percent' is accepted as a synonym for 'percentage' by both
+        // validateCoupon and pricing.service.js, and submitted by the admin
+        // form, so the enum has to hold it.
+        expect(sql).toMatch(/MODIFY COLUMN\s+type\s+ENUM\([^)]*'percent'[^)]*\)/i);
+    });
+
+    test('it keeps every enum member the baseline declared', () => {
+        // Dropping a member rewrites every row using it to ''.
+        const sql = stripComments(read('0049_coupons_schema.sql'));
+        const modified = sql.match(/MODIFY COLUMN\s+type\s+ENUM\(([^)]*)\)/i);
+
+        expect(modified).not.toBeNull();
+
+        for (const member of ['percentage', 'fixed', 'free_shipping']) {
+            expect(modified[1]).toContain(`'${member}'`);
+        }
+    });
+});
+
+describe('the renumbered migrations are intact', () => {
+    // Renumbering is safe here precisely because the collision meant none of
+    // the three could ever have been applied: the runner refused the directory
+    // before it read `schema_migrations`. Environments are migrated to 0048.
+    test.each([
+        ['0049_coupons_schema.sql', 'coupons'],
+        ['0050_product_search_fulltext.sql', 'products'],
+        ['0051_fraud_monitoring_queue.sql', 'fraud_monitoring_queue'],
+    ])('%s still targets %s', (name, table) => {
+        expect(sqlFiles).toContain(name);
+        expect(read(name)).toMatch(new RegExp(`\\b${table}\\b`));
+    });
+
+    test('nothing is left at a duplicated 0049', () => {
+        const at49 = sqlFiles.filter((name) => name.startsWith('0049'));
+
+        expect(at49).toEqual(['0049_coupons_schema.sql']);
+    });
+
+    test('the tables the services need all have an owning migration', () => {
+        // The three files were blocked together, so the three features were
+        // broken together. This is the list that has to survive the renumber.
+        const allSql = stripComments(sqlFiles.map(read).join('\n'));
+
+        for (const table of ['coupons', 'fraud_monitoring_queue']) {
+            expect(allSql).toMatch(
+                new RegExp(`CREATE TABLE(?:\\s+IF NOT EXISTS)?\\s+\`?${table}\`?`, 'i')
+            );
+        }
+
+        expect(allSql).toMatch(/FULLTEXT\s+INDEX\s+\w+\s*\(\s*name\s*\)/i);
+    });
+});
+
+describe('the convention the README states', () => {
+    const readme = fs.readFileSync(path.join(MIGRATIONS_DIR, 'README.md'), 'utf8');
+
+    test('README still documents the four-digit prefix rule', () => {
+        // If the convention ever changes, this test is the thing that should
+        // be updated first -- it is what the assertions above encode.
+        expect(readme).toMatch(/NNNN_short_name\.sql/);
+    });
+
+    test('no table is created by more than one migration', () => {
+        // "A table has exactly one owning migration. Later files amend it with
+        // ALTER TABLE. A second CREATE TABLE IF NOT EXISTS for a table that
+        // already exists is skipped silently, which is how the schema came to
+        // depend on apply order in the first place."
+        const owners = new Map();
+        const duplicated = [];
+
+        for (const name of sqlFiles) {
+            const sql = stripComments(read(name));
+            const pattern = /CREATE TABLE(?:\s+IF NOT EXISTS)?\s+`?([A-Za-z0-9_]+)`?/gi;
+            let match;
+
+            while ((match = pattern.exec(sql)) !== null) {
+                const table = match[1].toLowerCase();
+                if (owners.has(table) && owners.get(table) !== name) {
+                    duplicated.push(`${table}: ${owners.get(table)} and ${name}`);
+                }
+                owners.set(table, name);
+            }
+        }
+
+        expect(duplicated).toEqual([]);
+    });
+});

--- a/migrations/0049_coupons_schema.sql
+++ b/migrations/0049_coupons_schema.sql
@@ -1,22 +1,68 @@
--- Migration 0049: Discount Coupons Table Schema
-CREATE TABLE IF NOT EXISTS coupons (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    code VARCHAR(50) NOT NULL UNIQUE,
-    type ENUM('percent', 'fixed', 'percentage') NOT NULL DEFAULT 'percent',
-    value DECIMAL(10,2) NOT NULL,
-    minimum_order_amount DECIMAL(10,2) DEFAULT 0.00,
-    maximum_discount_amount DECIMAL(10,2) DEFAULT NULL,
-    usage_limit INT DEFAULT NULL,
-    used_count INT DEFAULT 0,
-    expires_at DATETIME NULL,
-    end_date TIMESTAMP NULL,
-    is_active TINYINT(1) DEFAULT 1,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+-- ============================================
+-- WHAT THE COUPON SERVICE NEEDS THAT THE BASELINE DOES NOT HAVE
+-- ============================================
+--
+-- This file used to be a second `CREATE TABLE IF NOT EXISTS coupons (...)`
+-- followed by `ALTER TABLE coupons ADD COLUMN IF NOT EXISTS expires_at`.
+-- Neither statement could do anything (#1700).
+--
+-- WHY THE CREATE TABLE WAS A NO-OP
+--
+-- `coupons` is already declared in 0001_baseline_schema.sql, and the baseline
+-- runs first on every database -- fresh or adopted. `CREATE TABLE IF NOT
+-- EXISTS` against a table that exists is skipped silently, so this migration
+-- would have recorded itself as applied while changing nothing at all.
+-- migrations/README.md names this exact hazard:
+--
+--     A table has exactly one owning migration. Later files amend it with
+--     ALTER TABLE. A second CREATE TABLE IF NOT EXISTS for a table that
+--     already exists is skipped silently, which is how the schema came to
+--     depend on apply order in the first place.
+--
+-- WHY THE ALTER WAS INVALID
+--
+-- `ADD COLUMN IF NOT EXISTS` is a MariaDB extension. MySQL 8.0 -- which this
+-- project runs: mysql2, utf8mb4_unicode_ci, ENGINE=InnoDB throughout -- answers
+--
+--     ERROR 1064 (42000): You have an error in your SQL syntax; check the
+--     manual ... near 'IF NOT EXISTS expires_at DATETIME NULL'
+--
+-- and because it sat after the CREATE TABLE, it would have aborted the
+-- migration partway through: table present, version unrecorded, and the next
+-- run hitting the "never edit an applied migration" checksum rule on the way
+-- past.
+--
+-- WHAT IS ACTUALLY MISSING
+--
+-- Two things, both read by services/couponService.js against the baseline's
+-- `coupons`:
+--
+--   expires_at  -- validateCoupon reads `coupon.expires_at || coupon.end_date
+--                  || coupon.expiry_date`. The baseline has end_date, which is
+--                  NOT NULL, so a coupon with no expiry cannot be expressed:
+--                  every row must name a date it stops working. expires_at is
+--                  the nullable form, and it is checked first.
+--
+--   type        -- the baseline enum is ('percentage','fixed','free_shipping').
+--                  validateCoupon and pricing.service.js both accept 'percent'
+--                  as a synonym for 'percentage', and the admin coupon form
+--                  submits it, so the column has to be able to hold it. The
+--                  existing three members are kept: dropping one would rewrite
+--                  every row that uses it to ''.
+--
+-- Plain ALTERs, not guarded ones. The runner applies each migration exactly
+-- once and records it, so a statement here does not need to be idempotent --
+-- and this file has never been applied anywhere, because the 0049 version
+-- collision meant the runner refused the whole directory before it read
+-- schema_migrations.
 
-    CONSTRAINT chk_coupon_value CHECK (`value` >= 0),
-    INDEX idx_coupons_code (code),
-    INDEX idx_coupons_active (is_active)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+ALTER TABLE coupons
+    ADD COLUMN expires_at DATETIME NULL AFTER end_date;
 
-ALTER TABLE coupons ADD COLUMN IF NOT EXISTS expires_at DATETIME NULL;
+ALTER TABLE coupons
+    MODIFY COLUMN type ENUM('percentage', 'percent', 'fixed', 'free_shipping') NOT NULL;
+
+-- validateCoupon's lookup is `WHERE UPPER(code) = UPPER(?)`, filtered on
+-- is_active and the expiry. idx_coupons_code and idx_coupons_active exist in
+-- the baseline; this covers the expiry check the new column introduces.
+CREATE INDEX idx_coupons_expires_at ON coupons (expires_at);

--- a/migrations/0050_product_search_fulltext.sql
+++ b/migrations/0050_product_search_fulltext.sql
@@ -4,5 +4,10 @@
 --
 -- Real-time product search requires full-text indexing on products.name for
 -- fast relevance-based matching.
+--
+-- Renumbered from 0049 (#1700). Three migrations claimed that version, and the
+-- runner refuses to load the directory at all when versions collide -- so
+-- nothing at all could be applied, not just the three. 0049 stays with
+-- 0049_coupons_schema.sql, which merged first.
 
 ALTER TABLE products ADD FULLTEXT INDEX idx_products_name_ft (name);

--- a/migrations/0051_fraud_monitoring_queue.sql
+++ b/migrations/0051_fraud_monitoring_queue.sql
@@ -14,6 +14,11 @@
 -- writing that record to `fraud_monitoring_queue` since the middleware landed,
 -- and no migration has ever created the table (#1674).
 --
+-- Renumbered from 0049 (#1700). Three migrations claimed that version, and the
+-- runner refuses to load the directory at all when versions collide -- so
+-- nothing at all could be applied, not just the three. 0049 stays with
+-- 0049_coupons_schema.sql, which merged first.
+--
 -- Every insert therefore failed with ER_NO_SUCH_TABLE. The catch around it
 -- swallows the error into a console.error -- correctly, because a monitoring
 -- write must never fail a signup -- so the account was created, nothing was


### PR DESCRIPTION
Closes #1700

## What was wrong

**Three migrations claimed version `0049`.** `loadMigrations` throws while building the file list, before it compares anything against `schema_migrations`, so the failure is total:

```
$ cd backend && npm run migrate:status
MigrationError: Duplicate migration version 0049: 0049_coupons_schema.sql and
0049_fraud_monitoring_queue.sql. Renumber one of them so the order is unambiguous.
```

Not the three files — **the whole directory.** No schema change could be applied to any environment. `migrations/README.md` names this hazard by name ("a collision takes the whole sequence down and not just the two files involved") and the three still merged, because each looked fine in isolation and in review. Nothing in CI runs the runner, so `main` stayed green.

## The renumber

By merge order, which is the only ordering that does not rewrite history someone might have applied:

| was | now | first appeared |
| --- | --- | --- |
| `0049_coupons_schema.sql` | `0049_coupons_schema.sql` | 2026-08-25 08:23 |
| `0049_product_search_fulltext.sql` | `0050_product_search_fulltext.sql` | 2026-08-25 17:35 |
| `0049_fraud_monitoring_queue.sql` | `0051_fraud_monitoring_queue.sql` | 2026-08-25 23:02 |

Renumbering is safe here *precisely because* of the collision: the runner refused the directory before it read `schema_migrations`, so none of the three has ever been applied anywhere. Environments are migrated to `0048`.

## 0049 needed more than a number

While writing the guard I found the coupons migration could not have worked even alone. It was:

```sql
CREATE TABLE IF NOT EXISTS coupons ( ... );
ALTER TABLE coupons ADD COLUMN IF NOT EXISTS expires_at DATETIME NULL;
```

**The `CREATE TABLE` was a no-op.** `coupons` is already declared in `0001_baseline_schema.sql`, and the baseline runs first on every database, fresh or adopted. `CREATE TABLE IF NOT EXISTS` against an existing table is skipped silently, so the migration would have recorded itself as applied having changed nothing. This is the exact case the README warns about:

> A table has exactly one owning migration. Later files amend it with `ALTER TABLE`. A second `CREATE TABLE IF NOT EXISTS` for a table that already exists is skipped silently, which is how the schema came to depend on apply order in the first place.

**The `ALTER` was invalid.** `ADD COLUMN IF NOT EXISTS` is a MariaDB extension; MySQL 8 answers `ERROR 1064`. Sitting after the `CREATE TABLE`, it would have aborted the migration partway through — table present, version unrecorded — and the next run would then hit the "never edit an applied migration" checksum rule on the way past.

So the file is now the ALTERs it should always have been, against the baseline's table:

- **`ADD COLUMN expires_at DATETIME NULL`** — `validateCoupon` reads `coupon.expires_at || coupon.end_date || coupon.expiry_date`. The baseline's `end_date` is `NOT NULL`, so without this a coupon that never expires cannot be expressed: every row has to name a date it stops working.
- **`MODIFY COLUMN type ENUM('percentage', 'percent', 'fixed', 'free_shipping')`** — `'percent'` is accepted as a synonym for `'percentage'` by both `validateCoupon` and `pricing.service.js`, and the admin coupon form submits it, so the column has to hold it. All three original members are kept: dropping one rewrites every row using it to `''`.
- An index on `expires_at`, covering the expiry check the new column introduces.

Plain ALTERs, not guarded ones — the runner applies each migration exactly once and records it, so nothing here needs to be idempotent.

## Guard

`backend/tests/migrationSequence.test.js`, 65 cases:

- **No duplicate versions**, and every `.sql` filename matches the runner's `NNNN_name.sql` pattern (anything else is ignored and reported rather than applied).
- **The baseline is still the lowest version** — `0001` declares stored procedures and is not safe to re-run; a file numbered below it would be applied against no schema.
- **No MariaDB-only syntax** in any migration: `ADD COLUMN IF NOT EXISTS`, `DROP COLUMN IF EXISTS`, `ADD INDEX IF NOT EXISTS`, `CREATE OR REPLACE TABLE`. This class of bug fails at deploy time on a fresh database rather than in review.
- **No table created by more than one migration** — the README rule that `0049` was breaking, now checked instead of remembered.
- The three renumbered files still target the tables they were written for, and the features they unblock (`coupons`, `fraud_monitoring_queue`, the products full-text index) all still have an owner.

## It also turns two red suites green

The repository already had guards for this collision; both have been failing on `main` since the third `0049` merged, and neither could be seen because `check:syntax` fails first and skips the test job on every PR:

```
FAIL tests/migrationViewColumns.test.js
  ● the sequence is still well formed › no two migrations claim the same version

FAIL tests/fraudMonitoringQueue.test.js
  ● the table the middleware writes to › takes the next free migration number
```

Both pass on this branch. `tests/migrationSequence.test.js` adds the checks those two do not make — the filename pattern, the MariaDB-only dialect scan, and the one-owning-migration-per-table rule.

## Verification

```
$ backend/node_modules/.bin/jest --config backend/jest.config.js tests/migrationSequence.test.js
Tests:       65 passed, 65 total

# related suites, unchanged:
$ ... tests/migrationViewColumns tests/fraudMonitoringQueue tests/couponValidator tests/couponEffectiveness
Tests:       135 passed, 135 total
```

Confirmed the guard is real by restoring `main`'s `migrations/` and re-running it:

```
✕ no two migrations claim the same version
✕ 0049_coupons_schema.sql uses no MariaDB-only syntax
✕ the coupons migration amends the baseline rather than re-creating it
✕ it adds the columns couponService reads
✕ nothing is left at a duplicated 0049
✕ no table is created by more than one migration
Tests:       9 failed, 56 passed, 65 total
```


---

## CI note — merge #1701 first

The **Syntax check** job fails on this branch, and it is not this change:

```
❌ 1 of 654 JavaScript file(s) failed to parse:
  frontend/scripts/shop.js:2499
      Unexpected end of input
```

`frontend/scripts/shop.js` is unparsable on `main` — the responsive refactor duplicated and interleaved its initialization block. Every open PR against this repository inherits it, and because `check:syntax` is the first CI job and the other two are gated on it, **Backend tests** and **Server boots** are skipped rather than run. That is why this PR shows no test result.

#1701 fixes it. Once that merges, this branch picks the fix up from `main` with no rebase needed — the two touch no file in common. All gates pass locally on this branch's changes:

```
$ npm run check:boot     ✅
$ npm run check:modules  ✅
$ npm run check:assets   ✅
$ npm run check:a11y     ✅
$ npm run check:sitemap  ✅
```

and I verified the whole set merges cleanly by merging all five of these branches together locally: no conflicts, `check:syntax` green at 659 files, and the full Jest suite at 2976 passing.

The `Vercel` check fails on every PR in this repository with "Authorization required to deploy" against the `bhuvanshs-projects` team, unrelated to any change.

