### PR TITLE
fix(search): apply publicProductCondition to filter inactive and draft products from search

### DIFF
--- a/backend/controllers/searchController.js
+++ b/backend/controllers/searchController.js
@@ -1,5 +1,6 @@
 const db = require("../config/db");
 const { sanitizeString } = require("../utils/helpers");
+const { publicProductCondition } = require("../constants/productVisibility");
 
 /**
  * GET /api/search?q=
@@ -18,6 +19,7 @@ const searchProducts = async (req, res) => {
             });
         }
 
+        const visible = publicProductCondition("products");
         const terms = queryStr.split(/\s+/).filter(Boolean);
         const formattedTerms = terms.map((t) => `+${t.replace(/[+\-><()~*\"@]/g, "")}*`).join(" ");
         const likeExact = `${queryStr}%`;
@@ -32,12 +34,12 @@ const searchProducts = async (req, res) => {
                    ) AS relevance
             FROM products
             WHERE (MATCH(name) AGAINST(? IN BOOLEAN MODE) OR name LIKE ?)
-              AND (deleted_at IS NULL)
+              AND ${visible.sql}
             ORDER BY relevance DESC, name ASC
             LIMIT 5
         `;
 
-        const params = [likeExact, likeContains, formattedTerms, formattedTerms, likeContains];
+        const params = [likeExact, likeContains, formattedTerms, formattedTerms, likeContains, ...visible.params];
 
         let rows = [];
         try {
@@ -49,11 +51,11 @@ const searchProducts = async (req, res) => {
                     SELECT id, name, price, compare_price, image, category_id, rating, stock,
                            (CASE WHEN name LIKE ? THEN 100 ELSE 50 END) AS relevance
                     FROM products
-                    WHERE name LIKE ? AND deleted_at IS NULL
+                    WHERE name LIKE ? AND ${visible.sql}
                     ORDER BY relevance DESC, name ASC
                     LIMIT 5
                 `;
-                const [fallbackResult] = await db.query(fallbackSql, [likeExact, likeContains]);
+                const [fallbackResult] = await db.query(fallbackSql, [likeExact, likeContains, ...visible.params]);
                 rows = fallbackResult || [];
             } catch (fallbackErr) {
                 rows = [];

--- a/backend/tests/searchVisibility.test.js
+++ b/backend/tests/searchVisibility.test.js
@@ -1,0 +1,60 @@
+const { searchProducts } = require('../controllers/searchController');
+const db = require('../config/db');
+
+jest.mock('../config/db', () => ({
+    query: jest.fn()
+}));
+
+describe('SearchController - Canonical Product Visibility Filtering', () => {
+    let req;
+    let res;
+
+    beforeEach(() => {
+        req = {
+            query: { q: 'shirt' }
+        };
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn()
+        };
+        jest.clearAllMocks();
+    });
+
+    test('should apply publicProductCondition checking status = active and deleted_at IS NULL', async () => {
+        db.query.mockResolvedValueOnce([
+            [{ id: 'p1', name: 'Cotton Shirt', price: 500, status: 'active', relevance: 100 }]
+        ]);
+
+        await searchProducts(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(db.query).toHaveBeenCalledTimes(1);
+
+        const sql = db.query.mock.calls[0][0];
+        const params = db.query.mock.calls[0][1];
+
+        expect(sql).toContain('products.status IN (?)');
+        expect(sql).toContain('products.deleted_at IS NULL');
+        expect(params).toContain('active');
+    });
+
+    test('fallback query should also include publicProductCondition', async () => {
+        db.query
+            .mockRejectedValueOnce(new Error('Fulltext index not available'))
+            .mockResolvedValueOnce([
+                [{ id: 'p1', name: 'Cotton Shirt', price: 500, status: 'active', relevance: 50 }]
+            ]);
+
+        await searchProducts(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(db.query).toHaveBeenCalledTimes(2);
+
+        const fallbackSql = db.query.mock.calls[1][0];
+        const fallbackParams = db.query.mock.calls[1][1];
+
+        expect(fallbackSql).toContain('products.status IN (?)');
+        expect(fallbackSql).toContain('products.deleted_at IS NULL');
+        expect(fallbackParams).toContain('active');
+    });
+});


### PR DESCRIPTION
## Description
Fixes draft, archived, and inactive product exposure in \ackend/controllers/searchController.js\. Previously, search queries and fallback queries checked only \deleted_at IS NULL\ and omitted \status = 'active'\, which exposed unpublished draft items in search results and caused 404 links on the storefront.

## Related Issue
Closes #1691

## Clean Architecture & Changes
- Imported and applied canonical \publicProductCondition('products')\ in \searchProducts\ (both primary fulltext and fallback queries).
- Added unit tests in \ackend/tests/searchVisibility.test.js\ validating SQL condition parameters and draft exclusions.

## Verification
- Run \
px jest tests/searchVisibility.test.js\ (All unit tests passing cleanly).