### PR TITLE
fix(coupon): properly update usage_count on promo_codes table in recordCouponUsage

### DIFF
--- a/backend/services/couponService.js
+++ b/backend/services/couponService.js
@@ -151,20 +151,47 @@ const validateCoupon = async (rawCode, rawCartTotal = 0, userId = null, connecti
  * @param {string} code - Coupon code.
  * @returns {Promise<void>}
  */
-const recordCouponUsage = async (connection, couponId, code) => {
+const recordCouponUsage = async (connection, couponId, code, isPromoTable = false) => {
     if (!connection) return;
 
     try {
+        if (isPromoTable) {
+            if (couponId) {
+                await connection.query(
+                    "UPDATE promo_codes SET usage_count = usage_count + 1 WHERE id = ?",
+                    [couponId]
+                );
+            } else if (code) {
+                await connection.query(
+                    "UPDATE promo_codes SET usage_count = usage_count + 1 WHERE UPPER(code) = UPPER(?)",
+                    [code]
+                );
+            }
+            return;
+        }
+
         if (couponId) {
-            await connection.query(
+            const [result] = await connection.query(
                 "UPDATE coupons SET used_count = used_count + 1 WHERE id = ?",
                 [couponId]
             );
+            if (!result || result.affectedRows === 0) {
+                await connection.query(
+                    "UPDATE promo_codes SET usage_count = usage_count + 1 WHERE id = ?",
+                    [couponId]
+                );
+            }
         } else if (code) {
-            await connection.query(
+            const [result] = await connection.query(
                 "UPDATE coupons SET used_count = used_count + 1 WHERE UPPER(code) = UPPER(?)",
                 [code]
             );
+            if (!result || result.affectedRows === 0) {
+                await connection.query(
+                    "UPDATE promo_codes SET usage_count = usage_count + 1 WHERE UPPER(code) = UPPER(?)",
+                    [code]
+                );
+            }
         }
     } catch (error) {
         console.error("RECORD COUPON USAGE ERROR:", error);

--- a/backend/tests/promoCodeUsage.test.js
+++ b/backend/tests/promoCodeUsage.test.js
@@ -1,0 +1,35 @@
+const { recordCouponUsage } = require('../services/couponService');
+
+describe('CouponService - recordCouponUsage Promo Codes Fallback', () => {
+    let connection;
+
+    beforeEach(() => {
+        connection = {
+            query: jest.fn()
+        };
+    });
+
+    test('should update promo_codes directly when isPromoTable is true', async () => {
+        connection.query.mockResolvedValueOnce([{}]);
+
+        await recordCouponUsage(connection, 'promo-1', 'SAVE10', true);
+
+        expect(connection.query).toHaveBeenCalledTimes(1);
+        expect(connection.query).toHaveBeenCalledWith(
+            'UPDATE promo_codes SET usage_count = usage_count + 1 WHERE id = ?',
+            ['promo-1']
+        );
+    });
+
+    test('should fallback to promo_codes when coupons update affects 0 rows', async () => {
+        connection.query
+            .mockResolvedValueOnce([{ affectedRows: 0 }]) // coupons update affected 0 rows
+            .mockResolvedValueOnce([{}]);                 // promo_codes update
+
+        await recordCouponUsage(connection, null, 'DISCOUNT20', false);
+
+        expect(connection.query).toHaveBeenCalledTimes(2);
+        expect(connection.query.mock.calls[0][0]).toContain('UPDATE coupons');
+        expect(connection.query.mock.calls[1][0]).toContain('UPDATE promo_codes');
+    });
+});


### PR DESCRIPTION
## Description
Fixes promo code usage tracking in \ackend/services/couponService.js\. Previously, \ecordCouponUsage\ exclusively updated the \coupons\ table, meaning coupons redeemed from the fallback \promo_codes\ table never had their \usage_count\ incremented, resulting in unlimited redemptions.

## Related Issue
Closes #1692

## Clean Architecture & Changes
- Supported \isPromoTable\ parameter and added automatic fallback to \promo_codes\ table when \coupons\ update does not match any rows.
- Incremented \usage_count\ properly on \promo_codes\.
- Added unit tests in \ackend/tests/promoCodeUsage.test.js\ validating \promo_codes\ usage updates.

## Verification
- Run \
px jest tests/promoCodeUsage.test.js\ (All unit tests passing cleanly).