### PR TITLE
fix(review): ensure moderation_status and is_approved default values on create in reviewRepository

### DIFF
--- a/backend/repositories/reviewRepository.js
+++ b/backend/repositories/reviewRepository.js
@@ -14,14 +14,24 @@ class ReviewRepository extends BaseRepository {
      * @param {Object} reviewData
      * @returns {Promise<Object>} Created review record
      */
-    async create({ productId, userId, rating, comment, title = null, images = null, isVerified = 0 }) {
+    async create({
+        productId,
+        userId,
+        rating,
+        comment,
+        title = null,
+        images = null,
+        isVerified = 0,
+        moderationStatus = 'approved',
+        isApproved = 1
+    }) {
         const numRating = Math.max(1, Math.min(5, Number(rating) || 5));
         const jsonImages = Array.isArray(images) ? JSON.stringify(images) : (typeof images === 'string' ? images : null);
 
         const [result] = await this.db.query(
-            `INSERT INTO ${this.tableName} (product_id, user_id, rating, title, comment, images, is_verified, created_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, NOW())`,
-            [productId, userId, numRating, title, comment, jsonImages, isVerified ? 1 : 0]
+            `INSERT INTO ${this.tableName} (product_id, user_id, rating, title, comment, images, is_verified, moderation_status, is_approved, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())`,
+            [productId, userId, numRating, title, comment, jsonImages, isVerified ? 1 : 0, moderationStatus, isApproved ? 1 : 0]
         );
 
         return this.findById(result.insertId);

--- a/backend/tests/reviewRepoModeration.test.js
+++ b/backend/tests/reviewRepoModeration.test.js
@@ -1,0 +1,34 @@
+const reviewRepo = require('../repositories/reviewRepository');
+
+describe('ReviewRepository - Moderation Status Defaults on Create', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        reviewRepo.db = {
+            query: jest.fn()
+        };
+    });
+
+    test('create should supply moderation_status = approved and is_approved = 1', async () => {
+        reviewRepo.db.query
+            .mockResolvedValueOnce([{ insertId: 42 }]) // insert query
+            .mockResolvedValueOnce([[{ id: 42, product_id: 'prod-1', user_id: 'user-1', moderation_status: 'approved', is_approved: 1 }]]); // findById query
+
+        const review = await reviewRepo.create({
+            productId: 'prod-1',
+            userId: 'user-1',
+            rating: 5,
+            comment: 'Great product!'
+        });
+
+        expect(review).toBeDefined();
+        expect(reviewRepo.db.query).toHaveBeenCalledTimes(2);
+
+        const insertSql = reviewRepo.db.query.mock.calls[0][0];
+        const insertParams = reviewRepo.db.query.mock.calls[0][1];
+
+        expect(insertSql).toContain('moderation_status');
+        expect(insertSql).toContain('is_approved');
+        expect(insertParams).toContain('approved');
+        expect(insertParams).toContain(1);
+    });
+});


### PR DESCRIPTION
## Description
Fixes missing review moderation defaults in \ackend/repositories/reviewRepository.js\. Previously, \ReviewRepository.create()\ omitted \moderation_status\ and \is_approved\ during database insertion, causing reviews created through the repository layer to be excluded by \indByProduct()\ queries that filter on \moderation_status = 'approved'\.

## Related Issue
Closes #1694

## Clean Architecture & Changes
- Explicitly specified default \moderation_status = 'approved'\ and \is_approved = 1\ in \ReviewRepository.create()\.
- Added unit tests in \ackend/tests/reviewRepoModeration.test.js\ validating SQL statement construction and parameter binding.

## Verification
- Run \
px jest tests/reviewRepoModeration.test.js\ (All unit tests passing cleanly).