### PR TITLE
fix: sync line.variantId to resolved variant ID to prevent inventory lock collision

### DIFF
--- a/backend/services/inventoryReservationService.js
+++ b/backend/services/inventoryReservationService.js
@@ -111,6 +111,9 @@ async function reserveStockInTransaction(conn, userId, productId, quantity, now,
 
     if (variant) {
         totalStock = safeNumber(variant.stock);
+        if(line.variantId <= NO_VARIANT_ID){
+            line.variantId = variant.id;
+        }
     }
 
     const [locks] = variant


### PR DESCRIPTION
## Summary
Fixes #1722

`reserveStockInTransaction()` resolves a variant via `resolveLockVariant()` when a
line specifies attribute choices (color/size) instead of an explicit `variantId`,
but `line.variantId` itself was never updated to match. This left it at
`NO_VARIANT_ID` even after the correct variant was resolved.

Because both the lock-check `SELECT` and the lock-creation `INSERT` key off
`line.variantId`, requests for the same physical variant made via explicit
`variantId` vs. via `color`/`size` were landing in different lock buckets and
never serializing against each other — allowing concurrent reservations to
oversell the same stock.

## Fix
After `resolveLockVariant()` resolves a variant, `line.variantId` is now synced
to `variant.id` whenever it wasn't already set to a real ID:

```js
if (variant) {
    totalStock = safeNumber(variant.stock);
    if (line.variantId <= NO_VARIANT_ID) {
        line.variantId = variant.id;
    }
}
```

Using `<= NO_VARIANT_ID` (rather than a truthy check) keeps this consistent with
how the rest of the file already treats `NO_VARIANT_ID` (see `hasVariantChoice()`
and `lockLine()`), regardless of what sentinel value it's actually set to.

Both downstream queries already read from `line.variantId`, so no other changes
were needed — they now automatically operate on the correct, resolved ID.

## Testing
Manually verified locally: sent one reservation request with an explicit
`variantId` and one with `color`/`size` for the same variant (stock = 1).
Before the fix, both succeeded. After the fix, the second correctly returns
`INVENTORY_CONFLICT`.

No automated test added — happy to add one if a maintainer can point me to the
existing test pattern for this service.