### PR TITLE
fix(review): normalize user_id comparisons in reviewRoutes to support numeric and string IDs

### DIFF
--- a/backend/routes/reviewRoutes.js
+++ b/backend/routes/reviewRoutes.js
@@ -119,7 +119,7 @@ router.put('/:id', authMiddleware, async (req, res) => {
             return res.status(404).json({ success: false, message: 'Review not found' });
         }
 
-        if (existing.user_id !== req.user.id && req.user.role !== 'admin') {
+        if (String(existing.user_id) !== String(req.user.id) && req.user.role !== 'admin') {
             return res.status(403).json({ success: false, message: 'Unauthorized to update this review' });
         }
 
@@ -168,7 +168,7 @@ router.delete('/:id', authMiddleware, async (req, res) => {
             return res.status(404).json({ success: false, message: 'Review not found' });
         }
 
-        if (existing.user_id !== req.user.id && req.user.role !== 'admin') {
+        if (String(existing.user_id) !== String(req.user.id) && req.user.role !== 'admin') {
             return res.status(403).json({ success: false, message: 'Unauthorized to delete this review' });
         }
 

--- a/backend/tests/reviewOwnershipType.test.js
+++ b/backend/tests/reviewOwnershipType.test.js
@@ -1,0 +1,82 @@
+const request = require('supertest');
+const express = require('express');
+
+let mockUser = { id: '10', role: 'user' };
+
+jest.mock('../middleware/authMiddleware', () => {
+    return jest.fn((req, res, next) => {
+        req.user = mockUser;
+        next();
+    });
+});
+
+jest.mock('../repositories/reviewRepository', () => ({
+    findById: jest.fn(),
+    update: jest.fn()
+}));
+
+jest.mock('../controllers/reviewController', () => ({
+    deleteProductReview: jest.fn((req, res) =>
+        res.status(200).json({ success: true, message: 'Review deleted successfully' })
+    ),
+    refreshProductReviewStats: jest.fn().mockResolvedValue({ averageRating: 5, reviewCount: 1 })
+}));
+
+const reviewRepo = require('../repositories/reviewRepository');
+const reviewRoutes = require('../routes/reviewRoutes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/reviews', reviewRoutes);
+
+describe('ReviewRoutes - User ID Type Normalization in Ownership Checks', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUser = { id: '10', role: 'user' };
+    });
+
+    test('PUT /api/reviews/:id should allow owner when existing.user_id is numeric 10 and req.user.id is string "10"', async () => {
+        reviewRepo.findById.mockResolvedValueOnce({
+            id: 1,
+            product_id: 'prod-1',
+            user_id: 10 // numeric in DB
+        });
+        reviewRepo.update.mockResolvedValueOnce({ id: 1, rating: 5, comment: 'Updated' });
+
+        const res = await request(app)
+            .put('/api/reviews/1')
+            .send({ rating: 5, comment: 'Updated' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
+    test('DELETE /api/reviews/:id should allow owner when existing.user_id is numeric 10 and req.user.id is string "10"', async () => {
+        reviewRepo.findById.mockResolvedValueOnce({
+            id: 1,
+            product_id: 'prod-1',
+            user_id: 10 // numeric in DB
+        });
+
+        const res = await request(app)
+            .delete('/api/reviews/1');
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
+    test('PUT /api/reviews/:id should reject when user ID does not match', async () => {
+        reviewRepo.findById.mockResolvedValueOnce({
+            id: 1,
+            product_id: 'prod-1',
+            user_id: 99 // different user
+        });
+
+        const res = await request(app)
+            .put('/api/reviews/1')
+            .send({ rating: 5, comment: 'Updated' });
+
+        expect(res.status).toBe(403);
+        expect(res.body.success).toBe(false);
+    });
+});


### PR DESCRIPTION
## Description
Fixes ownership verification failures in \ackend/routes/reviewRoutes.js\. Previously, \PUT /api/reviews/:id\ and \DELETE /api/reviews/:id\ compared \existing.user_id !== req.user.id\ using strict type inequality. When MySQL returns a numeric integer \user_id\ and the JWT token holds a string ID, the strict inequality evaluation failed, rejecting legitimate review authors with 403 Forbidden.

## Related Issue
Closes #1695

## Clean Architecture & Changes
- Normalized comparisons with \String(existing.user_id) !== String(req.user.id)\ in both update and delete route handlers.
- Added unit tests in \ackend/tests/reviewOwnershipType.test.js\ validating numeric and string user ID equality.

## Verification
- Run \
px jest tests/reviewOwnershipType.test.js\ (All unit tests passing cleanly).