### PR TITLE
fix(cart-recovery): filter candidate line counts by active and non-deleted products

### DIFF
--- a/backend/services/cartRecoveryService.js
+++ b/backend/services/cartRecoveryService.js
@@ -37,6 +37,7 @@ const crypto = require('crypto');
 const db = require('../config/db');
 const cartRecoveryConfig = require('../config/cartRecoveryConfig');
 const logger = require('../utils/logger');
+const { publicProductCondition } = require('../constants/productVisibility');
 const { safeInteger, safeUUID } = require('../utils/helpers');
 const { sendNotificationEmail } = require('./notificationEmailService');
 const { issueRestoreToken, buildRestoreUrl } = require('./cartRestoreService');
@@ -162,6 +163,7 @@ async function findRecoveryCandidates(options = {}) {
         safeInteger(options.batchSize, cartRecoveryConfig.SCAN_BATCH_SIZE)
     );
 
+    const visible = publicProductCondition('p');
     const [rows] = await db.query(
         `SELECT
              c.id AS cart_id,
@@ -174,7 +176,9 @@ async function findRecoveryCandidates(options = {}) {
              pref.cart_recovery_in_app,
              TIMESTAMPDIFF(MINUTE, c.abandoned_at, NOW()) AS minutes_since_abandoned,
              (SELECT COUNT(*) FROM cart_items ci
-               WHERE ci.cart_id = c.id) AS line_count,
+                JOIN products p ON p.id = ci.product_id
+               WHERE ci.cart_id = c.id
+                 AND ${visible.sql}) AS line_count,
              (SELECT COUNT(*) FROM cart_recovery_log l
                WHERE l.cart_id = c.id) AS messages_for_cart,
              (SELECT COUNT(*) FROM cart_recovery_log l
@@ -192,7 +196,7 @@ async function findRecoveryCandidates(options = {}) {
            AND c.abandoned_at > DATE_SUB(NOW(), INTERVAL ? MINUTE)
          ORDER BY c.abandoned_at ASC
          LIMIT ?`,
-        [frequencyCapHours, CART_STATUS_ABANDONED, giveUpAfterMinutes, batchSize]
+        [...visible.params, frequencyCapHours, CART_STATUS_ABANDONED, giveUpAfterMinutes, batchSize]
     );
 
     return rows;

--- a/backend/tests/cartRecoveryCandidateFilter.test.js
+++ b/backend/tests/cartRecoveryCandidateFilter.test.js
@@ -1,0 +1,38 @@
+const { findRecoveryCandidates } = require('../services/cartRecoveryService');
+const db = require('../config/db');
+
+jest.mock('../config/db', () => ({
+    query: jest.fn()
+}));
+
+describe('CartRecoveryService - Candidate Product Visibility Filter', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('findRecoveryCandidates should include product status = active and deleted_at IS NULL in line_count subquery', async () => {
+        db.query.mockResolvedValueOnce([
+            [{
+                cart_id: 'cart-1',
+                user_id: 'user-1',
+                line_count: 2,
+                messages_for_cart: 0,
+                messages_in_window: 0,
+                orders_since_abandoned: 0
+            }]
+        ]);
+
+        const candidates = await findRecoveryCandidates();
+
+        expect(candidates).toHaveLength(1);
+        expect(db.query).toHaveBeenCalledTimes(1);
+
+        const sql = db.query.mock.calls[0][0];
+        const params = db.query.mock.calls[0][1];
+
+        expect(sql).toContain('JOIN products p ON p.id = ci.product_id');
+        expect(sql).toContain('p.status IN (?)');
+        expect(sql).toContain('p.deleted_at IS NULL');
+        expect(params).toContain('active');
+    });
+});


### PR DESCRIPTION
## Description
Fixes erroneous abandoned cart recovery email dispatches for baskets containing only soft-deleted or withdrawn products in \ackend/services/cartRecoveryService.js\. Previously, \indRecoveryCandidates\ performed a raw subquery count on \cart_items\, sending recovery emails for abandoned carts whose items were unpurchasable and resulting in HTTP 410 dead-ends upon clicking the restore link.

## Related Issue
Closes #1725

## Clean Architecture & Changes
- Updated the \line_count\ subquery in \indRecoveryCandidates()\ to join \products p\ and enforce canonical \publicProductCondition('p')\.
- Added unit tests in \ackend/tests/cartRecoveryCandidateFilter.test.js\ validating line count query construction and active/non-deleted product filtering.

## Verification
- Run \
px jest tests/cartRecoveryCandidateFilter.test.js\ (All unit tests passing cleanly).